### PR TITLE
CI/CD fixes

### DIFF
--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -7,8 +7,24 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    name: Lint
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install black
+      - name: Check formatting
+        run: black . -l 79 --check
   check-version:
     name: Check version
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -21,8 +37,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
-      # - name: Install package
-      #   run: pip install -e ".[dev]"
       - name: Build changelog
         run: pip install "yaml-changelog>=0.1.7" && make changelog
       - name: Preview changelog update
@@ -30,7 +44,6 @@ jobs:
       - name: Check version number has been properly updated
         run: ".github/is-version-number-acceptable.sh"
       - name: Update changelog
-        # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: EndBug/add-and-commit@v9
         with:
           add: "."
@@ -63,21 +76,6 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI }}
           skip-existing: true
-  lint:
-    runs-on: ubuntu-latest
-    name: Lint
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install black
-      - name: Check formatting
-        run: black . -l 79 --check
 
   test:
     name: Build and Test

--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -51,6 +51,28 @@ jobs:
           author_name: Github Actions[bot]
           message: Update PolicyEngine US data
           github_token: ${{ secrets.POLICYENGINE_GITHUB }}
+  test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Fetch all history for all tags and branches
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - name: Install package
+        run: pip install -e ".[dev]"
+      - name: Download data inputs
+        run: make download
+        env:
+          POLICYENGINE_US_DATA_GITHUB_TOKEN: ${{ secrets.POLICYENGINE_US_DATA_GITHUB_TOKEN }}
+      - name: Build datasets
+        run: make data
+      - name: Run tests
+        run: pytest
   publish-to-pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest
@@ -76,31 +98,6 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI }}
           skip-existing: true
-
-  test:
-    name: Build and Test
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Fetch all history for all tags and branches
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
-      - name: Install package
-        run: pip install -e ".[dev]"
-      - name: Download data inputs
-        run: make download
-        env:
-          POLICYENGINE_US_DATA_GITHUB_TOKEN: ${{ secrets.POLICYENGINE_US_DATA_GITHUB_TOKEN }}
-      - name: Build datasets
-        run: make data
-      - name: Run tests
-        run: pytest
-
   docker:
     name: Docker
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_cd.yaml
+++ b/.github/workflows/ci_cd.yaml
@@ -115,7 +115,6 @@ jobs:
         run: docker build . -f docker/policyengine_us_data.Dockerfile -t ghcr.io/policyengine/policyengine-us-data:latest
       - name: Push container
         run: docker push ghcr.io/policyengine/policyengine-us-data:latest
-
   upload:
     name: Upload Data 
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2024-09-11 16:40:10
+
+### Fixed
+
+- Added GitHub Actions test job to PR and push
+- Run publish to PyPI GitHub Actions job only on push
+- Fix changelog GitHub Actions job
+
 ## [1.1.0] - 2024-09-11 13:48:15
 
 ### Changed
@@ -27,5 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+[1.1.1]: https://github.com/PolicyEngine/policyengine-us-data/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/PolicyEngine/policyengine-us-data/compare/1.0.0...1.1.0
 [1.0.0]: https://github.com/PolicyEngine/policyengine-us-data/compare/1.0.0...1.0.0

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -14,3 +14,10 @@
     - Updated required Python version
     - Removed setuptools_scm
   date: 2024-09-11 13:48:15
+- bump: patch
+  changes:
+    fixed:
+    - Added GitHub Actions test job to PR and push
+    - Run publish to PyPI GitHub Actions job only on push
+    - Fix changelog GitHub Actions job
+  date: 2024-09-11 16:40:10

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,6 @@
+- bump: patch
+  changes:
+    fixed:
+    - Added GitHub Actions test job to PR and push
+    - Run publish to PyPI GitHub Actions job only on push
+    - Fix changelog GitHub Actions job

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,6 +1,0 @@
-- bump: patch
-  changes:
-    fixed:
-    - Added GitHub Actions test job to PR and push
-    - Run publish to PyPI GitHub Actions job only on push
-    - Fix changelog GitHub Actions job

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "policyengine_us_data"
-version = "1.1.0"
+version = "1.1.1"
 description = "A package to create representative microdata for the US."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Fixes #41. This should now properly run the CI/CD script, execute the changelog update on PR and commit the changes, then publish to PyPI on merge. 

Note that on PR, this script initiates the Actions run, then commits a change, meaning the currently running Actions will always appear one commit above the most recent, as visible below. This can be deceptive, as the most recent changes will just show up as "able to merge successfully."