### PR TITLE
Fix data uploading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2024-09-12 19:47:01
+
+### Added
+
+- Added conditional deletion of existing resource
+- Added downloading of existing resources for backup purposes
+- Added tqdm to download script
+
+### Changed
+
+- Fixed upload script's use of tqdm
+
 ## [1.1.1] - 2024-09-11 16:40:10
 
 ### Fixed
@@ -35,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+[1.2.0]: https://github.com/PolicyEngine/policyengine-us-data/compare/1.1.1...1.2.0
 [1.1.1]: https://github.com/PolicyEngine/policyengine-us-data/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/PolicyEngine/policyengine-us-data/compare/1.0.0...1.1.0
 [1.0.0]: https://github.com/PolicyEngine/policyengine-us-data/compare/1.0.0...1.0.0

--- a/changelog.yaml
+++ b/changelog.yaml
@@ -21,3 +21,12 @@
     - Run publish to PyPI GitHub Actions job only on push
     - Fix changelog GitHub Actions job
   date: 2024-09-11 16:40:10
+- bump: minor
+  changes:
+    added:
+    - Added conditional deletion of existing resource
+    - Added downloading of existing resources for backup purposes
+    - Added tqdm to download script
+    changed:
+    - Fixed upload script's use of tqdm
+  date: 2024-09-12 19:47:01

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,8 @@
+- bump: minor
+  changes:
+    changed:
+    - Fixed upload script's use of tqdm
+    added:
+    - Added conditional deletion of existing resource
+    - Added downloading of existing resources for backup purposes
+    - Added tqdm to download script

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,8 +1,0 @@
-- bump: minor
-  changes:
-    changed:
-    - Fixed upload script's use of tqdm
-    added:
-    - Added conditional deletion of existing resource
-    - Added downloading of existing resources for backup purposes
-    - Added tqdm to download script

--- a/policyengine_us_data/utils/github.py
+++ b/policyengine_us_data/utils/github.py
@@ -81,6 +81,7 @@ def upload(
     headers = {
         "Accept": "application/vnd.github.v3+json",
         "Content-Type": "application/octet-stream",
+        "Content-Length": str(file_size),
         **auth_headers,
     }
 
@@ -95,14 +96,15 @@ def upload(
                         url,
                         headers=headers,
                         data=f,
-                        stream=True,
-                        hooks=dict(
-                            response=lambda r, *args, **kwargs: pbar.update(
-                                len(r.content)
-                            )
-                        ),
+                        # stream=True,
+                        # hooks=dict(
+                        #     response=lambda r, *args, **kwargs: pbar.update(
+                        #         len(r.content)
+                        #     )
+                        # ),
                         timeout=300,  # 5 minutes timeout
                     )
+                    pbar.update(file_size)
 
             if response.status_code == 201:
                 return response.json()

--- a/policyengine_us_data/utils/github.py
+++ b/policyengine_us_data/utils/github.py
@@ -32,7 +32,9 @@ def get_asset_url(
 def get_release_id(org: str, repo: str, release_tag: str) -> int:
     url = f"https://api.github.com/repos/{org}/{repo}/releases/tags/{release_tag}"
     response = requests.get(url, headers=auth_headers)
-    if response.status_code != 200:
+    if response.status_code == 404:
+        raise ValueError(f"Release {release_tag} not found in {org}/{repo}.")
+    elif response.status_code != 200:
         raise ValueError(
             f"Invalid response code {response.status_code} for url {url}."
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "policyengine_us_data"
-version = "1.1.1"
+version = "1.2.0"
 description = "A package to create representative microdata for the US."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Fixes #24.

Unfortunately, the endpoint that GitHub provides for uploading data to a release ([link](https://docs.github.com/en/rest/releases/assets?apiVersion=2022-11-28#upload-a-release-asset)) does not allow uploading if a resource already exists at the given asset's name. This is because GitHub envisions each release as a standalone item within a versioning system. This meant that when uploading a dataset that already existed in a given release (e.g., `cps_2024.h5`), the upload would fail with error 422. Unfortunately, GitHub's "update a release asset" endpoint ([link](https://docs.github.com/en/rest/releases/assets?apiVersion=2022-11-28#update-a-release-asset)) only exists to update metadata, not replace an existing asset.

Furthermore, the original code did not properly wrap the `upload` action in the `tqdm` library.

To get around this issue, this PR does the following:
* Fixes the tqdm implementation
* In the upload function, determines whether or not an item with the desired name already exists in the desired release. If so, it:
  * Downloads the given item and stores it locally as a backup
  * Deletes the given item
  * Uploads the new item
  * Deletes the backup
* If at any point, this new simulated transaction fails, the code uploads the backup

This PR also adds `tqdm` to the `download` function. 
