### PR TITLE
Add pooled 3-year CPS to __init__.py

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - Added pooled 3-year CPS to __init__.py

--- a/policyengine_us_data/datasets/__init__.py
+++ b/policyengine_us_data/datasets/__init__.py
@@ -14,9 +14,16 @@ from .cps import (
     CensusCPS_2023,
     EnhancedCPS_2024,
     ReweightedCPS_2024,
-    Pooled_3_Year_CPS_2023
+    Pooled_3_Year_CPS_2023,
 )
 from .puf import PUF_2015, PUF_2021, PUF_2024, IRS_PUF_2015
 from .acs import ACS_2022
 
-DATASETS = [CPS_2022, PUF_2021, CPS_2024, EnhancedCPS_2024, ACS_2022, Pooled_3_Year_CPS_2023]
+DATASETS = [
+    CPS_2022,
+    PUF_2021,
+    CPS_2024,
+    EnhancedCPS_2024,
+    ACS_2022,
+    Pooled_3_Year_CPS_2023,
+]

--- a/policyengine_us_data/datasets/__init__.py
+++ b/policyengine_us_data/datasets/__init__.py
@@ -14,8 +14,9 @@ from .cps import (
     CensusCPS_2023,
     EnhancedCPS_2024,
     ReweightedCPS_2024,
+    Pooled_3_Year_CPS_2023
 )
 from .puf import PUF_2015, PUF_2021, PUF_2024, IRS_PUF_2015
 from .acs import ACS_2022
 
-DATASETS = [CPS_2022, PUF_2021, CPS_2024, EnhancedCPS_2024, ACS_2022]
+DATASETS = [CPS_2022, PUF_2021, CPS_2024, EnhancedCPS_2024, ACS_2022, Pooled_3_Year_CPS_2023]


### PR DESCRIPTION
Fixes #80. This makes it possible to properly import the pooled 3-year CPS file by properly including in `__init__.py`.