### PR TITLE
Change Enhanced CPS and Pooled 3-Year CPS URL to Hugging Face datasets

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    changed:
+    - Changed GitHub release URLs to Hugging Face URLs for Enhanced CPS 2024 and Pooled 3-Year CPS 2023.

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -2,3 +2,4 @@
   changes:
     changed:
     - Changed GitHub release URLs to Hugging Face URLs for Enhanced CPS 2024 and Pooled 3-Year CPS 2023.
+    - Set minimum version for policyengine-core.

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -707,7 +707,7 @@ class Pooled_3_Year_CPS_2023(PooledCPS):
         CPS_2023,
     ]
     time_period = 2023
-    url = "release://PolicyEngine/policyengine-us-data/1.13.0/pooled_3_year_cps_2023.h5"
+    url = "hf://policyengine/policyengine-us-data/pooled_3_year_cps_2023.h5"
 
 
 if __name__ == "__main__":

--- a/policyengine_us_data/datasets/cps/enhanced_cps.py
+++ b/policyengine_us_data/datasets/cps/enhanced_cps.py
@@ -189,7 +189,7 @@ class EnhancedCPS_2024(EnhancedCPS):
     name = "enhanced_cps_2024"
     label = "Enhanced CPS 2024"
     file_path = STORAGE_FOLDER / "enhanced_cps_2024.h5"
-    url = "release://policyengine/policyengine-us-data/1.13.0/enhanced_cps_2024.h5"
+    url = "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5"
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 license = {file = "LICENSE"}
 requires-python = ">=3.10"
 dependencies = [
-    "policyengine_core",
+    "policyengine_core>=3.14.1",
     "requests",
     "tqdm",
     "microdf_python>=0.4.3",


### PR DESCRIPTION
Fixes #125. This changes the URLs we use for the Enhanced CPS and Pooled 3-Year CPS datasets to those deployed via Hugging Face. This also sets a minimum pin value for `policyengine-core`, where changes were made to enable datasets loaded from Hugging Face.