### PR TITLE
Adjust `test_ecps_has_mortgage_interest` to use `deductible_interest_expense` instead of `interest_expense`

### DIFF
--- a/policyengine_us_data/tests/test_datasets/test_enhanced_cps.py
+++ b/policyengine_us_data/tests/test_datasets/test_enhanced_cps.py
@@ -36,4 +36,4 @@ def test_ecps_has_mortgage_interest():
     sim = Microsimulation(dataset=EnhancedCPS_2024)
 
     assert sim.calculate("deductible_mortgage_interest").sum() > 1
-    assert sim.calculate("interest_expense").sum() > 1
+    assert sim.calculate("deductible_interest_expense").sum() > 1


### PR DESCRIPTION
Fixes #166