### PR TITLE
Don't downsample Pooled CPS

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -5,3 +5,4 @@
     - Non-downsampled versions of the 2021, 2022, and 2023 CPS datasets
     changed:
     - Pooled 3-Year CPS generation uses the non-downsampled versions of the 2021, 2022, and 2023 CPS datasets
+    - Downsampling method attempts to preserve original dtype values

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,8 +1,8 @@
 - bump: patch
   changes:
     added:
-    - A method to disable downsampling within the base CPS dataset generation class
     - Non-downsampled versions of the 2021, 2022, and 2023 CPS datasets
     changed:
+    - Modified downsampling method within CPS base dataset class
     - Pooled 3-Year CPS generation uses the non-downsampled versions of the 2021, 2022, and 2023 CPS datasets
     - Downsampling method attempts to preserve original dtype values

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,7 @@
+- bump: patch
+  changes:
+    added:
+    - A method to disable downsampling within the base CPS dataset generation class
+    - Non-downsampled versions of the 2021, 2022, and 2023 CPS datasets
+    changed:
+    - Pooled 3-Year CPS generation uses the non-downsampled versions of the 2021, 2022, and 2023 CPS datasets

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -20,6 +20,7 @@ class CPS(Dataset):
     raw_cps: Type[CensusCPS] = None
     previous_year_raw_cps: Type[CensusCPS] = None
     data_format = Dataset.ARRAYS
+    downsample_by_half: bool = True
 
     def generate(self):
         """Generates the Current Population Survey dataset for PolicyEngine US microsimulations.
@@ -58,7 +59,8 @@ class CPS(Dataset):
 
         # Downsample
 
-        self.downsample(fraction=0.5)
+        if self.downsample_by_half:
+            self.downsample(fraction=0.5)
 
     def downsample(self, fraction: float = 0.5):
         from policyengine_us import Microsimulation
@@ -673,6 +675,36 @@ class CPS_2024(CPS):
     url = "release://policyengine/policyengine-us-data/1.13.0/cps_2024.h5"
 
 
+class CPS_2021_Not_Downsampled(CPS):
+    name = "cps_2021_not_downsampled"
+    label = "CPS 2021 (not downsampled)"
+    raw_cps = CensusCPS_2021
+    previous_year_raw_cps = CensusCPS_2020
+    file_path = STORAGE_FOLDER / "cps_2021_not_downsampled.h5"
+    time_period = 2021
+    downsample_by_half = False
+
+
+class CPS_2022_Not_Downsampled(CPS):
+    name = "cps_2022_not_downsampled"
+    label = "CPS 2022 (not downsampled)"
+    raw_cps = CensusCPS_2022
+    previous_year_raw_cps = CensusCPS_2021
+    file_path = STORAGE_FOLDER / "cps_2022_not_downsampled.h5"
+    time_period = 2022
+    downsample_by_half = False
+
+
+class CPS_2023_Not_Downsampled(CPS):
+    name = "cps_2023_not_downsampled"
+    label = "CPS 2023 (not downsampled)"
+    raw_cps = CensusCPS_2023
+    previous_year_raw_cps = CensusCPS_2022
+    file_path = STORAGE_FOLDER / "cps_2023_not_downsampled.h5"
+    time_period = 2023
+    downsample_by_half = False
+
+
 class PooledCPS(Dataset):
     data_format = Dataset.ARRAYS
     input_datasets: list
@@ -724,9 +756,9 @@ class Pooled_3_Year_CPS_2023(PooledCPS):
     name = "pooled_3_year_cps_2023"
     file_path = STORAGE_FOLDER / "pooled_3_year_cps_2023.h5"
     input_datasets = [
-        CPS_2021,
-        CPS_2022,
-        CPS_2023,
+        CPS_2021_Not_Downsampled,
+        CPS_2022_Not_Downsampled,
+        CPS_2023_Not_Downsampled,
     ]
     time_period = 2023
     url = "hf://policyengine/policyengine-us-data/pooled_3_year_cps_2023.h5"
@@ -737,4 +769,7 @@ if __name__ == "__main__":
     CPS_2022().generate()
     CPS_2023().generate()
     CPS_2024().generate()
+    CPS_2021_Not_Downsampled().generate()
+    CPS_2022_Not_Downsampled().generate()
+    CPS_2023_Not_Downsampled().generate()
     Pooled_3_Year_CPS_2023().generate()

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -20,7 +20,7 @@ class CPS(Dataset):
     raw_cps: Type[CensusCPS] = None
     previous_year_raw_cps: Type[CensusCPS] = None
     data_format = Dataset.ARRAYS
-    downsample_by_half: bool = True
+    downsample_frac: float | None = 0.5
 
     def generate(self):
         """Generates the Current Population Survey dataset for PolicyEngine US microsimulations.
@@ -58,22 +58,8 @@ class CPS(Dataset):
         add_takeup(self)
 
         # Downsample
-
-        if self.downsample_by_half:
-            self.downsample(fraction=0.5)
-
-    # def downsample(self, fraction: float = 0.5):
-    #     from policyengine_us import Microsimulation
-
-    #     sim = Microsimulation(dataset=self)
-    #     sim.subsample(frac=fraction)
-    #     original_data: dict = self.load_dataset()
-    #     for key in original_data:
-    #         if key not in sim.tax_benefit_system.variables:
-    #             continue
-    #         original_data[key] = sim.calculate(key).values
-
-    #     self.save_dataset(original_data)
+        if self.downsample_frac is not None and self.downsample_frac < 1.0:
+            self.downsample(fraction=self.downsample_frac)
 
     def downsample(self, fraction: float = 0.5):
         from policyengine_us import Microsimulation
@@ -714,34 +700,34 @@ class CPS_2024(CPS):
 # The below datasets are a very naïve way of preventing downsampling in the
 # Pooled 3-Year CPS. They should be replaced by a more sustainable approach.
 # If these are still here on July 1, 2025, please open an issue and raise at standup.
-class CPS_2021_Not_Downsampled(CPS):
-    name = "cps_2021_not_downsampled"
-    label = "CPS 2021 (not downsampled)"
+class CPS_2021_Full(CPS):
+    name = "cps_2021_full"
+    label = "CPS 2021 (full)"
     raw_cps = CensusCPS_2021
     previous_year_raw_cps = CensusCPS_2020
-    file_path = STORAGE_FOLDER / "cps_2021_not_downsampled.h5"
+    file_path = STORAGE_FOLDER / "cps_2021_full.h5"
     time_period = 2021
-    downsample_by_half = False
+    downsample_frac = None
 
 
-class CPS_2022_Not_Downsampled(CPS):
-    name = "cps_2022_not_downsampled"
-    label = "CPS 2022 (not downsampled)"
+class CPS_2022_Full(CPS):
+    name = "cps_2022_full"
+    label = "CPS 2022 (full)"
     raw_cps = CensusCPS_2022
     previous_year_raw_cps = CensusCPS_2021
-    file_path = STORAGE_FOLDER / "cps_2022_not_downsampled.h5"
+    file_path = STORAGE_FOLDER / "cps_2022_full.h5"
     time_period = 2022
-    downsample_by_half = False
+    downsample_frac = None
 
 
-class CPS_2023_Not_Downsampled(CPS):
-    name = "cps_2023_not_downsampled"
-    label = "CPS 2023 (not downsampled)"
+class CPS_2023_Full(CPS):
+    name = "cps_2023_full"
+    label = "CPS 2023 (full)"
     raw_cps = CensusCPS_2023
     previous_year_raw_cps = CensusCPS_2022
-    file_path = STORAGE_FOLDER / "cps_2023_not_downsampled.h5"
+    file_path = STORAGE_FOLDER / "cps_2023_full.h5"
     time_period = 2023
-    downsample_by_half = False
+    downsample_frac = None
 
 
 class PooledCPS(Dataset):
@@ -795,9 +781,9 @@ class Pooled_3_Year_CPS_2023(PooledCPS):
     name = "pooled_3_year_cps_2023"
     file_path = STORAGE_FOLDER / "pooled_3_year_cps_2023.h5"
     input_datasets = [
-        CPS_2021_Not_Downsampled,
-        CPS_2022_Not_Downsampled,
-        CPS_2023_Not_Downsampled,
+        CPS_2021_Full,
+        CPS_2022_Full,
+        CPS_2023_Full,
     ]
     time_period = 2023
     url = "hf://policyengine/policyengine-us-data/pooled_3_year_cps_2023.h5"
@@ -808,7 +794,7 @@ if __name__ == "__main__":
     CPS_2022().generate()
     CPS_2023().generate()
     CPS_2024().generate()
-    CPS_2021_Not_Downsampled().generate()
-    CPS_2022_Not_Downsampled().generate()
-    CPS_2023_Not_Downsampled().generate()
+    CPS_2021_Full().generate()
+    CPS_2022_Full().generate()
+    CPS_2023_Full().generate()
     Pooled_3_Year_CPS_2023().generate()

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -675,6 +675,9 @@ class CPS_2024(CPS):
     url = "release://policyengine/policyengine-us-data/1.13.0/cps_2024.h5"
 
 
+# The below datasets are a very naïve way of preventing downsampling in the
+# Pooled 3-Year CPS. They should be replaced by a more sustainable approach.
+# If these are still here on July 1, 2025, please open an issue and raise at standup.
 class CPS_2021_Not_Downsampled(CPS):
     name = "cps_2021_not_downsampled"
     label = "CPS 2021 (not downsampled)"

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -20,11 +20,15 @@ class CPS(Dataset):
     raw_cps: Type[CensusCPS] = None
     previous_year_raw_cps: Type[CensusCPS] = None
     data_format = Dataset.ARRAYS
-    downsample_frac: float | None = 0.5
+    frac: float | None = 1
 
     def generate(self):
         """Generates the Current Population Survey dataset for PolicyEngine US microsimulations.
         Technical documentation and codebook here: https://www2.census.gov/programs-surveys/cps/techdocs/cpsmar21.pdf
+
+        Args:
+            frac (float, optional): Fraction of the dataset to keep. Defaults to 1. Example: To downsample to 25% of dataset,
+                set frac=0.25.
         """
 
         if self.raw_cps is None:
@@ -58,10 +62,10 @@ class CPS(Dataset):
         add_takeup(self)
 
         # Downsample
-        if self.downsample_frac is not None and self.downsample_frac < 1.0:
-            self.downsample(fraction=self.downsample_frac)
+        if self.frac is not None and self.frac < 1.0:
+            self.downsample(frac=self.frac)
 
-    def downsample(self, fraction: float = 0.5):
+    def downsample(self, frac: float):
         from policyengine_us import Microsimulation
 
         # Store original dtypes before modifying
@@ -71,7 +75,7 @@ class CPS(Dataset):
         }
 
         sim = Microsimulation(dataset=self)
-        sim.subsample(frac=fraction)
+        sim.subsample(frac=frac)
 
         for key in original_data:
             if key not in sim.tax_benefit_system.variables:
@@ -651,6 +655,7 @@ class CPS_2019(CPS):
     previous_year_raw_cps = CensusCPS_2018
     file_path = STORAGE_FOLDER / "cps_2019.h5"
     time_period = 2019
+    frac = 0.5
 
 
 class CPS_2020(CPS):
@@ -660,6 +665,7 @@ class CPS_2020(CPS):
     previous_year_raw_cps = CensusCPS_2019
     file_path = STORAGE_FOLDER / "cps_2020.h5"
     time_period = 2020
+    frac = 0.5
 
 
 class CPS_2021(CPS):
@@ -669,6 +675,7 @@ class CPS_2021(CPS):
     previous_year_raw_cps = CensusCPS_2020
     file_path = STORAGE_FOLDER / "cps_2021_v1_6_1.h5"
     time_period = 2021
+    frac = 0.5
 
 
 class CPS_2022(CPS):
@@ -678,6 +685,7 @@ class CPS_2022(CPS):
     previous_year_raw_cps = CensusCPS_2021
     file_path = STORAGE_FOLDER / "cps_2022_v1_6_1.h5"
     time_period = 2022
+    frac = 0.5
 
 
 class CPS_2023(CPS):
@@ -687,6 +695,7 @@ class CPS_2023(CPS):
     previous_year_raw_cps = CensusCPS_2022
     file_path = STORAGE_FOLDER / "cps_2023.h5"
     time_period = 2023
+    frac = 0.5
 
 
 class CPS_2024(CPS):
@@ -695,6 +704,7 @@ class CPS_2024(CPS):
     file_path = STORAGE_FOLDER / "cps_2024.h5"
     time_period = 2024
     url = "release://policyengine/policyengine-us-data/1.13.0/cps_2024.h5"
+    frac = 0.5
 
 
 # The below datasets are a very naïve way of preventing downsampling in the
@@ -707,7 +717,6 @@ class CPS_2021_Full(CPS):
     previous_year_raw_cps = CensusCPS_2020
     file_path = STORAGE_FOLDER / "cps_2021_full.h5"
     time_period = 2021
-    downsample_frac = None
 
 
 class CPS_2022_Full(CPS):
@@ -717,7 +726,6 @@ class CPS_2022_Full(CPS):
     previous_year_raw_cps = CensusCPS_2021
     file_path = STORAGE_FOLDER / "cps_2022_full.h5"
     time_period = 2022
-    downsample_frac = None
 
 
 class CPS_2023_Full(CPS):
@@ -727,7 +735,6 @@ class CPS_2023_Full(CPS):
     previous_year_raw_cps = CensusCPS_2022
     file_path = STORAGE_FOLDER / "cps_2023_full.h5"
     time_period = 2023
-    downsample_frac = None
 
 
 class PooledCPS(Dataset):


### PR DESCRIPTION
Fixes #207.

This PR introduces a _very_ naïve means of preventing downsampling when constructing the Pooled 3-Year CPS dataset, which we use by default for states due to states' limited number of observations in any given single year CPS set. This PR creates three new datasets - essentially the old un-downsampled 2021, '22, and '23 CPS - then uses those to construct the Pooled 3-Year while maintaining the default downsampled versions of these, as well. 

This code should be improved separately, and if this code is still here, unchanged, on July 1, 2025, someone should open a ticket.