### PR TITLE
Remove premature Census data caching

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,5 @@
+- bump: patch
+  changes:
+    fixed:
+    - Data downloads for Census datasets disabled.
+    - Warning added for downsampling non-existent policyengine-[country] variables.

--- a/policyengine_us_data/datasets/acs/census_acs.py
+++ b/policyengine_us_data/datasets/acs/census_acs.py
@@ -206,4 +206,3 @@ class CensusACS_2022(CensusACS):
     name = "census_acs_2022.h5"
     file_path = STORAGE_FOLDER / "census_acs_2022.h5"
     time_period = 2022
-    url = "hf://policyengine/policyengine-us-data/census_acs_2022.h5"

--- a/policyengine_us_data/datasets/cps/census_cps.py
+++ b/policyengine_us_data/datasets/cps/census_cps.py
@@ -124,7 +124,6 @@ class CensusCPS_2023(CensusCPS):
     name = "census_cps_2023"
     file_path = STORAGE_FOLDER / "census_cps_2023.h5"
     data_format = Dataset.TABLES
-    url = "hf://policyengine/policyengine-us-data/census_cps_2023.h5"
 
 
 class CensusCPS_2022(CensusCPS):
@@ -133,7 +132,6 @@ class CensusCPS_2022(CensusCPS):
     name = "census_cps_2022"
     file_path = STORAGE_FOLDER / "census_cps_2022.h5"
     data_format = Dataset.TABLES
-    url = "hf://policyengine/policyengine-us-data/census_cps_2022.h5"
 
 
 class CensusCPS_2021(CensusCPS):
@@ -142,7 +140,6 @@ class CensusCPS_2021(CensusCPS):
     name = "census_cps_2021"
     file_path = STORAGE_FOLDER / "census_cps_2021.h5"
     data_format = Dataset.TABLES
-    url = "hf://policyengine/policyengine-us-data/census_cps_2021.h5"
 
 
 class CensusCPS_2020(CensusCPS):
@@ -151,7 +148,6 @@ class CensusCPS_2020(CensusCPS):
     name = "census_cps_2020"
     file_path = STORAGE_FOLDER / "census_cps_2020.h5"
     data_format = Dataset.TABLES
-    url = "hf://policyengine/policyengine-us-data/census_cps_2020.h5"
 
 
 class CensusCPS_2019(CensusCPS):

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -12,6 +12,7 @@ from policyengine_us_data.utils.uprating import (
     create_policyengine_uprating_factors_table,
 )
 from policyengine_us_data.utils import QRF
+import logging
 
 
 class CPS(Dataset):
@@ -80,6 +81,9 @@ class CPS(Dataset):
 
         for key in original_data:
             if key not in sim.tax_benefit_system.variables:
+                logging.warning(
+                    f"Attempting to downsample the variable {key} but failing because it is not in the given country package."
+                )
                 continue
             values = sim.calculate(key).values
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "tqdm",
     "microdf_python>=0.4.3",
     "microimpute",
+    "pip-system-certs",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Fixes #241 

Also adds a user-friendly warning when downsampling fails because a variable is newly added.