### PR TITLE
Fix black formatting

### DIFF
--- a/policyengine_us_data/datasets/cps/extended_cps.py
+++ b/policyengine_us_data/datasets/cps/extended_cps.py
@@ -79,7 +79,7 @@ IMPUTED_VARIABLES = [
     "farm_rent_income_would_be_qualified",
     "partnership_s_corp_income_would_be_qualified",
     "rental_income_would_be_qualified",
-    "self_employment_income_would_be_qualified"
+    "self_employment_income_would_be_qualified",
 ]
 
 


### PR DESCRIPTION
## Summary
- fix black formatting on datasets

## Testing
- `black policyengine_us_data/datasets/cps/extended_cps.py policyengine_us_data/datasets/puf/puf.py -l 79 --check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'policyengine_core')*