### PR TITLE
Fix alias grouping in repair_inconsistencies

### DIFF
--- a/policyengine_us_data/tests/test_target_diagnostics.py
+++ b/policyengine_us_data/tests/test_target_diagnostics.py
@@ -1,0 +1,38 @@
+import numpy as np
+import importlib.util
+import typing
+import re
+
+spec = importlib.util.spec_from_file_location(
+    'td',
+    'policyengine_us_data/utils/target_diagnostics.py'
+)
+mod = importlib.util.module_from_spec(spec)
+mod.re = re
+mod.List = typing.List
+mod.Callable = typing.Callable
+mod.Iterable = typing.Iterable
+mod.Tuple = typing.Tuple
+mod.Sequence = typing.Sequence
+
+# pandas and numpy are required; if not installed, skip the test
+try:
+    import pandas as pd
+    mod.pd = pd
+    mod.np = np
+    spec.loader.exec_module(mod)
+except ModuleNotFoundError:
+    import pytest
+    pytest.skip("Required dependencies not available", allow_module_level=True)
+
+
+def test_repair_inconsistencies_runs():
+    names = [
+        "nation/irs/aca_enrollment",
+        "US06/irs/aca_enrollment",
+        "state/CA/irs/aca_enrollment/district1",
+        "state/CA/irs/aca_enrollment/district2",
+    ]
+    targets = np.array([100.0, 40.0, 20.0, 15.0])
+    result = mod.repair_inconsistencies(targets, names)
+    assert result.shape == targets.shape

--- a/policyengine_us_data/utils/target_diagnostics.py
+++ b/policyengine_us_data/utils/target_diagnostics.py
@@ -209,9 +209,10 @@ def repair_inconsistencies(targets: np.ndarray,
     # ---- 1. nation -> states -------------------------------------------------
     df = idx.copy()
     df["value"] = values[df["i"]]
+    df["metric_norm"] = df["metric"].map(ALIASES).fillna(df["metric"])
 
     # Work metric by metric
-    for metric, grp in df.groupby("metric_value"):
+    for metric, grp in df.groupby("metric_norm"):
         nat_val = grp.loc[grp.level == "nation", "value"]
         if nat_val.empty:
             continue                    # no national comparator


### PR DESCRIPTION
## Summary
- normalise metric names in `repair_inconsistencies`
- use `metric_norm` for grouping
- add minimal test invoking the helper

## Testing
- `pytest policyengine_us_data/tests/test_target_diagnostics.py -q` *(fails: ModuleNotFoundError: No module named 'policyengine_core')*
- `python` snippet to load module *(fails: Missing dependency: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68741d4f57d483269762c9781864838f