### PR TITLE
Deduplicate reweighting diagnostics

### DIFF
--- a/policyengine_us_data/tests/test_datasets/test_sparse_enhanced_cps.py
+++ b/policyengine_us_data/tests/test_datasets/test_sparse_enhanced_cps.py
@@ -2,7 +2,10 @@ import pytest
 
 import numpy as np
 
-from policyengine_us_data.utils import build_loss_matrix
+from policyengine_us_data.utils import (
+    build_loss_matrix,
+    print_reweighting_diagnostics,
+)
 
 
 def test_sparse_ecps():
@@ -51,32 +54,12 @@ def test_sparse_ecps():
     assert loss_matrix_clean.shape[1] == targets_array_clean.size
 
     optimised_weights = data["household_weight"]["2024"]
-    print("\n\n---Sparse Solutions: reweighting quick diagnostics----\n")
-    print(
-        f"{np.sum(optimised_weights == 0)} are zero, {np.sum(optimised_weights != 0)} weights are nonzero"
+    percent_within_10 = print_reweighting_diagnostics(
+        optimised_weights,
+        loss_matrix_clean,
+        targets_array_clean,
+        "Sparse Solutions",
     )
-    estimate = optimised_weights @ loss_matrix_clean
-    rel_error = (
-        ((estimate - targets_array_clean) + 1) / (targets_array_clean + 1)
-    ) ** 2
-    within_10_percent_mask = np.abs(estimate - targets_array_clean) <= (
-        0.10 * np.abs(targets_array_clean)
-    )
-    percent_within_10 = np.mean(within_10_percent_mask) * 100
-    print(
-        f"rel_error: min: {np.min(rel_error):.2f}\n"
-        f"max: {np.max(rel_error):.2f}\n"
-        f"mean: {np.mean(rel_error):.2f}\n"
-        f"median: {np.median(rel_error):.2f}\n"
-        f"Wthin 10% of target: {percent_within_10:.2f}%"
-    )
-    print("Relative error over 100% for:")
-    for i in np.where(rel_error > 1)[0]:
-        print(f"target_name: {loss_matrix_clean.columns[i]}")
-        print(f"target_value: {targets_array_clean[i]}")
-        print(f"estimate_value: {estimate[i]}")
-        print(f"has rel_error: {rel_error[i]:.2f}\n")
-    print("---End of reweighting quick diagnostics------")
 
     assert percent_within_10 > 70.0
 

--- a/policyengine_us_data/utils/loss.py
+++ b/policyengine_us_data/utils/loss.py
@@ -831,3 +831,36 @@ def _add_snap_metric_columns(
         loss_matrix[col_name] = metric
 
     return loss_matrix
+
+
+def print_reweighting_diagnostics(
+    optimised_weights, loss_matrix_clean, targets_array_clean, label
+):
+    print(f"\n\n---{label}: reweighting quick diagnostics----\n")
+    print(
+        f"{np.sum(optimised_weights == 0)} are zero, "
+        f"{np.sum(optimised_weights != 0)} weights are nonzero"
+    )
+    estimate = optimised_weights @ loss_matrix_clean
+    rel_error = (
+        ((estimate - targets_array_clean) + 1) / (targets_array_clean + 1)
+    ) ** 2
+    within_10_percent_mask = np.abs(estimate - targets_array_clean) <= (
+        0.10 * np.abs(targets_array_clean)
+    )
+    percent_within_10 = np.mean(within_10_percent_mask) * 100
+    print(
+        f"rel_error: min: {np.min(rel_error):.2f}\n"
+        f"max: {np.max(rel_error):.2f}\n"
+        f"mean: {np.mean(rel_error):.2f}\n"
+        f"median: {np.median(rel_error):.2f}\n"
+        f"Wthin 10% of target: {percent_within_10:.2f}%"
+    )
+    print("Relative error over 100% for:")
+    for i in np.where(rel_error > 1)[0]:
+        print(f"target_name: {loss_matrix_clean.columns[i]}")
+        print(f"target_value: {targets_array_clean[i]}")
+        print(f"estimate_value: {estimate[i]}")
+        print(f"has rel_error: {rel_error[i]:.2f}\n")
+    print("---End of reweighting quick diagnostics------")
+    return percent_within_10


### PR DESCRIPTION
## Summary
- refactor repeated diagnostic printing into `print_reweighting_diagnostics`
- use helper function in enhanced CPS dataset
- use helper in sparse CPS test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'policyengine_core')*

------
https://chatgpt.com/codex/tasks/task_e_6876fbcc93b08326bb9cb4180626c512