### PR TITLE
Replace prints with logging

### DIFF
--- a/policyengine_us_data/datasets/cps/extended_cps.py
+++ b/policyengine_us_data/datasets/cps/extended_cps.py
@@ -7,6 +7,7 @@ import pandas as pd
 import os
 from policyengine_us_data.utils import QRF
 import time
+import logging
 
 # These are sorted by magnitude.
 # First 15 contain 90%.
@@ -229,12 +230,14 @@ def impute_income_variables(
         X_train,
         y_train,
     )
-    print(
+    logging.info(
         f"Training imputation models from the PUF took {time.time() - start:.2f} seconds"
     )
     start = time.time()
     y = model.predict(X)
-    print(f"Predicting imputed values took {time.time() - start:.2f} seconds")
+    logging.info(
+        f"Predicting imputed values took {time.time() - start:.2f} seconds"
+    )
     return y
 
 

--- a/policyengine_us_data/datasets/cps/small_enhanced_cps.py
+++ b/policyengine_us_data/datasets/cps/small_enhanced_cps.py
@@ -7,6 +7,7 @@ from policyengine_us_data.datasets import EnhancedCPS_2024
 from policyengine_us_data.storage import STORAGE_FOLDER
 from policyengine_core.enums import Enum
 from policyengine_core.data.dataset import Dataset
+import logging
 
 
 def create_small_ecps():
@@ -126,6 +127,6 @@ def create_sparse_ecps():
 
 if __name__ == "__main__":
     create_small_ecps()
-    print("Small CPS dataset created successfully.")
+    logging.info("Small CPS dataset created successfully.")
     create_sparse_ecps()
-    print("Sparse CPS dataset created successfully.")
+    logging.info("Sparse CPS dataset created successfully.")

--- a/policyengine_us_data/utils/l0.py
+++ b/policyengine_us_data/utils/l0.py
@@ -2,6 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import math
+import logging
 
 
 class HardConcrete(nn.Module):
@@ -189,11 +190,11 @@ def train_with_l0(model, train_loader, epochs=10, l0_lambda=1e-3):
             total_l0 += l0_loss.item()
         if epoch % 1 == 0:
             sparsity_stats = model.get_sparsity_stats()
-            print(
+            logging.info(
                 f"Epoch {epoch}: Loss={total_loss/len(train_loader):.4f}, L0={total_l0/len(train_loader):.4f}"
             )
             for layer, stats in sparsity_stats.items():
-                print(
+                logging.info(
                     f"  {layer}: {stats['sparsity']*100:.1f}% sparse, {stats['active_params']:.1f} active params"
                 )
 

--- a/policyengine_us_data/utils/loss.py
+++ b/policyengine_us_data/utils/loss.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import numpy as np
+import logging
 
 from policyengine_us_data.storage import STORAGE_FOLDER
 from policyengine_us_data.storage.pull_soi_state_targets import (
@@ -552,7 +553,7 @@ def build_loss_matrix(dataset: type, time_period):
         # Convert to thousands for the target
         targets_array.append(row["enrollment"])
 
-        print(
+        logging.info(
             f"Targeting Medicaid enrollment for {row['state']} "
             f"with target {row['enrollment']:.0f}k"
         )
@@ -853,8 +854,8 @@ def print_reweighting_diagnostics(
         else np.asarray(targets_array)
     )
 
-    print(f"\n\n---{label}: reweighting quick diagnostics----\n")
-    print(
+    logging.info(f"\n\n---{label}: reweighting quick diagnostics----\n")
+    logging.info(
         f"{np.sum(optimised_weights_np == 0)} are zero, "
         f"{np.sum(optimised_weights_np != 0)} weights are nonzero"
     )
@@ -869,23 +870,23 @@ def print_reweighting_diagnostics(
         0.10 * np.abs(targets_array_np)
     )
     percent_within_10 = np.mean(within_10_percent_mask) * 100
-    print(
+    logging.info(
         f"rel_error: min: {np.min(rel_error):.2f}\n"
         f"max: {np.max(rel_error):.2f}\n"
         f"mean: {np.mean(rel_error):.2f}\n"
         f"median: {np.median(rel_error):.2f}\n"
         f"Within 10% of target: {percent_within_10:.2f}%"
     )
-    print("Relative error over 100% for:")
+    logging.info("Relative error over 100% for:")
     for i in np.where(rel_error > 1)[0]:
         # Keep this check, as Tensors won't have a .columns attribute
         if hasattr(loss_matrix, "columns"):
-            print(f"target_name: {loss_matrix.columns[i]}")
+            logging.info(f"target_name: {loss_matrix.columns[i]}")
         else:
-            print(f"target_index: {i}")
+            logging.info(f"target_index: {i}")
 
-        print(f"target_value: {targets_array_np[i]}")
-        print(f"estimate_value: {estimate[i]}")
-        print(f"has rel_error: {rel_error[i]:.2f}\n")
-    print("---End of reweighting quick diagnostics------")
+        logging.info(f"target_value: {targets_array_np[i]}")
+        logging.info(f"estimate_value: {estimate[i]}")
+        logging.info(f"has rel_error: {rel_error[i]:.2f}\n")
+    logging.info("---End of reweighting quick diagnostics------")
     return percent_within_10


### PR DESCRIPTION
## Summary
- use `logging.info` in `print_reweighting_diagnostics`
- log training statistics in `l0.py`
- log dataset creation messages
- log imputation timing in `extended_cps`
- log medicaid enrollment targeting messages

## Testing
- `pytest policyengine_us_data/tests/test_datasets/test_sparse_enhanced_cps.py::test_sparse_ecps -q` *(fails: ModuleNotFoundError: No module named 'policyengine_core')*

------
https://chatgpt.com/codex/tasks/task_e_6877a12a45848326ae36fab0c0f69b3d