### PR TITLE
Add Python 3.13 support and simplify CI matrix

### DIFF
--- a/.github/workflows/code_changes.yaml
+++ b/.github/workflows/code_changes.yaml
@@ -37,7 +37,7 @@ jobs:
           - name: Set up Python
             uses: actions/setup-python@v2
             with:
-                python-version: '3.11'
+                python-version: '3.13'
           - uses: "google-github-actions/auth@v2"
             with:
               workload_identity_provider: "projects/322898545428/locations/global/workloadIdentityPools/policyengine-research-id-pool/providers/prod-github-provider"

--- a/.github/workflows/pr_code_changes.yaml
+++ b/.github/workflows/pr_code_changes.yaml
@@ -28,8 +28,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        python-version: ['3.11', '3.12']
+        os: [ubuntu-latest]
+        python-version: ['3.13']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -63,7 +63,7 @@ jobs:
           - name: Set up Python
             uses: actions/setup-python@v2
             with:
-                python-version: '3.11'
+                python-version: '3.13'
           - name: Install package
             run: uv pip install -e .[dev] --system
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,16 @@ authors = [
     {name = "PolicyEngine", email = "hello@policyengine.org"},
 ]
 license = {file = "LICENSE"}
-requires-python = ">=3.11, <3.13.0"
+requires-python = ">=3.11, <3.14.0"
+classifiers = [
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
 dependencies = [
     "policyengine-us>=1.340.1",
     "policyengine-core>=3.14.1",
-    "pandas>=2.3.0",
+    "pandas>=2.3.1",
     "requests",
     "tqdm",
     "microdf_python",
@@ -28,8 +33,8 @@ dependencies = [
     "pip-system-certs",
     "google-cloud-storage",
     "google-auth",
-    "scipy<1.13",
-    "statsmodels>=0.14.0",
+    "scipy>=1.15.3",
+    "statsmodels>=0.14.5",
     "openpyxl>=3.1.5",
     "tables>=3.10.2",
     "torch>=2.7.1",
@@ -65,7 +70,7 @@ testpaths = [
 
 [tool.black]
 line-length = 79
-target-version = ['py311']
+target-version = ['py311', 'py312', 'py313']
 include = '\.pyi?$'
 extend-exclude = '''
 /(


### PR DESCRIPTION
## Summary
- Added Python 3.13 support to the project
- Simplified CI test matrix since this is an internal dev tool
- Updated dependency versions for Python 3.13 compatibility

## Changes
- Updated Python requirement from `<3.13.0` to `<3.14.0`
- Added Python 3.13 classifier
- Updated dependencies:
  - pandas: >=2.3.0 → >=2.3.1
  - scipy: <1.13 → >=1.15.3 (removed upper bound for Python 3.13 compatibility)
  - statsmodels: >=0.14.0 → >=0.14.5
- Simplified CI matrix to only test on Python 3.13 and Ubuntu (reduced from 4 combinations)
- Updated Black target versions to include py313

## Rationale
Since this is an internal tool for PolicyEngine developers to generate microdata (not user-facing), we don't need to test on all OS/Python combinations. This reduces CI time and complexity.

## Test plan
- [x] Dependencies updated in pyproject.toml
- [x] CI workflows updated to use Python 3.13
- [ ] CI passes with updated dependencies

🤖 Generated with [Claude Code](https://claude.ai/code)