### PR TITLE
Fix ORM naming for db models

### DIFF
--- a/policyengine_us_data/db/create_database_tables.py
+++ b/policyengine_us_data/db/create_database_tables.py
@@ -20,7 +20,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-class Strata(SQLModel, table=True):
+class Stratum(SQLModel, table=True):
     """Represents a unique population subgroup (stratum)."""
 
     __tablename__ = "strata"
@@ -52,28 +52,28 @@ class Strata(SQLModel, table=True):
         default=None, description="Descriptive notes about the stratum."
     )
 
-    children_rel: List["Strata"] = Relationship(
+    children_rel: List["Stratum"] = Relationship(
         back_populates="parent_rel",
-        sa_relationship_kwargs={"remote_side": "Strata.parent_stratum_id"},
+        sa_relationship_kwargs={"remote_side": "Stratum.parent_stratum_id"},
     )
-    parent_rel: Optional["Strata"] = Relationship(
+    parent_rel: Optional["Stratum"] = Relationship(
         back_populates="children_rel",
-        sa_relationship_kwargs={"remote_side": "Strata.stratum_id"},
+        sa_relationship_kwargs={"remote_side": "Stratum.stratum_id"},
     )
-    constraints_rel: List["StratumConstraints"] = Relationship(
+    constraints_rel: List["StratumConstraint"] = Relationship(
         back_populates="strata_rel",
         sa_relationship_kwargs={
             "cascade": "all, delete-orphan",
             "lazy": "joined",
         },
     )
-    targets_rel: List["Targets"] = Relationship(
+    targets_rel: List["Target"] = Relationship(
         back_populates="strata_rel",
         sa_relationship_kwargs={"cascade": "all, delete-orphan"},
     )
 
 
-class StratumConstraints(SQLModel, table=True):
+class StratumConstraint(SQLModel, table=True):
     """Defines the rules that make up a stratum."""
 
     __tablename__ = "stratum_constraints"
@@ -94,10 +94,10 @@ class StratumConstraints(SQLModel, table=True):
         default=None, description="Optional notes about the constraint."
     )
 
-    strata_rel: Strata = Relationship(back_populates="constraints_rel")
+    strata_rel: Stratum = Relationship(back_populates="constraints_rel")
 
 
-class Targets(SQLModel, table=True):
+class Target(SQLModel, table=True):
     """Stores the data values for a specific stratum."""
 
     __tablename__ = "targets"
@@ -142,15 +142,15 @@ class Targets(SQLModel, table=True):
         description="Optional descriptive notes about the target row.",
     )
 
-    strata_rel: Strata = Relationship(back_populates="targets_rel")
+    strata_rel: Stratum = Relationship(back_populates="targets_rel")
 
 
 # This SQLAlchemy event listener works directly with the SQLModel class
-@event.listens_for(Strata, "before_insert")
-@event.listens_for(Strata, "before_update")
-def calculate_definition_hash(mapper, connection, target: Strata):
+@event.listens_for(Stratum, "before_insert")
+@event.listens_for(Stratum, "before_update")
+def calculate_definition_hash(mapper, connection, target: Stratum):
     """
-    Calculate and set the definition_hash before saving a Strata instance.
+    Calculate and set the definition_hash before saving a Stratum instance.
     """
     constraints_history = get_history(target, "constraints_rel")
     if not (
@@ -172,7 +172,7 @@ def calculate_definition_hash(mapper, connection, target: Strata):
     h = hashlib.sha256(fingerprint_text.encode("utf-8"))
     target.definition_hash = h.hexdigest()
     logger.info(
-        f"Set definition_hash for Strata to '{target.definition_hash}'"
+        f"Set definition_hash for Stratum to '{target.definition_hash}'"
     )
 
 

--- a/policyengine_us_data/db/load_age_targets.py
+++ b/policyengine_us_data/db/load_age_targets.py
@@ -9,9 +9,9 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from policyengine_us_data.db.create_database_tables import (
-    Strata,
-    StratumConstraints,
-    Targets,
+    Stratum,
+    StratumConstraint,
+    Target,
 )
 
 
@@ -236,7 +236,7 @@ def load_age_data(df_long, geo, stratum_lookup={}):
 
     for _, row in df_long.iterrows():
 
-        # Create the parent Strata object.
+        # Create the parent Stratum object.
         # We will attach children to it before adding it to the session.
         note = f"Age: {row['age_range']}, Geo: {row['ucgid']}"
         parent_geo = get_parent_geo(geo)
@@ -246,18 +246,18 @@ def load_age_data(df_long, geo, stratum_lookup={}):
             else None
         )
 
-        new_stratum = Strata(
+        new_stratum = Stratum(
             parent_stratum_id=parent_stratum_id, stratum_group_id=0, notes=note
         )
 
         # Create constraints and link them to the parent's relationship attribute.
         new_stratum.constraints_rel = [
-            StratumConstraints(
+            StratumConstraint(
                 constraint_variable="ucgid",
                 operation="equals",
                 value=row["ucgid"],
             ),
-            StratumConstraints(
+            StratumConstraint(
                 constraint_variable="age",
                 operation="greater_than_or_equal",
                 value=str(row["age_greater_than_or_equal_to"]),
@@ -267,7 +267,7 @@ def load_age_data(df_long, geo, stratum_lookup={}):
         age_lt_value = row["age_less_than_or_equal_to"]
         if not np.isinf(age_lt_value):
             new_stratum.constraints_rel.append(
-                StratumConstraints(
+                StratumConstraint(
                     constraint_variable="age",
                     operation="less_than",
                     value=str(age_lt_value + 1),
@@ -276,7 +276,7 @@ def load_age_data(df_long, geo, stratum_lookup={}):
 
         # Create the Target and link it to the parent.
         new_stratum.targets_rel.append(
-            Targets(
+            Target(
                 variable=row["variable"],
                 period=row["period"],
                 value=row["value"],


### PR DESCRIPTION
## Summary
- use singular ORM class names while keeping plural tablenames
- update data loader to use new names

## Testing
- `black --check policyengine_us_data/db/create_database_tables.py policyengine_us_data/db/load_age_targets.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'policyengine_core')*

------
https://chatgpt.com/codex/tasks/task_e_688534c05c4c8326901f62a3c999b163