### PR TITLE
Fix remaining CI issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 **/*.db
 venv
 node_modules
+docs/node_modules
 
 ## old (not clean) targets
 !healthcare_spending.csv

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,3 +1,5 @@
-- bump: minor
-  added:
-    - Paper sections on inequality results, weights, demographic analysis, and PolicyEngine integration.
+- bump: patch
+  changes:
+    fixed:
+      - Added docs/node_modules to .gitignore
+      - Fixed CURRENT_YEAR definition in make_person test function

--- a/policyengine_us_data/tests/test_datasets/test_enhanced_cps.py
+++ b/policyengine_us_data/tests/test_datasets/test_enhanced_cps.py
@@ -138,6 +138,8 @@ def make_person(age, years_in_us, ssn_code, birth_country):
     from policyengine_us import Microsimulation
     from policyengine_core.reforms import Reform
 
+    CURRENT_YEAR = 2024
+
     return SimpleNamespace(
         A_AGE=np.array([age]),
         PEINUSYR=np.array([CURRENT_YEAR - 1981 - years_in_us]),


### PR DESCRIPTION
This PR fixes the remaining CI issues after merging #117:

## Changes
- Add `docs/node_modules` to .gitignore
- Fix CURRENT_YEAR definition in make_person test function

## Context
This is a clean replacement for #403 which had merge conflicts and accidental node_modules commits.