### PR TITLE
Fix push CI upload failure

### DIFF
--- a/.github/workflows/code_changes.yaml
+++ b/.github/workflows/code_changes.yaml
@@ -20,9 +20,7 @@ jobs:
       full_suite: true
       upload_data: true
       deploy_docs: true
-    secrets:
-      HUGGING_FACE_TOKEN: ${{ secrets.HUGGING_FACE_TOKEN }}
-      POLICYENGINE_US_DATA_GITHUB_TOKEN: ${{ secrets.POLICYENGINE_US_DATA_GITHUB_TOKEN }}
+    secrets: inherit
 
   Publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr_code_changes.yaml
+++ b/.github/workflows/pr_code_changes.yaml
@@ -48,5 +48,4 @@ jobs:
       full_suite: true
       upload_data: false
       deploy_docs: false
-    secrets:
-      HUGGING_FACE_TOKEN: ${{ secrets.HUGGING_FACE_TOKEN }}
+    secrets: inherit

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Fixed push CI upload failure by using 'secrets: inherit' in reusable workflows


### PR DESCRIPTION
## Issue
The push CI started failing after #406 was merged. The 'Upload data' step failed because environment variables (specifically HUGGING_FACE_TOKEN) were not being passed to the reusable workflow.

## Solution
Changed from explicitly passing secrets to using `secrets: inherit` which passes all secrets from the calling workflow to the reusable workflow.

## Changes
- Use `secrets: inherit` in code_changes.yaml for the Test job
- Use `secrets: inherit` in pr_code_changes.yaml for consistency

This ensures all required environment variables and secrets are available to the reusable test workflow.