### PR TITLE
Fix GitHub Pages documentation rendering

### DIFF
--- a/.github/workflows/reusable_test.yaml
+++ b/.github/workflows/reusable_test.yaml
@@ -81,6 +81,8 @@ jobs:
 
       - name: Test documentation builds
         run: make documentation
+        env:
+          BASE_URL: ${{ inputs.deploy_docs && '/policyengine-us-data' || '' }}
 
       - name: Deploy Github Pages documentation
         if: inputs.deploy_docs

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Fixed GitHub Pages documentation rendering by setting BASE_URL for MyST


### PR DESCRIPTION
## Summary
Fixes the GitHub Pages documentation site which was showing raw HTML instead of rendered pages.

## Problem
The documentation at https://policyengine.github.io/policyengine-us-data/ was not rendering properly because MyST was generating absolute paths (like `/build/`) that don't work when served from a GitHub Pages subdirectory.

## Solution
Set the `BASE_URL` environment variable to `/policyengine-us-data` when building documentation for deployment. MyST uses this to generate correct relative paths.

## Test
The documentation will render correctly at https://policyengine.github.io/policyengine-us-data/ after this fix is deployed.