### PR TITLE
Fix GitHub Pages documentation by adding .nojekyll

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ documentation:
 	rm -f _toc.yml && \
 	myst clean && \
 	timeout 10 myst build --html || true
+	cd docs && test -d _build/html && touch _build/html/.nojekyll || true
 
 documentation-build:
 	cd docs && \

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Fixed GitHub Pages documentation by adding .nojekyll file to serve underscore-prefixed directories


### PR DESCRIPTION
## Problem
The documentation site at https://policyengine.github.io/policyengine-us-data is not displaying correctly - CSS and JavaScript assets are not loading, resulting in a broken layout with no styling.

## Root Cause
GitHub Pages uses Jekyll by default to process sites. Jekyll ignores directories that start with underscores (like `_build`, `_assets`, etc.), which prevents CSS and JS files from being served.

## Solution
- Added a `.nojekyll` file to tell GitHub Pages to serve the site as static HTML without Jekyll processing
- Modified the Makefile to ensure the `.nojekyll` file is created in the `_build/html` directory during documentation builds

## Testing
The fix ensures that all assets in underscore-prefixed directories will be properly served by GitHub Pages.

Fixes #423