### PR TITLE
Add dedicated workflow for documentation deployment

### DIFF
--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -1,0 +1,41 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - '.github/workflows/deploy_docs.yaml'
+  workflow_dispatch:  # Allow manual trigger
+
+jobs:
+  deploy-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required for GitHub Pages deploy
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: |
+          pip install mystmd
+          pip install -e .
+
+      - name: Build documentation
+        run: make documentation
+        env:
+          BASE_URL: '/policyengine-us-data'
+
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: docs/_build/html
+          clean: true

--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -33,6 +33,23 @@ jobs:
         env:
           BASE_URL: '/policyengine-us-data'
 
+      - name: Verify documentation build
+        run: |
+          echo "Checking .nojekyll file exists..."
+          test -f docs/_build/html/.nojekyll || (echo "ERROR: .nojekyll file missing!" && exit 1)
+          
+          echo "Checking index.html exists..."
+          test -f docs/_build/html/index.html || (echo "ERROR: index.html missing!" && exit 1)
+          
+          echo "Checking for correct base URL in HTML..."
+          if grep -q 'href="/policyengine-us-data/' docs/_build/html/index.html; then
+            echo "✓ Base URL correctly set in HTML"
+          else
+            echo "ERROR: Base URL not found in HTML!" && exit 1
+          fi
+          
+          echo "Documentation build verification passed!"
+
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - Dedicated GitHub Actions workflow for faster documentation deployments


### PR DESCRIPTION
## Summary
This PR adds a separate GitHub Actions workflow specifically for deploying documentation, which avoids the need to run the full test suite for documentation-only changes.

## Problem
Currently, documentation deployment requires running the full test suite including dataset builds, which:
- Takes a long time (often 30+ minutes)
- Uses significant CI resources
- Creates unnecessary delays for documentation updates

## Solution
Added a new `deploy_docs.yaml` workflow that:
- Triggers on pushes to main that modify files in `docs/`
- Can be manually triggered via workflow_dispatch
- Only builds and deploys documentation without running tests
- Significantly reduces deployment time for documentation changes

## Benefits
- ⚡ Faster documentation updates (minutes instead of 30+ minutes)
- 💰 Reduced CI resource usage
- 🔄 Better developer experience for documentation contributors
- ✅ Still maintains full testing for code changes via existing workflows

The existing `code_changes.yaml` workflow remains unchanged and will still deploy docs after code changes with full testing.