### PR TITLE
Store policy database in storage folder

### DIFF
--- a/policyengine_us_data/db/create_database_tables.py
+++ b/policyengine_us_data/db/create_database_tables.py
@@ -12,6 +12,8 @@ from sqlmodel import (
     create_engine,
 )
 
+from policyengine_us_data.storage import STORAGE_FOLDER
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -176,7 +178,9 @@ def calculate_definition_hash(mapper, connection, target: Stratum):
     )
 
 
-def create_database(db_uri="sqlite:///policy_data.db"):
+def create_database(
+    db_uri: str = f"sqlite:///{STORAGE_FOLDER / 'policy_data.db'}",
+):
     """
     Creates a SQLite database and all the defined tables.
 

--- a/policyengine_us_data/db/create_initial_strata.py
+++ b/policyengine_us_data/db/create_initial_strata.py
@@ -3,6 +3,8 @@ from typing import Dict
 import pandas as pd
 from sqlmodel import Session, create_engine
 
+from policyengine_us_data.storage import STORAGE_FOLDER
+
 
 from policyengine_us.variables.household.demographic.geographic.ucgid.ucgid_enum import (
     UCGID,
@@ -32,7 +34,7 @@ def main():
         .reset_index(drop=True)
     )
 
-    DATABASE_URL = "sqlite:///policy_data.db"
+    DATABASE_URL = f"sqlite:///{STORAGE_FOLDER / 'policy_data.db'}"
     engine = create_engine(DATABASE_URL)
 
     # map the ucgid_str 'code' to auto-generated 'stratum_id'

--- a/policyengine_us_data/db/etl_age.py
+++ b/policyengine_us_data/db/etl_age.py
@@ -2,6 +2,8 @@ import pandas as pd
 import numpy as np
 from sqlmodel import Session, create_engine
 
+from policyengine_us_data.storage import STORAGE_FOLDER
+
 from policyengine_us_data.db.create_database_tables import (
     Stratum,
     StratumConstraint,
@@ -103,7 +105,7 @@ def load_age_data(df_long, geo, year, stratum_lookup=None):
         raise ValueError('geo must be one of "National", "State", "District"')
 
     # Prepare to load data -----------
-    DATABASE_URL = "sqlite:///policy_data.db"
+    DATABASE_URL = f"sqlite:///{STORAGE_FOLDER / 'policy_data.db'}"
     engine = create_engine(DATABASE_URL)
 
     if stratum_lookup is None:

--- a/policyengine_us_data/db/etl_irs_soi.py
+++ b/policyengine_us_data/db/etl_irs_soi.py
@@ -5,6 +5,8 @@ import pandas as pd
 
 from sqlmodel import Session, create_engine
 
+from policyengine_us_data.storage import STORAGE_FOLDER
+
 from policyengine_us_data.db.create_database_tables import (
     Stratum,
     StratumConstraint,
@@ -283,7 +285,7 @@ def transform_soi_data(raw_df):
 
 def load_soi_data(long_dfs, year):
 
-    DATABASE_URL = "sqlite:///policy_data.db"
+    DATABASE_URL = f"sqlite:///{STORAGE_FOLDER / 'policy_data.db'}"
     engine = create_engine(DATABASE_URL)
 
     session = Session(engine)

--- a/policyengine_us_data/db/etl_medicaid.py
+++ b/policyengine_us_data/db/etl_medicaid.py
@@ -3,6 +3,8 @@ import requests
 import pandas as pd
 from sqlmodel import Session, create_engine
 
+from policyengine_us_data.storage import STORAGE_FOLDER
+
 from policyengine_us_data.db.create_database_tables import (
     Stratum,
     StratumConstraint,
@@ -83,7 +85,7 @@ def transform_medicaid_data(state_admin_df, cd_survey_df, year):
 
 def load_medicaid_data(long_state, long_cd, year):
 
-    DATABASE_URL = "sqlite:///policy_data.db"
+    DATABASE_URL = f"sqlite:///{STORAGE_FOLDER / 'policy_data.db'}"
     engine = create_engine(DATABASE_URL)
 
     stratum_lookup = {}

--- a/policyengine_us_data/db/etl_snap.py
+++ b/policyengine_us_data/db/etl_snap.py
@@ -7,6 +7,8 @@ import numpy as np
 import us
 from sqlmodel import Session, create_engine
 
+from policyengine_us_data.storage import STORAGE_FOLDER
+
 from policyengine_us_data.db.create_database_tables import (
     Stratum,
     StratumConstraint,
@@ -144,7 +146,7 @@ def transform_survey_snap_data(raw_df):
 
 def load_administrative_snap_data(df_states, year):
 
-    DATABASE_URL = "sqlite:///policy_data.db"
+    DATABASE_URL = f"sqlite:///{STORAGE_FOLDER / 'policy_data.db'}"
     engine = create_engine(DATABASE_URL)
 
     stratum_lookup = {}
@@ -232,7 +234,7 @@ def load_survey_snap_data(survey_df, year, stratum_lookup=None):
     if stratum_lookup is None:
         raise ValueError("stratum_lookup must be provided")
 
-    DATABASE_URL = "sqlite:///policy_data.db"
+    DATABASE_URL = f"sqlite:///{STORAGE_FOLDER / 'policy_data.db'}"
     engine = create_engine(DATABASE_URL)
 
     with Session(engine) as session:


### PR DESCRIPTION
## Summary
- store the policy data SQLite database under the package storage folder
- adjust all ETL scripts and database creation to reference the new path

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'policyengine_core')*

------
https://chatgpt.com/codex/tasks/task_e_689f31c11b788326ae2df139374b7ee9