### PR TITLE
Add Great Expectations validation for database build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,12 +54,13 @@ documentation-dev:
 	myst start
 
 database:
-	python policyengine_us_data/db/create_database_tables.py
-	python policyengine_us_data/db/create_initial_strata.py
-	python policyengine_us_data/db/etl_age.py
-	python policyengine_us_data/db/etl_medicaid.py
-	python policyengine_us_data/db/etl_snap.py
-	python policyengine_us_data/db/etl_irs_soi.py
+        python policyengine_us_data/db/create_database_tables.py
+        python policyengine_us_data/db/create_initial_strata.py
+        python policyengine_us_data/db/etl_age.py
+        python policyengine_us_data/db/etl_medicaid.py
+        python policyengine_us_data/db/etl_snap.py
+        python policyengine_us_data/db/etl_irs_soi.py
+        python policyengine_us_data/db/validate_database.py
 
 data:
 	python policyengine_us_data/utils/uprating.py

--- a/great_expectations/checkpoints/policy_data_checkpoint.yml
+++ b/great_expectations/checkpoints/policy_data_checkpoint.yml
@@ -1,0 +1,13 @@
+name: policy_data_checkpoint
+config_version: 1.0
+class_name: SimpleCheckpoint
+validations:
+  - batch_request:
+      datasource_name: policy_db
+      data_connector_name: default_runtime_data_connector_name
+      data_asset_name: strata
+      runtime_parameters:
+        query: SELECT * FROM strata
+      batch_identifiers:
+        default_identifier_name: default
+    expectation_suite_name: policy_data_suite

--- a/great_expectations/expectations/policy_data_suite.json
+++ b/great_expectations/expectations/policy_data_suite.json
@@ -1,0 +1,12 @@
+{
+  "expectation_suite_name": "policy_data_suite",
+  "expectations": [
+    {
+      "expectation_type": "expect_table_row_count_to_be_greater_than",
+      "kwargs": {"value": 0}
+    }
+  ],
+  "meta": {
+    "great_expectations_version": "0.18"
+  }
+}

--- a/great_expectations/great_expectations.yml
+++ b/great_expectations/great_expectations.yml
@@ -1,0 +1,31 @@
+config_version: 3.0
+datasources:
+  policy_db:
+    class_name: Datasource
+    execution_engine:
+      class_name: SqlAlchemyExecutionEngine
+      connection_string: sqlite:///policyengine_us_data/storage/policy_data.db
+    data_connectors:
+      default_runtime_data_connector_name:
+        class_name: RuntimeDataConnector
+        batch_identifiers:
+          - default_identifier_name
+stores:
+  expectations_store:
+    class_name: ExpectationsStore
+    store_backend:
+      class_name: InlineStoreBackend
+  validations_store:
+    class_name: ValidationsStore
+    store_backend:
+      class_name: InlineStoreBackend
+  checkpoint_store:
+    class_name: CheckpointStore
+    store_backend:
+      class_name: InlineStoreBackend
+expectations_store_name: expectations_store
+validations_store_name: validations_store
+checkpoint_store_name: checkpoint_store
+data_docs_sites: {}
+anonymous_usage_statistics:
+  enabled: false

--- a/policyengine_us_data/db/validate_database.py
+++ b/policyengine_us_data/db/validate_database.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import great_expectations as ge
+
+
+def main() -> None:
+    """Run Great Expectations validation on the policy data database."""
+    # Ensure we load the DataContext from the repository root
+    context = ge.get_context()
+    # Execute the checkpoint configured for the policy database
+    result = context.run_checkpoint(checkpoint_name="policy_data_checkpoint")
+    if not result["success"]:
+        raise ValueError("Great Expectations validation failed")
+    print("Great Expectations validation succeeded")
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "sqlalchemy>=2.0.41",
     "sqlmodel>=0.0.24",
     "xlrd>=2.0.2",
+    "great_expectations>=0.18.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- run Great Expectations checkpoint after building policy_data.db
- configure Great Expectations datasource, suite, and checkpoint
- declare great_expectations as dependency

## Testing
- `pytest policyengine_us_data/tests/test_database.py -q` *(fails: No module named 'policyengine_core')*
- `pip install great_expectations -q` *(fails: 403 Forbidden)*
- `pip install policyengine-core -q` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a36d4e8de08326a132f1560a7cd297