### PR TITLE
Add self-hosted GCP runner for memory-intensive CI builds

### DIFF
--- a/.github/workflows/reusable_test.yaml
+++ b/.github/workflows/reusable_test.yaml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: write  # Required for GitHub Pages deploy
       id-token: write  # Required for GCP auth

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    changed:
+    - GitHub Actions workflow now uses self-hosted GCP runner to handle memory-intensive dataset builds


### PR DESCRIPTION
## Summary
- Migrates GitHub Actions workflow from `ubuntu-latest` to self-hosted GCP runner
- Resolves memory/timeout issues during dataset builds that were causing CI failures at ~17 minutes
- Uses n2-standard-16 spot instance (64GB RAM, 32GB swap) in `policyengine-research` GCP project

## Changes
- Updated `.github/workflows/reusable_test.yaml` to use `runs-on: self-hosted`
- Added changelog entry documenting infrastructure change

## Test plan
- [ ] Verify self-hosted runner is online and registered in GitHub Actions
- [ ] Push this PR and confirm workflow picks up job on self-hosted runner
- [ ] Monitor `make data` step completes without memory/timeout errors
- [ ] Verify all tests pass on self-hosted environment
- [ ] Confirm GCP service account authentication still works

## Infrastructure notes
Runner VM is managed via:
- Start/stop: `gcloud compute instances start/stop github-runner --zone=us-central1-a`
- Cost: ~$180/month running, ~$8/month stopped
- Setup documented in related GCP configuration scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)