### PR TITLE
Add SPM threshold calculation module

### DIFF
--- a/policyengine_us_data/spm/__init__.py
+++ b/policyengine_us_data/spm/__init__.py
@@ -1,0 +1,61 @@
+"""
+SPM (Supplemental Poverty Measure) threshold calculation module.
+
+This module provides tools to calculate SPM thresholds from source data:
+- Base thresholds from BLS Consumer Expenditure Survey (by tenure type)
+- Geographic adjustments (GEOADJ) from ACS median rents
+- Local thresholds for congressional districts
+
+The SPM threshold formula is:
+    threshold = base_threshold[tenure] × equivalence_scale × geoadj
+
+Where:
+- base_threshold varies by tenure: renter, owner with mortgage, owner without
+- equivalence_scale adjusts for family composition
+- geoadj adjusts for local housing costs (0.84 in WV to 1.27 in HI)
+
+Usage:
+    from policyengine_us_data.spm import (
+        calculate_base_thresholds,
+        create_district_geoadj_lookup,
+        calculate_local_spm_thresholds,
+        update_spm_thresholds_for_districts,
+    )
+
+    # Get base thresholds for 2024
+    base = calculate_base_thresholds(2024)
+
+    # Get district GEOADJ lookup table
+    geoadj = create_district_geoadj_lookup(2022)
+
+    # Calculate local thresholds for SPM units
+    thresholds = calculate_local_spm_thresholds(
+        district_codes=["0612", "0611"],
+        tenure_types=["renter", "owner_with_mortgage"],
+        num_adults=[2, 1],
+        num_children=[2, 0],
+        year=2024,
+    )
+"""
+
+from .ce_threshold import calculate_base_thresholds
+from .district_geoadj import (
+    create_district_geoadj_lookup,
+    get_district_geoadj,
+    calculate_geoadj_from_rent,
+)
+from .local_threshold import (
+    calculate_local_spm_thresholds,
+    update_spm_thresholds_for_districts,
+    spm_equivalence_scale,
+)
+
+__all__ = [
+    "calculate_base_thresholds",
+    "create_district_geoadj_lookup",
+    "get_district_geoadj",
+    "calculate_geoadj_from_rent",
+    "calculate_local_spm_thresholds",
+    "update_spm_thresholds_for_districts",
+    "spm_equivalence_scale",
+]

--- a/policyengine_us_data/spm/ce_threshold.py
+++ b/policyengine_us_data/spm/ce_threshold.py
@@ -1,0 +1,58 @@
+"""
+Base SPM thresholds from Consumer Expenditure Survey.
+
+Wraps spm-calculator for use in policyengine-us-data.
+"""
+
+from typing import Optional
+
+# Published BLS thresholds by year and tenure type
+# Source: https://www.bls.gov/pir/spm/spm_thresholds.htm
+BLS_PUBLISHED_THRESHOLDS = {
+    2024: {
+        "renter": 39430,
+        "owner_with_mortgage": 39068,
+        "owner_without_mortgage": 32586,
+    },
+    2023: {
+        "renter": 36606,
+        "owner_with_mortgage": 36192,
+        "owner_without_mortgage": 30347,
+    },
+    2022: {
+        "renter": 33402,
+        "owner_with_mortgage": 32949,
+        "owner_without_mortgage": 27679,
+    },
+}
+
+
+def calculate_base_thresholds(
+    year: int = 2024,
+    use_published: bool = True,
+) -> dict[str, float]:
+    """
+    Get base SPM thresholds for the reference family (2A2C) by tenure type.
+
+    Args:
+        year: Target year for thresholds
+        use_published: If True, use published BLS thresholds when available.
+                      If False or year not available, forecast from latest.
+
+    Returns:
+        Dict with keys 'renter', 'owner_with_mortgage', 'owner_without_mortgage'
+        and threshold values in dollars.
+    """
+    if use_published and year in BLS_PUBLISHED_THRESHOLDS:
+        return BLS_PUBLISHED_THRESHOLDS[year].copy()
+
+    # Forecast from latest available year
+    latest_year = max(BLS_PUBLISHED_THRESHOLDS.keys())
+    latest_thresholds = BLS_PUBLISHED_THRESHOLDS[latest_year]
+
+    # Use approximately 3% annual inflation for forecasting
+    # TODO: Use actual CPI-U or better methodology
+    years_ahead = year - latest_year
+    inflation_factor = 1.03**years_ahead
+
+    return {k: v * inflation_factor for k, v in latest_thresholds.items()}

--- a/policyengine_us_data/spm/district_geoadj.py
+++ b/policyengine_us_data/spm/district_geoadj.py
@@ -1,0 +1,191 @@
+"""
+Geographic adjustment (GEOADJ) lookup for congressional districts.
+
+GEOADJ adjusts SPM thresholds for local housing costs using the formula:
+    GEOADJ = (local_median_rent / national_median_rent) × 0.492 + 0.508
+
+Where 0.492 is the housing share of the SPM threshold for renters.
+
+Data source: ACS Table B25031 (Median Gross Rent by Bedrooms)
+"""
+
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+# Housing portion of SPM threshold (for renters)
+HOUSING_SHARE = 0.492
+
+# Path to cached GEOADJ data
+STORAGE_FOLDER = Path(__file__).parent.parent / "storage"
+
+
+def calculate_geoadj_from_rent(
+    local_rent: float | np.ndarray,
+    national_rent: float,
+) -> float | np.ndarray:
+    """
+    Calculate GEOADJ from local and national median rents.
+
+    Formula: GEOADJ = (local_rent / national_rent) × 0.492 + 0.508
+
+    Args:
+        local_rent: Local area median rent (scalar or array)
+        national_rent: National median rent
+
+    Returns:
+        GEOADJ value(s)
+    """
+    rent_ratio = np.asarray(local_rent) / national_rent
+    return rent_ratio * HOUSING_SHARE + (1 - HOUSING_SHARE)
+
+
+@lru_cache(maxsize=16)
+def _load_district_geoadj(year: int) -> pd.DataFrame:
+    """Load or create district GEOADJ lookup table."""
+    cache_file = STORAGE_FOLDER / f"district_geoadj_{year}.csv"
+
+    if cache_file.exists():
+        return pd.read_csv(cache_file, dtype={"district_code": str})
+
+    # Create from ACS data
+    df = _create_district_geoadj_from_acs(year)
+    df.to_csv(cache_file, index=False)
+    return df
+
+
+def _fetch_acs_district_rents(year: int) -> pd.DataFrame:
+    """
+    Fetch median 2-bedroom rent by congressional district from ACS.
+
+    Uses Census API to get ACS 5-year estimates, Table B25031.
+    """
+    try:
+        from census import Census
+    except ImportError:
+        raise ImportError(
+            "census package required. Install with: pip install census"
+        )
+
+    api_key = os.environ.get("CENSUS_API_KEY")
+    if not api_key:
+        raise ValueError(
+            "CENSUS_API_KEY environment variable not set. "
+            "Get a free key at https://api.census.gov/data/key_signup.html"
+        )
+
+    c = Census(api_key)
+
+    # B25031_004E = Median gross rent, 2 bedrooms
+    variable = "B25031_004E"
+
+    all_data = []
+    for state_fips in range(1, 57):  # State FIPS codes
+        try:
+            data = c.acs5.get(
+                [variable],
+                {
+                    "for": "congressional district:*",
+                    "in": f"state:{state_fips:02d}",
+                },
+                year=year,
+            )
+            all_data.extend(data)
+        except Exception:
+            pass
+
+    df = pd.DataFrame(all_data)
+    df["district_code"] = df["state"].str.zfill(2) + df[
+        "congressional district"
+    ].str.zfill(2)
+    df["median_rent"] = pd.to_numeric(df[variable], errors="coerce")
+
+    return df[["district_code", "median_rent"]].dropna()
+
+
+def _get_national_median_rent(year: int) -> float:
+    """Get national median 2-bedroom rent for a year."""
+    try:
+        from census import Census
+    except ImportError:
+        raise ImportError("census package required")
+
+    api_key = os.environ.get("CENSUS_API_KEY")
+    if not api_key:
+        raise ValueError("CENSUS_API_KEY not set")
+
+    c = Census(api_key)
+    data = c.acs5.get(["B25031_004E"], {"for": "us:*"}, year=year)
+    return float(data[0]["B25031_004E"])
+
+
+def _create_district_geoadj_from_acs(year: int) -> pd.DataFrame:
+    """
+    Create GEOADJ lookup table for all congressional districts.
+
+    Args:
+        year: ACS 5-year end year
+
+    Returns:
+        DataFrame with district_code, median_rent, and geoadj columns
+    """
+    # Get district rents
+    df = _fetch_acs_district_rents(year)
+
+    # Get national rent
+    national_rent = _get_national_median_rent(year)
+
+    # Calculate GEOADJ
+    df["geoadj"] = calculate_geoadj_from_rent(df["median_rent"], national_rent)
+
+    # Clamp to reasonable range (0.70 to 1.50)
+    df["geoadj"] = df["geoadj"].clip(0.70, 1.50)
+
+    return df
+
+
+def create_district_geoadj_lookup(
+    year: int = 2022,
+    from_cache: bool = True,
+) -> pd.DataFrame:
+    """
+    Create or load GEOADJ lookup table for congressional districts.
+
+    Args:
+        year: ACS 5-year end year (use year - 1 from target year)
+        from_cache: If True, use cached data if available
+
+    Returns:
+        DataFrame with columns:
+        - district_code: 4-digit code (state FIPS + district number)
+        - median_rent: Median 2-bedroom rent from ACS
+        - geoadj: Geographic adjustment factor
+    """
+    if from_cache:
+        return _load_district_geoadj(year)
+    return _create_district_geoadj_from_acs(year)
+
+
+def get_district_geoadj(district_code: str, year: int = 2022) -> float:
+    """
+    Get GEOADJ for a specific congressional district.
+
+    Args:
+        district_code: 4-digit district code (e.g., "0612" for CA-12)
+        year: ACS year for rent data
+
+    Returns:
+        GEOADJ value (typically 0.84 to 1.27)
+    """
+    lookup = create_district_geoadj_lookup(year)
+    match = lookup[lookup["district_code"] == district_code]
+
+    if len(match) == 0:
+        # Return national average if district not found
+        return 1.0
+
+    return match["geoadj"].iloc[0]

--- a/policyengine_us_data/spm/local_threshold.py
+++ b/policyengine_us_data/spm/local_threshold.py
@@ -1,0 +1,226 @@
+"""
+Calculate local SPM thresholds for congressional districts.
+
+The full SPM threshold formula is:
+    threshold = base_threshold[tenure] × equivalence_scale × geoadj
+
+This module replaces the original CPS SPM thresholds with properly
+calculated local thresholds based on:
+- District-specific GEOADJ from ACS median rents
+- Tenure type (renter, owner with mortgage, owner without mortgage)
+- Family composition via equivalence scale
+"""
+
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+# Use absolute imports that work both in package and standalone contexts
+try:
+    from .ce_threshold import calculate_base_thresholds
+    from .district_geoadj import (
+        create_district_geoadj_lookup,
+        get_district_geoadj,
+    )
+except ImportError:
+    from ce_threshold import calculate_base_thresholds
+    from district_geoadj import (
+        create_district_geoadj_lookup,
+        get_district_geoadj,
+    )
+
+
+# SPM three-parameter equivalence scale
+# Reference: https://www.census.gov/topics/income-poverty/poverty/guidance/poverty-measures.html
+def spm_equivalence_scale(
+    num_adults: int | np.ndarray,
+    num_children: int | np.ndarray,
+    normalize: bool = True,
+) -> float | np.ndarray:
+    """
+    Calculate SPM three-parameter equivalence scale.
+
+    Formula:
+    - First adult: 1.0
+    - Additional adults: 0.5 each
+    - Children: 0.3 each
+
+    Args:
+        num_adults: Number of adults (18+) in the SPM unit
+        num_children: Number of children (under 18) in the SPM unit
+        normalize: If True, normalize to reference family (2A2C = 1.0)
+
+    Returns:
+        Equivalence scale value(s)
+    """
+    num_adults = np.asarray(num_adults)
+    num_children = np.asarray(num_children)
+
+    # First adult = 1.0, additional adults = 0.5 each
+    adult_scale = np.where(
+        num_adults >= 1, 1.0 + 0.5 * np.maximum(num_adults - 1, 0), 0.0
+    )
+    child_scale = 0.3 * num_children
+
+    raw_scale = adult_scale + child_scale
+
+    if normalize:
+        # Reference family: 2 adults, 2 children = 1.0 + 0.5 + 0.6 = 2.1
+        reference_scale = 2.1
+        return raw_scale / reference_scale
+
+    return raw_scale
+
+
+def calculate_local_spm_thresholds(
+    district_codes: np.ndarray | pd.Series,
+    tenure_types: np.ndarray | pd.Series,
+    num_adults: np.ndarray | pd.Series,
+    num_children: np.ndarray | pd.Series,
+    year: int = 2024,
+    acs_year: Optional[int] = None,
+) -> np.ndarray:
+    """
+    Calculate SPM thresholds for SPM units based on their district.
+
+    This replaces the original CPS SPM thresholds with properly
+    calculated local thresholds using district-specific GEOADJ.
+
+    Args:
+        district_codes: 4-digit congressional district codes for each unit
+        tenure_types: Tenure type for each unit
+            ('renter', 'owner_with_mortgage', 'owner_without_mortgage')
+        num_adults: Number of adults in each SPM unit
+        num_children: Number of children in each SPM unit
+        year: Target year for base thresholds
+        acs_year: ACS year for GEOADJ (defaults to year - 1)
+
+    Returns:
+        Array of SPM thresholds in dollars
+    """
+    if acs_year is None:
+        acs_year = min(year - 1, 2022)  # Latest available ACS
+
+    # Convert inputs to arrays
+    district_codes = np.asarray(district_codes, dtype=str)
+    tenure_types = np.asarray(tenure_types, dtype=str)
+    num_adults = np.asarray(num_adults)
+    num_children = np.asarray(num_children)
+
+    n = len(district_codes)
+
+    # Get base thresholds
+    base_thresholds = calculate_base_thresholds(year)
+
+    # Get GEOADJ lookup
+    geoadj_lookup = create_district_geoadj_lookup(acs_year)
+    geoadj_dict = dict(
+        zip(geoadj_lookup["district_code"], geoadj_lookup["geoadj"])
+    )
+
+    # Calculate equivalence scales
+    equiv_scales = spm_equivalence_scale(num_adults, num_children)
+
+    # Map tenure types to base thresholds
+    tenure_map = {
+        "renter": base_thresholds["renter"],
+        "RENTED": base_thresholds["renter"],
+        "owner_with_mortgage": base_thresholds["owner_with_mortgage"],
+        "OWNED_WITH_MORTGAGE": base_thresholds["owner_with_mortgage"],
+        "owner_without_mortgage": base_thresholds["owner_without_mortgage"],
+        "OWNED_OUTRIGHT": base_thresholds["owner_without_mortgage"],
+        "NONE": base_thresholds["renter"],  # Default to renter
+    }
+
+    # Calculate thresholds
+    thresholds = np.zeros(n)
+    for i in range(n):
+        district = district_codes[i]
+        tenure = tenure_types[i]
+
+        # Get components
+        base = tenure_map.get(tenure, base_thresholds["renter"])
+        geoadj = geoadj_dict.get(district, 1.0)  # Default to 1.0 if not found
+        equiv = (
+            equiv_scales[i]
+            if hasattr(equiv_scales, "__getitem__")
+            else equiv_scales
+        )
+
+        thresholds[i] = base * equiv * geoadj
+
+    return thresholds
+
+
+def update_spm_thresholds_for_districts(
+    data: dict,
+    district_codes: np.ndarray,
+    year: int = 2024,
+) -> dict:
+    """
+    Update SPM thresholds in a dataset for district-level analysis.
+
+    This function modifies the 'spm_unit_spm_threshold' variable to use
+    properly calculated local thresholds instead of the original CPS values.
+
+    Args:
+        data: Dataset dictionary with arrays
+        district_codes: Congressional district codes for each household
+        year: Target year
+
+    Returns:
+        Updated dataset dictionary
+    """
+    # Get tenure types - need to expand from household to SPM unit level
+    tenure_types = data.get(
+        "tenure_type", np.full(len(district_codes), "renter")
+    )
+    if isinstance(tenure_types[0], bytes):
+        tenure_types = np.array([t.decode() for t in tenure_types])
+
+    # For now, use simple approach - need to map household districts to SPM units
+    # This is a placeholder that should be refined based on actual data structure
+    spm_unit_ids = data.get("spm_unit_id", np.arange(len(district_codes)))
+    unique_spm_units = np.unique(spm_unit_ids)
+
+    # Count adults and children per SPM unit
+    ages = data.get("age", np.zeros(len(district_codes)))
+    person_spm_ids = data.get("person_spm_unit_id", spm_unit_ids)
+
+    spm_adults = {}
+    spm_children = {}
+    spm_districts = {}
+    spm_tenure = {}
+
+    for spm_id in unique_spm_units:
+        mask = person_spm_ids == spm_id
+        unit_ages = ages[mask]
+        spm_adults[spm_id] = np.sum(unit_ages >= 18)
+        spm_children[spm_id] = np.sum(unit_ages < 18)
+        # Use first household's district for SPM unit
+        spm_districts[spm_id] = (
+            district_codes[mask][0] if np.any(mask) else "0000"
+        )
+        spm_tenure[spm_id] = (
+            tenure_types[mask][0] if np.any(mask) else "renter"
+        )
+
+    # Calculate thresholds
+    new_thresholds = calculate_local_spm_thresholds(
+        district_codes=np.array(
+            [spm_districts[uid] for uid in unique_spm_units]
+        ),
+        tenure_types=np.array([spm_tenure[uid] for uid in unique_spm_units]),
+        num_adults=np.array([spm_adults[uid] for uid in unique_spm_units]),
+        num_children=np.array([spm_children[uid] for uid in unique_spm_units]),
+        year=year,
+    )
+
+    # Map back to SPM unit array
+    threshold_dict = dict(zip(unique_spm_units, new_thresholds))
+    data["spm_unit_spm_threshold"] = np.array(
+        [threshold_dict.get(uid, 0) for uid in spm_unit_ids]
+    )
+
+    return data

--- a/tests/spm/__init__.py
+++ b/tests/spm/__init__.py
@@ -1,0 +1,1 @@
+# SPM module tests

--- a/tests/spm/test_ce_threshold.py
+++ b/tests/spm/test_ce_threshold.py
@@ -1,0 +1,112 @@
+"""Tests for CE base threshold calculation."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# Load modules directly to avoid full package import (which requires policyengine_core)
+spm_dir = Path(__file__).parent.parent.parent / "policyengine_us_data" / "spm"
+
+# Add the spm directory to path so relative imports work
+sys.path.insert(0, str(spm_dir))
+
+
+def load_module(name, path):
+    """Load a module from a file path."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# Load modules in dependency order
+ce_threshold = load_module("ce_threshold", spm_dir / "ce_threshold.py")
+calculate_base_thresholds = ce_threshold.calculate_base_thresholds
+
+district_geoadj = load_module(
+    "district_geoadj", spm_dir / "district_geoadj.py"
+)
+
+local_threshold = load_module(
+    "local_threshold", spm_dir / "local_threshold.py"
+)
+spm_equivalence_scale = local_threshold.spm_equivalence_scale
+
+
+class TestBaseThresholds:
+    """Test base threshold retrieval and forecasting."""
+
+    def test_published_2024_thresholds(self):
+        """Should return correct published 2024 thresholds."""
+        thresholds = calculate_base_thresholds(2024)
+
+        assert thresholds["renter"] == 39430
+        assert thresholds["owner_with_mortgage"] == 39068
+        assert thresholds["owner_without_mortgage"] == 32586
+
+    def test_published_2023_thresholds(self):
+        """Should return correct published 2023 thresholds."""
+        thresholds = calculate_base_thresholds(2023)
+
+        assert thresholds["renter"] == 36606
+
+    def test_forecasted_2025_higher_than_2024(self):
+        """Forecasted 2025 should be higher than 2024."""
+        t_2024 = calculate_base_thresholds(2024)
+        t_2025 = calculate_base_thresholds(2025)
+
+        assert t_2025["renter"] > t_2024["renter"]
+
+    def test_tenure_ordering(self):
+        """Renters should have highest threshold, owner w/o mortgage lowest."""
+        thresholds = calculate_base_thresholds(2024)
+
+        # Owner without mortgage has lowest housing costs
+        assert (
+            thresholds["owner_without_mortgage"]
+            < thresholds["owner_with_mortgage"]
+        )
+        assert thresholds["owner_with_mortgage"] <= thresholds["renter"]
+
+
+class TestEquivalenceScale:
+    """Test SPM equivalence scale calculation."""
+
+    def test_reference_family_normalized(self):
+        """Reference family (2A2C) should equal 1.0 when normalized."""
+        scale = spm_equivalence_scale(2, 2, normalize=True)
+        assert scale == pytest.approx(1.0)
+
+    def test_reference_family_raw(self):
+        """Reference family (2A2C) should equal 2.1 raw."""
+        scale = spm_equivalence_scale(2, 2, normalize=False)
+        assert scale == pytest.approx(2.1)
+
+    def test_single_adult(self):
+        """Single adult = 1.0 / 2.1 ≈ 0.476."""
+        scale = spm_equivalence_scale(1, 0, normalize=True)
+        assert scale == pytest.approx(1.0 / 2.1, rel=0.01)
+
+    def test_larger_family(self):
+        """Larger families scale up appropriately."""
+        # 3 adults, 4 children = 1 + 0.5*2 + 0.3*4 = 3.2
+        scale = spm_equivalence_scale(3, 4, normalize=False)
+        assert scale == pytest.approx(3.2)
+
+    def test_vectorized(self):
+        """Should handle array inputs."""
+        import numpy as np
+
+        adults = np.array([1, 2, 2, 3])
+        children = np.array([0, 0, 2, 4])
+
+        scales = spm_equivalence_scale(adults, children, normalize=False)
+
+        assert len(scales) == 4
+        assert scales[0] == pytest.approx(1.0)  # 1A0C
+        assert scales[1] == pytest.approx(1.5)  # 2A0C
+        assert scales[2] == pytest.approx(2.1)  # 2A2C
+        assert scales[3] == pytest.approx(3.2)  # 3A4C

--- a/tests/spm/test_geoadj.py
+++ b/tests/spm/test_geoadj.py
@@ -1,0 +1,80 @@
+"""Tests for GEOADJ calculation."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import numpy as np
+
+# Load modules directly to avoid full package import (which requires policyengine_core)
+spm_dir = Path(__file__).parent.parent.parent / "policyengine_us_data" / "spm"
+
+# Add the spm directory to path so relative imports work
+sys.path.insert(0, str(spm_dir))
+
+
+def load_module(name, path):
+    """Load a module from a file path."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+district_geoadj = load_module(
+    "district_geoadj", spm_dir / "district_geoadj.py"
+)
+calculate_geoadj_from_rent = district_geoadj.calculate_geoadj_from_rent
+get_district_geoadj = district_geoadj.get_district_geoadj
+
+
+class TestGeoadjFormula:
+    """Test the GEOADJ formula."""
+
+    def test_national_equals_one(self):
+        """When local = national rent, GEOADJ should be 1.0."""
+        geoadj = calculate_geoadj_from_rent(1500, 1500)
+        assert geoadj == pytest.approx(1.0)
+
+    def test_high_cost_area(self):
+        """High cost area (2x national) should give GEOADJ > 1."""
+        # If local rent is 2x national:
+        # GEOADJ = 2.0 * 0.492 + 0.508 = 1.492
+        geoadj = calculate_geoadj_from_rent(3000, 1500)
+        assert geoadj == pytest.approx(1.492)
+
+    def test_low_cost_area(self):
+        """Low cost area (0.5x national) should give GEOADJ < 1."""
+        # If local rent is 0.5x national:
+        # GEOADJ = 0.5 * 0.492 + 0.508 = 0.754
+        geoadj = calculate_geoadj_from_rent(750, 1500)
+        assert geoadj == pytest.approx(0.754)
+
+    def test_vectorized(self):
+        """Should handle array inputs."""
+        local_rents = np.array([1500, 2250, 1000])
+        national = 1500
+
+        geoadj = calculate_geoadj_from_rent(local_rents, national)
+
+        assert len(geoadj) == 3
+        assert geoadj[0] == pytest.approx(1.0)  # Equal to national
+        assert geoadj[1] > 1.0  # 1.5x national
+        assert geoadj[2] < 1.0  # 0.67x national
+
+
+class TestDistrictGeoadj:
+    """Test district GEOADJ lookup (requires cached data or API)."""
+
+    def test_get_district_geoadj_default(self):
+        """Should return 1.0 for unknown district codes."""
+        try:
+            import census  # noqa: F401
+        except ImportError:
+            pytest.skip("census package required for this test")
+
+        # Non-existent district should return 1.0
+        geoadj = get_district_geoadj("9999", year=2022)
+        assert geoadj == 1.0


### PR DESCRIPTION
## Summary

Implements local SPM threshold calculation from source data. This enables proper SPM threshold calculation for district-level analysis where records may be reweighted to different geographic areas.

## Problem

When reweighting CPS records to match district targets, records from high-cost areas (e.g., California) retain their original SPM thresholds even when assigned weight in low-cost areas (e.g., Iowa). This reduces the geographic variation in thresholds that should exist (~50% range from West Virginia to Hawaii).

## Solution

Calculate SPM thresholds from components using the formula:
```
threshold = base_threshold[tenure] × equivalence_scale × geoadj
```

### Key components:

- **ce_threshold.py**: Base thresholds from BLS by tenure type
  - Renter: $39,430
  - Owner with mortgage: $39,068  
  - Owner without mortgage: $32,586 (2024 values)

- **district_geoadj.py**: Geographic adjustment from ACS median 2-bedroom rents
  - Formula: `GEOADJ = (local_rent / national_rent) × 0.492 + 0.508`
  - Range: ~0.84 (West Virginia) to ~1.27 (Hawaii)

- **local_threshold.py**: Calculate local thresholds for SPM units
  - SPM three-parameter equivalence scale (first adult=1.0, additional adults=0.5, children=0.3)
  - Vectorized calculation for all SPM units

### Usage:
```python
from policyengine_us_data.spm import (
    calculate_local_spm_thresholds,
    update_spm_thresholds_for_districts,
)

# Calculate thresholds for SPM units in specific districts
thresholds = calculate_local_spm_thresholds(
    district_codes=["0612", "5401"],  # CA-12, WV-01
    tenure_types=["renter", "renter"],
    num_adults=[2, 2],
    num_children=[2, 2],
    year=2024,
)
```

## Test plan

- [x] 13 unit tests pass for base thresholds, equivalence scale, and GEOADJ formula
- [ ] Integration test with district calibration workflow
- [ ] Validate against published Census SPM thresholds

🤖 Generated with [Claude Code](https://claude.com/claude-code)