### PR TITLE
Fix versioning workflow checkout for push events

### DIFF
--- a/.github/workflows/versioning.yaml
+++ b/.github/workflows/versioning.yaml
@@ -18,8 +18,6 @@ jobs:
           - name: Checkout repo
             uses: actions/checkout@v4
             with:
-              repository: ${{ github.event.pull_request.head.repo.full_name }}
-              ref: ${{ github.event.pull_request.head.ref }}
               token: ${{ secrets.POLICYENGINE_GITHUB }}
           - name: Setup Python
             uses: actions/setup-python@v5

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,7 +1,4 @@
-- bump: minor
+- bump: patch
   changes:
-    added:
-    - Modal integration for CI/CD workflows, replacing self-hosted GCP runners
-    changed:
-    - Updated reusable_test.yaml to trigger data builds on Modal
-    - Updated local_area_publish.yaml to run on Modal
+    fixed:
+    - Versioning workflow checkout for push events


### PR DESCRIPTION
## Summary

- Remove PR-specific context variables from versioning workflow checkout step
- These variables (`github.event.pull_request.head.*`) are undefined for push events, causing checkout failures

Fixes #468

## Test plan

- [x] Verify PR CI passes
- [ ] After merge, verify versioning workflow runs successfully on the push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)