### PR TITLE
Add policyengine-claude plugin auto-install

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "plugins": {
+    "marketplaces": [
+      "PolicyEngine/policyengine-claude"
+    ],
+    "auto_install": [
+      "country-models@policyengine-claude"
+    ]
+  }
+}

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: minor
+  changes:
+    changed:
+      - Added policyengine-claude plugin auto-install configuration.


### PR DESCRIPTION
## Summary

Adds auto-install configuration for the policyengine-claude plugin.

## What This Does

When you trust this repo in Claude Code, the [policyengine-claude plugin](https://github.com/PolicyEngine/policyengine-claude) auto-installs, providing:

- **15+ specialized agents** for PolicyEngine development
- **Slash commands** like `/encode-policy`, `/review-pr`
- **Skills** for simulation patterns and code standards

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)