### PR TITLE
Add state income tax calibration targets from Census STC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ database:
 	python policyengine_us_data/db/etl_age.py
 	python policyengine_us_data/db/etl_medicaid.py
 	python policyengine_us_data/db/etl_snap.py
+	python policyengine_us_data/db/etl_state_income_tax.py
 	python policyengine_us_data/db/etl_irs_soi.py
 	python policyengine_us_data/db/validate_database.py
 

--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -24,5 +24,6 @@
     - Added stratum_group_id migration utilities
     - Added db_metadata utilities for source and variable group management
     - Added DATABASE_GUIDE.md with comprehensive calibration database documentation
+    - Added state income tax calibration targets from Census STC FY2023 data
     fixed:
     - Fixed cross-state recalculation in sparse matrix builder by adding time_period to calculate() calls

--- a/policyengine_us_data/datasets/cps/local_area_calibration/fit_calibration_weights.py
+++ b/policyengine_us_data/datasets/cps/local_area_calibration/fit_calibration_weights.py
@@ -105,7 +105,7 @@ builder = SparseMatrixBuilder(
 targets_df, X_sparse, household_id_mapping = builder.build_matrix(
     sim,
     target_filter={
-        "stratum_group_ids": [4, 5],  # 4=SNAP households, 5=state income tax
+        "stratum_group_ids": [4, 7],  # 4=SNAP households, 7=state income tax
         "variables": [
             "health_insurance_premiums_without_medicare_part_b",
             "snap",

--- a/policyengine_us_data/db/DATABASE_GUIDE.md
+++ b/policyengine_us_data/db/DATABASE_GUIDE.md
@@ -30,8 +30,9 @@ make promote-database   # Copy DB + raw inputs to HuggingFace clone
 | 4 | `etl_age.py` | Census ACS 1-year | Age distribution: 18 bins x 488 geographies |
 | 5 | `etl_medicaid.py` | Census ACS + CMS | Medicaid enrollment (admin state-level, survey district-level) |
 | 6 | `etl_snap.py` | USDA FNS + Census ACS | SNAP participation (admin state-level, survey district-level) |
-| 7 | `etl_irs_soi.py` | IRS | Tax variables, EITC by child count, AGI brackets, conditional strata |
-| 8 | `validate_database.py` | No | Checks all target variables exist in policyengine-us |
+| 7 | `etl_state_income_tax.py` | No | State income tax collections (Census STC FY2023, hardcoded) |
+| 8 | `etl_irs_soi.py` | IRS | Tax variables, EITC by child count, AGI brackets, conditional strata |
+| 9 | `validate_database.py` | No | Checks all target variables exist in policyengine-us |
 
 ### Raw Input Caching
 
@@ -108,6 +109,7 @@ The `stratum_group_id` field categorizes strata:
 | 4 | SNAP | SNAP recipient strata |
 | 5 | Medicaid | Medicaid enrollment strata |
 | 6 | EITC | EITC recipients by qualifying children |
+| 7 | State Income Tax | State-level income tax collections (Census STC) |
 | 100-118 | IRS Conditional | Each IRS variable paired with conditional count constraints |
 
 ### Conditional Strata (IRS SOI)
@@ -216,6 +218,7 @@ SELECT
         WHEN 4 THEN 'SNAP'
         WHEN 5 THEN 'Medicaid'
         WHEN 6 THEN 'EITC'
+        WHEN 7 THEN 'State Income Tax'
     END AS group_name,
     COUNT(*) AS stratum_count
 FROM strata


### PR DESCRIPTION
## Summary

- Adds ETL pipeline for state-level individual income tax collections from Census Bureau's Annual Survey of State Government Tax Collections (STC)
- Creates calibration targets using stratum_group_id 7 for state income tax
- Uses hardcoded FY2023 data for all 50 states + DC ($531B total)

## Test plan

- [ ] Run `make database` to verify ETL executes successfully
- [ ] Check database contains state income tax strata and targets
- [ ] Verify validation passes (state_income_tax variable exists in policyengine-us)

## Context

Addresses issue where PolicyEngine was overestimating state income tax revenue due to missing calibration targets. For example, Ohio showed ~$24B vs actual ~$10B.

Closes #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)