### PR TITLE
Fix federal income tax calibration to use income_tax_positive

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -26,3 +26,4 @@
     - Added DATABASE_GUIDE.md with comprehensive calibration database documentation
     fixed:
     - Fixed cross-state recalculation in sparse matrix builder by adding time_period to calculate() calls
+    - Fixed federal income tax calibration to use income_tax_positive (matches CBO receipts definition)

--- a/policyengine_us_data/db/etl_national_targets.py
+++ b/policyengine_us_data/db/etl_national_targets.py
@@ -260,19 +260,29 @@ def extract_national_targets():
     # CBO projection targets - get for a specific year
     CBO_YEAR = 2023  # Year the CBO projections are for
     cbo_vars = [
-        "income_tax",
+        # Note: income_tax_positive matches CBO's receipts definition where
+        # refundable credit payments in excess of liability are classified
+        # as outlays, not negative receipts. See:
+        # https://www.cbo.gov/publication/43767
+        "income_tax_positive",
         "snap",
         "social_security",
         "ssi",
         "unemployment_compensation",
     ]
 
+    # Mapping from target variable to CBO parameter name (when different)
+    cbo_param_name_map = {
+        "income_tax_positive": "income_tax",  # CBO param is income_tax
+    }
+
     cbo_targets = []
     for variable_name in cbo_vars:
+        param_name = cbo_param_name_map.get(variable_name, variable_name)
         try:
             value = sim.tax_benefit_system.parameters(
                 CBO_YEAR
-            ).calibration.gov.cbo._children[variable_name]
+            ).calibration.gov.cbo._children[param_name]
             cbo_targets.append(
                 {
                     "variable": variable_name,
@@ -284,7 +294,7 @@ def extract_national_targets():
             )
         except (KeyError, AttributeError) as e:
             print(
-                f"Warning: Could not extract CBO parameter for {variable_name}: {e}"
+                f"Warning: Could not extract CBO parameter for {variable_name} (param: {param_name}): {e}"
             )
 
     # Treasury/JCT targets (EITC) - get for a specific year
@@ -334,12 +344,16 @@ def transform_national_targets(raw_targets):
     """
 
     # Process direct sum targets (non-tax items and some CBO items)
-    # Note: income_tax from CBO and eitc from Treasury need filer constraint
+    # Note: income_tax_positive from CBO and eitc from Treasury need filer constraint
     cbo_non_tax = [
-        t for t in raw_targets["cbo_targets"] if t["variable"] != "income_tax"
+        t
+        for t in raw_targets["cbo_targets"]
+        if t["variable"] != "income_tax_positive"
     ]
     cbo_tax = [
-        t for t in raw_targets["cbo_targets"] if t["variable"] == "income_tax"
+        t
+        for t in raw_targets["cbo_targets"]
+        if t["variable"] == "income_tax_positive"
     ]
 
     all_direct_targets = raw_targets["direct_sum_targets"] + cbo_non_tax


### PR DESCRIPTION
## Summary

- Changes CBO income tax calibration target from `income_tax` to `income_tax_positive`
- Matches CBO's receipts definition where refundable credit payments in excess of liability are outlays

## Context

CBO reports income tax receipts where refundable credit payments *in excess of tax liability* are classified as **outlays** (spending), not negative receipts. PolicyEngine's `income_tax` can be negative when refundable credits exceed liability.

From [CBO](https://www.cbo.gov/publication/43767):
> "the portion of refundable credits that reduces the amount of taxes owed is counted as a reduction in revenues, and the portion that exceeds people's tax liabilities is treated as an outlay"

The impact is ~$81B (~4% of federal income tax receipts).

## Dependencies

Requires policyengine-us PR: https://github.com/PolicyEngine/policyengine-us/pull/7288

## Test plan

- [ ] Verify `income_tax_positive` variable exists in policyengine-us after PR merges
- [ ] Run `make database` to verify ETL executes successfully
- [ ] Verify database contains target for `income_tax_positive` instead of `income_tax`

Closes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)