### PR TITLE
Fix etl_state_income_tax.py API mismatches

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+    - Fix etl_state_income_tax.py API mismatches with db_metadata utility functions

--- a/policyengine_us_data/db/etl_state_income_tax.py
+++ b/policyengine_us_data/db/etl_state_income_tax.py
@@ -261,7 +261,7 @@ def load_state_income_tax_data(df: pd.DataFrame, year: int) -> dict:
         source = get_or_create_source(
             session,
             name="Census Bureau Annual Survey of State Tax Collections",
-            type=SourceType.administrative,
+            source_type=SourceType.ADMINISTRATIVE,
             url="https://www.census.gov/programs-surveys/stc.html",
             notes="Individual income tax collections by state",
         )
@@ -270,7 +270,7 @@ def load_state_income_tax_data(df: pd.DataFrame, year: int) -> dict:
         var_group = get_or_create_variable_group(
             session,
             name="state_income_tax",
-            display_name="State Income Tax",
+            category="taxes",
             description="State-level individual income tax collections",
         )
 
@@ -278,10 +278,10 @@ def load_state_income_tax_data(df: pd.DataFrame, year: int) -> dict:
         get_or_create_variable_metadata(
             session,
             variable="state_income_tax",
+            group=var_group,
             display_name="State Income Tax",
-            variable_group_id=var_group.variable_group_id,
             units="USD",
-            description="Total state individual income tax collections",
+            notes="Total state individual income tax collections",
         )
 
         # Get geographic strata to use as parents


### PR DESCRIPTION
## Summary
- Fix `SourceType.administrative` → `SourceType.ADMINISTRATIVE` (enum values are uppercase)
- Fix `type=` → `source_type=` parameter name in `get_or_create_source()`
- Fix `get_or_create_variable_group()`: use `category=` instead of `display_name=`
- Fix `get_or_create_variable_metadata()`: use `group=` instead of `variable_group_id=`, `notes=` instead of `description=`

These mismatches cause `make database` to fail on the `etl_state_income_tax.py` step.

## Test plan
- [ ] `make database` completes without errors
- [ ] State income tax targets loaded correctly (51 states, $494.9B total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)