### PR TITLE
Add cps_2024.h5 to HuggingFace upload list

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    added:
+    - cps_2024.h5 to HuggingFace upload list so the raw (unenhanced) 2024 CPS dataset is published

--- a/policyengine_us_data/storage/upload_completed_datasets.py
+++ b/policyengine_us_data/storage/upload_completed_datasets.py
@@ -1,6 +1,7 @@
 from policyengine_us_data.datasets import (
     EnhancedCPS_2024,
 )
+from policyengine_us_data.datasets.cps.cps import CPS_2024
 from policyengine_us_data.storage import STORAGE_FOLDER
 from policyengine_us_data.utils.data_upload import upload_data_files
 from google.cloud import storage
@@ -10,6 +11,7 @@ import google.auth
 def upload_datasets():
     dataset_files = [
         EnhancedCPS_2024.file_path,
+        CPS_2024.file_path,
         STORAGE_FOLDER / "small_enhanced_cps_2024.h5",
         STORAGE_FOLDER / "calibration" / "policy_data.db",
     ]


### PR DESCRIPTION
## Summary
- Adds `CPS_2024.file_path` (`cps_2024.h5`) to the HuggingFace upload list in `upload_completed_datasets.py`
- PR #438 added `CPS_2024` class and `CensusCPS_2024` (2024 ASEC / March 2025 survey), but the upload script was never updated to include the raw CPS dataset
- Only `enhanced_cps_2024.h5` and `small_enhanced_cps_2024.h5` were being uploaded — the unenhanced `cps_2024.h5` was missing from HuggingFace

## Why this matters
For the [SPM child poverty decomposition](https://github.com/PolicyEngine/policyengine-spm-decomposition), we need both the raw and enhanced CPS for 2024 to cleanly decompose the gap between Census-published child poverty (13.4%) and PolicyEngine's estimate (22.6%). Without `cps_2024.h5` on HuggingFace, we had to use `cps_2023.h5` (different survey year) as a workaround.

## Test plan
- [ ] Verify `cps_2024.h5` appears on HuggingFace after next dataset build
- [ ] Verify `Microsimulation(dataset="hf://policyengine/policyengine-us-data/cps_2024.h5")` works

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)