### PR TITLE
Add TANF takeup assignment to CPS data pipeline

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Add TANF takeup (22%) assignment to CPS data pipeline so takes_up_tanf_if_eligible is persisted in the dataset.

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -268,6 +268,11 @@ def add_takeup(self):
     rng = seeded_rng("takes_up_ssi_if_eligible")
     data["takes_up_ssi_if_eligible"] = rng.random(n_persons) < ssi_rate
 
+    # TANF
+    tanf_rate = load_take_up_rate("tanf", self.time_period)
+    rng = seeded_rng("takes_up_tanf_if_eligible")
+    data["takes_up_tanf_if_eligible"] = rng.random(n_spm_units) < tanf_rate
+
     # WIC: resolve draws to bools using category-specific rates
     wic_categories = baseline.calculate("wic_category_str").values
     wic_takeup_rates = load_take_up_rate("wic_takeup", self.time_period)


### PR DESCRIPTION
## Summary
- The TANF takeup rate parameter and SIMPLE_TAKEUP_VARS entry were added in PR #542, but `add_takeup()` in `cps.py` wasn't updated
- Without this, `takes_up_tanf_if_eligible` defaults to True (100%) in the dataset — the calibration reweighting alone brought TANF to $7.0B, but with wrong takeup semantics
- This adds the 5-line TANF block to `add_takeup()` matching the pattern used by SNAP, SSI, etc.

## Test plan
- [x] `load_take_up_rate('tanf', 2024)` returns 0.22
- [x] Random assignment produces ~22% True rate
- [ ] Full data build produces reasonable TANF totals

🤖 Generated with [Claude Code](https://claude.com/claude-code)