### PR TITLE
Fix enhanced_cps_2024.h5 being overwritten by sparse version

### DIFF
--- a/changelog.d/fix-enhanced-cps-overwrite.fixed.md
+++ b/changelog.d/fix-enhanced-cps-overwrite.fixed.md
@@ -1,0 +1,1 @@
+Fix create_sparse_ecps overwriting enhanced_cps_2024.h5 with sparse version that drops input variables like employment_income.

--- a/policyengine_us_data/datasets/cps/small_enhanced_cps.py
+++ b/policyengine_us_data/datasets/cps/small_enhanced_cps.py
@@ -104,7 +104,7 @@ def create_sparse_ecps():
             if len(data[variable]) == 0:
                 del data[variable]
 
-    with h5py.File(STORAGE_FOLDER / "enhanced_cps_2024.h5", "w") as f:
+    with h5py.File(STORAGE_FOLDER / "sparse_enhanced_cps_2024.h5", "w") as f:
         for variable, periods in data.items():
             grp = f.create_group(variable)
             for period, values in periods.items():


### PR DESCRIPTION
## Summary

**CRITICAL BUG FIX** — policyengine.org has been showing ~39% baseline poverty rate instead of ~14%.

`create_sparse_ecps()` in `small_enhanced_cps.py` was writing to `enhanced_cps_2024.h5` instead of `sparse_enhanced_cps_2024.h5`. Since `small_enhanced_cps.py` runs AFTER `enhanced_cps.py` in the Modal data build pipeline, it was destroying the full enhanced CPS dataset and replacing it with a sparse version that drops input variables like `employment_income`.

The broken file was then uploaded to HuggingFace as the default dataset, causing:
- All `employment_income` values = $0
- Baseline SPM poverty rate inflated from ~14% to ~39%
- All microsimulation results on policyengine.org incorrect

### Root cause
Introduced in commit 20572be0 ("Streamline data build: remove TEST_LITE/LOCAL_AREA_CALIBRATION, eliminate dense reweighting") which changed the output path from `sparse_enhanced_cps_2024.h5` to `enhanced_cps_2024.h5`.

### Fix
Revert the output filename back to `sparse_enhanced_cps_2024.h5`.

### After merge
CI will rebuild and re-upload the correct `enhanced_cps_2024.h5` to HuggingFace.

## Test plan
- [ ] CI passes (data build + upload)
- [ ] After upload, verify `enhanced_cps_2024.h5` on HF has non-zero employment_income
- [ ] Verify baseline poverty rate returns to ~14%

🤖 Generated with [Claude Code](https://claude.com/claude-code)