### PR TITLE
Fix weekly hours worked deflation bug

### DIFF
--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -400,8 +400,8 @@ def add_personal_income_variables(
     # Assign CPS variables.
     cps["employment_income"] = person.WSAL_VAL
 
-    cps["weekly_hours_worked"] = person.HRSWK * person.WKSWORK / 52
-    cps["hours_worked_last_week"] = person.A_HRS1 * person.WKSWORK / 52
+    cps["weekly_hours_worked"] = person.HRSWK
+    cps["hours_worked_last_week"] = person.A_HRS1
 
     cps["taxable_interest_income"] = person.INT_VAL * (
         p["taxable_interest_fraction"]


### PR DESCRIPTION
## Summary

- **HRSWK** (usual hours worked per week) and **A_HRS1** (hours worked last week) are already weekly measures in the CPS ASEC — they should be assigned directly, not multiplied by `WKSWORK / 52`
- The old code deflated part-year workers' weekly hours: e.g., someone working 40 hrs/wk for only 26 weeks would show as 20 hrs/wk
- Downstream impact: FLSA overtime eligibility, SNAP work requirements, and other hours-based eligibility rules all depend on accurate weekly hours

## Test plan

- [ ] Verify CPS dataset builds successfully
- [ ] Spot-check weekly_hours_worked distribution against raw HRSWK values
- [ ] Confirm part-year workers now show correct weekly hours

Fixes part of #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)