### PR TITLE
Fix wrong takeup variable names in sanity_checks.py

### DIFF
--- a/policyengine_us_data/calibration/sanity_checks.py
+++ b/policyengine_us_data/calibration/sanity_checks.py
@@ -27,12 +27,12 @@ KEY_MONETARY_VARS = [
 TAKEUP_VARS = [
     "takes_up_snap_if_eligible",
     "takes_up_ssi_if_eligible",
-    "takes_up_aca_ptc_if_eligible",
+    "takes_up_aca_if_eligible",
     "takes_up_medicaid_if_eligible",
     "takes_up_tanf_if_eligible",
     "takes_up_head_start_if_eligible",
     "takes_up_early_head_start_if_eligible",
-    "takes_up_dc_property_tax_credit_if_eligible",
+    "takes_up_dc_ptc",
 ]
 
 


### PR DESCRIPTION
Fixes #614

## Summary

- Fixed two incorrect takeup variable names in `TAKEUP_VARS` in `sanity_checks.py` that caused their boolean validation checks to be silently skipped:
  - `takes_up_aca_ptc_if_eligible` → `takes_up_aca_if_eligible`
  - `takes_up_dc_property_tax_credit_if_eligible` → `takes_up_dc_ptc`

## Test plan

- [ ] Verify the corrected variable names match `SIMPLE_TAKEUP_VARS` in `utils/takeup.py`
- [ ] Run `sanity_checks.py` against a built H5 file and confirm ACA and DC PTC takeup checks now execute (PASS or FAIL) instead of being skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)