### PR TITLE
Align CPS health coverage anchors with at-interview rule inputs

### DIFF
--- a/changelog.d/630.fixed.md
+++ b/changelog.d/630.fixed.md
@@ -1,0 +1,1 @@
+Anchor ACA take-up to subsidized Marketplace coverage reports so unsubsidized exchange enrollment does not force premium tax credit take-up.

--- a/policyengine_us_data/calibration/publish_local_area.py
+++ b/policyengine_us_data/calibration/publish_local_area.py
@@ -38,7 +38,7 @@ from policyengine_us_data.calibration.clone_and_assign import (
 from policyengine_us_data.utils.takeup import (
     SIMPLE_TAKEUP_VARS,
     apply_block_takeup_to_arrays,
-    reported_subsidized_marketplace_by_tax_unit,
+    any_person_flag_by_entity,
 )
 
 CHECKPOINT_FILE = Path("completed_states.txt")
@@ -575,25 +575,7 @@ def build_h5(
         }
         hh_state_fips = clone_geo["state_fips"].astype(np.int32)
         original_hh_ids = household_ids[active_hh].astype(np.int64)
-<<<<<<< HEAD
         reported_anchors = _build_reported_takeup_anchors(data, time_period)
-=======
-        reported_anchors = {}
-        if "reported_has_subsidized_marketplace_health_coverage_at_interview" in data:
-            reported_anchors["takes_up_aca_if_eligible"] = (
-                reported_subsidized_marketplace_by_tax_unit(
-                    data["person_tax_unit_id"][time_period],
-                    data["tax_unit_id"][time_period],
-                    data[
-                        "reported_has_subsidized_marketplace_health_coverage_at_interview"
-                    ][time_period],
-                )
-            )
-        if "has_medicaid_health_coverage_at_interview" in data:
-            reported_anchors["takes_up_medicaid_if_eligible"] = data[
-                "has_medicaid_health_coverage_at_interview"
-            ][time_period].astype(bool)
->>>>>>> b0eca6f0 (Align health coverage anchors with rules inputs)
 
         takeup_results = apply_block_takeup_to_arrays(
             hh_blocks=active_blocks,

--- a/policyengine_us_data/calibration/publish_local_area.py
+++ b/policyengine_us_data/calibration/publish_local_area.py
@@ -38,6 +38,7 @@ from policyengine_us_data.calibration.clone_and_assign import (
 from policyengine_us_data.utils.takeup import (
     SIMPLE_TAKEUP_VARS,
     apply_block_takeup_to_arrays,
+    any_person_flag_by_entity,
 )
 
 CHECKPOINT_FILE = Path("completed_states.txt")
@@ -155,6 +156,31 @@ def load_completed_cities() -> set:
 def record_completed_city(city_name: str):
     with open(CHECKPOINT_FILE_CITIES, "a") as f:
         f.write(f"{city_name}\n")
+
+
+def _build_reported_takeup_anchors(
+    data: dict, time_period: int
+) -> dict[str, np.ndarray]:
+    reported_anchors = {}
+    if (
+        "reported_has_marketplace_health_coverage_at_interview" in data
+        and time_period in data["reported_has_marketplace_health_coverage_at_interview"]
+    ):
+        reported_anchors["takes_up_aca_if_eligible"] = any_person_flag_by_entity(
+            data["person_tax_unit_id"][time_period],
+            data["tax_unit_id"][time_period],
+            data["reported_has_marketplace_health_coverage_at_interview"][
+                time_period
+            ],
+        )
+    if (
+        "reported_has_means_tested_health_coverage_at_interview" in data
+        and time_period in data["reported_has_means_tested_health_coverage_at_interview"]
+    ):
+        reported_anchors["takes_up_medicaid_if_eligible"] = data[
+            "reported_has_means_tested_health_coverage_at_interview"
+        ][time_period].astype(bool)
+    return reported_anchors
 
 
 def build_h5(
@@ -551,6 +577,7 @@ def build_h5(
         }
         hh_state_fips = clone_geo["state_fips"].astype(np.int32)
         original_hh_ids = household_ids[active_hh].astype(np.int64)
+        reported_anchors = _build_reported_takeup_anchors(data, time_period)
 
         takeup_results = apply_block_takeup_to_arrays(
             hh_blocks=active_blocks,
@@ -561,6 +588,7 @@ def build_h5(
             entity_counts=entity_counts,
             time_period=time_period,
             takeup_filter=takeup_filter,
+            reported_anchors=reported_anchors,
         )
         for var_name, bools in takeup_results.items():
             data[var_name] = {time_period: bools}

--- a/policyengine_us_data/calibration/publish_local_area.py
+++ b/policyengine_us_data/calibration/publish_local_area.py
@@ -163,22 +163,20 @@ def _build_reported_takeup_anchors(
 ) -> dict[str, np.ndarray]:
     reported_anchors = {}
     if (
-        "reported_has_marketplace_health_coverage_at_interview" in data
-        and time_period in data["reported_has_marketplace_health_coverage_at_interview"]
+        "has_marketplace_health_coverage_at_interview" in data
+        and time_period in data["has_marketplace_health_coverage_at_interview"]
     ):
         reported_anchors["takes_up_aca_if_eligible"] = any_person_flag_by_entity(
             data["person_tax_unit_id"][time_period],
             data["tax_unit_id"][time_period],
-            data["reported_has_marketplace_health_coverage_at_interview"][
-                time_period
-            ],
+            data["has_marketplace_health_coverage_at_interview"][time_period],
         )
     if (
-        "reported_has_means_tested_health_coverage_at_interview" in data
-        and time_period in data["reported_has_means_tested_health_coverage_at_interview"]
+        "has_medicaid_health_coverage_at_interview" in data
+        and time_period in data["has_medicaid_health_coverage_at_interview"]
     ):
         reported_anchors["takes_up_medicaid_if_eligible"] = data[
-            "reported_has_means_tested_health_coverage_at_interview"
+            "has_medicaid_health_coverage_at_interview"
         ][time_period].astype(bool)
     return reported_anchors
 
@@ -577,7 +575,21 @@ def build_h5(
         }
         hh_state_fips = clone_geo["state_fips"].astype(np.int32)
         original_hh_ids = household_ids[active_hh].astype(np.int64)
+<<<<<<< HEAD
         reported_anchors = _build_reported_takeup_anchors(data, time_period)
+=======
+        reported_anchors = {}
+        if "has_marketplace_health_coverage_at_interview" in data:
+            reported_anchors["takes_up_aca_if_eligible"] = any_person_flag_by_entity(
+                data["person_tax_unit_id"][time_period],
+                data["tax_unit_id"][time_period],
+                data["has_marketplace_health_coverage_at_interview"][time_period],
+            )
+        if "has_medicaid_health_coverage_at_interview" in data:
+            reported_anchors["takes_up_medicaid_if_eligible"] = data[
+                "has_medicaid_health_coverage_at_interview"
+            ][time_period].astype(bool)
+>>>>>>> b0eca6f0 (Align health coverage anchors with rules inputs)
 
         takeup_results = apply_block_takeup_to_arrays(
             hh_blocks=active_blocks,

--- a/policyengine_us_data/calibration/publish_local_area.py
+++ b/policyengine_us_data/calibration/publish_local_area.py
@@ -38,7 +38,7 @@ from policyengine_us_data.calibration.clone_and_assign import (
 from policyengine_us_data.utils.takeup import (
     SIMPLE_TAKEUP_VARS,
     apply_block_takeup_to_arrays,
-    any_person_flag_by_entity,
+    reported_subsidized_marketplace_by_tax_unit,
 )
 
 CHECKPOINT_FILE = Path("completed_states.txt")
@@ -163,13 +163,18 @@ def _build_reported_takeup_anchors(
 ) -> dict[str, np.ndarray]:
     reported_anchors = {}
     if (
-        "has_marketplace_health_coverage_at_interview" in data
-        and time_period in data["has_marketplace_health_coverage_at_interview"]
+        "reported_has_subsidized_marketplace_health_coverage_at_interview" in data
+        and time_period
+        in data["reported_has_subsidized_marketplace_health_coverage_at_interview"]
     ):
-        reported_anchors["takes_up_aca_if_eligible"] = any_person_flag_by_entity(
-            data["person_tax_unit_id"][time_period],
-            data["tax_unit_id"][time_period],
-            data["has_marketplace_health_coverage_at_interview"][time_period],
+        reported_anchors["takes_up_aca_if_eligible"] = (
+            reported_subsidized_marketplace_by_tax_unit(
+                data["person_tax_unit_id"][time_period],
+                data["tax_unit_id"][time_period],
+                data[
+                    "reported_has_subsidized_marketplace_health_coverage_at_interview"
+                ][time_period],
+            )
         )
     if (
         "has_medicaid_health_coverage_at_interview" in data

--- a/policyengine_us_data/calibration/publish_local_area.py
+++ b/policyengine_us_data/calibration/publish_local_area.py
@@ -38,7 +38,7 @@ from policyengine_us_data.calibration.clone_and_assign import (
 from policyengine_us_data.utils.takeup import (
     SIMPLE_TAKEUP_VARS,
     apply_block_takeup_to_arrays,
-    any_person_flag_by_entity,
+    reported_subsidized_marketplace_by_tax_unit,
 )
 
 CHECKPOINT_FILE = Path("completed_states.txt")
@@ -579,11 +579,18 @@ def build_h5(
         reported_anchors = _build_reported_takeup_anchors(data, time_period)
 =======
         reported_anchors = {}
-        if "has_marketplace_health_coverage_at_interview" in data:
-            reported_anchors["takes_up_aca_if_eligible"] = any_person_flag_by_entity(
-                data["person_tax_unit_id"][time_period],
-                data["tax_unit_id"][time_period],
-                data["has_marketplace_health_coverage_at_interview"][time_period],
+        if (
+            "reported_has_subsidized_marketplace_health_coverage_at_interview"
+            in data
+        ):
+            reported_anchors["takes_up_aca_if_eligible"] = (
+                reported_subsidized_marketplace_by_tax_unit(
+                    data["person_tax_unit_id"][time_period],
+                    data["tax_unit_id"][time_period],
+                    data[
+                        "reported_has_subsidized_marketplace_health_coverage_at_interview"
+                    ][time_period],
+                )
             )
         if "has_medicaid_health_coverage_at_interview" in data:
             reported_anchors["takes_up_medicaid_if_eligible"] = data[

--- a/policyengine_us_data/calibration/publish_local_area.py
+++ b/policyengine_us_data/calibration/publish_local_area.py
@@ -579,10 +579,7 @@ def build_h5(
         reported_anchors = _build_reported_takeup_anchors(data, time_period)
 =======
         reported_anchors = {}
-        if (
-            "reported_has_subsidized_marketplace_health_coverage_at_interview"
-            in data
-        ):
+        if "reported_has_subsidized_marketplace_health_coverage_at_interview" in data:
             reported_anchors["takes_up_aca_if_eligible"] = (
                 reported_subsidized_marketplace_by_tax_unit(
                     data["person_tax_unit_id"][time_period],

--- a/policyengine_us_data/calibration/unified_matrix_builder.py
+++ b/policyengine_us_data/calibration/unified_matrix_builder.py
@@ -2135,7 +2135,7 @@ class UnifiedMatrixBuilder:
             from policyengine_us_data.utils.takeup import (
                 TAKEUP_AFFECTED_TARGETS,
                 compute_block_takeup_for_entities,
-                any_person_flag_by_entity,
+                reported_subsidized_marketplace_by_tax_unit,
             )
             from policyengine_us_data.parameters import (
                 load_take_up_rate,
@@ -2168,16 +2168,20 @@ class UnifiedMatrixBuilder:
             with h5py.File(self.dataset_path, "r") as f:
                 period_key = str(self.time_period)
                 if (
-                    "has_marketplace_health_coverage_at_interview" in f
-                    and period_key in f["has_marketplace_health_coverage_at_interview"]
+                    "reported_has_subsidized_marketplace_health_coverage_at_interview"
+                    in f
+                    and period_key
+                    in f[
+                        "reported_has_subsidized_marketplace_health_coverage_at_interview"
+                    ]
                 ):
                     person_marketplace = f[
-                        "has_marketplace_health_coverage_at_interview"
+                        "reported_has_subsidized_marketplace_health_coverage_at_interview"
                     ][period_key][...].astype(bool)
                     person_tax_unit_ids = f["person_tax_unit_id"][period_key][...]
                     tax_unit_ids = f["tax_unit_id"][period_key][...]
                     reported_takeup_anchors["takes_up_aca_if_eligible"] = (
-                        any_person_flag_by_entity(
+                        reported_subsidized_marketplace_by_tax_unit(
                             person_tax_unit_ids,
                             tax_unit_ids,
                             person_marketplace,

--- a/policyengine_us_data/calibration/unified_matrix_builder.py
+++ b/policyengine_us_data/calibration/unified_matrix_builder.py
@@ -14,6 +14,7 @@ import logging
 from collections import defaultdict
 from typing import Dict, List, Optional, Tuple
 
+import h5py
 import numpy as np
 import pandas as pd
 from scipy import sparse
@@ -668,6 +669,7 @@ def _process_single_clone(
     entity_hh_idx_map = sd.get("entity_hh_idx_map", {})
     entity_to_person_idx = sd.get("entity_to_person_idx", {})
     precomputed_rates = sd.get("precomputed_rates", {})
+    reported_takeup_anchors = sd.get("reported_takeup_anchors", {})
 
     # Slice geography for this clone
     clone_states = geo_states[col_start:col_end]
@@ -789,6 +791,7 @@ def _process_single_clone(
                 ent_blocks,
                 ent_hh_ids,
                 ent_ci,
+                reported_mask=reported_takeup_anchors.get(takeup_var),
             )
 
             ent_values = (ent_eligible * ent_takeup).astype(np.float32)
@@ -2132,6 +2135,7 @@ class UnifiedMatrixBuilder:
             from policyengine_us_data.utils.takeup import (
                 TAKEUP_AFFECTED_TARGETS,
                 compute_block_takeup_for_entities,
+                any_person_flag_by_entity,
             )
             from policyengine_us_data.parameters import (
                 load_take_up_rate,
@@ -2159,6 +2163,35 @@ class UnifiedMatrixBuilder:
                 "tax_unit": tu_hh_idx,
                 "person": person_hh_indices,
             }
+
+            reported_takeup_anchors = {}
+            with h5py.File(self.dataset_path, "r") as f:
+                period_key = str(self.time_period)
+                if (
+                    "reported_has_marketplace_health_coverage_at_interview" in f
+                    and period_key
+                    in f["reported_has_marketplace_health_coverage_at_interview"]
+                ):
+                    person_marketplace = f[
+                        "reported_has_marketplace_health_coverage_at_interview"
+                    ][period_key][...].astype(bool)
+                    person_tax_unit_ids = f["person_tax_unit_id"][period_key][...]
+                    tax_unit_ids = f["tax_unit_id"][period_key][...]
+                    reported_takeup_anchors["takes_up_aca_if_eligible"] = (
+                        any_person_flag_by_entity(
+                            person_tax_unit_ids,
+                            tax_unit_ids,
+                            person_marketplace,
+                        )
+                    )
+                if (
+                    "reported_has_means_tested_health_coverage_at_interview" in f
+                    and period_key
+                    in f["reported_has_means_tested_health_coverage_at_interview"]
+                ):
+                    reported_takeup_anchors["takes_up_medicaid_if_eligible"] = f[
+                        "reported_has_means_tested_health_coverage_at_interview"
+                    ][period_key][...].astype(bool)
 
             entity_to_person_idx = {}
             for entity_level in ("spm_unit", "tax_unit"):
@@ -2200,6 +2233,7 @@ class UnifiedMatrixBuilder:
             self.household_ids = household_ids
             self.precomputed_rates = precomputed_rates
             self.affected_target_info = affected_target_info
+            self.reported_takeup_anchors = reported_takeup_anchors
 
         # 5d. Clone loop
         from pathlib import Path
@@ -2249,6 +2283,7 @@ class UnifiedMatrixBuilder:
                 shared_data["entity_hh_idx_map"] = entity_hh_idx_map
                 shared_data["entity_to_person_idx"] = entity_to_person_idx
                 shared_data["precomputed_rates"] = precomputed_rates
+                shared_data["reported_takeup_anchors"] = reported_takeup_anchors
 
             logger.info(
                 "Starting parallel clone processing: %d clones, %d workers",
@@ -2452,6 +2487,7 @@ class UnifiedMatrixBuilder:
                             ent_blocks,
                             ent_hh_ids,
                             ent_ci,
+                            reported_mask=reported_takeup_anchors.get(takeup_var),
                         )
 
                         ent_values = (ent_eligible * ent_takeup).astype(np.float32)

--- a/policyengine_us_data/calibration/unified_matrix_builder.py
+++ b/policyengine_us_data/calibration/unified_matrix_builder.py
@@ -2168,12 +2168,11 @@ class UnifiedMatrixBuilder:
             with h5py.File(self.dataset_path, "r") as f:
                 period_key = str(self.time_period)
                 if (
-                    "reported_has_marketplace_health_coverage_at_interview" in f
-                    and period_key
-                    in f["reported_has_marketplace_health_coverage_at_interview"]
+                    "has_marketplace_health_coverage_at_interview" in f
+                    and period_key in f["has_marketplace_health_coverage_at_interview"]
                 ):
                     person_marketplace = f[
-                        "reported_has_marketplace_health_coverage_at_interview"
+                        "has_marketplace_health_coverage_at_interview"
                     ][period_key][...].astype(bool)
                     person_tax_unit_ids = f["person_tax_unit_id"][period_key][...]
                     tax_unit_ids = f["tax_unit_id"][period_key][...]
@@ -2185,12 +2184,11 @@ class UnifiedMatrixBuilder:
                         )
                     )
                 if (
-                    "reported_has_means_tested_health_coverage_at_interview" in f
-                    and period_key
-                    in f["reported_has_means_tested_health_coverage_at_interview"]
+                    "has_medicaid_health_coverage_at_interview" in f
+                    and period_key in f["has_medicaid_health_coverage_at_interview"]
                 ):
                     reported_takeup_anchors["takes_up_medicaid_if_eligible"] = f[
-                        "reported_has_means_tested_health_coverage_at_interview"
+                        "has_medicaid_health_coverage_at_interview"
                     ][period_key][...].astype(bool)
 
             entity_to_person_idx = {}

--- a/policyengine_us_data/datasets/cps/census_cps.py
+++ b/policyengine_us_data/datasets/cps/census_cps.py
@@ -7,6 +7,53 @@ import pandas as pd
 from policyengine_us_data.storage import STORAGE_FOLDER
 
 
+OPTIONAL_PERSON_COLUMNS = {
+    "NOW_COV",
+    "NOW_DIR",
+    "NOW_MRK",
+    "NOW_MRKS",
+    "NOW_MRKUN",
+    "NOW_NONM",
+    "NOW_PRIV",
+    "NOW_PUB",
+    "NOW_GRP",
+    "NOW_CAID",
+    "NOW_MCAID",
+    "NOW_PCHIP",
+    "NOW_OTHMT",
+    "NOW_MCARE",
+    "NOW_MIL",
+    "NOW_CHAMPVA",
+    "NOW_VACARE",
+    "NOW_IHSFLG",
+}
+
+
+def _resolve_person_usecols(
+    available_columns, spm_unit_columns: list[str]
+) -> list[str]:
+    requested_columns = PERSON_COLUMNS + spm_unit_columns + TAX_UNIT_COLUMNS
+    available_columns = set(available_columns)
+    missing_required = sorted(
+        column
+        for column in requested_columns
+        if column not in available_columns and column not in OPTIONAL_PERSON_COLUMNS
+    )
+    if missing_required:
+        raise KeyError(
+            "Missing required CPS person columns: "
+            + ", ".join(missing_required[:10])
+        )
+    return [column for column in requested_columns if column in available_columns]
+
+
+def _fill_missing_optional_person_columns(person: pd.DataFrame) -> pd.DataFrame:
+    for column in OPTIONAL_PERSON_COLUMNS:
+        if column not in person.columns:
+            person[column] = 0
+    return person
+
+
 class CensusCPS(Dataset):
     """Dataset containing CPS ASEC tables in the Census format."""
 
@@ -59,12 +106,19 @@ class CensusCPS(Dataset):
                     file_prefix = "cpspb/asec/prod/data/2019/"
                 else:
                     file_prefix = ""
-                with zipfile.open(f"{file_prefix}pppub{file_year_code}.csv") as f:
-                    storage["person"] = pd.read_csv(
+                person_path = f"{file_prefix}pppub{file_year_code}.csv"
+                with zipfile.open(person_path) as f:
+                    person_columns = pd.read_csv(f, nrows=0).columns
+                person_usecols = _resolve_person_usecols(
+                    person_columns, spm_unit_columns
+                )
+                with zipfile.open(person_path) as f:
+                    person = pd.read_csv(
                         f,
-                        usecols=PERSON_COLUMNS + spm_unit_columns + TAX_UNIT_COLUMNS,
+                        usecols=person_usecols,
                     ).fillna(0)
-                    person = storage["person"]
+                person = _fill_missing_optional_person_columns(person)
+                storage["person"] = person
                 with zipfile.open(f"{file_prefix}ffpub{file_year_code}.csv") as f:
                     person_family_id = person.PH_SEQ * 10 + person.PF_SEQ
                     family = pd.read_csv(f).fillna(0)
@@ -236,7 +290,24 @@ PERSON_COLUMNS = [
     "A_AGE",
     "A_SEX",
     "PEDISEYE",
+    "NOW_COV",
+    "NOW_DIR",
     "NOW_MRK",
+    "NOW_MRKS",
+    "NOW_MRKUN",
+    "NOW_NONM",
+    "NOW_PRIV",
+    "NOW_PUB",
+    "NOW_GRP",
+    "NOW_CAID",
+    "NOW_MCAID",
+    "NOW_PCHIP",
+    "NOW_OTHMT",
+    "NOW_MCARE",
+    "NOW_MIL",
+    "NOW_CHAMPVA",
+    "NOW_VACARE",
+    "NOW_IHSFLG",
     "WSAL_VAL",
     "INT_VAL",
     "SEMP_VAL",
@@ -294,7 +365,6 @@ PERSON_COLUMNS = [
     "PMED_VAL",
     "PEMCPREM",
     "PRCITSHP",
-    "NOW_GRP",
     "POCCU2",
     "PEINUSYR",
     "MCARE",

--- a/policyengine_us_data/datasets/cps/census_cps.py
+++ b/policyengine_us_data/datasets/cps/census_cps.py
@@ -41,8 +41,7 @@ def _resolve_person_usecols(
     )
     if missing_required:
         raise KeyError(
-            "Missing required CPS person columns: "
-            + ", ".join(missing_required[:10])
+            "Missing required CPS person columns: " + ", ".join(missing_required[:10])
         )
     return [column for column in requested_columns if column in available_columns]
 

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -287,14 +287,10 @@ def add_takeup(self):
 
     # ACA
     rng = seeded_rng("takes_up_aca_if_eligible")
-    reported_marketplace_by_tax_unit = (
-        reported_subsidized_marketplace_by_tax_unit(
-            data["person_tax_unit_id"],
-            data["tax_unit_id"],
-            data[
-                "reported_has_subsidized_marketplace_health_coverage_at_interview"
-            ],
-        )
+    reported_marketplace_by_tax_unit = reported_subsidized_marketplace_by_tax_unit(
+        data["person_tax_unit_id"],
+        data["tax_unit_id"],
+        data["reported_has_subsidized_marketplace_health_coverage_at_interview"],
     )
     data["takes_up_aca_if_eligible"] = assign_takeup_with_reported_anchors(
         rng.random(n_tax_units),

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -56,6 +56,33 @@ CURRENT_HEALTH_COVERAGE_REPORTED_VAR_MAP = {
     "reported_has_indian_health_service_coverage_at_interview": "NOW_IHSFLG",
 }
 
+CURRENT_HEALTH_COVERAGE_RULE_INPUT_ALIAS_MAP = {
+    "has_marketplace_health_coverage_at_interview": (
+        "reported_has_marketplace_health_coverage_at_interview"
+    ),
+    "has_non_marketplace_direct_purchase_health_coverage_at_interview": (
+        "reported_has_non_marketplace_direct_purchase_health_coverage_at_interview"
+    ),
+    "has_medicaid_health_coverage_at_interview": (
+        "reported_has_medicaid_health_coverage_at_interview"
+    ),
+    "has_other_means_tested_health_coverage_at_interview": (
+        "reported_has_other_means_tested_health_coverage_at_interview"
+    ),
+    "has_tricare_health_coverage_at_interview": (
+        "reported_has_tricare_health_coverage_at_interview"
+    ),
+    "has_champva_health_coverage_at_interview": (
+        "reported_has_champva_health_coverage_at_interview"
+    ),
+    "has_va_health_coverage_at_interview": (
+        "reported_has_va_health_coverage_at_interview"
+    ),
+    "has_indian_health_service_coverage_at_interview": (
+        "reported_has_indian_health_service_coverage_at_interview"
+    ),
+}
+
 
 class CPS(Dataset):
     name = "cps"
@@ -263,7 +290,7 @@ def add_takeup(self):
     reported_marketplace_by_tax_unit = any_person_flag_by_entity(
         data["person_tax_unit_id"],
         data["tax_unit_id"],
-        data["reported_has_marketplace_health_coverage_at_interview"],
+        data["has_marketplace_health_coverage_at_interview"],
     )
     data["takes_up_aca_if_eligible"] = assign_takeup_with_reported_anchors(
         rng.random(n_tax_units),
@@ -284,7 +311,7 @@ def add_takeup(self):
     data["takes_up_medicaid_if_eligible"] = assign_takeup_with_reported_anchors(
         rng.random(n_persons),
         medicaid_rate_by_person,
-        reported_mask=data["reported_has_means_tested_health_coverage_at_interview"],
+        reported_mask=data["has_medicaid_health_coverage_at_interview"],
         group_keys=person_states,
     )
 
@@ -496,6 +523,12 @@ def add_personal_variables(cps: h5py.File, person: DataFrame) -> None:
 
     for variable, cps_column in CURRENT_HEALTH_COVERAGE_REPORTED_VAR_MAP.items():
         cps[variable] = person[cps_column] == 1
+
+    for (
+        variable,
+        reported_variable,
+    ) in CURRENT_HEALTH_COVERAGE_RULE_INPUT_ALIAS_MAP.items():
+        cps[variable] = cps[reported_variable]
 
     cps["reported_has_private_health_coverage_at_interview"] = person.NOW_PRIV == 1
     cps["reported_has_public_health_coverage_at_interview"] = person.NOW_PUB == 1

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -31,8 +31,8 @@ from policyengine_us_data.datasets.cps.tipped_occupation import (
 from policyengine_us_data.utils.downsample import downsample_dataset_arrays
 from policyengine_us_data.utils.randomness import seeded_rng
 from policyengine_us_data.utils.takeup import (
-    any_person_flag_by_entity,
     assign_takeup_with_reported_anchors,
+    reported_subsidized_marketplace_by_tax_unit,
 )
 
 
@@ -287,10 +287,14 @@ def add_takeup(self):
 
     # ACA
     rng = seeded_rng("takes_up_aca_if_eligible")
-    reported_marketplace_by_tax_unit = any_person_flag_by_entity(
-        data["person_tax_unit_id"],
-        data["tax_unit_id"],
-        data["has_marketplace_health_coverage_at_interview"],
+    reported_marketplace_by_tax_unit = (
+        reported_subsidized_marketplace_by_tax_unit(
+            data["person_tax_unit_id"],
+            data["tax_unit_id"],
+            data[
+                "reported_has_subsidized_marketplace_health_coverage_at_interview"
+            ],
+        )
     )
     data["takes_up_aca_if_eligible"] = assign_takeup_with_reported_anchors(
         rng.random(n_tax_units),

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -24,12 +24,37 @@ from policyengine_us_data.datasets.org import (
     build_org_receiver_frame,
     predict_org_features,
 )
-from policyengine_us_data.utils.downsample import downsample_dataset_arrays
-from policyengine_us_data.utils.randomness import seeded_rng
 from policyengine_us_data.datasets.cps.tipped_occupation import (
     derive_treasury_tipped_occupation_code,
     derive_is_tipped_occupation,
 )
+from policyengine_us_data.utils.downsample import downsample_dataset_arrays
+from policyengine_us_data.utils.randomness import seeded_rng
+from policyengine_us_data.utils.takeup import (
+    any_person_flag_by_entity,
+    assign_takeup_with_reported_anchors,
+)
+
+
+CURRENT_HEALTH_COVERAGE_REPORTED_VAR_MAP = {
+    "reported_has_direct_purchase_health_coverage_at_interview": "NOW_DIR",
+    "reported_has_marketplace_health_coverage_at_interview": "NOW_MRK",
+    "reported_has_subsidized_marketplace_health_coverage_at_interview": "NOW_MRKS",
+    "reported_has_unsubsidized_marketplace_health_coverage_at_interview": "NOW_MRKUN",
+    "reported_has_non_marketplace_direct_purchase_health_coverage_at_interview": (
+        "NOW_NONM"
+    ),
+    "reported_has_employer_sponsored_health_coverage_at_interview": "NOW_GRP",
+    "reported_has_medicare_health_coverage_at_interview": "NOW_MCARE",
+    "reported_has_medicaid_health_coverage_at_interview": "NOW_CAID",
+    "reported_has_means_tested_health_coverage_at_interview": "NOW_MCAID",
+    "reported_has_chip_health_coverage_at_interview": "NOW_PCHIP",
+    "reported_has_other_means_tested_health_coverage_at_interview": "NOW_OTHMT",
+    "reported_has_tricare_health_coverage_at_interview": "NOW_MIL",
+    "reported_has_champva_health_coverage_at_interview": "NOW_CHAMPVA",
+    "reported_has_va_health_coverage_at_interview": "NOW_VACARE",
+    "reported_has_indian_health_service_coverage_at_interview": "NOW_IHSFLG",
+}
 
 
 class CPS(Dataset):
@@ -235,7 +260,16 @@ def add_takeup(self):
 
     # ACA
     rng = seeded_rng("takes_up_aca_if_eligible")
-    data["takes_up_aca_if_eligible"] = rng.random(n_tax_units) < aca_rate
+    reported_marketplace_by_tax_unit = any_person_flag_by_entity(
+        data["person_tax_unit_id"],
+        data["tax_unit_id"],
+        data["reported_has_marketplace_health_coverage_at_interview"],
+    )
+    data["takes_up_aca_if_eligible"] = assign_takeup_with_reported_anchors(
+        rng.random(n_tax_units),
+        aca_rate,
+        reported_mask=reported_marketplace_by_tax_unit,
+    )
 
     # Medicaid: state-specific rates
     state_codes = baseline.calculate("state_code_str").values
@@ -247,8 +281,11 @@ def add_takeup(self):
         [medicaid_rates_by_state.get(s, 0.93) for s in person_states]
     )
     rng = seeded_rng("takes_up_medicaid_if_eligible")
-    data["takes_up_medicaid_if_eligible"] = (
-        rng.random(n_persons) < medicaid_rate_by_person
+    data["takes_up_medicaid_if_eligible"] = assign_takeup_with_reported_anchors(
+        rng.random(n_persons),
+        medicaid_rate_by_person,
+        reported_mask=data["reported_has_means_tested_health_coverage_at_interview"],
+        group_keys=person_states,
     )
 
     # Head Start
@@ -457,9 +494,38 @@ def add_personal_variables(cps: h5py.File, person: DataFrame) -> None:
     )
     cps["own_children_in_household"] = tmp.children.fillna(0)
 
-    cps["has_marketplace_health_coverage"] = person.NOW_MRK == 1
+    for variable, cps_column in CURRENT_HEALTH_COVERAGE_REPORTED_VAR_MAP.items():
+        cps[variable] = person[cps_column] == 1
 
-    cps["has_esi"] = person.NOW_GRP == 1
+    cps["reported_has_private_health_coverage_at_interview"] = person.NOW_PRIV == 1
+    cps["reported_has_public_health_coverage_at_interview"] = person.NOW_PUB == 1
+    cps["reported_is_insured_at_interview"] = person.NOW_COV == 1
+    cps["reported_is_uninsured_at_interview"] = person.NOW_COV != 1
+
+    coverage_families = np.column_stack(
+        [
+            cps["reported_has_employer_sponsored_health_coverage_at_interview"],
+            cps["reported_has_marketplace_health_coverage_at_interview"],
+            cps[
+                "reported_has_non_marketplace_direct_purchase_health_coverage_at_interview"
+            ],
+            cps["reported_has_medicare_health_coverage_at_interview"],
+            cps["reported_has_means_tested_health_coverage_at_interview"],
+            cps["reported_has_tricare_health_coverage_at_interview"],
+            cps["reported_has_champva_health_coverage_at_interview"],
+            cps["reported_has_va_health_coverage_at_interview"],
+            cps["reported_has_indian_health_service_coverage_at_interview"],
+        ]
+    )
+    cps["reported_has_multiple_health_coverage_at_interview"] = (
+        coverage_families.sum(axis=1) > 1
+    )
+
+    # Legacy aliases retained for compatibility until rules-side names catch up.
+    cps["has_marketplace_health_coverage"] = cps[
+        "reported_has_marketplace_health_coverage_at_interview"
+    ]
+    cps["has_esi"] = cps["reported_has_employer_sponsored_health_coverage_at_interview"]
 
     cps["cps_race"] = person.PRDTRACE
     cps["is_hispanic"] = person.PRDTHSP != 0

--- a/policyengine_us_data/utils/takeup.py
+++ b/policyengine_us_data/utils/takeup.py
@@ -146,6 +146,103 @@ _FIPS_TO_STATE_CODE = {
 }
 
 
+def any_person_flag_by_entity(
+    person_entity_ids: np.ndarray,
+    entity_ids: np.ndarray,
+    person_mask: np.ndarray,
+) -> np.ndarray:
+    """Aggregate a person-level boolean to any-covered at entity level."""
+    person_entity_ids = np.asarray(person_entity_ids)
+    entity_ids = np.asarray(entity_ids)
+    person_mask = np.asarray(person_mask, dtype=bool)
+    if len(person_entity_ids) != len(person_mask):
+        raise ValueError("person_entity_ids and person_mask must align")
+    if not person_mask.any():
+        return np.zeros(len(entity_ids), dtype=bool)
+    flagged_ids = np.unique(person_entity_ids[person_mask])
+    return np.isin(entity_ids, flagged_ids)
+
+
+def reported_subsidized_marketplace_by_tax_unit(
+    person_tax_unit_ids: np.ndarray,
+    tax_unit_ids: np.ndarray,
+    person_has_subsidized_marketplace_coverage: np.ndarray,
+) -> np.ndarray:
+    """Aggregate subsidized Marketplace coverage reports to tax units."""
+    return any_person_flag_by_entity(
+        person_tax_unit_ids,
+        tax_unit_ids,
+        person_has_subsidized_marketplace_coverage,
+    )
+
+
+def assign_takeup_with_reported_anchors(
+    draws: np.ndarray,
+    rates,
+    reported_mask: Optional[np.ndarray] = None,
+    group_keys: Optional[np.ndarray] = None,
+) -> np.ndarray:
+    """Apply the SSI/SNAP-style reported-first takeup pattern.
+
+    Reported recipients are always assigned takeup=True. Remaining
+    non-reporters are filled probabilistically to reach the target count
+    implied by the rate, either globally or within each ``group_keys``
+    group.
+    """
+    draws = np.asarray(draws, dtype=np.float64)
+    if np.isscalar(rates):
+        rates_arr = np.full(len(draws), float(rates), dtype=np.float64)
+    else:
+        rates_arr = np.asarray(rates, dtype=np.float64)
+        if len(rates_arr) != len(draws):
+            raise ValueError("rates and draws must align")
+
+    baseline = draws < rates_arr
+    if reported_mask is None:
+        return baseline
+
+    reported_mask = np.asarray(reported_mask, dtype=bool)
+    if len(reported_mask) != len(draws):
+        raise ValueError("reported_mask and draws must align")
+
+    result = reported_mask.copy()
+
+    if group_keys is None:
+        unique_rates = np.unique(rates_arr)
+        if len(unique_rates) != 1:
+            raise ValueError("group_keys required when rates vary by entity")
+        target_count = int(unique_rates[0] * len(draws))
+        non_reporters = ~reported_mask
+        remaining_needed = max(0, target_count - int(reported_mask.sum()))
+        adjusted_rate = (
+            remaining_needed / int(non_reporters.sum()) if non_reporters.any() else 0
+        )
+        result |= non_reporters & (draws < adjusted_rate)
+        return result
+
+    group_keys = np.asarray(group_keys)
+    if len(group_keys) != len(draws):
+        raise ValueError("group_keys and draws must align")
+
+    for key in np.unique(group_keys):
+        group_mask = group_keys == key
+        group_rates = np.unique(rates_arr[group_mask])
+        if len(group_rates) != 1:
+            raise ValueError("Each takeup group must have a single rate")
+        target_count = int(group_rates[0] * int(group_mask.sum()))
+        group_reported = reported_mask[group_mask]
+        remaining_needed = max(0, target_count - int(group_reported.sum()))
+        group_non_reporters = group_mask & ~reported_mask
+        adjusted_rate = (
+            remaining_needed / int(group_non_reporters.sum())
+            if group_non_reporters.any()
+            else 0
+        )
+        result[group_non_reporters] = draws[group_non_reporters] < adjusted_rate
+
+    return result
+
+
 def _resolve_rate(
     rate_or_dict,
     state_fips: int,
@@ -211,6 +308,7 @@ def compute_block_takeup_for_entities(
     entity_blocks: np.ndarray,
     entity_hh_ids: np.ndarray = None,
     entity_clone_ids: np.ndarray = None,
+    reported_mask: Optional[np.ndarray] = None,
 ) -> np.ndarray:
     """Compute boolean takeup via block-level seeded draws."""
     draws = compute_block_takeup_draws_for_entities(
@@ -227,7 +325,17 @@ def compute_block_takeup_for_entities(
         blk_mask = entity_blocks == block
         rates[blk_mask] = _resolve_rate(rate_or_dict, int(str(block)[:2]))
 
-    return draws < rates
+    group_keys = (
+        np.array([int(str(block)[:2]) for block in entity_blocks], dtype=np.int32)
+        if isinstance(rate_or_dict, dict)
+        else None
+    )
+    return assign_takeup_with_reported_anchors(
+        draws,
+        rates,
+        reported_mask=reported_mask,
+        group_keys=group_keys,
+    )
 
 
 def extend_aca_takeup_to_match_target(
@@ -276,6 +384,7 @@ def apply_block_takeup_to_arrays(
     time_period: int,
     takeup_filter: List[str] = None,
     precomputed_rates: Optional[Dict[str, Any]] = None,
+    reported_anchors: Optional[Dict[str, np.ndarray]] = None,
 ) -> Dict[str, np.ndarray]:
     """Compute takeup draws from raw arrays.
 
@@ -307,6 +416,7 @@ def apply_block_takeup_to_arrays(
     """
     filter_set = set(takeup_filter) if takeup_filter is not None else None
     result = {}
+    reported_anchors = reported_anchors or {}
 
     for spec in SIMPLE_TAKEUP_VARS:
         var_name = spec["variable"]
@@ -327,12 +437,16 @@ def apply_block_takeup_to_arrays(
             rate_or_dict = precomputed_rates[rate_key]
         else:
             rate_or_dict = load_take_up_rate(rate_key, time_period)
+        reported_mask = reported_anchors.get(var_name)
+        if reported_mask is not None and len(reported_mask) != n_ent:
+            raise ValueError(f"reported anchor for {var_name} has wrong length")
         bools = compute_block_takeup_for_entities(
             var_name,
             rate_or_dict,
             ent_blocks,
             ent_hh_ids,
             ent_clone_indices,
+            reported_mask=reported_mask,
         )
         result[var_name] = bools
 

--- a/policyengine_us_data/utils/takeup.py
+++ b/policyengine_us_data/utils/takeup.py
@@ -284,12 +284,6 @@ def compute_block_takeup_draws_for_entities(
     if entity_clone_indices is None:
         entity_clone_indices = np.zeros(n, dtype=np.int64)
 
-    # Iterate block groups first so draws stay stable within geography slices.
-    for block in np.unique(entity_blocks):
-        if block == "":
-            continue
-        blk_mask = entity_blocks == block
-
     # Draw per (hh_id, clone_idx) pair
     for hh_id in np.unique(entity_hh_ids):
         hh_mask = entity_hh_ids == hh_id
@@ -318,18 +312,17 @@ def compute_block_takeup_for_entities(
         entity_clone_ids,
     )
     rates = np.ones(len(entity_blocks), dtype=np.float64)
+    state_fips = np.zeros(len(entity_blocks), dtype=np.int32)
 
     for block in np.unique(entity_blocks):
         if block == "":
             continue
         blk_mask = entity_blocks == block
-        rates[blk_mask] = _resolve_rate(rate_or_dict, int(str(block)[:2]))
+        block_state_fips = int(str(block)[:2])
+        rates[blk_mask] = _resolve_rate(rate_or_dict, block_state_fips)
+        state_fips[blk_mask] = block_state_fips
 
-    group_keys = (
-        np.array([int(str(block)[:2]) for block in entity_blocks], dtype=np.int32)
-        if isinstance(rate_or_dict, dict)
-        else None
-    )
+    group_keys = state_fips if isinstance(rate_or_dict, dict) else None
     return assign_takeup_with_reported_anchors(
         draws,
         rates,

--- a/tests/integration/test_census_cps.py
+++ b/tests/integration/test_census_cps.py
@@ -40,3 +40,44 @@ def test_census_cps_has_all_tables(year: int):
     for table in TABLES:
         df = dataset.load(table)
         assert len(df) > 0
+
+
+def test_resolve_person_usecols_allows_missing_optional_now_columns():
+    from policyengine_us_data.datasets.cps.census_cps import (
+        PERSON_COLUMNS,
+        SPM_UNIT_COLUMNS,
+        TAX_UNIT_COLUMNS,
+        _resolve_person_usecols,
+    )
+
+    missing_optional = {"NOW_MRKS", "NOW_MRKUN"}
+    available_columns = [
+        column
+        for column in PERSON_COLUMNS + SPM_UNIT_COLUMNS + TAX_UNIT_COLUMNS
+        if column not in missing_optional
+    ]
+
+    usecols = _resolve_person_usecols(available_columns, SPM_UNIT_COLUMNS)
+
+    assert "NOW_MRKS" not in usecols
+    assert "NOW_MRKUN" not in usecols
+    assert "PH_SEQ" in usecols
+    assert "A_FNLWGT" in usecols
+
+
+def test_fill_missing_optional_person_columns_backfills_zeroes():
+    import pandas as pd
+
+    from policyengine_us_data.datasets.cps.census_cps import (
+        OPTIONAL_PERSON_COLUMNS,
+        _fill_missing_optional_person_columns,
+    )
+
+    person = pd.DataFrame({"PH_SEQ": [1], "NOW_COV": [1]})
+
+    filled = _fill_missing_optional_person_columns(person)
+
+    for column in OPTIONAL_PERSON_COLUMNS:
+        assert column in filled.columns
+    assert filled.loc[0, "NOW_COV"] == 1
+    assert filled.loc[0, "NOW_MRKS"] == 0

--- a/tests/integration/test_cps.py
+++ b/tests/integration/test_cps.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pytest
+import pandas as pd
 
 
 @pytest.fixture(scope="module")
@@ -10,6 +11,86 @@ def cps_sim():
     from policyengine_us import Microsimulation
 
     return Microsimulation(dataset=CPS_2024)
+
+
+def test_add_personal_variables_maps_current_health_coverage_flags():
+    from policyengine_us_data.datasets.cps.cps import add_personal_variables
+
+    person = pd.DataFrame(
+        {
+            "A_AGE": [30, 45, 28],
+            "A_SEX": [2, 1, 2],
+            "PEDISEYE": [0, 1, 0],
+            "PEDISDRS": [0, 0, 0],
+            "PEDISEAR": [0, 0, 0],
+            "PEDISOUT": [0, 0, 0],
+            "PEDISPHY": [0, 0, 0],
+            "PEDISREM": [0, 0, 0],
+            "PEPAR1": [0, 0, 0],
+            "PEPAR2": [0, 0, 0],
+            "PH_SEQ": [1, 1, 2],
+            "A_LINENO": [1, 2, 1],
+            "NOW_COV": [1, 1, 0],
+            "NOW_DIR": [1, 0, 0],
+            "NOW_MRK": [1, 0, 0],
+            "NOW_MRKS": [1, 0, 0],
+            "NOW_MRKUN": [0, 0, 0],
+            "NOW_NONM": [0, 0, 0],
+            "NOW_PRIV": [1, 0, 0],
+            "NOW_PUB": [0, 1, 0],
+            "NOW_GRP": [0, 1, 0],
+            "NOW_CAID": [0, 0, 0],
+            "NOW_MCAID": [0, 1, 0],
+            "NOW_PCHIP": [0, 0, 0],
+            "NOW_OTHMT": [0, 1, 0],
+            "NOW_MCARE": [0, 0, 0],
+            "NOW_MIL": [0, 0, 0],
+            "NOW_CHAMPVA": [0, 0, 0],
+            "NOW_VACARE": [0, 0, 0],
+            "NOW_IHSFLG": [0, 0, 0],
+            "PRDTRACE": [1, 2, 3],
+            "PRDTHSP": [0, 1, 0],
+            "A_MARITL": [1, 4, 1],
+            "A_HSCOL": [0, 2, 0],
+            "POCCU2": [39, 52, 29],
+        }
+    )
+    cps = {}
+
+    add_personal_variables(cps, person)
+
+    np.testing.assert_array_equal(
+        cps["reported_has_marketplace_health_coverage_at_interview"],
+        [True, False, False],
+    )
+    np.testing.assert_array_equal(
+        cps["has_marketplace_health_coverage_at_interview"],
+        [True, False, False],
+    )
+    np.testing.assert_array_equal(
+        cps["has_other_means_tested_health_coverage_at_interview"],
+        [False, True, False],
+    )
+    np.testing.assert_array_equal(
+        cps["has_medicaid_health_coverage_at_interview"],
+        [False, False, False],
+    )
+    np.testing.assert_array_equal(
+        cps["reported_has_means_tested_health_coverage_at_interview"],
+        [False, True, False],
+    )
+    np.testing.assert_array_equal(
+        cps["reported_is_uninsured_at_interview"],
+        [False, False, True],
+    )
+    np.testing.assert_array_equal(
+        cps["reported_has_multiple_health_coverage_at_interview"],
+        [False, True, False],
+    )
+    np.testing.assert_array_equal(
+        cps["has_marketplace_health_coverage"], [True, False, False]
+    )
+    np.testing.assert_array_equal(cps["has_esi"], [False, True, False])
 
 
 # ── Sanity checks ─────────────────────────────────────────────

--- a/tests/integration/test_cps.py
+++ b/tests/integration/test_cps.py
@@ -53,6 +53,7 @@ def test_add_personal_variables_maps_current_health_coverage_flags():
             "A_MARITL": [1, 4, 1],
             "A_HSCOL": [0, 2, 0],
             "POCCU2": [39, 52, 29],
+            "PEIOOCC": [4040, 9999, 4020],
         }
     )
     cps = {}

--- a/tests/unit/calibration/test_publish_local_area.py
+++ b/tests/unit/calibration/test_publish_local_area.py
@@ -1,0 +1,44 @@
+import numpy as np
+
+from policyengine_us_data.calibration.publish_local_area import (
+    _build_reported_takeup_anchors,
+)
+
+
+def test_build_reported_takeup_anchors_skips_missing_period():
+    data = {
+        "person_tax_unit_id": {2024: np.array([1, 2], dtype=np.int64)},
+        "tax_unit_id": {2024: np.array([1, 2], dtype=np.int64)},
+        "reported_has_marketplace_health_coverage_at_interview": {
+            2023: np.array([True, False])
+        },
+        "reported_has_means_tested_health_coverage_at_interview": {
+            2023: np.array([True, False])
+        },
+    }
+
+    assert _build_reported_takeup_anchors(data, 2024) == {}
+
+
+def test_build_reported_takeup_anchors_uses_present_period():
+    data = {
+        "person_tax_unit_id": {2024: np.array([1, 1, 2], dtype=np.int64)},
+        "tax_unit_id": {2024: np.array([1, 2], dtype=np.int64)},
+        "reported_has_marketplace_health_coverage_at_interview": {
+            2024: np.array([True, False, False])
+        },
+        "reported_has_means_tested_health_coverage_at_interview": {
+            2024: np.array([False, True, False])
+        },
+    }
+
+    anchors = _build_reported_takeup_anchors(data, 2024)
+
+    np.testing.assert_array_equal(
+        anchors["takes_up_aca_if_eligible"],
+        np.array([True, False]),
+    )
+    np.testing.assert_array_equal(
+        anchors["takes_up_medicaid_if_eligible"],
+        np.array([False, True, False]),
+    )

--- a/tests/unit/calibration/test_publish_local_area.py
+++ b/tests/unit/calibration/test_publish_local_area.py
@@ -9,12 +9,8 @@ def test_build_reported_takeup_anchors_skips_missing_period():
     data = {
         "person_tax_unit_id": {2024: np.array([1, 2], dtype=np.int64)},
         "tax_unit_id": {2024: np.array([1, 2], dtype=np.int64)},
-        "reported_has_marketplace_health_coverage_at_interview": {
-            2023: np.array([True, False])
-        },
-        "reported_has_means_tested_health_coverage_at_interview": {
-            2023: np.array([True, False])
-        },
+        "has_marketplace_health_coverage_at_interview": {2023: np.array([True, False])},
+        "has_medicaid_health_coverage_at_interview": {2023: np.array([True, False])},
     }
 
     assert _build_reported_takeup_anchors(data, 2024) == {}
@@ -24,10 +20,10 @@ def test_build_reported_takeup_anchors_uses_present_period():
     data = {
         "person_tax_unit_id": {2024: np.array([1, 1, 2], dtype=np.int64)},
         "tax_unit_id": {2024: np.array([1, 2], dtype=np.int64)},
-        "reported_has_marketplace_health_coverage_at_interview": {
+        "has_marketplace_health_coverage_at_interview": {
             2024: np.array([True, False, False])
         },
-        "reported_has_means_tested_health_coverage_at_interview": {
+        "has_medicaid_health_coverage_at_interview": {
             2024: np.array([False, True, False])
         },
     }

--- a/tests/unit/calibration/test_publish_local_area.py
+++ b/tests/unit/calibration/test_publish_local_area.py
@@ -9,7 +9,9 @@ def test_build_reported_takeup_anchors_skips_missing_period():
     data = {
         "person_tax_unit_id": {2024: np.array([1, 2], dtype=np.int64)},
         "tax_unit_id": {2024: np.array([1, 2], dtype=np.int64)},
-        "has_marketplace_health_coverage_at_interview": {2023: np.array([True, False])},
+        "reported_has_subsidized_marketplace_health_coverage_at_interview": {
+            2023: np.array([True, False])
+        },
         "has_medicaid_health_coverage_at_interview": {2023: np.array([True, False])},
     }
 
@@ -20,7 +22,7 @@ def test_build_reported_takeup_anchors_uses_present_period():
     data = {
         "person_tax_unit_id": {2024: np.array([1, 1, 2], dtype=np.int64)},
         "tax_unit_id": {2024: np.array([1, 2], dtype=np.int64)},
-        "has_marketplace_health_coverage_at_interview": {
+        "reported_has_subsidized_marketplace_health_coverage_at_interview": {
             2024: np.array([True, False, False])
         },
         "has_medicaid_health_coverage_at_interview": {
@@ -37,4 +39,24 @@ def test_build_reported_takeup_anchors_uses_present_period():
     np.testing.assert_array_equal(
         anchors["takes_up_medicaid_if_eligible"],
         np.array([False, True, False]),
+    )
+
+
+def test_build_reported_takeup_anchors_uses_subsidized_marketplace_only():
+    data = {
+        "person_tax_unit_id": {2024: np.array([1, 1, 2], dtype=np.int64)},
+        "tax_unit_id": {2024: np.array([1, 2], dtype=np.int64)},
+        "has_marketplace_health_coverage_at_interview": {
+            2024: np.array([True, False, True])
+        },
+        "reported_has_subsidized_marketplace_health_coverage_at_interview": {
+            2024: np.array([False, False, True])
+        },
+    }
+
+    anchors = _build_reported_takeup_anchors(data, 2024)
+
+    np.testing.assert_array_equal(
+        anchors["takes_up_aca_if_eligible"],
+        np.array([False, True]),
     )

--- a/tests/unit/calibration/test_unified_calibration.py
+++ b/tests/unit/calibration/test_unified_calibration.py
@@ -200,6 +200,22 @@ class TestApplyBlockTakeupToArrays:
         differs = any(not np.array_equal(r1[v], r2[v]) for v in r1)
         assert differs
 
+    def test_reported_anchors_feed_through_for_aca(self):
+        args = self._make_arrays(4, 1, 1, 1)
+        result = apply_block_takeup_to_arrays(
+            *args,
+            time_period=2024,
+            takeup_filter=["takes_up_aca_if_eligible"],
+            precomputed_rates={"aca": 0.25},
+            reported_anchors={
+                "takes_up_aca_if_eligible": np.array([True, False, False, False])
+            },
+        )
+        np.testing.assert_array_equal(
+            result["takes_up_aca_if_eligible"],
+            [True, False, False, False],
+        )
+
 
 class TestAcaTakeupTargeting:
     """Verify ACA post-calibration targeting helpers."""

--- a/tests/unit/calibration/test_unified_calibration.py
+++ b/tests/unit/calibration/test_unified_calibration.py
@@ -134,6 +134,19 @@ class TestBlockSaltedDraws:
         )
         assert not np.array_equal(d1, d2)
 
+    def test_empty_blocks_do_not_crash_state_rate_takeup(self):
+        result = compute_block_takeup_for_entities(
+            "takes_up_medicaid_if_eligible",
+            {"NC": 0.9},
+            np.array(["", "370010001001001"]),
+            np.array([1, 2], dtype=np.int64),
+            np.array([0, 0], dtype=np.int64),
+        )
+
+        assert result.dtype == bool
+        assert len(result) == 2
+        assert result[0]
+
 
 class TestApplyBlockTakeupToArrays:
     """Verify apply_block_takeup_to_arrays returns correct

--- a/tests/unit/test_stochastic_variables.py
+++ b/tests/unit/test_stochastic_variables.py
@@ -5,6 +5,7 @@ from policyengine_us_data.parameters import load_take_up_rate
 from policyengine_us_data.utils.takeup import (
     any_person_flag_by_entity,
     assign_takeup_with_reported_anchors,
+    reported_subsidized_marketplace_by_tax_unit,
 )
 from policyengine_us_data.utils.randomness import (
     _stable_string_hash,
@@ -187,3 +188,14 @@ class TestReportedTakeupAnchors:
             person_marketplace,
         )
         np.testing.assert_array_equal(result, [True, False, True])
+
+    def test_subsidized_marketplace_anchor_excludes_unsubsidized_only(self):
+        person_tax_unit_ids = np.array([10, 10, 20, 30])
+        tax_unit_ids = np.array([10, 20, 30])
+        person_subsidized_marketplace = np.array([False, False, False, True])
+        result = reported_subsidized_marketplace_by_tax_unit(
+            person_tax_unit_ids,
+            tax_unit_ids,
+            person_subsidized_marketplace,
+        )
+        np.testing.assert_array_equal(result, [False, False, True])

--- a/tests/unit/test_stochastic_variables.py
+++ b/tests/unit/test_stochastic_variables.py
@@ -2,6 +2,10 @@
 
 import numpy as np
 from policyengine_us_data.parameters import load_take_up_rate
+from policyengine_us_data.utils.takeup import (
+    any_person_flag_by_entity,
+    assign_takeup_with_reported_anchors,
+)
 from policyengine_us_data.utils.randomness import (
     _stable_string_hash,
     seeded_rng,
@@ -147,3 +151,39 @@ class TestTakeUpProportions:
         for state, expected_rate in [("UT", 0.53), ("CO", 0.99)]:
             take_up = draws[:10_000] < expected_rate
             assert abs(take_up.mean() - expected_rate) < 0.05
+
+
+class TestReportedTakeupAnchors:
+    def test_global_anchor_preserves_reported_and_fills_remaining(self):
+        draws = np.array([0.9, 0.2, 0.6, 0.9])
+        reported = np.array([True, False, False, False])
+        result = assign_takeup_with_reported_anchors(
+            draws,
+            0.5,
+            reported_mask=reported,
+        )
+        np.testing.assert_array_equal(result, [True, True, False, False])
+
+    def test_grouped_anchor_applies_within_each_group(self):
+        draws = np.array([0.9, 0.2, 0.1, 0.9])
+        rates = np.array([0.5, 0.5, 0.5, 0.5])
+        reported = np.array([True, False, False, False])
+        groups = np.array(["A", "A", "B", "B"])
+        result = assign_takeup_with_reported_anchors(
+            draws,
+            rates,
+            reported_mask=reported,
+            group_keys=groups,
+        )
+        np.testing.assert_array_equal(result, [True, False, True, False])
+
+    def test_any_person_flag_by_entity_aggregates_correctly(self):
+        person_tax_unit_ids = np.array([10, 10, 20, 30])
+        tax_unit_ids = np.array([10, 20, 30])
+        person_marketplace = np.array([False, True, False, True])
+        result = any_person_flag_by_entity(
+            person_tax_unit_ids,
+            tax_unit_ids,
+            person_marketplace,
+        )
+        np.testing.assert_array_equal(result, [True, False, True])


### PR DESCRIPTION
Closes #629

## Summary
- import CPS `NOW_*` current-coverage flags as reported health coverage fields and emit the corresponding `has_*_health_coverage_at_interview` rule inputs needed by `policyengine-us`
- keep compatibility aliases for existing Marketplace and ESI inputs while adding current-coverage detail used for ACA and Medicaid reconciliation
- anchor ACA takeup to tax-unit-level reports of `reported_has_subsidized_marketplace_health_coverage_at_interview`, while anchoring Medicaid takeup to `has_medicaid_health_coverage_at_interview`, in CPS construction, local-area publishing, and unified calibration
- add regression coverage that keeps unsubsidized Marketplace coverage separate from the ACA takeup anchor

## Testing
- `uv run pytest tests/unit/test_stochastic_variables.py tests/unit/calibration/test_unified_calibration.py tests/integration/test_cps.py::test_add_personal_variables_maps_current_health_coverage_flags -q`
- `uv run make format`