### PR TITLE
Archive pipeline runs and artifacts to HuggingFace

### DIFF
--- a/changelog.d/pipeline-hf-archival.added.md
+++ b/changelog.d/pipeline-hf-archival.added.md
@@ -1,0 +1,1 @@
+Archive pipeline runs, diagnostics, and intermediate build artifacts to a dedicated HuggingFace repo (`PolicyEngine/policyengine-us-data-pipeline`) for durable run history that survives Modal volume deletion.

--- a/modal_app/pipeline.py
+++ b/modal_app/pipeline.py
@@ -108,13 +108,18 @@ def write_run_meta(
     meta: RunMetadata,
     vol: modal.Volume,
 ) -> None:
-    """Write run metadata to the pipeline volume."""
+    """Write run metadata to the pipeline volume and mirror to HF."""
     run_dir = Path(RUNS_DIR) / meta.run_id
     run_dir.mkdir(parents=True, exist_ok=True)
     meta_path = run_dir / "meta.json"
     with open(meta_path, "w") as f:
         json.dump(meta.to_dict(), f, indent=2)
     vol.commit()
+
+    _mirror_to_pipeline_repo(
+        meta.run_id,
+        [[str(meta_path), "meta.json"]],
+    )
 
 
 def read_run_meta(
@@ -170,7 +175,7 @@ def archive_diagnostics(
     vol: modal.Volume,
     prefix: str = "",
 ) -> None:
-    """Archive calibration diagnostics to the run directory."""
+    """Archive calibration diagnostics to the run directory and mirror to HF."""
     diag_dir = Path(RUNS_DIR) / run_id / "diagnostics"
     diag_dir.mkdir(parents=True, exist_ok=True)
 
@@ -180,6 +185,7 @@ def archive_diagnostics(
         "config": f"{prefix}unified_run_config.json",
     }
 
+    written_files = []
     for key, filename in file_map.items():
         data = result_bytes.get(key)
         if data:
@@ -187,8 +193,12 @@ def archive_diagnostics(
             with open(path, "wb") as f:
                 f.write(data)
             print(f"  Archived {filename} ({len(data):,} bytes)")
+            written_files.append([str(path), f"diagnostics/{filename}"])
 
     vol.commit()
+
+    if written_files:
+        _mirror_to_pipeline_repo(run_id, written_files)
 
 
 def _step_completed(meta: RunMetadata, step: str) -> bool:
@@ -246,6 +256,111 @@ def _record_step(
         "status": status,
     }
     write_run_meta(meta, vol)
+
+
+# ── Pipeline repo archival ────────────────────────────────────────
+
+
+def _mirror_to_pipeline_repo(
+    run_id: str,
+    files_with_paths: list,
+) -> None:
+    """Upload files to the pipeline archival HF repo.
+
+    Non-fatal: logs warnings on failure but does not raise.
+
+    Args:
+        run_id: Pipeline run identifier.
+        files_with_paths: List of [local_path, path_within_run] pairs.
+    """
+    if not files_with_paths:
+        return
+
+    existing = [[p, r] for p, r in files_with_paths if Path(p).exists()]
+    if not existing:
+        return
+
+    import json as _json
+
+    pairs_json = _json.dumps(existing)
+
+    try:
+        result = subprocess.run(
+            [
+                "uv",
+                "run",
+                "python",
+                "-c",
+                f"""
+import json
+from policyengine_us_data.utils.data_upload import upload_to_pipeline_repo
+
+pairs = json.loads('''{pairs_json}''')
+count = upload_to_pipeline_repo(pairs, "{run_id}")
+print(f"Mirrored {{count}} file(s) to pipeline repo")
+""",
+            ],
+            cwd="/root/policyengine-us-data",
+            capture_output=True,
+            text=True,
+            env=os.environ.copy(),
+        )
+        if result.returncode != 0:
+            print(f"  WARNING: Pipeline repo mirror failed: {result.stderr[:500]}")
+        else:
+            if result.stdout.strip():
+                print(f"  {result.stdout.strip()}")
+    except Exception as e:
+        print(f"  WARNING: Pipeline repo mirror error: {e}")
+
+
+# Intermediate artifacts from Step 1 to archive (not shipped elsewhere).
+INTERMEDIATE_ARTIFACTS = [
+    "acs_2022.h5",
+    "irs_puf_2015.h5",
+    "puf_2024.h5",
+    "extended_cps_2024.h5",
+    "stratified_extended_cps_2024.h5",
+    "build_log.txt",
+    "calibration_log.csv",
+    "uprating_factors.csv",
+]
+
+
+def _archive_build_artifacts(run_id: str) -> None:
+    """Archive intermediate build artifacts to the pipeline HF repo."""
+    artifacts_dir = Path(ARTIFACTS_DIR)
+    files = []
+    for name in INTERMEDIATE_ARTIFACTS:
+        path = artifacts_dir / name
+        if path.exists():
+            repo_name = name
+            if name == "calibration_log.csv":
+                repo_name = "calibration_log_legacy.csv"
+            files.append([str(path), f"artifacts/{repo_name}"])
+            print(f"  Archiving {name} ({path.stat().st_size:,} bytes)")
+
+    if files:
+        print(f"  Uploading {len(files)} intermediate artifact(s)...")
+        _mirror_to_pipeline_repo(run_id, files)
+    else:
+        print("  No intermediate artifacts found to archive")
+
+
+def _archive_package_artifacts(run_id: str) -> None:
+    """Archive calibration package metadata to the pipeline HF repo."""
+    meta_path = Path(ARTIFACTS_DIR) / "calibration_package_meta.json"
+    if meta_path.exists():
+        print(
+            f"  Archiving calibration_package_meta.json "
+            f"({meta_path.stat().st_size:,} bytes)"
+        )
+        _mirror_to_pipeline_repo(
+            run_id,
+            [[str(meta_path), "artifacts/calibration_package_meta.json"]],
+        )
+    else:
+        print("  No calibration_package_meta.json found")
 
 
 # ── Include other Modal apps ─────────────────────────────────────
@@ -570,6 +685,17 @@ def _write_validation_diagnostics(
 
     vol.commit()
 
+    # Mirror validation files to pipeline archival HF repo
+    mirror_files = []
+    csv_path = diag_dir / "validation_results.csv"
+    if csv_path.exists():
+        mirror_files.append([str(csv_path), "diagnostics/validation_results.csv"])
+    nat_path = diag_dir / "national_validation.txt"
+    if nat_path.exists():
+        mirror_files.append([str(nat_path), "diagnostics/national_validation.txt"])
+    if mirror_files:
+        _mirror_to_pipeline_repo(run_id, mirror_files)
+
 
 # ── Orchestrator ─────────────────────────────────────────────────
 
@@ -706,11 +832,6 @@ def run_pipeline(
                 skip_enhanced_cps=False,
             )
 
-            # The build_datasets step produces files in its
-            # own volume. Key outputs (source_imputed,
-            # policy_data.db) are staged to HF in step 4.
-            # TODO(#617): When pipeline_artifacts.py lands,
-            # call mirror_to_pipeline() here for audit trail.
             _record_step(
                 meta,
                 "build_datasets",
@@ -720,6 +841,11 @@ def run_pipeline(
             print(
                 f"  Completed in {meta.step_timings['build_datasets']['duration_s']}s"
             )
+
+            # Archive intermediate build artifacts to pipeline HF repo
+            print("  Archiving intermediate artifacts...")
+            pipeline_volume.reload()
+            _archive_build_artifacts(run_id)
         else:
             print("\n[Step 1/5] Build datasets (skipped - completed)")
 
@@ -742,6 +868,11 @@ def run_pipeline(
                 pipeline_volume,
             )
             print(f"  Completed in {meta.step_timings['build_package']['duration_s']}s")
+
+            # Archive package metadata to pipeline HF repo
+            print("  Archiving package metadata...")
+            pipeline_volume.reload()
+            _archive_package_artifacts(run_id)
         else:
             print("\n[Step 2/5] Build package (skipped - completed)")
 

--- a/modal_app/pipeline.py
+++ b/modal_app/pipeline.py
@@ -107,8 +107,17 @@ def generate_run_id(version: str, sha: str) -> str:
 def write_run_meta(
     meta: RunMetadata,
     vol: modal.Volume,
+    mirror: bool = True,
 ) -> None:
-    """Write run metadata to the pipeline volume and mirror to HF."""
+    """Write run metadata to the pipeline volume and optionally mirror to HF.
+
+    Args:
+        meta: Run metadata to persist.
+        vol: Modal volume to write to.
+        mirror: If True, also upload meta.json to the pipeline
+            archival HF repo. Set to False in error handlers to
+            avoid network calls that could hang.
+    """
     run_dir = Path(RUNS_DIR) / meta.run_id
     run_dir.mkdir(parents=True, exist_ok=True)
     meta_path = run_dir / "meta.json"
@@ -116,10 +125,11 @@ def write_run_meta(
         json.dump(meta.to_dict(), f, indent=2)
     vol.commit()
 
-    _mirror_to_pipeline_repo(
-        meta.run_id,
-        [[str(meta_path), "meta.json"]],
-    )
+    if mirror:
+        _mirror_to_pipeline_repo(
+            meta.run_id,
+            [[str(meta_path), "meta.json"]],
+        )
 
 
 def read_run_meta(
@@ -261,13 +271,29 @@ def _record_step(
 # ── Pipeline repo archival ────────────────────────────────────────
 
 
+_MIRROR_SCRIPT = """\
+import os, json
+from policyengine_us_data.utils.data_upload import upload_to_pipeline_repo
+
+pairs = json.loads(os.environ["_MIRROR_PAIRS"])
+run_id = os.environ["_MIRROR_RUN_ID"]
+count = upload_to_pipeline_repo(pairs, run_id)
+print(f"Mirrored {count} file(s) to pipeline repo")
+"""
+
+# 10-minute timeout for non-critical archival subprocess calls.
+_MIRROR_TIMEOUT_S = 600
+
+
 def _mirror_to_pipeline_repo(
     run_id: str,
-    files_with_paths: list,
+    files_with_paths: list[list[str]],
 ) -> None:
     """Upload files to the pipeline archival HF repo.
 
     Non-fatal: logs warnings on failure but does not raise.
+    Uses environment variables (not f-string interpolation) to
+    pass data to the subprocess, avoiding injection risks.
 
     Args:
         run_id: Pipeline run identifier.
@@ -276,91 +302,75 @@ def _mirror_to_pipeline_repo(
     if not files_with_paths:
         return
 
-    existing = [[p, r] for p, r in files_with_paths if Path(p).exists()]
-    if not existing:
-        return
-
-    import json as _json
-
-    pairs_json = _json.dumps(existing)
+    env = os.environ.copy()
+    env["_MIRROR_PAIRS"] = json.dumps(files_with_paths)
+    env["_MIRROR_RUN_ID"] = run_id
 
     try:
         result = subprocess.run(
-            [
-                "uv",
-                "run",
-                "python",
-                "-c",
-                f"""
-import json
-from policyengine_us_data.utils.data_upload import upload_to_pipeline_repo
-
-pairs = json.loads('''{pairs_json}''')
-count = upload_to_pipeline_repo(pairs, "{run_id}")
-print(f"Mirrored {{count}} file(s) to pipeline repo")
-""",
-            ],
+            ["uv", "run", "python", "-c", _MIRROR_SCRIPT],
             cwd="/root/policyengine-us-data",
             capture_output=True,
             text=True,
-            env=os.environ.copy(),
+            env=env,
+            timeout=_MIRROR_TIMEOUT_S,
         )
         if result.returncode != 0:
             print(f"  WARNING: Pipeline repo mirror failed: {result.stderr[:500]}")
-        else:
-            if result.stdout.strip():
-                print(f"  {result.stdout.strip()}")
-    except Exception as e:
+        elif result.stdout.strip():
+            print(f"  {result.stdout.strip()}")
+    except subprocess.TimeoutExpired:
+        print(f"  WARNING: Pipeline repo mirror timed out after {_MIRROR_TIMEOUT_S}s")
+    except (subprocess.SubprocessError, OSError) as e:
         print(f"  WARNING: Pipeline repo mirror error: {e}")
 
 
 # Intermediate artifacts from Step 1 to archive (not shipped elsewhere).
-INTERMEDIATE_ARTIFACTS = [
-    "acs_2022.h5",
-    "irs_puf_2015.h5",
-    "puf_2024.h5",
-    "extended_cps_2024.h5",
-    "stratified_extended_cps_2024.h5",
-    "build_log.txt",
-    "calibration_log.csv",
-    "uprating_factors.csv",
-]
+# Maps local filename -> repo-relative path inside artifacts/.
+STEP1_ARTIFACTS: dict[str, str] = {
+    "acs_2022.h5": "artifacts/acs_2022.h5",
+    "irs_puf_2015.h5": "artifacts/irs_puf_2015.h5",
+    "puf_2024.h5": "artifacts/puf_2024.h5",
+    "extended_cps_2024.h5": "artifacts/extended_cps_2024.h5",
+    "stratified_extended_cps_2024.h5": "artifacts/stratified_extended_cps_2024.h5",
+    "build_log.txt": "artifacts/build_log.txt",
+    "calibration_log.csv": "artifacts/calibration_log_legacy.csv",
+    "uprating_factors.csv": "artifacts/uprating_factors.csv",
+}
+
+STEP2_ARTIFACTS: dict[str, str] = {
+    "calibration_package_meta.json": "artifacts/calibration_package_meta.json",
+}
 
 
-def _archive_build_artifacts(run_id: str) -> None:
-    """Archive intermediate build artifacts to the pipeline HF repo."""
+def _archive_artifacts(
+    run_id: str,
+    artifact_names: dict[str, str],
+) -> None:
+    """Archive named artifacts from ARTIFACTS_DIR to the pipeline HF repo.
+
+    Args:
+        run_id: Pipeline run identifier.
+        artifact_names: Mapping of {local_filename: repo_relative_path}.
+    """
     artifacts_dir = Path(ARTIFACTS_DIR)
-    files = []
-    for name in INTERMEDIATE_ARTIFACTS:
+    files: list[list[str]] = []
+    for name, repo_path in artifact_names.items():
         path = artifacts_dir / name
-        if path.exists():
-            repo_name = name
-            if name == "calibration_log.csv":
-                repo_name = "calibration_log_legacy.csv"
-            files.append([str(path), f"artifacts/{repo_name}"])
-            print(f"  Archiving {name} ({path.stat().st_size:,} bytes)")
+        if not path.exists():
+            continue
+        try:
+            size = path.stat().st_size
+        except OSError:
+            continue
+        files.append([str(path), repo_path])
+        print(f"  Archiving {name} ({size:,} bytes)")
 
     if files:
-        print(f"  Uploading {len(files)} intermediate artifact(s)...")
+        print(f"  Uploading {len(files)} artifact(s)...")
         _mirror_to_pipeline_repo(run_id, files)
     else:
-        print("  No intermediate artifacts found to archive")
-
-
-def _archive_package_artifacts(run_id: str) -> None:
-    """Archive calibration package metadata to the pipeline HF repo."""
-    meta_path = Path(ARTIFACTS_DIR) / "calibration_package_meta.json"
-    if meta_path.exists():
-        print(
-            f"  Archiving calibration_package_meta.json "
-            f"({meta_path.stat().st_size:,} bytes)"
-        )
-        _mirror_to_pipeline_repo(
-            run_id,
-            [[str(meta_path), "artifacts/calibration_package_meta.json"]],
-        )
-    else:
-        print("  No calibration_package_meta.json found")
+        print("  No artifacts found to archive")
 
 
 # ── Include other Modal apps ─────────────────────────────────────
@@ -585,6 +595,8 @@ def _write_validation_diagnostics(
     diag_dir = Path(RUNS_DIR) / run_id / "diagnostics"
     diag_dir.mkdir(parents=True, exist_ok=True)
 
+    mirror_files: list[list[str]] = []
+
     # Write regional validation CSV
     if validation_rows:
         csv_columns = [
@@ -611,6 +623,7 @@ def _write_validation_diagnostics(
             for row in validation_rows:
                 writer.writerow({k: row.get(k, "") for k in csv_columns})
         print(f"  Wrote {len(validation_rows)} rows to {csv_path}")
+        mirror_files.append([str(csv_path), "diagnostics/validation_results.csv"])
 
         # Compute summary
         n_sanity_fail = sum(
@@ -682,17 +695,11 @@ def _write_validation_diagnostics(
         with open(nat_path, "w") as f:
             f.write(national_output)
         print(f"  Wrote national validation to {nat_path}")
+        mirror_files.append([str(nat_path), "diagnostics/national_validation.txt"])
 
     vol.commit()
 
     # Mirror validation files to pipeline archival HF repo
-    mirror_files = []
-    csv_path = diag_dir / "validation_results.csv"
-    if csv_path.exists():
-        mirror_files.append([str(csv_path), "diagnostics/validation_results.csv"])
-    nat_path = diag_dir / "national_validation.txt"
-    if nat_path.exists():
-        mirror_files.append([str(nat_path), "diagnostics/national_validation.txt"])
     if mirror_files:
         _mirror_to_pipeline_repo(run_id, mirror_files)
 
@@ -845,7 +852,7 @@ def run_pipeline(
             # Archive intermediate build artifacts to pipeline HF repo
             print("  Archiving intermediate artifacts...")
             pipeline_volume.reload()
-            _archive_build_artifacts(run_id)
+            _archive_artifacts(run_id, STEP1_ARTIFACTS)
         else:
             print("\n[Step 1/5] Build datasets (skipped - completed)")
 
@@ -872,7 +879,7 @@ def run_pipeline(
             # Archive package metadata to pipeline HF repo
             print("  Archiving package metadata...")
             pipeline_volume.reload()
-            _archive_package_artifacts(run_id)
+            _archive_artifacts(run_id, STEP2_ARTIFACTS)
         else:
             print("\n[Step 2/5] Build package (skipped - completed)")
 
@@ -1093,7 +1100,7 @@ def run_pipeline(
     except Exception as e:
         meta.status = "failed"
         meta.error = f"{type(e).__name__}: {e}\n{traceback.format_exc()}"
-        write_run_meta(meta, pipeline_volume)
+        write_run_meta(meta, pipeline_volume, mirror=False)
         print(f"\nPIPELINE FAILED: {e}")
         print(f"Resume with: --resume-run-id {run_id}")
         raise

--- a/modal_app/pipeline.py
+++ b/modal_app/pipeline.py
@@ -340,6 +340,7 @@ STEP1_ARTIFACTS: dict[str, str] = {
 
 STEP2_ARTIFACTS: dict[str, str] = {
     "calibration_package_meta.json": "artifacts/calibration_package_meta.json",
+    "calibration_package.pkl": "artifacts/calibration_package.pkl",
 }
 
 

--- a/policyengine_us_data/utils/data_upload.py
+++ b/policyengine_us_data/utils/data_upload.py
@@ -273,6 +273,73 @@ def hf_create_commit_with_retry(
     )
 
 
+def _batched_hf_upload(
+    files_with_repo_paths: List[Tuple[str, str]],
+    repo_id: str,
+    repo_type: str,
+    commit_message_prefix: str,
+    batch_size: int = 50,
+) -> int:
+    """Upload files to a HuggingFace repo in batches with retry.
+
+    Args:
+        files_with_repo_paths: List of (local_path, path_in_repo) tuples.
+        repo_id: HuggingFace repository ID.
+        repo_type: Repository type.
+        commit_message_prefix: Prefix for commit messages.
+        batch_size: Number of files per commit batch.
+
+    Returns:
+        Number of files uploaded.
+
+    Raises:
+        EnvironmentError: If HUGGING_FACE_TOKEN is not set.
+    """
+    token = os.environ.get("HUGGING_FACE_TOKEN")
+    if not token:
+        raise EnvironmentError(
+            "HUGGING_FACE_TOKEN environment variable is not set. "
+            "Cannot upload to HuggingFace."
+        )
+    api = HfApi()
+
+    total_uploaded = 0
+    for i in range(0, len(files_with_repo_paths), batch_size):
+        batch = files_with_repo_paths[i : i + batch_size]
+        operations = []
+        for local_path, repo_path in batch:
+            local_path = Path(local_path)
+            if not local_path.exists():
+                logging.warning(f"File {local_path} does not exist, skipping.")
+                continue
+            operations.append(
+                CommitOperationAdd(
+                    path_in_repo=repo_path,
+                    path_or_fileobj=str(local_path),
+                )
+            )
+
+        if not operations:
+            continue
+
+        batch_num = i // batch_size + 1
+        hf_create_commit_with_retry(
+            api=api,
+            operations=operations,
+            repo_id=repo_id,
+            repo_type=repo_type,
+            token=token,
+            commit_message=f"{commit_message_prefix}: batch {batch_num} ({len(operations)} files)",
+        )
+        total_uploaded += len(operations)
+        logging.info(
+            f"Uploaded batch {batch_num}: {len(operations)} files to {repo_id}"
+        )
+
+    logging.info(f"Total: uploaded {total_uploaded} files to {repo_id}")
+    return total_uploaded
+
+
 def upload_to_staging_hf(
     files_with_paths: List[Tuple[Path, str]],
     version: str,
@@ -295,44 +362,17 @@ def upload_to_staging_hf(
     Returns:
         Number of files uploaded
     """
-    token = os.environ.get("HUGGING_FACE_TOKEN")
-    api = HfApi()
-
-    total_uploaded = 0
-    for i in range(0, len(files_with_paths), batch_size):
-        batch = files_with_paths[i : i + batch_size]
-        operations = []
-        for local_path, rel_path in batch:
-            local_path = Path(local_path)
-            if not local_path.exists():
-                logging.warning(f"File {local_path} does not exist, skipping.")
-                continue
-            staging_prefix = f"staging/{run_id}" if run_id else "staging"
-            operations.append(
-                CommitOperationAdd(
-                    path_in_repo=f"{staging_prefix}/{rel_path}",
-                    path_or_fileobj=str(local_path),
-                )
-            )
-
-        if not operations:
-            continue
-
-        hf_create_commit_with_retry(
-            api=api,
-            operations=operations,
-            repo_id=hf_repo_name,
-            repo_type=hf_repo_type,
-            token=token,
-            commit_message=f"Upload batch {i // batch_size + 1} to staging for version {version}",
-        )
-        total_uploaded += len(operations)
-        logging.info(
-            f"Uploaded batch {i // batch_size + 1}: {len(operations)} files to staging/"
-        )
-
-    logging.info(f"Total: uploaded {total_uploaded} files to staging/ in HuggingFace")
-    return total_uploaded
+    staging_prefix = f"staging/{run_id}" if run_id else "staging"
+    repo_paths = [
+        (str(local), f"{staging_prefix}/{rel}") for local, rel in files_with_paths
+    ]
+    return _batched_hf_upload(
+        repo_paths,
+        hf_repo_name,
+        hf_repo_type,
+        f"Upload to staging for version {version}",
+        batch_size,
+    )
 
 
 def promote_staging_to_production_hf(
@@ -491,47 +531,14 @@ def upload_to_pipeline_repo(
     Returns:
         Number of files uploaded.
     """
-    token = os.environ.get("HUGGING_FACE_TOKEN")
-    api = HfApi()
-
-    total_uploaded = 0
-    for i in range(0, len(files_with_paths), batch_size):
-        batch = files_with_paths[i : i + batch_size]
-        operations = []
-        for local_path, path_within_run in batch:
-            local_path = Path(local_path)
-            if not local_path.exists():
-                logging.warning(f"File {local_path} does not exist, skipping.")
-                continue
-            operations.append(
-                CommitOperationAdd(
-                    path_in_repo=f"{run_id}/{path_within_run}",
-                    path_or_fileobj=str(local_path),
-                )
-            )
-
-        if not operations:
-            continue
-
-        hf_create_commit_with_retry(
-            api=api,
-            operations=operations,
-            repo_id=repo_name,
-            repo_type=repo_type,
-            token=token,
-            commit_message=(
-                f"Archive run {run_id}: batch {i // batch_size + 1} "
-                f"({len(operations)} files)"
-            ),
-        )
-        total_uploaded += len(operations)
-        logging.info(
-            f"Uploaded batch {i // batch_size + 1}: "
-            f"{len(operations)} files to {repo_name}/{run_id}/"
-        )
-
-    logging.info(f"Total: uploaded {total_uploaded} files to {repo_name}/{run_id}/")
-    return total_uploaded
+    repo_paths = [(local, f"{run_id}/{path}") for local, path in files_with_paths]
+    return _batched_hf_upload(
+        repo_paths,
+        repo_name,
+        repo_type,
+        f"Archive run {run_id}",
+        batch_size,
+    )
 
 
 def upload_from_hf_staging_to_gcs(

--- a/policyengine_us_data/utils/data_upload.py
+++ b/policyengine_us_data/utils/data_upload.py
@@ -466,6 +466,74 @@ def cleanup_staging_hf(
     return len(files)
 
 
+PIPELINE_HF_REPO = "PolicyEngine/policyengine-us-data-pipeline"
+
+
+def upload_to_pipeline_repo(
+    files_with_paths: List[Tuple[str, str]],
+    run_id: str,
+    repo_name: str = PIPELINE_HF_REPO,
+    repo_type: str = "model",
+    batch_size: int = 10,
+) -> int:
+    """Upload files to the pipeline archival HF repo.
+
+    Each file is placed under {run_id}/{path_within_run} in the repo.
+
+    Args:
+        files_with_paths: List of (local_path, path_within_run) tuples.
+            path_within_run is like "meta.json" or "artifacts/acs_2022.h5".
+        run_id: Pipeline run identifier.
+        repo_name: HuggingFace repository name.
+        repo_type: Repository type.
+        batch_size: Number of files per commit batch.
+
+    Returns:
+        Number of files uploaded.
+    """
+    token = os.environ.get("HUGGING_FACE_TOKEN")
+    api = HfApi()
+
+    total_uploaded = 0
+    for i in range(0, len(files_with_paths), batch_size):
+        batch = files_with_paths[i : i + batch_size]
+        operations = []
+        for local_path, path_within_run in batch:
+            local_path = Path(local_path)
+            if not local_path.exists():
+                logging.warning(f"File {local_path} does not exist, skipping.")
+                continue
+            operations.append(
+                CommitOperationAdd(
+                    path_in_repo=f"{run_id}/{path_within_run}",
+                    path_or_fileobj=str(local_path),
+                )
+            )
+
+        if not operations:
+            continue
+
+        hf_create_commit_with_retry(
+            api=api,
+            operations=operations,
+            repo_id=repo_name,
+            repo_type=repo_type,
+            token=token,
+            commit_message=(
+                f"Archive run {run_id}: batch {i // batch_size + 1} "
+                f"({len(operations)} files)"
+            ),
+        )
+        total_uploaded += len(operations)
+        logging.info(
+            f"Uploaded batch {i // batch_size + 1}: "
+            f"{len(operations)} files to {repo_name}/{run_id}/"
+        )
+
+    logging.info(f"Total: uploaded {total_uploaded} files to {repo_name}/{run_id}/")
+    return total_uploaded
+
+
 def upload_from_hf_staging_to_gcs(
     rel_paths: List[str],
     version: str,


### PR DESCRIPTION
## Summary

- Publish full pipeline run records (metadata, diagnostics, intermediate build artifacts) to a dedicated HF model repo (`PolicyEngine/policyengine-us-data-pipeline`)
- All existing uploads to `policyengine/policyengine-us-data` are unchanged
- Archival is non-fatal — pipeline never fails due to archival issues

Fixes #641

## Changes

### `policyengine_us_data/utils/data_upload.py`
- Extract `_batched_hf_upload()` shared helper from `upload_to_staging_hf` (deduplicates ~30 lines of batch/retry logic)
- Add `upload_to_pipeline_repo()` thin wrapper targeting `PolicyEngine/policyengine-us-data-pipeline`
- Validate `HUGGING_FACE_TOKEN` before attempting uploads (fail-fast instead of misleading 401 after retries)

### `modal_app/pipeline.py`
- Add `_mirror_to_pipeline_repo()` — non-fatal subprocess wrapper with 10-min timeout, env-var data passing (no f-string injection), narrow exception handling
- Add `_archive_artifacts()` — unified helper for archiving named artifacts from the pipeline volume
- `write_run_meta()` gains `mirror` param (set to `False` in the failure handler to prevent hanging on network errors)
- `archive_diagnostics()` mirrors diagnostic files to the pipeline repo after volume commit
- `_write_validation_diagnostics()` builds mirror list inline as files are written (no re-probing filesystem)
- Archive Step 1 intermediate artifacts (`STEP1_ARTIFACTS`) and Step 2 metadata (`STEP2_ARTIFACTS`) after each step completes

### `changelog.d/pipeline-hf-archival.added.md`
- Towncrier changelog fragment

## Test plan

- [ ] Create `PolicyEngine/policyengine-us-data-pipeline` model repo on HuggingFace (one-time)
- [ ] Run `make pipeline` on Modal with small epoch count
- [ ] Verify HF repo contains `{run_id}/meta.json`, `{run_id}/diagnostics/*`, `{run_id}/artifacts/*`
- [ ] Verify existing uploads to `policyengine/policyengine-us-data` are unchanged
- [ ] Verify pipeline failure handler writes meta.json locally but does not attempt HF mirror

🤖 Generated with [Claude Code](https://claude.com/claude-code)