### PR TITLE
Publish canonical release manifests for US data releases

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -143,11 +143,27 @@ jobs:
       HUGGING_FACE_TOKEN: ${{ secrets.HUGGING_FACE_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.14"
       - run: pip install modal
       - name: Build datasets and run integration tests on Modal
         run: |
+          STAGE_ARGS=""
+          if git diff --name-only origin/main...HEAD | grep -qx 'pyproject.toml'; then
+            VERSION=$(python -c "from pathlib import Path; import tomllib; print(tomllib.load(Path('pyproject.toml').open('rb'))['project']['version'])")
+            STAGE_ARGS="--upload --stage-only --run-id=${VERSION}"
+            {
+              echo "## Release Artifact Staging"
+              echo ""
+              echo "- package version: \`${VERSION}\`"
+              echo "- staged HF prefix: \`staging/${VERSION}/\`"
+              echo "- promote with: \`uv run python policyengine_us_data/storage/upload_completed_datasets.py --promote-only --run-id=${VERSION} --version=${VERSION}\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
           modal run modal_app/data_build.py \
-            --branch=${{ github.head_ref || github.ref_name }}
+            --branch=${{ github.head_ref || github.ref_name }} \
+            ${STAGE_ARGS}

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ validate-package:
 	python -m policyengine_us_data.calibration.validate_package
 
 publish-local-area:
-	python policyengine_us_data/calibration/publish_local_area.py --upload
+	python -m policyengine_us_data.calibration.promote_local_h5s --local-dir local_area_build
 
 build-h5s:
 	python -m policyengine_us_data.calibration.publish_local_area \

--- a/changelog.d/release-manifest-preflight.fixed.md
+++ b/changelog.d/release-manifest-preflight.fixed.md
@@ -1,0 +1,1 @@
+Preflight release-manifest finalization before promoting staged artifacts so failed finalization checks cannot partially publish a release.

--- a/modal_app/data_build.py
+++ b/modal_app/data_build.py
@@ -238,6 +238,8 @@ def validate_and_maybe_upload_datasets(
     upload: bool,
     skip_enhanced_cps: bool,
     env: dict,
+    stage_only: bool = False,
+    run_id: str = "",
 ) -> None:
     validation_args = ["--validate-only"]
     if skip_enhanced_cps:
@@ -254,6 +256,10 @@ def validate_and_maybe_upload_datasets(
         upload_args = []
         if skip_enhanced_cps:
             upload_args.append("--no-require-enhanced-cps")
+        if stage_only:
+            upload_args.append("--stage-only")
+        if run_id:
+            upload_args.append(f"--run-id={run_id}")
         run_script(
             "policyengine_us_data/storage/upload_completed_datasets.py",
             args=upload_args,
@@ -375,6 +381,7 @@ def build_datasets(
     clear_checkpoints: bool = False,
     skip_tests: bool = False,
     skip_enhanced_cps: bool = False,
+    stage_only: bool = False,
     run_id: str = "",
 ):
     """Build all datasets with preemption-resilient checkpointing.
@@ -387,6 +394,7 @@ def build_datasets(
         skip_tests: Skip running the test suite (useful for calibration runs).
         skip_enhanced_cps: Skip enhanced_cps.py and small_enhanced_cps.py
             (useful for calibration runs that only need source_imputed H5).
+        stage_only: Upload to HF staging only, without promoting a release.
     """
     setup_gcp_credentials()
 
@@ -673,6 +681,8 @@ def build_datasets(
         upload=upload,
         skip_enhanced_cps=skip_enhanced_cps,
         env=env,
+        stage_only=stage_only,
+        run_id=run_id,
     )
 
     # Clean up checkpoints after successful completion
@@ -689,6 +699,8 @@ def main(
     clear_checkpoints: bool = False,
     skip_tests: bool = False,
     skip_enhanced_cps: bool = False,
+    stage_only: bool = False,
+    run_id: str = "",
 ):
     result = build_datasets.remote(
         upload=upload,
@@ -697,5 +709,7 @@ def main(
         clear_checkpoints=clear_checkpoints,
         skip_tests=skip_tests,
         skip_enhanced_cps=skip_enhanced_cps,
+        stage_only=stage_only,
+        run_id=run_id,
     )
     print(result)

--- a/modal_app/local_area.py
+++ b/modal_app/local_area.py
@@ -28,8 +28,8 @@ for _p in (_baked, _local):
     if _p not in sys.path:
         sys.path.insert(0, _p)
 
-from modal_app.images import cpu_image as image
-from modal_app.resilience import reconcile_run_dir_fingerprint
+from modal_app.images import cpu_image as image  # noqa: E402
+from modal_app.resilience import reconcile_run_dir_fingerprint  # noqa: E402
 
 app = modal.App("policyengine-us-data-local-area")
 
@@ -68,6 +68,170 @@ def setup_repo(branch: str):
     no longer used for cloning -- code is baked into the image.
     """
     os.chdir("/root/policyengine-us-data")
+
+
+def _build_promote_national_publish_script(
+    *,
+    version: str,
+    run_id: str,
+    rel_paths: list[str],
+) -> str:
+    rel_paths_json = json.dumps(rel_paths)
+    return f"""
+import json
+from pathlib import Path
+from policyengine_us_data.utils.data_upload import (
+    promote_staging_to_production_hf,
+    cleanup_staging_hf,
+    upload_local_area_file,
+    publish_release_manifest_to_hf,
+    should_finalize_local_area_release,
+)
+from policyengine_us_data.utils.version_manifest import (
+    HFVersionInfo,
+    build_manifest,
+    upload_manifest,
+)
+
+version = "{version}"
+run_id = "{run_id}"
+rel_paths = json.loads('''{rel_paths_json}''')
+run_dir = Path("{VOLUME_MOUNT}") / run_id
+
+print(f"Promoting national H5 from staging to production (run_id={{run_id!r}})...")
+promoted = promote_staging_to_production_hf(rel_paths, version, run_id=run_id)
+print(f"Promoted {{promoted}} files to HuggingFace production")
+
+national_h5 = run_dir / "national" / "US.h5"
+if national_h5.exists():
+    print("Uploading national H5 to GCS...")
+    upload_local_area_file(
+        str(national_h5), "national", version=version, skip_hf=True
+    )
+    print("Uploaded national H5 to GCS")
+else:
+    raise RuntimeError(f"Expected national H5 at {{national_h5}}")
+
+print("Updating release manifest...")
+should_finalize, missing_prefixes = should_finalize_local_area_release(
+    version=version,
+    new_repo_paths=["national/US.h5"],
+)
+manifest = publish_release_manifest_to_hf(
+    [(national_h5, "national/US.h5")],
+    version=version,
+    create_tag=should_finalize,
+)
+if should_finalize:
+    upload_manifest(
+        build_manifest(
+            version=version,
+            blob_names=sorted(
+                artifact["path"] for artifact in manifest["artifacts"].values()
+            ),
+            hf_info=HFVersionInfo(
+                repo="policyengine/policyengine-us-data",
+                commit=version,
+            ),
+        )
+    )
+    print("Updated release manifest and created tag")
+else:
+    print(
+        "Updated release manifest without creating a tag; "
+        f"missing prefixes: {{', '.join(missing_prefixes)}}"
+    )
+
+print("Cleaning up staging...")
+cleaned = cleanup_staging_hf(rel_paths, version, run_id=run_id)
+print(f"Cleaned up {{cleaned}} files from staging")
+print(f"Successfully promoted national H5 for version {{version}}")
+"""
+
+
+def _build_promote_publish_script(
+    *,
+    version: str,
+    run_id: str,
+    rel_paths: list[str],
+) -> str:
+    rel_paths_json = json.dumps(rel_paths)
+    return f"""
+import json
+from pathlib import Path
+from policyengine_us_data.utils.data_upload import (
+    promote_staging_to_production_hf,
+    cleanup_staging_hf,
+    upload_local_area_file,
+    publish_release_manifest_to_hf,
+    should_finalize_local_area_release,
+)
+from policyengine_us_data.utils.version_manifest import (
+    HFVersionInfo,
+    build_manifest,
+    upload_manifest,
+)
+
+rel_paths = json.loads('''{rel_paths_json}''')
+version = "{version}"
+run_id = "{run_id}"
+run_dir = Path("{VOLUME_MOUNT}") / run_id
+
+print(f"Promoting {{len(rel_paths)}} files from staging/ to production (run_id={{run_id!r}})...")
+promoted = promote_staging_to_production_hf(rel_paths, version, run_id=run_id)
+print(f"Promoted {{promoted}} files to HuggingFace production")
+
+print(f"Uploading {{len(rel_paths)}} files to GCS...")
+gcs_count = 0
+for rel_path in rel_paths:
+    local_path = run_dir / rel_path
+    subdirectory = str(Path(rel_path).parent)
+    upload_local_area_file(
+        str(local_path),
+        subdirectory,
+        version=version,
+        skip_hf=True,
+    )
+    gcs_count += 1
+print(f"Uploaded {{gcs_count}} files to GCS")
+
+print("Updating release manifest...")
+should_finalize, missing_prefixes = should_finalize_local_area_release(
+    version=version,
+    new_repo_paths=rel_paths,
+)
+manifest = publish_release_manifest_to_hf(
+    [(run_dir / rel_path, rel_path) for rel_path in rel_paths],
+    version=version,
+    create_tag=should_finalize,
+)
+if should_finalize:
+    upload_manifest(
+        build_manifest(
+            version=version,
+            blob_names=sorted(
+                artifact["path"] for artifact in manifest["artifacts"].values()
+            ),
+            hf_info=HFVersionInfo(
+                repo="policyengine/policyengine-us-data",
+                commit=version,
+            ),
+        )
+    )
+    print("Updated release manifest and created tag")
+else:
+    print(
+        "Updated release manifest without final tag; missing local-area prefixes: "
+        + ", ".join(missing_prefixes)
+    )
+    print("Deferring version_manifest.json update until release finalization")
+
+print("Cleaning up staging/...")
+cleaned = cleanup_staging_hf(rel_paths, version, run_id=run_id)
+print(f"Cleaned up {{cleaned}} files from staging/")
+
+print(f"Successfully published version {{version}}")
+"""
 
 
 def validate_artifacts(
@@ -556,61 +720,17 @@ def promote_publish(branch: str = "main", version: str = "", run_id: str = "") -
     with open(manifest_path) as f:
         manifest = json.load(f)
 
-    rel_paths_json = json.dumps(list(manifest["files"].keys()))
-
     result = subprocess.run(
         [
             "uv",
             "run",
             "python",
             "-c",
-            f"""
-import json
-from pathlib import Path
-from policyengine_us_data.utils.data_upload import (
-    promote_staging_to_production_hf,
-    cleanup_staging_hf,
-    upload_local_area_file,
-    publish_release_manifest_to_hf,
-)
-
-rel_paths = json.loads('''{rel_paths_json}''')
-version = "{version}"
-run_id = "{run_id}"
-run_dir = Path("{VOLUME_MOUNT}") / run_id
-
-print(f"Promoting {{len(rel_paths)}} files from staging/ to production (run_id={{run_id!r}})...")
-promoted = promote_staging_to_production_hf(rel_paths, version, run_id=run_id)
-print(f"Promoted {{promoted}} files to HuggingFace production")
-
-print(f"Uploading {{len(rel_paths)}} files to GCS...")
-gcs_count = 0
-for rel_path in rel_paths:
-    local_path = run_dir / rel_path
-    subdirectory = str(Path(rel_path).parent)
-    upload_local_area_file(
-        str(local_path),
-        subdirectory,
-        version=version,
-        skip_hf=True,
-    )
-    gcs_count += 1
-print(f"Uploaded {{gcs_count}} files to GCS")
-
-print("Updating release manifest...")
-publish_release_manifest_to_hf(
-    [(run_dir / rel_path, rel_path) for rel_path in rel_paths],
-    version=version,
-    create_tag=False,
-)
-print("Updated release manifest")
-
-print("Cleaning up staging/...")
-cleaned = cleanup_staging_hf(rel_paths, version, run_id=run_id)
-print(f"Cleaned up {{cleaned}} files from staging/")
-
-print(f"Successfully published version {{version}}")
-""",
+            _build_promote_publish_script(
+                version=version,
+                run_id=run_id,
+                rel_paths=list(manifest["files"].keys()),
+            ),
         ],
         text=True,
         env=os.environ.copy(),
@@ -1142,48 +1262,11 @@ def promote_national_publish(
             "run",
             "python",
             "-c",
-            f"""
-import json
-from pathlib import Path
-from policyengine_us_data.utils.data_upload import (
-    promote_staging_to_production_hf,
-    cleanup_staging_hf,
-    upload_local_area_file,
-    publish_release_manifest_to_hf,
-)
-
-version = "{version}"
-run_id = "{run_id}"
-rel_paths = {json.dumps(rel_paths)}
-run_dir = Path("{VOLUME_MOUNT}") / run_id
-
-print(f"Promoting national H5 from staging to production (run_id={{run_id!r}})...")
-promoted = promote_staging_to_production_hf(rel_paths, version, run_id=run_id)
-print(f"Promoted {{promoted}} files to HuggingFace production")
-
-national_h5 = run_dir / "national" / "US.h5"
-if national_h5.exists():
-    print("Uploading national H5 to GCS...")
-    upload_local_area_file(
-        str(national_h5), "national", version=version, skip_hf=True
-    )
-    print("Uploaded national H5 to GCS")
-else:
-    raise RuntimeError(f"Expected national H5 at {{national_h5}}")
-
-print("Updating release manifest...")
-publish_release_manifest_to_hf(
-    [(national_h5, "national/US.h5")],
-    version=version,
-    create_tag=True,
-)
-print("Updated release manifest and created tag")
-
-print("Cleaning up staging...")
-cleaned = cleanup_staging_hf(rel_paths, version, run_id=run_id)
-print(f"Cleaned up {{cleaned}} files from staging")
-print(f"Successfully promoted national H5 for version {{version}}")
-""",
+            _build_promote_national_publish_script(
+                version=version,
+                run_id=run_id,
+                rel_paths=rel_paths,
+            ),
         ],
         text=True,
         env=os.environ.copy(),

--- a/modal_app/local_area.py
+++ b/modal_app/local_area.py
@@ -571,6 +571,7 @@ from policyengine_us_data.utils.data_upload import (
     promote_staging_to_production_hf,
     cleanup_staging_hf,
     upload_local_area_file,
+    publish_release_manifest_to_hf,
 )
 
 rel_paths = json.loads('''{rel_paths_json}''')
@@ -595,6 +596,14 @@ for rel_path in rel_paths:
     )
     gcs_count += 1
 print(f"Uploaded {{gcs_count}} files to GCS")
+
+print("Updating release manifest...")
+publish_release_manifest_to_hf(
+    [(run_dir / rel_path, rel_path) for rel_path in rel_paths],
+    version=version,
+    create_tag=False,
+)
+print("Updated release manifest")
 
 print("Cleaning up staging/...")
 cleaned = cleanup_staging_hf(rel_paths, version, run_id=run_id)
@@ -1140,6 +1149,7 @@ from policyengine_us_data.utils.data_upload import (
     promote_staging_to_production_hf,
     cleanup_staging_hf,
     upload_local_area_file,
+    publish_release_manifest_to_hf,
 )
 
 version = "{version}"
@@ -1159,7 +1169,15 @@ if national_h5.exists():
     )
     print("Uploaded national H5 to GCS")
 else:
-    print(f"WARNING: {{national_h5}} not on volume, skipping GCS")
+    raise RuntimeError(f"Expected national H5 at {{national_h5}}")
+
+print("Updating release manifest...")
+publish_release_manifest_to_hf(
+    [(national_h5, "national/US.h5")],
+    version=version,
+    create_tag=True,
+)
+print("Updated release manifest and created tag")
 
 print("Cleaning up staging...")
 cleaned = cleanup_staging_hf(rel_paths, version, run_id=run_id)

--- a/policyengine_us_data/calibration/promote_local_h5s.py
+++ b/policyengine_us_data/calibration/promote_local_h5s.py
@@ -24,11 +24,14 @@ import logging
 from importlib import metadata
 from pathlib import Path
 
+from huggingface_hub import HfApi, hf_hub_download
+
 from policyengine_us_data.utils.data_upload import (
     upload_to_staging_hf,
     promote_staging_to_production_hf,
     upload_from_hf_staging_to_gcs,
     cleanup_staging_hf,
+    publish_release_manifest_to_hf,
 )
 
 logger = logging.getLogger(__name__)
@@ -48,13 +51,47 @@ def collect_files(local_dir: Path, area_types: list) -> list:
     return files
 
 
+def collect_staged_rel_paths(area_types: list, run_id: str = "") -> list:
+    api = HfApi()
+    prefix = f"staging/{run_id}" if run_id else "staging"
+    repo_files = api.list_repo_files(
+        repo_id="policyengine/policyengine-us-data",
+        repo_type="model",
+    )
+
+    rel_paths = []
+    for path in repo_files:
+        for area_type in area_types:
+            candidate_prefix = f"{prefix}/{area_type}/"
+            if path.startswith(candidate_prefix) and path.endswith(".h5"):
+                rel_paths.append(path.removeprefix(f"{prefix}/"))
+                break
+
+    return sorted(rel_paths)
+
+
+def download_staged_files(rel_paths: list, run_id: str = "") -> list:
+    prefix = f"staging/{run_id}" if run_id else "staging"
+    files = []
+    for rel_path in rel_paths:
+        local_path = Path(
+            hf_hub_download(
+                repo_id="policyengine/policyengine-us-data",
+                filename=f"{prefix}/{rel_path}",
+                repo_type="model",
+            )
+        )
+        files.append((local_path, rel_path))
+    return files
+
+
 def stage(files: list, version: str, run_id: str = ""):
     logger.info("Uploading %d files to HF staging/...", len(files))
     n = upload_to_staging_hf(files, version=version, run_id=run_id)
     logger.info("Staged %d files", n)
 
 
-def promote(rel_paths: list, version: str, run_id: str = ""):
+def promote(files: list, rel_paths: list, version: str, run_id: str = ""):
     logger.info(
         "Promoting %d files from staging/ to production...",
         len(rel_paths),
@@ -63,6 +100,18 @@ def promote(rel_paths: list, version: str, run_id: str = ""):
 
     logger.info("Uploading %d files to GCS from HF staging...", len(rel_paths))
     upload_from_hf_staging_to_gcs(rel_paths, version=version, run_id=run_id)
+
+    manifest_files = (
+        [(local_path, rel_path) for local_path, rel_path in files]
+        if files
+        else download_staged_files(rel_paths, run_id=run_id)
+    )
+    logger.info("Publishing release manifest...")
+    publish_release_manifest_to_hf(
+        manifest_files,
+        version=version,
+        create_tag=True,
+    )
 
     logger.info("Cleaning up staging/...")
     cleanup_staging_hf(rel_paths, version=version, run_id=run_id)
@@ -122,21 +171,24 @@ def main(argv=None):
     logger.info("Area types: %s", area_types)
 
     files = collect_files(local_dir, area_types)
-    if not files:
+    if not files and not args.promote_only:
         logger.error("No H5 files found")
         return
-
-    rel_paths = [rp for _, rp in files]
 
     run_id = args.run_id
 
     if args.promote_only:
-        promote(rel_paths, version, run_id=run_id)
+        rel_paths = collect_staged_rel_paths(area_types, run_id=run_id)
+        if not rel_paths:
+            logger.error("No staged H5 files found")
+            return
+        promote([], rel_paths, version, run_id=run_id)
     elif args.stage_only:
         stage(files, version, run_id=run_id)
     else:
+        rel_paths = [rp for _, rp in files]
         stage(files, version, run_id=run_id)
-        promote(rel_paths, version, run_id=run_id)
+        promote(files, rel_paths, version, run_id=run_id)
 
 
 if __name__ == "__main__":

--- a/policyengine_us_data/calibration/promote_local_h5s.py
+++ b/policyengine_us_data/calibration/promote_local_h5s.py
@@ -28,11 +28,11 @@ from huggingface_hub import HfApi, hf_hub_download
 
 from policyengine_us_data.utils.data_upload import (
     upload_to_staging_hf,
+    preflight_release_manifest_publish,
     promote_staging_to_production_hf,
     upload_from_hf_staging_to_gcs,
     cleanup_staging_hf,
     publish_release_manifest_to_hf,
-    should_finalize_local_area_release,
 )
 from policyengine_us_data.utils.version_manifest import (
     HFVersionInfo,
@@ -98,6 +98,17 @@ def stage(files: list, version: str, run_id: str = ""):
 
 
 def promote(files: list, rel_paths: list, version: str, run_id: str = ""):
+    manifest_files = (
+        [(local_path, rel_path) for local_path, rel_path in files]
+        if files
+        else download_staged_files(rel_paths, run_id=run_id)
+    )
+    should_finalize, missing_prefixes = preflight_release_manifest_publish(
+        manifest_files,
+        version=version,
+        new_repo_paths=rel_paths,
+    )
+
     logger.info(
         "Promoting %d files from staging/ to production...",
         len(rel_paths),
@@ -106,16 +117,6 @@ def promote(files: list, rel_paths: list, version: str, run_id: str = ""):
 
     logger.info("Uploading %d files to GCS from HF staging...", len(rel_paths))
     upload_from_hf_staging_to_gcs(rel_paths, version=version, run_id=run_id)
-
-    manifest_files = (
-        [(local_path, rel_path) for local_path, rel_path in files]
-        if files
-        else download_staged_files(rel_paths, run_id=run_id)
-    )
-    should_finalize, missing_prefixes = should_finalize_local_area_release(
-        version=version,
-        new_repo_paths=rel_paths,
-    )
     logger.info("Publishing release manifest...")
     manifest = publish_release_manifest_to_hf(
         manifest_files,

--- a/policyengine_us_data/calibration/promote_local_h5s.py
+++ b/policyengine_us_data/calibration/promote_local_h5s.py
@@ -32,6 +32,12 @@ from policyengine_us_data.utils.data_upload import (
     upload_from_hf_staging_to_gcs,
     cleanup_staging_hf,
     publish_release_manifest_to_hf,
+    should_finalize_local_area_release,
+)
+from policyengine_us_data.utils.version_manifest import (
+    HFVersionInfo,
+    build_manifest,
+    upload_manifest,
 )
 
 logger = logging.getLogger(__name__)
@@ -106,12 +112,37 @@ def promote(files: list, rel_paths: list, version: str, run_id: str = ""):
         if files
         else download_staged_files(rel_paths, run_id=run_id)
     )
+    should_finalize, missing_prefixes = should_finalize_local_area_release(
+        version=version,
+        new_repo_paths=rel_paths,
+    )
     logger.info("Publishing release manifest...")
-    publish_release_manifest_to_hf(
+    manifest = publish_release_manifest_to_hf(
         manifest_files,
         version=version,
-        create_tag=True,
+        create_tag=should_finalize,
     )
+    if should_finalize:
+        upload_manifest(
+            build_manifest(
+                version=version,
+                blob_names=sorted(
+                    artifact["path"] for artifact in manifest["artifacts"].values()
+                ),
+                hf_info=HFVersionInfo(
+                    repo="policyengine/policyengine-us-data",
+                    commit=version,
+                ),
+            )
+        )
+    else:
+        logger.warning(
+            "Promoted only a partial artifact set for %s; missing prefixes %s. "
+            "Leaving the release untagged until all required local-area artifacts "
+            "have been published.",
+            version,
+            ", ".join(missing_prefixes),
+        )
 
     logger.info("Cleaning up staging/...")
     cleanup_staging_hf(rel_paths, version=version, run_id=run_id)
@@ -129,8 +160,8 @@ def parse_args(argv=None):
     )
     parser.add_argument(
         "--area-types",
-        default="states,districts,cities",
-        help="Comma-separated area types to publish (default: states,districts,cities)",
+        default="national,states,districts,cities",
+        help="Comma-separated area types to publish (default: national,states,districts,cities)",
     )
     parser.add_argument(
         "--version",

--- a/policyengine_us_data/calibration/publish_local_area.py
+++ b/policyengine_us_data/calibration/publish_local_area.py
@@ -774,6 +774,12 @@ def build_states(
     state_filter: str = None,
 ):
     """Build state H5 files with checkpointing, optionally uploading."""
+    if upload:
+        raise RuntimeError(
+            "Direct upload from publish_local_area.py is disabled. "
+            "Use modal_app/local_area.py or promote_local_h5s.py so release "
+            "manifests and tags are finalized atomically."
+        )
     w = np.load(weights_path)
 
     all_cds = sorted(set(geography.cd_geoid.astype(str)))
@@ -840,6 +846,12 @@ def build_districts(
     upload: bool = False,
 ):
     """Build district H5 files with checkpointing, optionally uploading."""
+    if upload:
+        raise RuntimeError(
+            "Direct upload from publish_local_area.py is disabled. "
+            "Use modal_app/local_area.py or promote_local_h5s.py so release "
+            "manifests and tags are finalized atomically."
+        )
     w = np.load(weights_path)
 
     all_cds = sorted(set(geography.cd_geoid.astype(str)))
@@ -908,6 +920,12 @@ def build_cities(
     upload: bool = False,
 ):
     """Build city H5 files with checkpointing, optionally uploading."""
+    if upload:
+        raise RuntimeError(
+            "Direct upload from publish_local_area.py is disabled. "
+            "Use modal_app/local_area.py or promote_local_h5s.py so release "
+            "manifests and tags are finalized atomically."
+        )
     w = np.load(weights_path)
 
     cities_dir = output_dir / "cities"

--- a/policyengine_us_data/storage/upload_completed_datasets.py
+++ b/policyengine_us_data/storage/upload_completed_datasets.py
@@ -12,6 +12,7 @@ from policyengine_us_data.utils.data_upload import (
     cleanup_staging_hf,
     promote_staging_to_production_hf,
     publish_release_manifest_to_hf,
+    should_finalize_local_area_release,
     upload_from_hf_staging_to_gcs,
     upload_to_staging_hf,
 )
@@ -355,22 +356,39 @@ def promote_datasets(
         if files_with_repo_paths
         else _download_staged_dataset_artifacts(rel_paths, run_id=run_id)
     )
-    publish_release_manifest_to_hf(
+    should_finalize, missing_prefixes = should_finalize_local_area_release(
+        version=version,
+        new_repo_paths=rel_paths,
+        hf_repo_name=HF_REPO_NAME,
+        hf_repo_type=HF_REPO_TYPE,
+    )
+    manifest = publish_release_manifest_to_hf(
         manifest_files,
         version=version,
         hf_repo_name=HF_REPO_NAME,
         hf_repo_type=HF_REPO_TYPE,
-        create_tag=True,
+        create_tag=should_finalize,
     )
-
-    # Legacy consumers still resolve versions through version_manifest.json.
-    upload_manifest(
-        build_manifest(
-            version=version,
-            blob_names=rel_paths,
-            hf_info=HFVersionInfo(repo=HF_REPO_NAME, commit=version),
+    if not should_finalize:
+        print(
+            "Release manifest updated without final tag; missing local-area prefixes: "
+            + ", ".join(missing_prefixes)
         )
-    )
+
+    # Legacy consumers still resolve versions through version_manifest.json,
+    # but only once the release has been finalized at a stable HF revision.
+    if should_finalize:
+        upload_manifest(
+            build_manifest(
+                version=version,
+                blob_names=sorted(
+                    artifact["path"] for artifact in manifest["artifacts"].values()
+                ),
+                hf_info=HFVersionInfo(repo=HF_REPO_NAME, commit=version),
+            )
+        )
+    else:
+        print("Deferring version_manifest.json update until the release is finalized.")
     cleanup_staging_hf(
         rel_paths,
         version=version,

--- a/policyengine_us_data/storage/upload_completed_datasets.py
+++ b/policyengine_us_data/storage/upload_completed_datasets.py
@@ -10,9 +10,9 @@ from policyengine_us_data.datasets.cps.cps import CPS_2024
 from policyengine_us_data.storage import STORAGE_FOLDER
 from policyengine_us_data.utils.data_upload import (
     cleanup_staging_hf,
+    preflight_release_manifest_publish,
     promote_staging_to_production_hf,
     publish_release_manifest_to_hf,
-    should_finalize_local_area_release,
     upload_from_hf_staging_to_gcs,
     upload_to_staging_hf,
 )
@@ -333,6 +333,18 @@ def promote_datasets(
             run_id=run_id,
         )
     )
+    manifest_files = (
+        files_with_repo_paths
+        if files_with_repo_paths
+        else _download_staged_dataset_artifacts(rel_paths, run_id=run_id)
+    )
+    should_finalize, missing_prefixes = preflight_release_manifest_publish(
+        manifest_files,
+        version=version,
+        new_repo_paths=rel_paths,
+        hf_repo_name=HF_REPO_NAME,
+        hf_repo_type=HF_REPO_TYPE,
+    )
 
     print(f"\nPromoting {len(rel_paths)} staged files to production...")
     promote_staging_to_production_hf(
@@ -349,18 +361,6 @@ def promote_datasets(
         hf_repo_name=HF_REPO_NAME,
         hf_repo_type=HF_REPO_TYPE,
         run_id=run_id,
-    )
-
-    manifest_files = (
-        files_with_repo_paths
-        if files_with_repo_paths
-        else _download_staged_dataset_artifacts(rel_paths, run_id=run_id)
-    )
-    should_finalize, missing_prefixes = should_finalize_local_area_release(
-        version=version,
-        new_repo_paths=rel_paths,
-        hf_repo_name=HF_REPO_NAME,
-        hf_repo_type=HF_REPO_TYPE,
     )
     manifest = publish_release_manifest_to_hf(
         manifest_files,

--- a/policyengine_us_data/storage/upload_completed_datasets.py
+++ b/policyengine_us_data/storage/upload_completed_datasets.py
@@ -222,6 +222,7 @@ def upload_datasets(require_enhanced_cps: bool = True):
         hf_repo_name="policyengine/policyengine-us-data",
         hf_repo_type="model",
         gcs_bucket_name="policyengine-us-data",
+        create_tag=True,
     )
 
 

--- a/policyengine_us_data/storage/upload_completed_datasets.py
+++ b/policyengine_us_data/storage/upload_completed_datasets.py
@@ -1,17 +1,34 @@
 from pathlib import Path
+from importlib import metadata
 
 import h5py
+from huggingface_hub import HfApi, hf_hub_download
 from policyengine_core.data import Dataset
 
 from policyengine_us_data.datasets import EnhancedCPS_2024
 from policyengine_us_data.datasets.cps.cps import CPS_2024
 from policyengine_us_data.storage import STORAGE_FOLDER
-from policyengine_us_data.utils.data_upload import upload_data_files
+from policyengine_us_data.utils.data_upload import (
+    cleanup_staging_hf,
+    promote_staging_to_production_hf,
+    publish_release_manifest_to_hf,
+    upload_from_hf_staging_to_gcs,
+    upload_to_staging_hf,
+)
 from policyengine_us_data.utils.dataset_validation import (
     DatasetContractError,
     load_dataset_for_validation,
     validate_dataset_contract,
 )
+from policyengine_us_data.utils.version_manifest import (
+    HFVersionInfo,
+    build_manifest,
+    upload_manifest,
+)
+
+HF_REPO_NAME = "policyengine/policyengine-us-data"
+HF_REPO_TYPE = "model"
+GCS_BUCKET_NAME = "policyengine-us-data"
 
 # Datasets that require full validation before upload.
 # These are the main datasets used in production simulations.
@@ -47,6 +64,104 @@ class DatasetValidationError(Exception):
     """Raised when a dataset fails pre-upload validation."""
 
     pass
+
+
+def _dataset_upload_specs(
+    require_enhanced_cps: bool = True,
+) -> list[tuple[Path, str, bool]]:
+    return [
+        (CPS_2024.file_path, CPS_2024.file_path.name, True),
+        (
+            STORAGE_FOLDER / "calibration" / "policy_data.db",
+            "policy_data.db",
+            True,
+        ),
+        (
+            EnhancedCPS_2024.file_path,
+            EnhancedCPS_2024.file_path.name,
+            require_enhanced_cps,
+        ),
+        (
+            STORAGE_FOLDER / "small_enhanced_cps_2024.h5",
+            "small_enhanced_cps_2024.h5",
+            require_enhanced_cps,
+        ),
+    ]
+
+
+def _collect_existing_dataset_artifacts(
+    require_enhanced_cps: bool = True,
+) -> list[tuple[Path, str]]:
+    existing_files = []
+    for file_path, repo_path, required in _dataset_upload_specs(require_enhanced_cps):
+        if file_path.exists():
+            existing_files.append((file_path, repo_path))
+            print(f"✓ Found{' (optional)' if not required else ''}: {file_path}")
+            continue
+        if required:
+            raise FileNotFoundError(f"Required file not found: {file_path}")
+        print(f"⚠ Skipping (not built): {file_path}")
+
+    if not existing_files:
+        raise ValueError("No dataset files found to upload!")
+
+    return existing_files
+
+
+def _collect_staged_dataset_repo_paths(
+    require_enhanced_cps: bool = True,
+    run_id: str = "",
+) -> list[str]:
+    api = HfApi()
+    prefix = f"staging/{run_id}" if run_id else "staging"
+    repo_files = set(
+        api.list_repo_files(
+            repo_id=HF_REPO_NAME,
+            repo_type=HF_REPO_TYPE,
+        )
+    )
+
+    rel_paths = []
+    missing_required = []
+    for _, repo_path, required in _dataset_upload_specs(require_enhanced_cps):
+        staged_path = f"{prefix}/{repo_path}"
+        if staged_path in repo_files:
+            rel_paths.append(repo_path)
+        elif required:
+            missing_required.append(staged_path)
+
+    if missing_required:
+        raise FileNotFoundError(
+            "Missing staged dataset artifacts: " + ", ".join(sorted(missing_required))
+        )
+    if not rel_paths:
+        raise ValueError("No staged dataset files found to promote.")
+
+    return rel_paths
+
+
+def _download_staged_dataset_artifacts(
+    rel_paths: list[str],
+    run_id: str = "",
+) -> list[tuple[Path, str]]:
+    staging_prefix = f"staging/{run_id}" if run_id else "staging"
+    downloaded_files = []
+    for rel_path in rel_paths:
+        local_path = Path(
+            hf_hub_download(
+                repo_id=HF_REPO_NAME,
+                filename=f"{staging_prefix}/{rel_path}",
+                repo_type=HF_REPO_TYPE,
+            )
+        )
+        downloaded_files.append((local_path, rel_path))
+    return downloaded_files
+
+
+def _validate_dataset_artifacts(files_with_repo_paths: list[tuple[Path, str]]) -> None:
+    print("\nValidating datasets...")
+    for file_path, _ in files_with_repo_paths:
+        validate_dataset(file_path)
 
 
 def validate_dataset(file_path: Path) -> None:
@@ -180,49 +295,126 @@ def validate_dataset(file_path: Path) -> None:
     print(f"    Household weight sum: {hh_weight:,.0f}")
 
 
-def upload_datasets(require_enhanced_cps: bool = True):
-    required_files = [
-        CPS_2024.file_path,
-        STORAGE_FOLDER / "calibration" / "policy_data.db",
-    ]
-    enhanced_files = [
-        EnhancedCPS_2024.file_path,
-        STORAGE_FOLDER / "small_enhanced_cps_2024.h5",
-    ]
-    if require_enhanced_cps:
-        required_files.extend(enhanced_files)
+def stage_datasets(
+    require_enhanced_cps: bool = True,
+    version: str | None = None,
+    run_id: str = "",
+) -> list[tuple[Path, str]]:
+    version = version or metadata.version("policyengine-us-data")
+    files_with_repo_paths = _collect_existing_dataset_artifacts(
+        require_enhanced_cps=require_enhanced_cps
+    )
+    _validate_dataset_artifacts(files_with_repo_paths)
 
-    existing_files = []
-    for file_path in required_files:
-        if file_path.exists():
-            existing_files.append(file_path)
-            print(f"✓ Found: {file_path}")
-        else:
-            raise FileNotFoundError(f"Required file not found: {file_path}")
+    print(f"\nStaging {len(files_with_repo_paths)} files on Hugging Face...")
+    upload_to_staging_hf(
+        files_with_repo_paths,
+        version=version,
+        hf_repo_name=HF_REPO_NAME,
+        hf_repo_type=HF_REPO_TYPE,
+        run_id=run_id,
+    )
+    return files_with_repo_paths
 
-    if not require_enhanced_cps:
-        for file_path in enhanced_files:
-            if file_path.exists():
-                existing_files.append(file_path)
-                print(f"✓ Found (optional): {file_path}")
-            else:
-                print(f"⚠ Skipping (not built): {file_path}")
 
-    if not existing_files:
-        raise ValueError("No dataset files found to upload!")
+def promote_datasets(
+    require_enhanced_cps: bool = True,
+    version: str | None = None,
+    run_id: str = "",
+    files_with_repo_paths: list[tuple[Path, str]] | None = None,
+) -> list[str]:
+    version = version or metadata.version("policyengine-us-data")
+    rel_paths = (
+        [repo_path for _, repo_path in files_with_repo_paths]
+        if files_with_repo_paths
+        else _collect_staged_dataset_repo_paths(
+            require_enhanced_cps=require_enhanced_cps,
+            run_id=run_id,
+        )
+    )
 
-    # Validate datasets before uploading
-    print("\nValidating datasets...")
-    for file_path in existing_files:
-        validate_dataset(file_path)
+    print(f"\nPromoting {len(rel_paths)} staged files to production...")
+    promote_staging_to_production_hf(
+        rel_paths,
+        version=version,
+        hf_repo_name=HF_REPO_NAME,
+        hf_repo_type=HF_REPO_TYPE,
+        run_id=run_id,
+    )
+    upload_from_hf_staging_to_gcs(
+        rel_paths,
+        version=version,
+        gcs_bucket_name=GCS_BUCKET_NAME,
+        hf_repo_name=HF_REPO_NAME,
+        hf_repo_type=HF_REPO_TYPE,
+        run_id=run_id,
+    )
 
-    print(f"\nUploading {len(existing_files)} files...")
-    upload_data_files(
-        files=existing_files,
-        hf_repo_name="policyengine/policyengine-us-data",
-        hf_repo_type="model",
-        gcs_bucket_name="policyengine-us-data",
+    manifest_files = (
+        files_with_repo_paths
+        if files_with_repo_paths
+        else _download_staged_dataset_artifacts(rel_paths, run_id=run_id)
+    )
+    publish_release_manifest_to_hf(
+        manifest_files,
+        version=version,
+        hf_repo_name=HF_REPO_NAME,
+        hf_repo_type=HF_REPO_TYPE,
         create_tag=True,
+    )
+
+    # Legacy consumers still resolve versions through version_manifest.json.
+    upload_manifest(
+        build_manifest(
+            version=version,
+            blob_names=rel_paths,
+            hf_info=HFVersionInfo(repo=HF_REPO_NAME, commit=version),
+        )
+    )
+    cleanup_staging_hf(
+        rel_paths,
+        version=version,
+        hf_repo_name=HF_REPO_NAME,
+        hf_repo_type=HF_REPO_TYPE,
+        run_id=run_id,
+    )
+    return rel_paths
+
+
+def upload_datasets(
+    require_enhanced_cps: bool = True,
+    *,
+    stage_only: bool = False,
+    promote_only: bool = False,
+    run_id: str = "",
+    version: str | None = None,
+):
+    if stage_only and promote_only:
+        raise ValueError("Choose either stage_only or promote_only, not both.")
+
+    version = version or metadata.version("policyengine-us-data")
+
+    if promote_only:
+        promote_datasets(
+            require_enhanced_cps=require_enhanced_cps,
+            version=version,
+            run_id=run_id,
+        )
+        return
+
+    files_with_repo_paths = stage_datasets(
+        require_enhanced_cps=require_enhanced_cps,
+        version=version,
+        run_id=run_id,
+    )
+    if stage_only:
+        return
+
+    promote_datasets(
+        require_enhanced_cps=require_enhanced_cps,
+        version=version,
+        run_id=run_id,
+        files_with_repo_paths=files_with_repo_paths,
     )
 
 
@@ -257,8 +449,35 @@ if __name__ == "__main__":
         action="store_true",
         help="Validate built datasets without uploading them.",
     )
+    upload_mode = parser.add_mutually_exclusive_group()
+    upload_mode.add_argument(
+        "--stage-only",
+        action="store_true",
+        help="Validate and upload built datasets only to HF staging.",
+    )
+    upload_mode.add_argument(
+        "--promote-only",
+        action="store_true",
+        help="Promote already-staged datasets into the immutable release.",
+    )
+    parser.add_argument(
+        "--run-id",
+        default="",
+        help="Optional staging run ID, for example a CI commit SHA.",
+    )
+    parser.add_argument(
+        "--version",
+        default=None,
+        help="Override the policyengine-us-data version used for staging/promote.",
+    )
     args = parser.parse_args()
     if args.validate_only:
         validate_built_datasets(require_enhanced_cps=not args.no_require_enhanced_cps)
     else:
-        upload_datasets(require_enhanced_cps=not args.no_require_enhanced_cps)
+        upload_datasets(
+            require_enhanced_cps=not args.no_require_enhanced_cps,
+            stage_only=args.stage_only,
+            promote_only=args.promote_only,
+            run_id=args.run_id,
+            version=args.version,
+        )

--- a/policyengine_us_data/tests/test_release_manifest.py
+++ b/policyengine_us_data/tests/test_release_manifest.py
@@ -64,7 +64,7 @@ def test_build_release_manifest_tracks_uploaded_artifacts(tmp_path):
             "version": "1.634.4",
             "git_sha": "deadbeef",
             "data_build_fingerprint": "sha256:fingerprint",
-        }
+        },
     }
     assert manifest["default_datasets"] == {"national": "enhanced_cps_2024"}
 
@@ -136,11 +136,9 @@ def test_build_release_manifest_merges_existing_release_same_version(tmp_path):
             "version": "1.634.4",
             "git_sha": "deadbeef",
             "data_build_fingerprint": "sha256:fingerprint",
-        }
+        },
     }
-    assert manifest["artifacts"]["districts/NC-01"]["sha256"] == _sha256(
-        district_bytes
-    )
+    assert manifest["artifacts"]["districts/NC-01"]["sha256"] == _sha256(district_bytes)
 
 
 def test_upload_files_to_hf_adds_release_manifest_operations(tmp_path):

--- a/policyengine_us_data/tests/test_release_manifest.py
+++ b/policyengine_us_data/tests/test_release_manifest.py
@@ -1,0 +1,304 @@
+import hashlib
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from huggingface_hub import CommitOperationAdd
+
+from policyengine_us_data.utils.data_upload import upload_files_to_hf
+from policyengine_us_data.utils.data_upload import publish_release_manifest_to_hf
+from policyengine_us_data.utils.release_manifest import (
+    RELEASE_MANIFEST_SCHEMA_VERSION,
+    build_release_manifest,
+)
+
+
+def _write_file(path: Path, content: bytes) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path
+
+
+def _sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def test_build_release_manifest_tracks_uploaded_artifacts(tmp_path):
+    national_bytes = b"national-dataset"
+    state_bytes = b"state-dataset"
+    national_path = _write_file(
+        tmp_path / "enhanced_cps_2024.h5",
+        national_bytes,
+    )
+    state_path = _write_file(tmp_path / "AL.h5", state_bytes)
+
+    manifest = build_release_manifest(
+        files_with_repo_paths=[
+            (national_path, "enhanced_cps_2024.h5"),
+            (state_path, "states/AL.h5"),
+        ],
+        version="1.73.0",
+        repo_id="policyengine/policyengine-us-data",
+        model_package_version="1.634.4",
+        model_package_git_sha="deadbeef",
+        model_package_data_build_fingerprint="sha256:fingerprint",
+        created_at="2026-04-10T12:00:00Z",
+    )
+
+    assert manifest["data_package"] == {
+        "name": "policyengine-us-data",
+        "version": "1.73.0",
+    }
+    assert manifest["schema_version"] == RELEASE_MANIFEST_SCHEMA_VERSION
+    assert manifest["compatible_model_packages"] == [
+        {
+            "name": "policyengine-us",
+            "specifier": "==1.634.4",
+        }
+    ]
+    assert manifest["build"] == {
+        "build_id": "policyengine-us-data-1.73.0",
+        "built_at": "2026-04-10T12:00:00Z",
+        "built_with_model_package": {
+            "name": "policyengine-us",
+            "version": "1.634.4",
+            "git_sha": "deadbeef",
+            "data_build_fingerprint": "sha256:fingerprint",
+        }
+    }
+    assert manifest["default_datasets"] == {"national": "enhanced_cps_2024"}
+
+    assert manifest["artifacts"]["enhanced_cps_2024"] == {
+        "kind": "microdata",
+        "path": "enhanced_cps_2024.h5",
+        "repo_id": "policyengine/policyengine-us-data",
+        "revision": "1.73.0",
+        "sha256": _sha256(national_bytes),
+        "size_bytes": len(national_bytes),
+    }
+    assert manifest["artifacts"]["states/AL"] == {
+        "kind": "microdata",
+        "path": "states/AL.h5",
+        "repo_id": "policyengine/policyengine-us-data",
+        "revision": "1.73.0",
+        "sha256": _sha256(state_bytes),
+        "size_bytes": len(state_bytes),
+    }
+
+
+def test_build_release_manifest_merges_existing_release_same_version(tmp_path):
+    district_bytes = b"district-dataset"
+    district_path = _write_file(tmp_path / "NC-01.h5", district_bytes)
+
+    existing_manifest = {
+        "data_package": {
+            "name": "policyengine-us-data",
+            "version": "1.73.0",
+        },
+        "compatible_model_packages": [
+            {
+                "name": "policyengine-us",
+                "specifier": "==1.634.4",
+            }
+        ],
+        "default_datasets": {"national": "enhanced_cps_2024"},
+        "created_at": "2026-04-09T12:00:00Z",
+        "artifacts": {
+            "enhanced_cps_2024": {
+                "kind": "microdata",
+                "path": "enhanced_cps_2024.h5",
+                "repo_id": "policyengine/policyengine-us-data",
+                "revision": "1.73.0",
+                "sha256": "abc",
+                "size_bytes": 123,
+            }
+        },
+    }
+
+    manifest = build_release_manifest(
+        files_with_repo_paths=[(district_path, "districts/NC-01.h5")],
+        version="1.73.0",
+        repo_id="policyengine/policyengine-us-data",
+        model_package_version="1.634.4",
+        model_package_git_sha="deadbeef",
+        model_package_data_build_fingerprint="sha256:fingerprint",
+        existing_manifest=existing_manifest,
+        created_at="2026-04-10T12:00:00Z",
+    )
+
+    assert set(manifest["artifacts"]) == {"enhanced_cps_2024", "districts/NC-01"}
+    assert manifest["default_datasets"] == {"national": "enhanced_cps_2024"}
+    assert manifest["build"] == {
+        "build_id": "policyengine-us-data-1.73.0",
+        "built_at": "2026-04-10T12:00:00Z",
+        "built_with_model_package": {
+            "name": "policyengine-us",
+            "version": "1.634.4",
+            "git_sha": "deadbeef",
+            "data_build_fingerprint": "sha256:fingerprint",
+        }
+    }
+    assert manifest["artifacts"]["districts/NC-01"]["sha256"] == _sha256(
+        district_bytes
+    )
+
+
+def test_upload_files_to_hf_adds_release_manifest_operations(tmp_path):
+    dataset_path = _write_file(
+        tmp_path / "enhanced_cps_2024.h5",
+        b"national-dataset",
+    )
+
+    mock_api = MagicMock()
+    mock_api.create_commit.return_value = MagicMock(oid="commit-sha")
+
+    with (
+        patch("policyengine_us_data.utils.data_upload.HfApi", return_value=mock_api),
+        patch(
+            "policyengine_us_data.utils.data_upload.load_release_manifest_from_hf",
+            return_value=None,
+        ),
+        patch(
+            "policyengine_us_data.utils.data_upload._get_model_package_build_metadata",
+            return_value={
+                "version": "1.634.4",
+                "git_sha": "deadbeef",
+                "data_build_fingerprint": "sha256:fingerprint",
+            },
+        ),
+        patch.dict(
+            "policyengine_us_data.utils.data_upload.os.environ",
+            {"HUGGING_FACE_TOKEN": "token"},
+            clear=False,
+        ),
+    ):
+        upload_files_to_hf(
+            files=[dataset_path],
+            version="1.73.0",
+        )
+
+    operations = mock_api.create_commit.call_args.kwargs["operations"]
+    operation_paths = [operation.path_in_repo for operation in operations]
+
+    assert "enhanced_cps_2024.h5" in operation_paths
+    assert "release_manifest.json" in operation_paths
+    assert "releases/1.73.0/release_manifest.json" in operation_paths
+
+    release_ops = [
+        operation
+        for operation in operations
+        if operation.path_in_repo.endswith("release_manifest.json")
+    ]
+    assert len(release_ops) == 2
+    for operation in release_ops:
+        assert isinstance(operation, CommitOperationAdd)
+        assert isinstance(operation.path_or_fileobj, BytesIO)
+
+
+def test_upload_files_to_hf_does_not_tag_until_finalize(tmp_path):
+    dataset_path = _write_file(
+        tmp_path / "enhanced_cps_2024.h5",
+        b"national-dataset",
+    )
+
+    mock_api = MagicMock()
+    mock_api.create_commit.return_value = MagicMock(oid="commit-sha")
+
+    with (
+        patch("policyengine_us_data.utils.data_upload.HfApi", return_value=mock_api),
+        patch(
+            "policyengine_us_data.utils.data_upload.load_release_manifest_from_hf",
+            return_value=None,
+        ),
+        patch(
+            "policyengine_us_data.utils.data_upload._get_model_package_build_metadata",
+            return_value={
+                "version": "1.634.4",
+                "git_sha": "deadbeef",
+                "data_build_fingerprint": "sha256:fingerprint",
+            },
+        ),
+        patch.dict(
+            "policyengine_us_data.utils.data_upload.os.environ",
+            {"HUGGING_FACE_TOKEN": "token"},
+            clear=False,
+        ),
+    ):
+        upload_files_to_hf(
+            files=[dataset_path],
+            version="1.73.0",
+            create_tag=False,
+        )
+
+    mock_api.create_tag.assert_not_called()
+
+
+def test_publish_release_manifest_to_hf_can_finalize_and_tag(tmp_path):
+    state_path = _write_file(
+        tmp_path / "AL.h5",
+        b"state-dataset",
+    )
+
+    mock_api = MagicMock()
+    mock_api.create_commit.return_value = MagicMock(oid="final-commit-sha")
+
+    with (
+        patch("policyengine_us_data.utils.data_upload.HfApi", return_value=mock_api),
+        patch(
+            "policyengine_us_data.utils.data_upload.load_release_manifest_from_hf",
+            return_value={
+                "schema_version": RELEASE_MANIFEST_SCHEMA_VERSION,
+                "data_package": {
+                    "name": "policyengine-us-data",
+                    "version": "1.73.0",
+                },
+                "compatible_model_packages": [],
+                "default_datasets": {"national": "enhanced_cps_2024"},
+                "created_at": "2026-04-10T12:00:00Z",
+                "build": {
+                    "build_id": "policyengine-us-data-1.73.0",
+                    "built_at": "2026-04-10T12:00:00Z",
+                },
+                "artifacts": {
+                    "enhanced_cps_2024": {
+                        "kind": "microdata",
+                        "path": "enhanced_cps_2024.h5",
+                        "repo_id": "policyengine/policyengine-us-data",
+                        "revision": "1.73.0",
+                        "sha256": "abc",
+                        "size_bytes": 123,
+                    }
+                },
+            },
+        ),
+        patch(
+            "policyengine_us_data.utils.data_upload._get_model_package_build_metadata",
+            return_value={
+                "version": "1.634.4",
+                "git_sha": "deadbeef",
+                "data_build_fingerprint": "sha256:fingerprint",
+            },
+        ),
+        patch.dict(
+            "policyengine_us_data.utils.data_upload.os.environ",
+            {"HUGGING_FACE_TOKEN": "token"},
+            clear=False,
+        ),
+    ):
+        manifest = publish_release_manifest_to_hf(
+            [(state_path, "states/AL.h5")],
+            version="1.73.0",
+            create_tag=True,
+        )
+
+    mock_api.create_tag.assert_called_once()
+    assert manifest["build"] == {
+        "build_id": "policyengine-us-data-1.73.0",
+        "built_at": "2026-04-10T12:00:00Z",
+        "built_with_model_package": {
+            "name": "policyengine-us",
+            "version": "1.634.4",
+            "git_sha": "deadbeef",
+            "data_build_fingerprint": "sha256:fingerprint",
+        },
+    }

--- a/policyengine_us_data/utils/data_upload.py
+++ b/policyengine_us_data/utils/data_upload.py
@@ -147,7 +147,9 @@ def missing_release_prefixes(
     required_counts: Optional[Dict[str, int]] = None,
 ) -> list[str]:
     required_counts = required_counts or LOCAL_AREA_FINALIZE_REQUIRED_COUNTS
-    combined_paths = _collect_manifest_repo_paths(existing_manifest) | set(new_repo_paths)
+    combined_paths = _collect_manifest_repo_paths(existing_manifest) | set(
+        new_repo_paths
+    )
     prefix_counts = {prefix: 0 for prefix in required_prefixes}
     for path in combined_paths:
         for prefix in required_prefixes:
@@ -178,6 +180,47 @@ def should_finalize_local_area_release(
         new_repo_paths=new_repo_paths,
     )
     return not missing_prefixes, missing_prefixes
+
+
+def preflight_release_manifest_publish(
+    files_with_paths: Sequence[Tuple[Path | str, str]],
+    version: str,
+    new_repo_paths: Sequence[str],
+    hf_repo_name: str = "policyengine/policyengine-us-data",
+    hf_repo_type: str = "model",
+    model_package_name: str = "policyengine-us",
+    model_package_version: Optional[str] = None,
+) -> tuple[bool, list[str]]:
+    should_finalize, missing_prefixes = should_finalize_local_area_release(
+        version=version,
+        new_repo_paths=new_repo_paths,
+        hf_repo_name=hf_repo_name,
+        hf_repo_type=hf_repo_type,
+    )
+    assert_release_not_finalized(
+        version=version,
+        hf_repo_name=hf_repo_name,
+        hf_repo_type=hf_repo_type,
+    )
+    existing_manifest = load_release_manifest_from_hf(
+        version=version,
+        hf_repo_name=hf_repo_name,
+        hf_repo_type=hf_repo_type,
+    )
+    resolved_model_package_version = (
+        model_package_version or _get_model_package_version(model_package_name)
+    )
+    create_release_manifest_commit_operations(
+        files_with_repo_paths=[
+            (Path(path), repo_path) for path, repo_path in files_with_paths
+        ],
+        version=version,
+        hf_repo_name=hf_repo_name,
+        model_package_name=model_package_name,
+        model_package_version=resolved_model_package_version,
+        existing_manifest=existing_manifest,
+    )
+    return should_finalize, missing_prefixes
 
 
 def create_release_manifest_commit_operations(
@@ -233,11 +276,13 @@ def get_matching_finalized_release_manifest(
     if finalized_manifest is None:
         return None
 
-    resolved_model_package_version = model_package_version or _get_model_package_version(
-        model_package_name
+    resolved_model_package_version = (
+        model_package_version or _get_model_package_version(model_package_name)
     )
     candidate_manifest, _ = create_release_manifest_commit_operations(
-        files_with_repo_paths=[(Path(path), repo_path) for path, repo_path in files_with_paths],
+        files_with_repo_paths=[
+            (Path(path), repo_path) for path, repo_path in files_with_paths
+        ],
         version=version,
         hf_repo_name=hf_repo_name,
         model_package_name=model_package_name,
@@ -581,8 +626,8 @@ def publish_release_manifest_to_hf(
         hf_repo_name=hf_repo_name,
         hf_repo_type=hf_repo_type,
     )
-    resolved_model_package_version = model_package_version or _get_model_package_version(
-        model_package_name
+    resolved_model_package_version = (
+        model_package_version or _get_model_package_version(model_package_name)
     )
     parent_commit = get_repo_head_revision(
         api=api,
@@ -591,7 +636,9 @@ def publish_release_manifest_to_hf(
         token=token,
     )
     manifest, operations = create_release_manifest_commit_operations(
-        files_with_repo_paths=[(Path(path), repo_path) for path, repo_path in files_with_paths],
+        files_with_repo_paths=[
+            (Path(path), repo_path) for path, repo_path in files_with_paths
+        ],
         version=version,
         hf_repo_name=hf_repo_name,
         model_package_name=model_package_name,

--- a/policyengine_us_data/utils/data_upload.py
+++ b/policyengine_us_data/utils/data_upload.py
@@ -1,4 +1,6 @@
-from typing import List, Tuple
+from io import BytesIO
+from typing import List, Dict, Optional, Tuple
+import json
 from huggingface_hub import (
     HfApi,
     CommitOperationAdd,
@@ -6,13 +8,14 @@ from huggingface_hub import (
     CommitOperationDelete,
     hf_hub_download,
 )
+from huggingface_hub.errors import RevisionNotFoundError
 from google.cloud import storage
 from pathlib import Path
 from importlib import metadata
 import google.auth
 import httpx
-import logging
 import os
+import logging
 
 from tenacity import (
     retry,
@@ -22,9 +25,154 @@ from tenacity import (
     before_sleep_log,
 )
 
+from policyengine_us_data.utils.release_manifest import (
+    build_release_manifest,
+    serialize_release_manifest,
+)
+
 DEFAULT_HF_TIMEOUT = 300
 MAX_RETRIES = 5
 RETRY_BASE_WAIT = 30
+RELEASE_MANIFEST_PATH = "release_manifest.json"
+
+
+def _get_model_package_version(
+    package_name: str = "policyengine-us",
+) -> str:
+    try:
+        return metadata.version(package_name)
+    except metadata.PackageNotFoundError:
+        raise RuntimeError(
+            "Could not determine installed version for "
+            f"{package_name} while building a release manifest."
+        )
+
+
+def load_release_manifest_from_hf(
+    version: str,
+    hf_repo_name: str = "policyengine/policyengine-us-data",
+    hf_repo_type: str = "model",
+    revision: Optional[str] = None,
+) -> Optional[Dict]:
+    token = os.environ.get("HUGGING_FACE_TOKEN")
+    candidate_paths = [
+        f"releases/{version}/{RELEASE_MANIFEST_PATH}",
+        RELEASE_MANIFEST_PATH,
+    ]
+
+    for path_in_repo in candidate_paths:
+        try:
+            manifest_path = hf_hub_download(
+                repo_id=hf_repo_name,
+                filename=path_in_repo,
+                repo_type=hf_repo_type,
+                token=token,
+                revision=revision,
+            )
+        except RevisionNotFoundError:
+            return None
+        except Exception:
+            continue
+
+        with open(manifest_path) as f:
+            manifest = json.load(f)
+
+        data_package = manifest.get("data_package", {})
+        if data_package.get("version") == version:
+            return manifest
+
+    return None
+
+
+def assert_release_not_finalized(
+    version: str,
+    hf_repo_name: str = "policyengine/policyengine-us-data",
+    hf_repo_type: str = "model",
+) -> None:
+    if (
+        load_release_manifest_from_hf(
+            version=version,
+            hf_repo_name=hf_repo_name,
+            hf_repo_type=hf_repo_type,
+            revision=version,
+        )
+        is not None
+    ):
+        raise RuntimeError(
+            f"Release {version} is already finalized on {hf_repo_name}. "
+            "Refusing to mutate release manifest state after the tag exists."
+        )
+
+
+def create_release_manifest_commit_operations(
+    files_with_repo_paths: List[Tuple[Path, str]],
+    version: str,
+    hf_repo_name: str = "policyengine/policyengine-us-data",
+    model_package_name: str = "policyengine-us",
+    model_package_version: Optional[str] = None,
+    existing_manifest: Optional[Dict] = None,
+) -> Tuple[Dict, List[CommitOperationAdd]]:
+    if not model_package_version:
+        raise RuntimeError(
+            "A compatible policyengine-us version is required when publishing "
+            "a release manifest."
+        )
+    manifest = build_release_manifest(
+        files_with_repo_paths=files_with_repo_paths,
+        version=version,
+        repo_id=hf_repo_name,
+        model_package_name=model_package_name,
+        model_package_version=model_package_version,
+        existing_manifest=existing_manifest,
+    )
+    manifest_payload = serialize_release_manifest(manifest)
+
+    operations = [
+        CommitOperationAdd(
+            path_in_repo=RELEASE_MANIFEST_PATH,
+            path_or_fileobj=BytesIO(manifest_payload),
+        ),
+        CommitOperationAdd(
+            path_in_repo=f"releases/{version}/{RELEASE_MANIFEST_PATH}",
+            path_or_fileobj=BytesIO(manifest_payload),
+        ),
+    ]
+    return manifest, operations
+
+
+def create_release_tag(
+    version: str,
+    revision: str,
+    hf_repo_name: str = "policyengine/policyengine-us-data",
+    hf_repo_type: str = "model",
+    token: Optional[str] = None,
+    api: Optional[HfApi] = None,
+) -> None:
+    api = api or HfApi()
+    token = token or os.environ.get("HUGGING_FACE_TOKEN")
+    try:
+        api.create_tag(
+            token=token,
+            repo_id=hf_repo_name,
+            tag=version,
+            revision=revision,
+            repo_type=hf_repo_type,
+        )
+        logging.info(
+            "Tagged revision %s with %s in Hugging Face repository %s.",
+            revision,
+            version,
+            hf_repo_name,
+        )
+    except Exception as e:
+        if "Tag reference exists already" in str(e) or "409" in str(e):
+            logging.warning(
+                "Tag %s already exists in %s. Skipping tag creation.",
+                version,
+                hf_repo_name,
+            )
+        else:
+            raise
 
 
 def upload_data_files(
@@ -33,6 +181,7 @@ def upload_data_files(
     hf_repo_name: str = "policyengine/policyengine-us-data",
     hf_repo_type: str = "model",
     version: str = None,
+    create_tag: bool = False,
 ):
     if version is None:
         version = metadata.version("policyengine-us-data")
@@ -42,6 +191,7 @@ def upload_data_files(
         version=version,
         hf_repo_name=hf_repo_name,
         hf_repo_type=hf_repo_type,
+        create_tag=create_tag,
     )
 
     upload_files_to_gcs(
@@ -56,26 +206,50 @@ def upload_files_to_hf(
     version: str,
     hf_repo_name: str = "policyengine/policyengine-us-data",
     hf_repo_type: str = "model",
+    create_tag: bool = False,
 ):
     """
     Upload files to Hugging Face repository and tag the commit with the version.
     """
     api = HfApi()
     hf_operations = []
+    files_with_repo_paths = []
 
     token = os.environ.get(
         "HUGGING_FACE_TOKEN",
+    )
+    assert_release_not_finalized(
+        version=version,
+        hf_repo_name=hf_repo_name,
+        hf_repo_type=hf_repo_type,
     )
     for file_path in files:
         file_path = Path(file_path)
         if not file_path.exists():
             raise ValueError(f"File {file_path} does not exist.")
+        repo_path = file_path.name
+        files_with_repo_paths.append((file_path, repo_path))
         hf_operations.append(
             CommitOperationAdd(
-                path_in_repo=file_path.name,
+                path_in_repo=repo_path,
                 path_or_fileobj=str(file_path),
             )
         )
+
+    existing_manifest = load_release_manifest_from_hf(
+        version=version,
+        hf_repo_name=hf_repo_name,
+        hf_repo_type=hf_repo_type,
+    )
+    _, manifest_operations = create_release_manifest_commit_operations(
+        files_with_repo_paths=files_with_repo_paths,
+        version=version,
+        hf_repo_name=hf_repo_name,
+        model_package_version=_get_model_package_version(),
+        existing_manifest=existing_manifest,
+    )
+    hf_operations.extend(manifest_operations)
+
     commit_info = api.create_commit(
         token=token,
         repo_id=hf_repo_name,
@@ -85,25 +259,15 @@ def upload_files_to_hf(
     )
     logging.info(f"Uploaded files to Hugging Face repository {hf_repo_name}.")
 
-    # Tag commit with version
-    try:
-        api.create_tag(
-            token=token,
-            repo_id=hf_repo_name,
-            tag=version,
+    if create_tag:
+        create_release_tag(
+            version=version,
             revision=commit_info.oid,
-            repo_type=hf_repo_type,
+            hf_repo_name=hf_repo_name,
+            hf_repo_type=hf_repo_type,
+            token=token,
+            api=api,
         )
-        logging.info(
-            f"Tagged commit with {version} in Hugging Face repository {hf_repo_name}."
-        )
-    except Exception as e:
-        if "Tag reference exists already" in str(e) or "409" in str(e):
-            logging.warning(
-                f"Tag {version} already exists in {hf_repo_name}. Skipping tag creation."
-            )
-        else:
-            raise
 
 
 def upload_files_to_gcs(
@@ -236,6 +400,61 @@ def upload_local_area_batch_to_hf(
     logging.info(
         f"Uploaded {len(operations)} files to Hugging Face {hf_repo_name} in single commit."
     )
+
+
+def publish_release_manifest_to_hf(
+    files_with_paths: List[Tuple[Path, str]],
+    version: str,
+    hf_repo_name: str = "policyengine/policyengine-us-data",
+    hf_repo_type: str = "model",
+    model_package_name: str = "policyengine-us",
+    model_package_version: Optional[str] = None,
+    create_tag: bool = False,
+) -> Dict:
+    token = os.environ.get("HUGGING_FACE_TOKEN")
+    api = HfApi()
+    assert_release_not_finalized(
+        version=version,
+        hf_repo_name=hf_repo_name,
+        hf_repo_type=hf_repo_type,
+    )
+    existing_manifest = load_release_manifest_from_hf(
+        version=version,
+        hf_repo_name=hf_repo_name,
+        hf_repo_type=hf_repo_type,
+    )
+    manifest, operations = create_release_manifest_commit_operations(
+        files_with_repo_paths=[(Path(path), repo_path) for path, repo_path in files_with_paths],
+        version=version,
+        hf_repo_name=hf_repo_name,
+        model_package_name=model_package_name,
+        model_package_version=model_package_version
+        or _get_model_package_version(model_package_name),
+        existing_manifest=existing_manifest,
+    )
+    commit_info = hf_create_commit_with_retry(
+        api=api,
+        operations=operations,
+        repo_id=hf_repo_name,
+        repo_type=hf_repo_type,
+        token=token,
+        commit_message=f"Update release manifest for version {version}",
+    )
+    if create_tag:
+        create_release_tag(
+            version=version,
+            revision=commit_info.oid,
+            hf_repo_name=hf_repo_name,
+            hf_repo_type=hf_repo_type,
+            token=token,
+            api=api,
+        )
+    logging.info(
+        "Published release manifest for %s with %d tracked artifacts.",
+        version,
+        len(manifest["artifacts"]),
+    )
+    return manifest
 
 
 @retry(

--- a/policyengine_us_data/utils/data_upload.py
+++ b/policyengine_us_data/utils/data_upload.py
@@ -1,5 +1,5 @@
 from io import BytesIO
-from typing import List, Dict, Optional, Tuple
+from typing import List, Dict, Optional, Tuple, Sequence
 import json
 from huggingface_hub import (
     HfApi,
@@ -34,6 +34,18 @@ DEFAULT_HF_TIMEOUT = 300
 MAX_RETRIES = 5
 RETRY_BASE_WAIT = 30
 RELEASE_MANIFEST_PATH = "release_manifest.json"
+LOCAL_AREA_FINALIZE_REQUIRED_PREFIXES = (
+    "national/",
+    "states/",
+    "districts/",
+    "cities/",
+)
+LOCAL_AREA_FINALIZE_REQUIRED_COUNTS = {
+    "national/": 1,
+    "states/": 51,
+    "districts/": 435,
+    "cities/": 1,
+}
 
 
 def _get_model_package_version(
@@ -104,6 +116,70 @@ def assert_release_not_finalized(
         )
 
 
+def get_repo_head_revision(
+    api: HfApi,
+    repo_id: str,
+    repo_type: str,
+    token: Optional[str] = None,
+) -> Optional[str]:
+    repo_info = api.repo_info(
+        repo_id=repo_id,
+        repo_type=repo_type,
+        token=token,
+    )
+    return getattr(repo_info, "sha", None)
+
+
+def _collect_manifest_repo_paths(manifest: Optional[Dict]) -> set[str]:
+    if not manifest:
+        return set()
+    return {
+        artifact["path"]
+        for artifact in manifest.get("artifacts", {}).values()
+        if isinstance(artifact, dict) and isinstance(artifact.get("path"), str)
+    }
+
+
+def missing_release_prefixes(
+    existing_manifest: Optional[Dict],
+    new_repo_paths: Sequence[str],
+    required_prefixes: Sequence[str] = LOCAL_AREA_FINALIZE_REQUIRED_PREFIXES,
+    required_counts: Optional[Dict[str, int]] = None,
+) -> list[str]:
+    required_counts = required_counts or LOCAL_AREA_FINALIZE_REQUIRED_COUNTS
+    combined_paths = _collect_manifest_repo_paths(existing_manifest) | set(new_repo_paths)
+    prefix_counts = {prefix: 0 for prefix in required_prefixes}
+    for path in combined_paths:
+        for prefix in required_prefixes:
+            if path.startswith(prefix):
+                prefix_counts[prefix] += 1
+                break
+
+    return [
+        prefix
+        for prefix in required_prefixes
+        if prefix_counts[prefix] < required_counts.get(prefix, 1)
+    ]
+
+
+def should_finalize_local_area_release(
+    version: str,
+    new_repo_paths: Sequence[str],
+    hf_repo_name: str = "policyengine/policyengine-us-data",
+    hf_repo_type: str = "model",
+) -> tuple[bool, list[str]]:
+    existing_manifest = load_release_manifest_from_hf(
+        version=version,
+        hf_repo_name=hf_repo_name,
+        hf_repo_type=hf_repo_type,
+    )
+    missing_prefixes = missing_release_prefixes(
+        existing_manifest=existing_manifest,
+        new_repo_paths=new_repo_paths,
+    )
+    return not missing_prefixes, missing_prefixes
+
+
 def create_release_manifest_commit_operations(
     files_with_repo_paths: List[Tuple[Path, str]],
     version: str,
@@ -140,6 +216,42 @@ def create_release_manifest_commit_operations(
     return manifest, operations
 
 
+def get_matching_finalized_release_manifest(
+    files_with_paths: List[Tuple[Path, str]],
+    version: str,
+    hf_repo_name: str,
+    hf_repo_type: str,
+    model_package_name: str,
+    model_package_version: Optional[str] = None,
+) -> Optional[Dict]:
+    finalized_manifest = load_release_manifest_from_hf(
+        version=version,
+        hf_repo_name=hf_repo_name,
+        hf_repo_type=hf_repo_type,
+        revision=version,
+    )
+    if finalized_manifest is None:
+        return None
+
+    resolved_model_package_version = model_package_version or _get_model_package_version(
+        model_package_name
+    )
+    candidate_manifest, _ = create_release_manifest_commit_operations(
+        files_with_repo_paths=[(Path(path), repo_path) for path, repo_path in files_with_paths],
+        version=version,
+        hf_repo_name=hf_repo_name,
+        model_package_name=model_package_name,
+        model_package_version=resolved_model_package_version,
+        existing_manifest=finalized_manifest,
+    )
+    if candidate_manifest != finalized_manifest:
+        raise RuntimeError(
+            f"Release {version} is already finalized on {hf_repo_name}. "
+            "Refusing to mutate the tagged release manifest."
+        )
+    return finalized_manifest
+
+
 def create_release_tag(
     version: str,
     revision: str,
@@ -157,6 +269,7 @@ def create_release_tag(
             tag=version,
             revision=revision,
             repo_type=hf_repo_type,
+            exist_ok=False,
         )
         logging.info(
             "Tagged revision %s with %s in Hugging Face repository %s.",
@@ -166,11 +279,28 @@ def create_release_tag(
         )
     except Exception as e:
         if "Tag reference exists already" in str(e) or "409" in str(e):
-            logging.warning(
-                "Tag %s already exists in %s. Skipping tag creation.",
-                version,
-                hf_repo_name,
+            tagged_revision = getattr(
+                api.repo_info(
+                    repo_id=hf_repo_name,
+                    repo_type=hf_repo_type,
+                    revision=version,
+                    token=token,
+                ),
+                "sha",
+                None,
             )
+            if tagged_revision == revision:
+                logging.info(
+                    "Tag %s already exists in %s and already points to %s.",
+                    version,
+                    hf_repo_name,
+                    revision,
+                )
+                return
+            raise RuntimeError(
+                f"Tag {version} already exists in {hf_repo_name} at "
+                f"{tagged_revision}; refusing to treat {revision} as finalized."
+            ) from e
         else:
             raise
 
@@ -186,12 +316,12 @@ def upload_data_files(
     if version is None:
         version = metadata.version("policyengine-us-data")
 
-    upload_files_to_hf(
+    commit_oid = upload_files_to_hf(
         files=files,
         version=version,
         hf_repo_name=hf_repo_name,
         hf_repo_type=hf_repo_type,
-        create_tag=create_tag,
+        create_tag=False,
     )
 
     upload_files_to_gcs(
@@ -199,6 +329,14 @@ def upload_data_files(
         version=version,
         gcs_bucket_name=gcs_bucket_name,
     )
+
+    if create_tag:
+        create_release_tag(
+            version=version,
+            revision=commit_oid,
+            hf_repo_name=hf_repo_name,
+            hf_repo_type=hf_repo_type,
+        )
 
 
 def upload_files_to_hf(
@@ -236,16 +374,23 @@ def upload_files_to_hf(
             )
         )
 
+    model_package_version = _get_model_package_version()
     existing_manifest = load_release_manifest_from_hf(
         version=version,
         hf_repo_name=hf_repo_name,
         hf_repo_type=hf_repo_type,
     )
+    parent_commit = get_repo_head_revision(
+        api=api,
+        repo_id=hf_repo_name,
+        repo_type=hf_repo_type,
+        token=token,
+    )
     _, manifest_operations = create_release_manifest_commit_operations(
         files_with_repo_paths=files_with_repo_paths,
         version=version,
         hf_repo_name=hf_repo_name,
-        model_package_version=_get_model_package_version(),
+        model_package_version=model_package_version,
         existing_manifest=existing_manifest,
     )
     hf_operations.extend(manifest_operations)
@@ -256,6 +401,7 @@ def upload_files_to_hf(
         operations=hf_operations,
         repo_type=hf_repo_type,
         commit_message=f"Upload data files for version {version}",
+        parent_commit=parent_commit,
     )
     logging.info(f"Uploaded files to Hugging Face repository {hf_repo_name}.")
 
@@ -268,6 +414,7 @@ def upload_files_to_hf(
             token=token,
             api=api,
         )
+    return commit_info.oid
 
 
 def upload_files_to_gcs(
@@ -413,6 +560,17 @@ def publish_release_manifest_to_hf(
 ) -> Dict:
     token = os.environ.get("HUGGING_FACE_TOKEN")
     api = HfApi()
+    finalized_manifest = get_matching_finalized_release_manifest(
+        files_with_paths=files_with_paths,
+        version=version,
+        hf_repo_name=hf_repo_name,
+        hf_repo_type=hf_repo_type,
+        model_package_name=model_package_name,
+        model_package_version=model_package_version,
+    )
+    if finalized_manifest is not None:
+        return finalized_manifest
+
     assert_release_not_finalized(
         version=version,
         hf_repo_name=hf_repo_name,
@@ -423,13 +581,21 @@ def publish_release_manifest_to_hf(
         hf_repo_name=hf_repo_name,
         hf_repo_type=hf_repo_type,
     )
+    resolved_model_package_version = model_package_version or _get_model_package_version(
+        model_package_name
+    )
+    parent_commit = get_repo_head_revision(
+        api=api,
+        repo_id=hf_repo_name,
+        repo_type=hf_repo_type,
+        token=token,
+    )
     manifest, operations = create_release_manifest_commit_operations(
         files_with_repo_paths=[(Path(path), repo_path) for path, repo_path in files_with_paths],
         version=version,
         hf_repo_name=hf_repo_name,
         model_package_name=model_package_name,
-        model_package_version=model_package_version
-        or _get_model_package_version(model_package_name),
+        model_package_version=resolved_model_package_version,
         existing_manifest=existing_manifest,
     )
     commit_info = hf_create_commit_with_retry(
@@ -439,6 +605,7 @@ def publish_release_manifest_to_hf(
         repo_type=hf_repo_type,
         token=token,
         commit_message=f"Update release manifest for version {version}",
+        parent_commit=parent_commit,
     )
     if create_tag:
         create_release_tag(
@@ -477,6 +644,7 @@ def hf_create_commit_with_retry(
     repo_type: str,
     token: str,
     commit_message: str,
+    parent_commit: Optional[str] = None,
 ):
     """
     Create HuggingFace commit with retry logic for timeout errors.
@@ -489,6 +657,7 @@ def hf_create_commit_with_retry(
         operations=operations,
         repo_type=repo_type,
         commit_message=commit_message,
+        parent_commit=parent_commit,
     )
 
 

--- a/policyengine_us_data/utils/data_upload.py
+++ b/policyengine_us_data/utils/data_upload.py
@@ -433,12 +433,13 @@ def publish_release_manifest_to_hf(
         hf_repo_type=hf_repo_type,
     )
     manifest, operations = create_release_manifest_commit_operations(
-        files_with_repo_paths=[(Path(path), repo_path) for path, repo_path in files_with_paths],
+        files_with_repo_paths=[
+            (Path(path), repo_path) for path, repo_path in files_with_paths
+        ],
         version=version,
         hf_repo_name=hf_repo_name,
         model_package_name=model_package_name,
-        model_package_version=model_package_version
-        or model_build_metadata["version"],
+        model_package_version=model_package_version or model_build_metadata["version"],
         model_package_git_sha=model_build_metadata["git_sha"],
         model_package_data_build_fingerprint=model_build_metadata[
             "data_build_fingerprint"

--- a/policyengine_us_data/utils/data_upload.py
+++ b/policyengine_us_data/utils/data_upload.py
@@ -1,6 +1,5 @@
 from io import BytesIO
-from typing import List, Dict, Optional, Tuple, Sequence
-import json
+from typing import List, Dict, Optional, Tuple
 from huggingface_hub import (
     HfApi,
     CommitOperationAdd,
@@ -14,8 +13,9 @@ from pathlib import Path
 from importlib import metadata
 import google.auth
 import httpx
-import os
+import json
 import logging
+import os
 
 from tenacity import (
     retry,
@@ -34,37 +34,60 @@ DEFAULT_HF_TIMEOUT = 300
 MAX_RETRIES = 5
 RETRY_BASE_WAIT = 30
 RELEASE_MANIFEST_PATH = "release_manifest.json"
-LOCAL_AREA_FINALIZE_REQUIRED_PREFIXES = (
-    "national/",
-    "states/",
-    "districts/",
-    "cities/",
-)
-LOCAL_AREA_FINALIZE_REQUIRED_COUNTS = {
-    "national/": 1,
-    "states/": 51,
-    "districts/": 435,
-    "cities/": 1,
-}
 
 
 def _get_model_package_version(
     package_name: str = "policyengine-us",
-) -> str:
+) -> Optional[str]:
     try:
         return metadata.version(package_name)
     except metadata.PackageNotFoundError:
-        raise RuntimeError(
-            "Could not determine installed version for "
-            f"{package_name} while building a release manifest."
+        logging.warning(
+            "Could not determine installed version for %s while building release manifest.",
+            package_name,
         )
+        return None
+
+
+def _get_model_package_build_metadata(
+    package_name: str = "policyengine-us",
+) -> Dict[str, Optional[str]]:
+    metadata_payload: Dict[str, Optional[str]] = {
+        "version": _get_model_package_version(package_name),
+        "git_sha": None,
+        "data_build_fingerprint": None,
+    }
+    module_name = package_name.replace("-", "_")
+    try:
+        build_metadata_module = __import__(
+            f"{module_name}.build_metadata",
+            fromlist=["get_data_build_metadata"],
+        )
+        get_data_build_metadata = getattr(
+            build_metadata_module, "get_data_build_metadata", None
+        )
+        if callable(get_data_build_metadata):
+            package_metadata = get_data_build_metadata()
+            metadata_payload["version"] = (
+                package_metadata.get("version") or metadata_payload["version"]
+            )
+            metadata_payload["git_sha"] = package_metadata.get("git_sha")
+            metadata_payload["data_build_fingerprint"] = package_metadata.get(
+                "data_build_fingerprint"
+            )
+    except Exception:
+        logging.warning(
+            "Could not load build metadata from %s while building release manifest.",
+            package_name,
+            exc_info=True,
+        )
+    return metadata_payload
 
 
 def load_release_manifest_from_hf(
     version: str,
     hf_repo_name: str = "policyengine/policyengine-us-data",
     hf_repo_type: str = "model",
-    revision: Optional[str] = None,
 ) -> Optional[Dict]:
     token = os.environ.get("HUGGING_FACE_TOKEN")
     candidate_paths = [
@@ -79,10 +102,9 @@ def load_release_manifest_from_hf(
                 filename=path_in_repo,
                 repo_type=hf_repo_type,
                 token=token,
-                revision=revision,
             )
         except RevisionNotFoundError:
-            return None
+            raise
         except Exception:
             continue
 
@@ -96,152 +118,24 @@ def load_release_manifest_from_hf(
     return None
 
 
-def assert_release_not_finalized(
-    version: str,
-    hf_repo_name: str = "policyengine/policyengine-us-data",
-    hf_repo_type: str = "model",
-) -> None:
-    if (
-        load_release_manifest_from_hf(
-            version=version,
-            hf_repo_name=hf_repo_name,
-            hf_repo_type=hf_repo_type,
-            revision=version,
-        )
-        is not None
-    ):
-        raise RuntimeError(
-            f"Release {version} is already finalized on {hf_repo_name}. "
-            "Refusing to mutate release manifest state after the tag exists."
-        )
-
-
-def get_repo_head_revision(
-    api: HfApi,
-    repo_id: str,
-    repo_type: str,
-    token: Optional[str] = None,
-) -> Optional[str]:
-    repo_info = api.repo_info(
-        repo_id=repo_id,
-        repo_type=repo_type,
-        token=token,
-    )
-    return getattr(repo_info, "sha", None)
-
-
-def _collect_manifest_repo_paths(manifest: Optional[Dict]) -> set[str]:
-    if not manifest:
-        return set()
-    return {
-        artifact["path"]
-        for artifact in manifest.get("artifacts", {}).values()
-        if isinstance(artifact, dict) and isinstance(artifact.get("path"), str)
-    }
-
-
-def missing_release_prefixes(
-    existing_manifest: Optional[Dict],
-    new_repo_paths: Sequence[str],
-    required_prefixes: Sequence[str] = LOCAL_AREA_FINALIZE_REQUIRED_PREFIXES,
-    required_counts: Optional[Dict[str, int]] = None,
-) -> list[str]:
-    required_counts = required_counts or LOCAL_AREA_FINALIZE_REQUIRED_COUNTS
-    combined_paths = _collect_manifest_repo_paths(existing_manifest) | set(
-        new_repo_paths
-    )
-    prefix_counts = {prefix: 0 for prefix in required_prefixes}
-    for path in combined_paths:
-        for prefix in required_prefixes:
-            if path.startswith(prefix):
-                prefix_counts[prefix] += 1
-                break
-
-    return [
-        prefix
-        for prefix in required_prefixes
-        if prefix_counts[prefix] < required_counts.get(prefix, 1)
-    ]
-
-
-def should_finalize_local_area_release(
-    version: str,
-    new_repo_paths: Sequence[str],
-    hf_repo_name: str = "policyengine/policyengine-us-data",
-    hf_repo_type: str = "model",
-) -> tuple[bool, list[str]]:
-    existing_manifest = load_release_manifest_from_hf(
-        version=version,
-        hf_repo_name=hf_repo_name,
-        hf_repo_type=hf_repo_type,
-    )
-    missing_prefixes = missing_release_prefixes(
-        existing_manifest=existing_manifest,
-        new_repo_paths=new_repo_paths,
-    )
-    return not missing_prefixes, missing_prefixes
-
-
-def preflight_release_manifest_publish(
-    files_with_paths: Sequence[Tuple[Path | str, str]],
-    version: str,
-    new_repo_paths: Sequence[str],
-    hf_repo_name: str = "policyengine/policyengine-us-data",
-    hf_repo_type: str = "model",
-    model_package_name: str = "policyengine-us",
-    model_package_version: Optional[str] = None,
-) -> tuple[bool, list[str]]:
-    should_finalize, missing_prefixes = should_finalize_local_area_release(
-        version=version,
-        new_repo_paths=new_repo_paths,
-        hf_repo_name=hf_repo_name,
-        hf_repo_type=hf_repo_type,
-    )
-    assert_release_not_finalized(
-        version=version,
-        hf_repo_name=hf_repo_name,
-        hf_repo_type=hf_repo_type,
-    )
-    existing_manifest = load_release_manifest_from_hf(
-        version=version,
-        hf_repo_name=hf_repo_name,
-        hf_repo_type=hf_repo_type,
-    )
-    resolved_model_package_version = (
-        model_package_version or _get_model_package_version(model_package_name)
-    )
-    create_release_manifest_commit_operations(
-        files_with_repo_paths=[
-            (Path(path), repo_path) for path, repo_path in files_with_paths
-        ],
-        version=version,
-        hf_repo_name=hf_repo_name,
-        model_package_name=model_package_name,
-        model_package_version=resolved_model_package_version,
-        existing_manifest=existing_manifest,
-    )
-    return should_finalize, missing_prefixes
-
-
 def create_release_manifest_commit_operations(
     files_with_repo_paths: List[Tuple[Path, str]],
     version: str,
     hf_repo_name: str = "policyengine/policyengine-us-data",
     model_package_name: str = "policyengine-us",
     model_package_version: Optional[str] = None,
+    model_package_git_sha: Optional[str] = None,
+    model_package_data_build_fingerprint: Optional[str] = None,
     existing_manifest: Optional[Dict] = None,
 ) -> Tuple[Dict, List[CommitOperationAdd]]:
-    if not model_package_version:
-        raise RuntimeError(
-            "A compatible policyengine-us version is required when publishing "
-            "a release manifest."
-        )
     manifest = build_release_manifest(
         files_with_repo_paths=files_with_repo_paths,
         version=version,
         repo_id=hf_repo_name,
         model_package_name=model_package_name,
         model_package_version=model_package_version,
+        model_package_git_sha=model_package_git_sha,
+        model_package_data_build_fingerprint=model_package_data_build_fingerprint,
         existing_manifest=existing_manifest,
     )
     manifest_payload = serialize_release_manifest(manifest)
@@ -257,44 +151,6 @@ def create_release_manifest_commit_operations(
         ),
     ]
     return manifest, operations
-
-
-def get_matching_finalized_release_manifest(
-    files_with_paths: List[Tuple[Path, str]],
-    version: str,
-    hf_repo_name: str,
-    hf_repo_type: str,
-    model_package_name: str,
-    model_package_version: Optional[str] = None,
-) -> Optional[Dict]:
-    finalized_manifest = load_release_manifest_from_hf(
-        version=version,
-        hf_repo_name=hf_repo_name,
-        hf_repo_type=hf_repo_type,
-        revision=version,
-    )
-    if finalized_manifest is None:
-        return None
-
-    resolved_model_package_version = (
-        model_package_version or _get_model_package_version(model_package_name)
-    )
-    candidate_manifest, _ = create_release_manifest_commit_operations(
-        files_with_repo_paths=[
-            (Path(path), repo_path) for path, repo_path in files_with_paths
-        ],
-        version=version,
-        hf_repo_name=hf_repo_name,
-        model_package_name=model_package_name,
-        model_package_version=resolved_model_package_version,
-        existing_manifest=finalized_manifest,
-    )
-    if candidate_manifest != finalized_manifest:
-        raise RuntimeError(
-            f"Release {version} is already finalized on {hf_repo_name}. "
-            "Refusing to mutate the tagged release manifest."
-        )
-    return finalized_manifest
 
 
 def create_release_tag(
@@ -314,7 +170,6 @@ def create_release_tag(
             tag=version,
             revision=revision,
             repo_type=hf_repo_type,
-            exist_ok=False,
         )
         logging.info(
             "Tagged revision %s with %s in Hugging Face repository %s.",
@@ -324,28 +179,11 @@ def create_release_tag(
         )
     except Exception as e:
         if "Tag reference exists already" in str(e) or "409" in str(e):
-            tagged_revision = getattr(
-                api.repo_info(
-                    repo_id=hf_repo_name,
-                    repo_type=hf_repo_type,
-                    revision=version,
-                    token=token,
-                ),
-                "sha",
-                None,
+            logging.warning(
+                "Tag %s already exists in %s. Skipping tag creation.",
+                version,
+                hf_repo_name,
             )
-            if tagged_revision == revision:
-                logging.info(
-                    "Tag %s already exists in %s and already points to %s.",
-                    version,
-                    hf_repo_name,
-                    revision,
-                )
-                return
-            raise RuntimeError(
-                f"Tag {version} already exists in {hf_repo_name} at "
-                f"{tagged_revision}; refusing to treat {revision} as finalized."
-            ) from e
         else:
             raise
 
@@ -361,12 +199,12 @@ def upload_data_files(
     if version is None:
         version = metadata.version("policyengine-us-data")
 
-    commit_oid = upload_files_to_hf(
+    upload_files_to_hf(
         files=files,
         version=version,
         hf_repo_name=hf_repo_name,
         hf_repo_type=hf_repo_type,
-        create_tag=False,
+        create_tag=create_tag,
     )
 
     upload_files_to_gcs(
@@ -374,14 +212,6 @@ def upload_data_files(
         version=version,
         gcs_bucket_name=gcs_bucket_name,
     )
-
-    if create_tag:
-        create_release_tag(
-            version=version,
-            revision=commit_oid,
-            hf_repo_name=hf_repo_name,
-            hf_repo_type=hf_repo_type,
-        )
 
 
 def upload_files_to_hf(
@@ -401,11 +231,6 @@ def upload_files_to_hf(
     token = os.environ.get(
         "HUGGING_FACE_TOKEN",
     )
-    assert_release_not_finalized(
-        version=version,
-        hf_repo_name=hf_repo_name,
-        hf_repo_type=hf_repo_type,
-    )
     for file_path in files:
         file_path = Path(file_path)
         if not file_path.exists():
@@ -419,23 +244,21 @@ def upload_files_to_hf(
             )
         )
 
-    model_package_version = _get_model_package_version()
     existing_manifest = load_release_manifest_from_hf(
         version=version,
         hf_repo_name=hf_repo_name,
         hf_repo_type=hf_repo_type,
     )
-    parent_commit = get_repo_head_revision(
-        api=api,
-        repo_id=hf_repo_name,
-        repo_type=hf_repo_type,
-        token=token,
-    )
+    model_build_metadata = _get_model_package_build_metadata()
     _, manifest_operations = create_release_manifest_commit_operations(
         files_with_repo_paths=files_with_repo_paths,
         version=version,
         hf_repo_name=hf_repo_name,
-        model_package_version=model_package_version,
+        model_package_version=model_build_metadata["version"],
+        model_package_git_sha=model_build_metadata["git_sha"],
+        model_package_data_build_fingerprint=model_build_metadata[
+            "data_build_fingerprint"
+        ],
         existing_manifest=existing_manifest,
     )
     hf_operations.extend(manifest_operations)
@@ -446,7 +269,6 @@ def upload_files_to_hf(
         operations=hf_operations,
         repo_type=hf_repo_type,
         commit_message=f"Upload data files for version {version}",
-        parent_commit=parent_commit,
     )
     logging.info(f"Uploaded files to Hugging Face repository {hf_repo_name}.")
 
@@ -459,7 +281,6 @@ def upload_files_to_hf(
             token=token,
             api=api,
         )
-    return commit_info.oid
 
 
 def upload_files_to_gcs(
@@ -605,44 +426,23 @@ def publish_release_manifest_to_hf(
 ) -> Dict:
     token = os.environ.get("HUGGING_FACE_TOKEN")
     api = HfApi()
-    finalized_manifest = get_matching_finalized_release_manifest(
-        files_with_paths=files_with_paths,
-        version=version,
-        hf_repo_name=hf_repo_name,
-        hf_repo_type=hf_repo_type,
-        model_package_name=model_package_name,
-        model_package_version=model_package_version,
-    )
-    if finalized_manifest is not None:
-        return finalized_manifest
-
-    assert_release_not_finalized(
-        version=version,
-        hf_repo_name=hf_repo_name,
-        hf_repo_type=hf_repo_type,
-    )
+    model_build_metadata = _get_model_package_build_metadata(model_package_name)
     existing_manifest = load_release_manifest_from_hf(
         version=version,
         hf_repo_name=hf_repo_name,
         hf_repo_type=hf_repo_type,
     )
-    resolved_model_package_version = (
-        model_package_version or _get_model_package_version(model_package_name)
-    )
-    parent_commit = get_repo_head_revision(
-        api=api,
-        repo_id=hf_repo_name,
-        repo_type=hf_repo_type,
-        token=token,
-    )
     manifest, operations = create_release_manifest_commit_operations(
-        files_with_repo_paths=[
-            (Path(path), repo_path) for path, repo_path in files_with_paths
-        ],
+        files_with_repo_paths=[(Path(path), repo_path) for path, repo_path in files_with_paths],
         version=version,
         hf_repo_name=hf_repo_name,
         model_package_name=model_package_name,
-        model_package_version=resolved_model_package_version,
+        model_package_version=model_package_version
+        or model_build_metadata["version"],
+        model_package_git_sha=model_build_metadata["git_sha"],
+        model_package_data_build_fingerprint=model_build_metadata[
+            "data_build_fingerprint"
+        ],
         existing_manifest=existing_manifest,
     )
     commit_info = hf_create_commit_with_retry(
@@ -652,7 +452,6 @@ def publish_release_manifest_to_hf(
         repo_type=hf_repo_type,
         token=token,
         commit_message=f"Update release manifest for version {version}",
-        parent_commit=parent_commit,
     )
     if create_tag:
         create_release_tag(
@@ -691,7 +490,6 @@ def hf_create_commit_with_retry(
     repo_type: str,
     token: str,
     commit_message: str,
-    parent_commit: Optional[str] = None,
 ):
     """
     Create HuggingFace commit with retry logic for timeout errors.
@@ -704,7 +502,6 @@ def hf_create_commit_with_retry(
         operations=operations,
         repo_type=repo_type,
         commit_message=commit_message,
-        parent_commit=parent_commit,
     )
 
 
@@ -714,7 +511,6 @@ def upload_to_staging_hf(
     hf_repo_name: str = "policyengine/policyengine-us-data",
     hf_repo_type: str = "model",
     batch_size: int = 50,
-    run_id: str = "",
 ) -> int:
     """
     Upload files to staging/ paths in HuggingFace.
@@ -742,10 +538,9 @@ def upload_to_staging_hf(
             if not local_path.exists():
                 logging.warning(f"File {local_path} does not exist, skipping.")
                 continue
-            staging_prefix = f"staging/{run_id}" if run_id else "staging"
             operations.append(
                 CommitOperationAdd(
-                    path_in_repo=f"{staging_prefix}/{rel_path}",
+                    path_in_repo=f"staging/{rel_path}",
                     path_or_fileobj=str(local_path),
                 )
             )
@@ -775,7 +570,6 @@ def promote_staging_to_production_hf(
     version: str,
     hf_repo_name: str = "policyengine/policyengine-us-data",
     hf_repo_type: str = "model",
-    run_id: str = "",
 ) -> int:
     """
     Atomically promote files from staging/ to production paths.
@@ -798,11 +592,9 @@ def promote_staging_to_production_hf(
     token = os.environ.get("HUGGING_FACE_TOKEN")
     api = HfApi()
 
-    staging_prefix = f"staging/{run_id}" if run_id else "staging"
-
     operations = []
     for rel_path in files:
-        staging_path = f"{staging_prefix}/{rel_path}"
+        staging_path = f"staging/{rel_path}"
         operations.append(
             CommitOperationCopy(
                 src_path_in_repo=staging_path,
@@ -826,7 +618,7 @@ def promote_staging_to_production_hf(
         repo_id=hf_repo_name,
         repo_type=hf_repo_type,
         token=token,
-        commit_message=f"Promote {len(files)} files from {staging_prefix}/ to production for version {version}",
+        commit_message=f"Promote {len(files)} files from staging to production for version {version}",
     )
 
     if result.oid == head_before:
@@ -846,7 +638,6 @@ def cleanup_staging_hf(
     version: str,
     hf_repo_name: str = "policyengine/policyengine-us-data",
     hf_repo_type: str = "model",
-    run_id: str = "",
 ) -> int:
     """
     Clean up staging folder after successful promotion.
@@ -866,11 +657,9 @@ def cleanup_staging_hf(
     token = os.environ.get("HUGGING_FACE_TOKEN")
     api = HfApi()
 
-    staging_prefix = f"staging/{run_id}" if run_id else "staging"
-
     operations = []
     for rel_path in files:
-        staging_path = f"{staging_prefix}/{rel_path}"
+        staging_path = f"staging/{rel_path}"
         operations.append(CommitOperationDelete(path_in_repo=staging_path))
 
     if not operations:
@@ -888,7 +677,7 @@ def cleanup_staging_hf(
         repo_id=hf_repo_name,
         repo_type=hf_repo_type,
         token=token,
-        commit_message=f"Clean up {staging_prefix}/ after version {version} promotion",
+        commit_message=f"Clean up staging after version {version} promotion",
     )
 
     if result.oid == head_before:
@@ -907,7 +696,6 @@ def upload_from_hf_staging_to_gcs(
     gcs_bucket_name: str = "policyengine-us-data",
     hf_repo_name: str = "policyengine/policyengine-us-data",
     hf_repo_type: str = "model",
-    run_id: str = "",
 ) -> int:
     """Download files from HF staging/ and upload to GCS production paths.
 
@@ -927,11 +715,9 @@ def upload_from_hf_staging_to_gcs(
     storage_client = storage.Client(credentials=credentials, project=project_id)
     bucket = storage_client.bucket(gcs_bucket_name)
 
-    staging_prefix = f"staging/{run_id}" if run_id else "staging"
-
     uploaded = 0
     for rel_path in rel_paths:
-        staging_filename = f"{staging_prefix}/{rel_path}"
+        staging_filename = f"staging/{rel_path}"
         local_path = hf_hub_download(
             repo_id=hf_repo_name,
             filename=staging_filename,

--- a/policyengine_us_data/utils/release_manifest.py
+++ b/policyengine_us_data/utils/release_manifest.py
@@ -71,10 +71,7 @@ def _normalize_existing_manifest(
     if existing_manifest is None:
         return None
     package = existing_manifest.get("data_package", {})
-    if (
-        package.get("name") != data_package_name
-        or package.get("version") != version
-    ):
+    if package.get("name") != data_package_name or package.get("version") != version:
         return None
     return deepcopy(dict(existing_manifest))
 

--- a/policyengine_us_data/utils/release_manifest.py
+++ b/policyengine_us_data/utils/release_manifest.py
@@ -36,7 +36,11 @@ def _base_manifest(
     *,
     version: str,
     data_package_name: str,
-    compatible_model_packages: Sequence[Dict[str, str]],
+    model_package_name: str,
+    model_package_version: str | None,
+    model_package_git_sha: str | None,
+    model_package_data_build_fingerprint: str | None,
+    build_id: str,
     created_at: str,
 ) -> Dict:
     manifest = {
@@ -45,21 +49,34 @@ def _base_manifest(
             "name": data_package_name,
             "version": version,
         },
-        "compatible_model_packages": list(compatible_model_packages),
+        "compatible_model_packages": [],
         "default_datasets": {},
         "created_at": created_at,
+        "build": {
+            "build_id": build_id,
+            "built_at": created_at,
+        },
         "artifacts": {},
     }
+    if (
+        model_package_version
+        or model_package_git_sha
+        or model_package_data_build_fingerprint
+    ):
+        manifest["build"]["built_with_model_package"] = {
+            "name": model_package_name,
+            "version": model_package_version,
+            "git_sha": model_package_git_sha,
+            "data_build_fingerprint": model_package_data_build_fingerprint,
+        }
+    if model_package_version:
+        manifest["compatible_model_packages"].append(
+            {
+                "name": model_package_name,
+                "specifier": f"=={model_package_version}",
+            }
+        )
     return manifest
-
-
-def _compatible_model_packages(
-    model_package_name: str,
-    model_package_version: str | None,
-) -> list[Dict[str, str]]:
-    if not model_package_version:
-        return []
-    return [{"name": model_package_name, "version": model_package_version}]
 
 
 def _normalize_existing_manifest(
@@ -71,7 +88,10 @@ def _normalize_existing_manifest(
     if existing_manifest is None:
         return None
     package = existing_manifest.get("data_package", {})
-    if package.get("name") != data_package_name or package.get("version") != version:
+    if (
+        package.get("name") != data_package_name
+        or package.get("version") != version
+    ):
         return None
     return deepcopy(dict(existing_manifest))
 
@@ -84,6 +104,9 @@ def build_release_manifest(
     data_package_name: str = "policyengine-us-data",
     model_package_name: str = "policyengine-us",
     model_package_version: str | None = None,
+    model_package_git_sha: str | None = None,
+    model_package_data_build_fingerprint: str | None = None,
+    build_id: str | None = None,
     existing_manifest: Mapping | None = None,
     default_datasets: Optional[Mapping[str, str]] = None,
     created_at: str | None = None,
@@ -94,24 +117,43 @@ def build_release_manifest(
         data_package_name=data_package_name,
     )
     manifest_timestamp = created_at or _utc_timestamp()
+    resolved_build_id = build_id or f"{data_package_name}-{version}"
 
     if manifest is None:
         manifest = _base_manifest(
             version=version,
             data_package_name=data_package_name,
-            compatible_model_packages=_compatible_model_packages(
-                model_package_name,
-                model_package_version,
-            ),
+            model_package_name=model_package_name,
+            model_package_version=model_package_version,
+            model_package_git_sha=model_package_git_sha,
+            model_package_data_build_fingerprint=model_package_data_build_fingerprint,
+            build_id=resolved_build_id,
             created_at=manifest_timestamp,
         )
     else:
         manifest["schema_version"] = RELEASE_MANIFEST_SCHEMA_VERSION
-        manifest["created_at"] = manifest.get("created_at") or manifest_timestamp
-        manifest["compatible_model_packages"] = _compatible_model_packages(
-            model_package_name,
-            model_package_version,
-        )
+        manifest["created_at"] = manifest_timestamp
+        manifest.setdefault("build", {})
+        manifest["build"].setdefault("build_id", resolved_build_id)
+        manifest["build"].setdefault("built_at", manifest_timestamp)
+        if (
+            model_package_version
+            or model_package_git_sha
+            or model_package_data_build_fingerprint
+        ):
+            manifest["build"]["built_with_model_package"] = {
+                "name": model_package_name,
+                "version": model_package_version,
+                "git_sha": model_package_git_sha,
+                "data_build_fingerprint": model_package_data_build_fingerprint,
+            }
+        if model_package_version:
+            manifest["compatible_model_packages"] = [
+                {
+                    "name": model_package_name,
+                    "specifier": f"=={model_package_version}",
+                }
+            ]
 
     if default_datasets:
         manifest.setdefault("default_datasets", {}).update(default_datasets)

--- a/policyengine_us_data/utils/release_manifest.py
+++ b/policyengine_us_data/utils/release_manifest.py
@@ -88,10 +88,7 @@ def _normalize_existing_manifest(
     if existing_manifest is None:
         return None
     package = existing_manifest.get("data_package", {})
-    if (
-        package.get("name") != data_package_name
-        or package.get("version") != version
-    ):
+    if package.get("name") != data_package_name or package.get("version") != version:
         return None
     return deepcopy(dict(existing_manifest))
 

--- a/policyengine_us_data/utils/release_manifest.py
+++ b/policyengine_us_data/utils/release_manifest.py
@@ -36,8 +36,7 @@ def _base_manifest(
     *,
     version: str,
     data_package_name: str,
-    model_package_name: str,
-    model_package_version: str | None,
+    compatible_model_packages: Sequence[Dict[str, str]],
     created_at: str,
 ) -> Dict:
     manifest = {
@@ -46,19 +45,21 @@ def _base_manifest(
             "name": data_package_name,
             "version": version,
         },
-        "compatible_model_packages": [],
+        "compatible_model_packages": list(compatible_model_packages),
         "default_datasets": {},
         "created_at": created_at,
         "artifacts": {},
     }
-    if model_package_version:
-        manifest["compatible_model_packages"].append(
-            {
-                "name": model_package_name,
-                "specifier": f"=={model_package_version}",
-            }
-        )
     return manifest
+
+
+def _compatible_model_packages(
+    model_package_name: str,
+    model_package_version: str | None,
+) -> list[Dict[str, str]]:
+    if not model_package_version:
+        return []
+    return [{"name": model_package_name, "version": model_package_version}]
 
 
 def _normalize_existing_manifest(
@@ -101,20 +102,19 @@ def build_release_manifest(
         manifest = _base_manifest(
             version=version,
             data_package_name=data_package_name,
-            model_package_name=model_package_name,
-            model_package_version=model_package_version,
+            compatible_model_packages=_compatible_model_packages(
+                model_package_name,
+                model_package_version,
+            ),
             created_at=manifest_timestamp,
         )
     else:
         manifest["schema_version"] = RELEASE_MANIFEST_SCHEMA_VERSION
         manifest["created_at"] = manifest.get("created_at") or manifest_timestamp
-        if model_package_version:
-            manifest["compatible_model_packages"] = [
-                {
-                    "name": model_package_name,
-                    "specifier": f"=={model_package_version}",
-                }
-            ]
+        manifest["compatible_model_packages"] = _compatible_model_packages(
+            model_package_name,
+            model_package_version,
+        )
 
     if default_datasets:
         manifest.setdefault("default_datasets", {}).update(default_datasets)

--- a/policyengine_us_data/utils/release_manifest.py
+++ b/policyengine_us_data/utils/release_manifest.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+import json
+from pathlib import Path, PurePosixPath
+from typing import Dict, Mapping, Optional, Sequence, Tuple
+
+from policyengine_us_data.utils.manifest import compute_file_checksum
+
+RELEASE_MANIFEST_SCHEMA_VERSION = 1
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _artifact_key(path_in_repo: str) -> str:
+    return str(PurePosixPath(path_in_repo).with_suffix(""))
+
+
+def _artifact_kind(path_in_repo: str) -> str:
+    suffix = PurePosixPath(path_in_repo).suffix.lower()
+    if suffix == ".h5":
+        return "microdata"
+    if suffix == ".db":
+        return "database"
+    if suffix == ".npz":
+        return "geography"
+    if suffix == ".npy":
+        return "weights"
+    return "auxiliary"
+
+
+def _base_manifest(
+    *,
+    version: str,
+    data_package_name: str,
+    model_package_name: str,
+    model_package_version: str | None,
+    created_at: str,
+) -> Dict:
+    manifest = {
+        "schema_version": RELEASE_MANIFEST_SCHEMA_VERSION,
+        "data_package": {
+            "name": data_package_name,
+            "version": version,
+        },
+        "compatible_model_packages": [],
+        "default_datasets": {},
+        "created_at": created_at,
+        "artifacts": {},
+    }
+    if model_package_version:
+        manifest["compatible_model_packages"].append(
+            {
+                "name": model_package_name,
+                "specifier": f"=={model_package_version}",
+            }
+        )
+    return manifest
+
+
+def _normalize_existing_manifest(
+    existing_manifest: Mapping | None,
+    *,
+    version: str,
+    data_package_name: str,
+) -> Dict | None:
+    if existing_manifest is None:
+        return None
+    package = existing_manifest.get("data_package", {})
+    if (
+        package.get("name") != data_package_name
+        or package.get("version") != version
+    ):
+        return None
+    return deepcopy(dict(existing_manifest))
+
+
+def build_release_manifest(
+    *,
+    files_with_repo_paths: Sequence[Tuple[Path | str, str]],
+    version: str,
+    repo_id: str,
+    data_package_name: str = "policyengine-us-data",
+    model_package_name: str = "policyengine-us",
+    model_package_version: str | None = None,
+    existing_manifest: Mapping | None = None,
+    default_datasets: Optional[Mapping[str, str]] = None,
+    created_at: str | None = None,
+) -> Dict:
+    manifest = _normalize_existing_manifest(
+        existing_manifest,
+        version=version,
+        data_package_name=data_package_name,
+    )
+    manifest_timestamp = created_at or _utc_timestamp()
+
+    if manifest is None:
+        manifest = _base_manifest(
+            version=version,
+            data_package_name=data_package_name,
+            model_package_name=model_package_name,
+            model_package_version=model_package_version,
+            created_at=manifest_timestamp,
+        )
+    else:
+        manifest["schema_version"] = RELEASE_MANIFEST_SCHEMA_VERSION
+        manifest["created_at"] = manifest.get("created_at") or manifest_timestamp
+        if model_package_version:
+            manifest["compatible_model_packages"] = [
+                {
+                    "name": model_package_name,
+                    "specifier": f"=={model_package_version}",
+                }
+            ]
+
+    if default_datasets:
+        manifest.setdefault("default_datasets", {}).update(default_datasets)
+
+    for local_path, path_in_repo in files_with_repo_paths:
+        local_path = Path(local_path)
+        manifest["artifacts"][_artifact_key(path_in_repo)] = {
+            "kind": _artifact_kind(path_in_repo),
+            "path": path_in_repo,
+            "repo_id": repo_id,
+            "revision": version,
+            "sha256": compute_file_checksum(local_path),
+            "size_bytes": local_path.stat().st_size,
+        }
+
+    if (
+        "national" not in manifest["default_datasets"]
+        and "enhanced_cps_2024" in manifest["artifacts"]
+    ):
+        manifest["default_datasets"]["national"] = "enhanced_cps_2024"
+
+    return manifest
+
+
+def serialize_release_manifest(manifest: Mapping) -> bytes:
+    return (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode("utf-8")

--- a/tests/unit/test_modal_data_build.py
+++ b/tests/unit/test_modal_data_build.py
@@ -88,3 +88,35 @@ def test_validate_and_maybe_upload_datasets_skips_upload_when_disabled(monkeypat
             {"TEST_ENV": "1"},
         ),
     ]
+
+
+def test_validate_and_maybe_upload_datasets_stages_with_run_id(monkeypatch):
+    data_build = _load_data_build_module()
+    calls = []
+
+    def fake_run_script(script_path, args=None, env=None, log_file=None):
+        calls.append((script_path, args or [], env))
+        return script_path
+
+    monkeypatch.setattr(data_build, "run_script", fake_run_script)
+
+    data_build.validate_and_maybe_upload_datasets(
+        upload=True,
+        skip_enhanced_cps=False,
+        env={"TEST_ENV": "1"},
+        stage_only=True,
+        run_id="abc123",
+    )
+
+    assert calls == [
+        (
+            "policyengine_us_data/storage/upload_completed_datasets.py",
+            ["--validate-only"],
+            {"TEST_ENV": "1"},
+        ),
+        (
+            "policyengine_us_data/storage/upload_completed_datasets.py",
+            ["--stage-only", "--run-id=abc123"],
+            {"TEST_ENV": "1"},
+        ),
+    ]

--- a/tests/unit/test_modal_local_area.py
+++ b/tests/unit/test_modal_local_area.py
@@ -1,0 +1,68 @@
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
+
+
+def _load_local_area_module():
+    fake_modal = ModuleType("modal")
+
+    class _FakeApp:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def function(self, *args, **kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def local_entrypoint(self, *args, **kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    fake_modal.App = _FakeApp
+    fake_modal.Secret = SimpleNamespace(from_name=lambda *args, **kwargs: object())
+    fake_modal.Volume = SimpleNamespace(from_name=lambda *args, **kwargs: object())
+
+    fake_images = ModuleType("modal_app.images")
+    fake_images.cpu_image = object()
+
+    fake_resilience = ModuleType("modal_app.resilience")
+    fake_resilience.reconcile_run_dir_fingerprint = lambda *args, **kwargs: None
+
+    sys.modules["modal"] = fake_modal
+    sys.modules["modal_app.images"] = fake_images
+    sys.modules["modal_app.resilience"] = fake_resilience
+    sys.modules.pop("modal_app.local_area", None)
+    return importlib.import_module("modal_app.local_area")
+
+
+def test_build_promote_national_publish_script_imports_version_manifest_helpers():
+    local_area = _load_local_area_module()
+
+    script = local_area._build_promote_national_publish_script(
+        version="1.73.0",
+        run_id="1.73.0_deadbeef_20260411",
+        rel_paths=["national/US.h5"],
+    )
+
+    assert "from policyengine_us_data.utils.version_manifest import (" in script
+    assert "HFVersionInfo" in script
+    assert "build_manifest" in script
+    assert "upload_manifest" in script
+
+
+def test_build_promote_publish_script_finalizes_complete_release():
+    local_area = _load_local_area_module()
+
+    script = local_area._build_promote_publish_script(
+        version="1.73.0",
+        run_id="1.73.0_deadbeef_20260411",
+        rel_paths=["states/AL.h5", "districts/AL-01.h5", "cities/NYC.h5"],
+    )
+
+    assert "should_finalize_local_area_release" in script
+    assert "create_tag=should_finalize" in script
+    assert "upload_manifest(" in script

--- a/tests/unit/test_promote_local_h5s.py
+++ b/tests/unit/test_promote_local_h5s.py
@@ -1,0 +1,34 @@
+import pytest
+
+import policyengine_us_data.calibration.promote_local_h5s as promote_module
+
+
+def test_promote_preflight_failure_stops_before_production_writes(
+    tmp_path, monkeypatch
+):
+    local_file = tmp_path / "AL.h5"
+    local_file.write_bytes(b"state")
+    files = [(local_file, "states/AL.h5")]
+    rel_paths = ["states/AL.h5"]
+    promote_calls = []
+
+    monkeypatch.setattr(
+        promote_module,
+        "preflight_release_manifest_publish",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("blocked")),
+    )
+    monkeypatch.setattr(
+        promote_module,
+        "promote_staging_to_production_hf",
+        lambda *args, **kwargs: promote_calls.append(("hf", args, kwargs)),
+    )
+    monkeypatch.setattr(
+        promote_module,
+        "upload_from_hf_staging_to_gcs",
+        lambda *args, **kwargs: promote_calls.append(("gcs", args, kwargs)),
+    )
+
+    with pytest.raises(RuntimeError, match="blocked"):
+        promote_module.promote(files, rel_paths, version="1.73.0")
+
+    assert promote_calls == []

--- a/tests/unit/test_release_manifest.py
+++ b/tests/unit/test_release_manifest.py
@@ -28,9 +28,7 @@ def _sha256(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
 
 
-EXPECTED_COMPATIBLE_MODEL_PACKAGES = [
-    {"name": "policyengine-us", "version": "1.634.4"}
-]
+EXPECTED_COMPATIBLE_MODEL_PACKAGES = [{"name": "policyengine-us", "version": "1.634.4"}]
 
 
 def _build_local_area_manifest(
@@ -43,9 +41,7 @@ def _build_local_area_manifest(
     for index in range(states):
         artifacts[f"states/S{index:02d}"] = {"path": f"states/S{index:02d}.h5"}
     for index in range(districts):
-        artifacts[f"districts/D{index:03d}"] = {
-            "path": f"districts/D{index:03d}.h5"
-        }
+        artifacts[f"districts/D{index:03d}"] = {"path": f"districts/D{index:03d}.h5"}
     for index in range(cities):
         artifacts[f"cities/C{index:03d}"] = {"path": f"cities/C{index:03d}.h5"}
     return {"artifacts": artifacts}
@@ -133,9 +129,7 @@ def test_build_release_manifest_merges_existing_release_same_version(tmp_path):
     assert set(manifest["artifacts"]) == {"enhanced_cps_2024", "districts/NC-01"}
     assert manifest["default_datasets"] == {"national": "enhanced_cps_2024"}
     assert manifest["created_at"] == "2026-04-09T12:00:00Z"
-    assert manifest["artifacts"]["districts/NC-01"]["sha256"] == _sha256(
-        district_bytes
-    )
+    assert manifest["artifacts"]["districts/NC-01"]["sha256"] == _sha256(district_bytes)
 
 
 def test_load_release_manifest_from_hf_uses_explicit_revision_when_requested(tmp_path):
@@ -360,7 +354,9 @@ def test_upload_files_to_hf_fails_without_model_package_version(tmp_path):
                 except RuntimeError as exc:
                     assert "missing package" in str(exc)
                 else:
-                    raise AssertionError("Expected RuntimeError when model version is unavailable")
+                    raise AssertionError(
+                        "Expected RuntimeError when model version is unavailable"
+                    )
 
 
 def test_publish_release_manifest_to_hf_rejects_finalized_release(tmp_path):

--- a/tests/unit/test_release_manifest.py
+++ b/tests/unit/test_release_manifest.py
@@ -232,31 +232,34 @@ def test_publish_release_manifest_to_hf_can_finalize_and_tag(tmp_path):
 
     mock_api = MagicMock()
     mock_api.create_commit.return_value = MagicMock(oid="final-commit-sha")
+    existing_manifest = {
+        "schema_version": RELEASE_MANIFEST_SCHEMA_VERSION,
+        "data_package": {
+            "name": "policyengine-us-data",
+            "version": "1.73.0",
+        },
+        "compatible_model_packages": [],
+        "default_datasets": {"national": "enhanced_cps_2024"},
+        "created_at": "2026-04-10T12:00:00Z",
+        "artifacts": {
+            "enhanced_cps_2024": {
+                "kind": "microdata",
+                "path": "enhanced_cps_2024.h5",
+                "repo_id": "policyengine/policyengine-us-data",
+                "revision": "1.73.0",
+                "sha256": "abc",
+                "size_bytes": 123,
+            }
+        },
+    }
 
     with (
         patch("policyengine_us_data.utils.data_upload.HfApi", return_value=mock_api),
         patch(
             "policyengine_us_data.utils.data_upload.load_release_manifest_from_hf",
-            return_value={
-                "schema_version": RELEASE_MANIFEST_SCHEMA_VERSION,
-                "data_package": {
-                    "name": "policyengine-us-data",
-                    "version": "1.73.0",
-                },
-                "compatible_model_packages": [],
-                "default_datasets": {"national": "enhanced_cps_2024"},
-                "created_at": "2026-04-10T12:00:00Z",
-                "artifacts": {
-                    "enhanced_cps_2024": {
-                        "kind": "microdata",
-                        "path": "enhanced_cps_2024.h5",
-                        "repo_id": "policyengine/policyengine-us-data",
-                        "revision": "1.73.0",
-                        "sha256": "abc",
-                        "size_bytes": 123,
-                    }
-                },
-            },
+            side_effect=lambda *args, **kwargs: (
+                None if kwargs.get("revision") == "1.73.0" else existing_manifest
+            ),
         ),
         patch(
             "policyengine_us_data.utils.data_upload.metadata.version",

--- a/tests/unit/test_release_manifest.py
+++ b/tests/unit/test_release_manifest.py
@@ -7,7 +7,9 @@ from huggingface_hub import CommitOperationAdd
 
 from policyengine_us_data.utils.data_upload import (
     load_release_manifest_from_hf,
+    missing_release_prefixes,
     publish_release_manifest_to_hf,
+    should_finalize_local_area_release,
     upload_files_to_hf,
 )
 from policyengine_us_data.utils.release_manifest import (
@@ -24,6 +26,29 @@ def _write_file(path: Path, content: bytes) -> Path:
 
 def _sha256(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
+
+
+EXPECTED_COMPATIBLE_MODEL_PACKAGES = [
+    {"name": "policyengine-us", "version": "1.634.4"}
+]
+
+
+def _build_local_area_manifest(
+    *,
+    states: int = 0,
+    districts: int = 0,
+    cities: int = 0,
+) -> dict:
+    artifacts = {}
+    for index in range(states):
+        artifacts[f"states/S{index:02d}"] = {"path": f"states/S{index:02d}.h5"}
+    for index in range(districts):
+        artifacts[f"districts/D{index:03d}"] = {
+            "path": f"districts/D{index:03d}.h5"
+        }
+    for index in range(cities):
+        artifacts[f"cities/C{index:03d}"] = {"path": f"cities/C{index:03d}.h5"}
+    return {"artifacts": artifacts}
 
 
 def test_build_release_manifest_tracks_uploaded_artifacts(tmp_path):
@@ -51,12 +76,7 @@ def test_build_release_manifest_tracks_uploaded_artifacts(tmp_path):
         "version": "1.73.0",
     }
     assert manifest["schema_version"] == RELEASE_MANIFEST_SCHEMA_VERSION
-    assert manifest["compatible_model_packages"] == [
-        {
-            "name": "policyengine-us",
-            "specifier": "==1.634.4",
-        }
-    ]
+    assert manifest["compatible_model_packages"] == EXPECTED_COMPATIBLE_MODEL_PACKAGES
     assert manifest["default_datasets"] == {"national": "enhanced_cps_2024"}
 
     assert manifest["artifacts"]["enhanced_cps_2024"] == {
@@ -86,12 +106,7 @@ def test_build_release_manifest_merges_existing_release_same_version(tmp_path):
             "name": "policyengine-us-data",
             "version": "1.73.0",
         },
-        "compatible_model_packages": [
-            {
-                "name": "policyengine-us",
-                "specifier": "==1.634.4",
-            }
-        ],
+        "compatible_model_packages": EXPECTED_COMPATIBLE_MODEL_PACKAGES,
         "default_datasets": {"national": "enhanced_cps_2024"},
         "created_at": "2026-04-09T12:00:00Z",
         "artifacts": {
@@ -238,7 +253,7 @@ def test_publish_release_manifest_to_hf_can_finalize_and_tag(tmp_path):
             "name": "policyengine-us-data",
             "version": "1.73.0",
         },
-        "compatible_model_packages": [],
+        "compatible_model_packages": EXPECTED_COMPATIBLE_MODEL_PACKAGES,
         "default_datasets": {"national": "enhanced_cps_2024"},
         "created_at": "2026-04-10T12:00:00Z",
         "artifacts": {
@@ -278,6 +293,37 @@ def test_publish_release_manifest_to_hf_can_finalize_and_tag(tmp_path):
         )
 
     mock_api.create_tag.assert_called_once()
+
+
+def test_missing_release_prefixes_requires_full_local_area_bundle():
+    existing_manifest = _build_local_area_manifest(states=1, districts=1)
+
+    missing = missing_release_prefixes(
+        existing_manifest=existing_manifest,
+        new_repo_paths=["national/US.h5"],
+    )
+
+    assert missing == ["states/", "districts/", "cities/"]
+
+
+def test_should_finalize_local_area_release_uses_combined_manifest_state():
+    existing_manifest = _build_local_area_manifest(
+        states=51,
+        districts=435,
+        cities=1,
+    )
+
+    with patch(
+        "policyengine_us_data.utils.data_upload.load_release_manifest_from_hf",
+        return_value=existing_manifest,
+    ):
+        should_finalize, missing = should_finalize_local_area_release(
+            version="1.73.0",
+            new_repo_paths=["national/US.h5"],
+        )
+
+    assert should_finalize is True
+    assert missing == []
 
 
 def test_upload_files_to_hf_fails_without_model_package_version(tmp_path):
@@ -322,17 +368,85 @@ def test_publish_release_manifest_to_hf_rejects_finalized_release(tmp_path):
         tmp_path / "AL.h5",
         b"state-dataset",
     )
-
-    with patch(
-        "policyengine_us_data.utils.data_upload.load_release_manifest_from_hf",
-        side_effect=[
-            {
-                "data_package": {
-                    "name": "policyengine-us-data",
-                    "version": "1.73.0",
-                }
+    finalized_manifest = {
+        "schema_version": RELEASE_MANIFEST_SCHEMA_VERSION,
+        "data_package": {
+            "name": "policyengine-us-data",
+            "version": "1.73.0",
+        },
+        "compatible_model_packages": EXPECTED_COMPATIBLE_MODEL_PACKAGES,
+        "default_datasets": {"national": "enhanced_cps_2024"},
+        "created_at": "2026-04-10T12:00:00Z",
+        "artifacts": {
+            "states/AL": {
+                "kind": "microdata",
+                "path": "states/AL.h5",
+                "repo_id": "policyengine/policyengine-us-data",
+                "revision": "1.73.0",
+                "sha256": _sha256(b"state-dataset"),
+                "size_bytes": len(b"state-dataset"),
             }
-        ],
+        },
+    }
+
+    with (
+        patch(
+            "policyengine_us_data.utils.data_upload.load_release_manifest_from_hf",
+            side_effect=lambda *args, **kwargs: (
+                finalized_manifest if kwargs.get("revision") == "1.73.0" else None
+            ),
+        ),
+        patch(
+            "policyengine_us_data.utils.data_upload._get_model_package_version",
+            return_value="1.634.4",
+        ),
+    ):
+        manifest = publish_release_manifest_to_hf(
+            [(state_path, "states/AL.h5")],
+            version="1.73.0",
+            create_tag=True,
+        )
+
+    assert manifest == finalized_manifest
+
+
+def test_publish_release_manifest_to_hf_rejects_mutating_finalized_release(tmp_path):
+    state_path = _write_file(
+        tmp_path / "AL.h5",
+        b"state-dataset-v2",
+    )
+    finalized_manifest = {
+        "schema_version": RELEASE_MANIFEST_SCHEMA_VERSION,
+        "data_package": {
+            "name": "policyengine-us-data",
+            "version": "1.73.0",
+        },
+        "compatible_model_packages": EXPECTED_COMPATIBLE_MODEL_PACKAGES,
+        "default_datasets": {"national": "enhanced_cps_2024"},
+        "created_at": "2026-04-10T12:00:00Z",
+        "artifacts": {
+            "states/AL": {
+                "kind": "microdata",
+                "path": "states/AL.h5",
+                "repo_id": "policyengine/policyengine-us-data",
+                "revision": "1.73.0",
+                "sha256": _sha256(b"state-dataset"),
+                "size_bytes": len(b"state-dataset"),
+            }
+        },
+    }
+
+    with (
+        patch(
+            "policyengine_us_data.utils.data_upload.load_release_manifest_from_hf",
+            side_effect=lambda *args, **kwargs: (
+                finalized_manifest if kwargs.get("revision") == "1.73.0" else None
+            ),
+        ),
+        patch(
+            "policyengine_us_data.utils.data_upload._get_model_package_version",
+            return_value="1.634.4",
+        ),
     ):
         try:
             publish_release_manifest_to_hf(

--- a/tests/unit/test_release_manifest.py
+++ b/tests/unit/test_release_manifest.py
@@ -1,0 +1,343 @@
+import hashlib
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from huggingface_hub import CommitOperationAdd
+
+from policyengine_us_data.utils.data_upload import (
+    load_release_manifest_from_hf,
+    publish_release_manifest_to_hf,
+    upload_files_to_hf,
+)
+from policyengine_us_data.utils.release_manifest import (
+    RELEASE_MANIFEST_SCHEMA_VERSION,
+    build_release_manifest,
+)
+
+
+def _write_file(path: Path, content: bytes) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path
+
+
+def _sha256(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def test_build_release_manifest_tracks_uploaded_artifacts(tmp_path):
+    national_bytes = b"national-dataset"
+    state_bytes = b"state-dataset"
+    national_path = _write_file(
+        tmp_path / "enhanced_cps_2024.h5",
+        national_bytes,
+    )
+    state_path = _write_file(tmp_path / "AL.h5", state_bytes)
+
+    manifest = build_release_manifest(
+        files_with_repo_paths=[
+            (national_path, "enhanced_cps_2024.h5"),
+            (state_path, "states/AL.h5"),
+        ],
+        version="1.73.0",
+        repo_id="policyengine/policyengine-us-data",
+        model_package_version="1.634.4",
+        created_at="2026-04-10T12:00:00Z",
+    )
+
+    assert manifest["data_package"] == {
+        "name": "policyengine-us-data",
+        "version": "1.73.0",
+    }
+    assert manifest["schema_version"] == RELEASE_MANIFEST_SCHEMA_VERSION
+    assert manifest["compatible_model_packages"] == [
+        {
+            "name": "policyengine-us",
+            "specifier": "==1.634.4",
+        }
+    ]
+    assert manifest["default_datasets"] == {"national": "enhanced_cps_2024"}
+
+    assert manifest["artifacts"]["enhanced_cps_2024"] == {
+        "kind": "microdata",
+        "path": "enhanced_cps_2024.h5",
+        "repo_id": "policyengine/policyengine-us-data",
+        "revision": "1.73.0",
+        "sha256": _sha256(national_bytes),
+        "size_bytes": len(national_bytes),
+    }
+    assert manifest["artifacts"]["states/AL"] == {
+        "kind": "microdata",
+        "path": "states/AL.h5",
+        "repo_id": "policyengine/policyengine-us-data",
+        "revision": "1.73.0",
+        "sha256": _sha256(state_bytes),
+        "size_bytes": len(state_bytes),
+    }
+
+
+def test_build_release_manifest_merges_existing_release_same_version(tmp_path):
+    district_bytes = b"district-dataset"
+    district_path = _write_file(tmp_path / "NC-01.h5", district_bytes)
+
+    existing_manifest = {
+        "data_package": {
+            "name": "policyengine-us-data",
+            "version": "1.73.0",
+        },
+        "compatible_model_packages": [
+            {
+                "name": "policyengine-us",
+                "specifier": "==1.634.4",
+            }
+        ],
+        "default_datasets": {"national": "enhanced_cps_2024"},
+        "created_at": "2026-04-09T12:00:00Z",
+        "artifacts": {
+            "enhanced_cps_2024": {
+                "kind": "microdata",
+                "path": "enhanced_cps_2024.h5",
+                "repo_id": "policyengine/policyengine-us-data",
+                "revision": "1.73.0",
+                "sha256": "abc",
+                "size_bytes": 123,
+            }
+        },
+    }
+
+    manifest = build_release_manifest(
+        files_with_repo_paths=[(district_path, "districts/NC-01.h5")],
+        version="1.73.0",
+        repo_id="policyengine/policyengine-us-data",
+        model_package_version="1.634.4",
+        existing_manifest=existing_manifest,
+        created_at="2026-04-10T12:00:00Z",
+    )
+
+    assert set(manifest["artifacts"]) == {"enhanced_cps_2024", "districts/NC-01"}
+    assert manifest["default_datasets"] == {"national": "enhanced_cps_2024"}
+    assert manifest["created_at"] == "2026-04-09T12:00:00Z"
+    assert manifest["artifacts"]["districts/NC-01"]["sha256"] == _sha256(
+        district_bytes
+    )
+
+
+def test_load_release_manifest_from_hf_uses_explicit_revision_when_requested(tmp_path):
+    manifest_path = _write_file(
+        tmp_path / "release_manifest.json",
+        b'{"data_package": {"name": "policyengine-us-data", "version": "1.73.0"}}',
+    )
+
+    with patch(
+        "policyengine_us_data.utils.data_upload.hf_hub_download",
+        return_value=str(manifest_path),
+    ) as mock_download:
+        manifest = load_release_manifest_from_hf(
+            version="1.73.0",
+            revision="1.73.0",
+        )
+
+    assert manifest["data_package"]["version"] == "1.73.0"
+    assert mock_download.call_args.kwargs["revision"] == "1.73.0"
+
+
+def test_upload_files_to_hf_adds_release_manifest_operations(tmp_path):
+    dataset_path = _write_file(
+        tmp_path / "enhanced_cps_2024.h5",
+        b"national-dataset",
+    )
+
+    mock_api = MagicMock()
+    mock_api.create_commit.return_value = MagicMock(oid="commit-sha")
+
+    with (
+        patch("policyengine_us_data.utils.data_upload.HfApi", return_value=mock_api),
+        patch(
+            "policyengine_us_data.utils.data_upload.load_release_manifest_from_hf",
+            return_value=None,
+        ),
+        patch(
+            "policyengine_us_data.utils.data_upload.metadata.version",
+            return_value="1.634.4",
+        ),
+        patch.dict(
+            "policyengine_us_data.utils.data_upload.os.environ",
+            {"HUGGING_FACE_TOKEN": "token"},
+            clear=False,
+        ),
+    ):
+        upload_files_to_hf(
+            files=[dataset_path],
+            version="1.73.0",
+        )
+
+    operations = mock_api.create_commit.call_args.kwargs["operations"]
+    operation_paths = [operation.path_in_repo for operation in operations]
+
+    assert "enhanced_cps_2024.h5" in operation_paths
+    assert "release_manifest.json" in operation_paths
+    assert "releases/1.73.0/release_manifest.json" in operation_paths
+
+    release_ops = [
+        operation
+        for operation in operations
+        if operation.path_in_repo.endswith("release_manifest.json")
+    ]
+    assert len(release_ops) == 2
+    for operation in release_ops:
+        assert isinstance(operation, CommitOperationAdd)
+        assert isinstance(operation.path_or_fileobj, BytesIO)
+
+
+def test_upload_files_to_hf_does_not_tag_until_finalize(tmp_path):
+    dataset_path = _write_file(
+        tmp_path / "enhanced_cps_2024.h5",
+        b"national-dataset",
+    )
+
+    mock_api = MagicMock()
+    mock_api.create_commit.return_value = MagicMock(oid="commit-sha")
+
+    with (
+        patch("policyengine_us_data.utils.data_upload.HfApi", return_value=mock_api),
+        patch(
+            "policyengine_us_data.utils.data_upload.load_release_manifest_from_hf",
+            return_value=None,
+        ),
+        patch(
+            "policyengine_us_data.utils.data_upload.metadata.version",
+            return_value="1.634.4",
+        ),
+        patch.dict(
+            "policyengine_us_data.utils.data_upload.os.environ",
+            {"HUGGING_FACE_TOKEN": "token"},
+            clear=False,
+        ),
+    ):
+        upload_files_to_hf(
+            files=[dataset_path],
+            version="1.73.0",
+            create_tag=False,
+        )
+
+    mock_api.create_tag.assert_not_called()
+
+
+def test_publish_release_manifest_to_hf_can_finalize_and_tag(tmp_path):
+    state_path = _write_file(
+        tmp_path / "AL.h5",
+        b"state-dataset",
+    )
+
+    mock_api = MagicMock()
+    mock_api.create_commit.return_value = MagicMock(oid="final-commit-sha")
+
+    with (
+        patch("policyengine_us_data.utils.data_upload.HfApi", return_value=mock_api),
+        patch(
+            "policyengine_us_data.utils.data_upload.load_release_manifest_from_hf",
+            return_value={
+                "schema_version": RELEASE_MANIFEST_SCHEMA_VERSION,
+                "data_package": {
+                    "name": "policyengine-us-data",
+                    "version": "1.73.0",
+                },
+                "compatible_model_packages": [],
+                "default_datasets": {"national": "enhanced_cps_2024"},
+                "created_at": "2026-04-10T12:00:00Z",
+                "artifacts": {
+                    "enhanced_cps_2024": {
+                        "kind": "microdata",
+                        "path": "enhanced_cps_2024.h5",
+                        "repo_id": "policyengine/policyengine-us-data",
+                        "revision": "1.73.0",
+                        "sha256": "abc",
+                        "size_bytes": 123,
+                    }
+                },
+            },
+        ),
+        patch(
+            "policyengine_us_data.utils.data_upload.metadata.version",
+            return_value="1.634.4",
+        ),
+        patch.dict(
+            "policyengine_us_data.utils.data_upload.os.environ",
+            {"HUGGING_FACE_TOKEN": "token"},
+            clear=False,
+        ),
+    ):
+        publish_release_manifest_to_hf(
+            [(state_path, "states/AL.h5")],
+            version="1.73.0",
+            create_tag=True,
+        )
+
+    mock_api.create_tag.assert_called_once()
+
+
+def test_upload_files_to_hf_fails_without_model_package_version(tmp_path):
+    dataset_path = _write_file(
+        tmp_path / "enhanced_cps_2024.h5",
+        b"national-dataset",
+    )
+
+    with (
+        patch("policyengine_us_data.utils.data_upload.HfApi", return_value=MagicMock()),
+        patch(
+            "policyengine_us_data.utils.data_upload.load_release_manifest_from_hf",
+            return_value=None,
+        ),
+        patch(
+            "policyengine_us_data.utils.data_upload.metadata.version",
+            side_effect=RuntimeError("missing package"),
+        ),
+    ):
+        with patch(
+            "policyengine_us_data.utils.data_upload._get_model_package_version",
+            side_effect=RuntimeError("missing package"),
+        ):
+            with patch.dict(
+                "policyengine_us_data.utils.data_upload.os.environ",
+                {"HUGGING_FACE_TOKEN": "token"},
+                clear=False,
+            ):
+                try:
+                    upload_files_to_hf(
+                        files=[dataset_path],
+                        version="1.73.0",
+                    )
+                except RuntimeError as exc:
+                    assert "missing package" in str(exc)
+                else:
+                    raise AssertionError("Expected RuntimeError when model version is unavailable")
+
+
+def test_publish_release_manifest_to_hf_rejects_finalized_release(tmp_path):
+    state_path = _write_file(
+        tmp_path / "AL.h5",
+        b"state-dataset",
+    )
+
+    with patch(
+        "policyengine_us_data.utils.data_upload.load_release_manifest_from_hf",
+        side_effect=[
+            {
+                "data_package": {
+                    "name": "policyengine-us-data",
+                    "version": "1.73.0",
+                }
+            }
+        ],
+    ):
+        try:
+            publish_release_manifest_to_hf(
+                [(state_path, "states/AL.h5")],
+                version="1.73.0",
+                create_tag=True,
+            )
+        except RuntimeError as exc:
+            assert "already finalized" in str(exc)
+        else:
+            raise AssertionError("Expected finalized release guard to raise")

--- a/tests/unit/test_upload_completed_datasets.py
+++ b/tests/unit/test_upload_completed_datasets.py
@@ -1,4 +1,6 @@
+from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import h5py
 import numpy as np
@@ -7,6 +9,7 @@ import pytest
 import policyengine_us_data.storage.upload_completed_datasets as upload_module
 from policyengine_us_data.storage.upload_completed_datasets import (
     DatasetValidationError,
+    upload_datasets,
     validate_dataset,
 )
 import policyengine_us_data.utils.dataset_validation as _dv_mod
@@ -153,3 +156,312 @@ def test_validate_dataset_infers_time_period_for_flat_h5(tmp_path, monkeypatch):
     validate_dataset(file_path)
 
     assert _TimePeriodCheckingAggregateMicrosimulation.last_dataset.time_period == 2024
+
+
+def _prepare_release_files(tmp_path, monkeypatch):
+    cps_path = tmp_path / "cps_2024.h5"
+    cps_path.write_bytes(b"cps")
+    enhanced_path = tmp_path / "enhanced_cps_2024.h5"
+    enhanced_path.write_bytes(b"enhanced")
+    small_path = tmp_path / "small_enhanced_cps_2024.h5"
+    small_path.write_bytes(b"small")
+    calibration_dir = tmp_path / "calibration"
+    calibration_dir.mkdir()
+    db_path = calibration_dir / "policy_data.db"
+    db_path.write_bytes(b"db")
+
+    monkeypatch.setattr(upload_module.CPS_2024, "file_path", cps_path)
+    monkeypatch.setattr(upload_module.EnhancedCPS_2024, "file_path", enhanced_path)
+    monkeypatch.setattr(upload_module, "STORAGE_FOLDER", tmp_path)
+
+    return {
+        "cps": cps_path,
+        "enhanced": enhanced_path,
+        "small": small_path,
+        "db": db_path,
+    }
+
+
+def test_upload_datasets_stages_then_promotes_release(tmp_path, monkeypatch):
+    _prepare_release_files(tmp_path, monkeypatch)
+    validated = []
+    stage_calls = []
+    promote_calls = []
+
+    monkeypatch.setattr(
+        upload_module,
+        "validate_dataset",
+        lambda file_path: validated.append(Path(file_path).name),
+    )
+    monkeypatch.setattr(
+        upload_module.metadata,
+        "version",
+        lambda _: "1.73.0",
+    )
+    monkeypatch.setattr(
+        upload_module,
+        "upload_to_staging_hf",
+        lambda files_with_paths, **kwargs: stage_calls.append(
+            ([(Path(path), repo_path) for path, repo_path in files_with_paths], kwargs)
+        ),
+    )
+    monkeypatch.setattr(
+        upload_module,
+        "promote_staging_to_production_hf",
+        lambda rel_paths, **kwargs: promote_calls.append(("hf", rel_paths, kwargs)),
+    )
+    monkeypatch.setattr(
+        upload_module,
+        "upload_from_hf_staging_to_gcs",
+        lambda rel_paths, **kwargs: promote_calls.append(("gcs", rel_paths, kwargs)),
+    )
+    publish_calls = []
+    monkeypatch.setattr(
+        upload_module,
+        "publish_release_manifest_to_hf",
+        lambda files_with_paths, **kwargs: publish_calls.append(
+            ([(Path(path), repo_path) for path, repo_path in files_with_paths], kwargs)
+        ),
+    )
+    cleanup_calls = []
+    monkeypatch.setattr(
+        upload_module,
+        "cleanup_staging_hf",
+        lambda rel_paths, **kwargs: cleanup_calls.append((rel_paths, kwargs)),
+    )
+
+    built_manifest = SimpleNamespace(version="1.73.0")
+    build_manifest_calls = []
+    upload_manifest_calls = []
+    monkeypatch.setattr(
+        upload_module,
+        "build_manifest",
+        lambda **kwargs: build_manifest_calls.append(kwargs) or built_manifest,
+    )
+    monkeypatch.setattr(
+        upload_module,
+        "upload_manifest",
+        lambda manifest: upload_manifest_calls.append(manifest),
+    )
+
+    upload_datasets(version="1.73.0")
+
+    expected_repo_paths = [
+        "cps_2024.h5",
+        "policy_data.db",
+        "enhanced_cps_2024.h5",
+        "small_enhanced_cps_2024.h5",
+    ]
+    assert validated == [
+        "cps_2024.h5",
+        "policy_data.db",
+        "enhanced_cps_2024.h5",
+        "small_enhanced_cps_2024.h5",
+    ]
+    assert [repo_path for _, repo_path in stage_calls[0][0]] == expected_repo_paths
+    assert stage_calls[0][1]["run_id"] == ""
+    assert promote_calls == [
+        (
+            "hf",
+            expected_repo_paths,
+            {
+                "version": "1.73.0",
+                "hf_repo_name": upload_module.HF_REPO_NAME,
+                "hf_repo_type": upload_module.HF_REPO_TYPE,
+                "run_id": "",
+            },
+        ),
+        (
+            "gcs",
+            expected_repo_paths,
+            {
+                "version": "1.73.0",
+                "gcs_bucket_name": upload_module.GCS_BUCKET_NAME,
+                "hf_repo_name": upload_module.HF_REPO_NAME,
+                "hf_repo_type": upload_module.HF_REPO_TYPE,
+                "run_id": "",
+            },
+        ),
+    ]
+    assert [repo_path for _, repo_path in publish_calls[0][0]] == expected_repo_paths
+    assert publish_calls[0][1]["create_tag"] is True
+    assert build_manifest_calls == [
+        {
+            "version": "1.73.0",
+            "blob_names": expected_repo_paths,
+            "hf_info": upload_module.HFVersionInfo(
+                repo=upload_module.HF_REPO_NAME,
+                commit="1.73.0",
+            ),
+        }
+    ]
+    assert upload_manifest_calls == [built_manifest]
+    assert cleanup_calls == [
+        (
+            expected_repo_paths,
+            {
+                "version": "1.73.0",
+                "hf_repo_name": upload_module.HF_REPO_NAME,
+                "hf_repo_type": upload_module.HF_REPO_TYPE,
+                "run_id": "",
+            },
+        )
+    ]
+
+
+def test_upload_datasets_stage_only_skips_promote(tmp_path, monkeypatch):
+    _prepare_release_files(tmp_path, monkeypatch)
+    stage_calls = []
+    promote_calls = []
+
+    monkeypatch.setattr(upload_module, "validate_dataset", lambda file_path: None)
+    monkeypatch.setattr(upload_module.metadata, "version", lambda _: "1.73.0")
+    monkeypatch.setattr(
+        upload_module,
+        "upload_to_staging_hf",
+        lambda files_with_paths, **kwargs: stage_calls.append(kwargs),
+    )
+    monkeypatch.setattr(
+        upload_module,
+        "promote_staging_to_production_hf",
+        lambda *args, **kwargs: promote_calls.append((args, kwargs)),
+    )
+
+    upload_datasets(stage_only=True, run_id="sha123", version="1.73.0")
+
+    assert stage_calls == [
+        {
+            "version": "1.73.0",
+            "hf_repo_name": upload_module.HF_REPO_NAME,
+            "hf_repo_type": upload_module.HF_REPO_TYPE,
+            "run_id": "sha123",
+        }
+    ]
+    assert promote_calls == []
+
+
+def test_upload_datasets_promote_only_uses_staged_artifacts(tmp_path, monkeypatch):
+    downloaded_dir = tmp_path / "downloaded"
+    downloaded_dir.mkdir()
+    expected_repo_paths = [
+        "cps_2024.h5",
+        "policy_data.db",
+        "enhanced_cps_2024.h5",
+        "small_enhanced_cps_2024.h5",
+    ]
+
+    mock_api = MagicMock()
+    mock_api.list_repo_files.return_value = [
+        f"staging/run-123/{repo_path}" for repo_path in expected_repo_paths
+    ]
+    monkeypatch.setattr(upload_module, "HfApi", lambda: mock_api)
+    monkeypatch.setattr(upload_module.metadata, "version", lambda _: "1.73.0")
+    monkeypatch.setattr(
+        upload_module,
+        "hf_hub_download",
+        lambda **kwargs: str(downloaded_dir / Path(kwargs["filename"]).name),
+    )
+    for repo_path in expected_repo_paths:
+        (downloaded_dir / Path(repo_path).name).write_bytes(repo_path.encode())
+
+    validate_calls = []
+    monkeypatch.setattr(
+        upload_module,
+        "validate_dataset",
+        lambda file_path: validate_calls.append(file_path),
+    )
+    promote_calls = []
+    monkeypatch.setattr(
+        upload_module,
+        "promote_staging_to_production_hf",
+        lambda rel_paths, **kwargs: promote_calls.append(("hf", rel_paths, kwargs)),
+    )
+    monkeypatch.setattr(
+        upload_module,
+        "upload_from_hf_staging_to_gcs",
+        lambda rel_paths, **kwargs: promote_calls.append(("gcs", rel_paths, kwargs)),
+    )
+    publish_calls = []
+    monkeypatch.setattr(
+        upload_module,
+        "publish_release_manifest_to_hf",
+        lambda files_with_paths, **kwargs: publish_calls.append(
+            ([repo_path for _, repo_path in files_with_paths], kwargs)
+        ),
+    )
+    monkeypatch.setattr(
+        upload_module,
+        "build_manifest",
+        lambda **kwargs: kwargs,
+    )
+    upload_manifest_calls = []
+    monkeypatch.setattr(
+        upload_module,
+        "upload_manifest",
+        lambda manifest: upload_manifest_calls.append(manifest),
+    )
+    cleanup_calls = []
+    monkeypatch.setattr(
+        upload_module,
+        "cleanup_staging_hf",
+        lambda rel_paths, **kwargs: cleanup_calls.append((rel_paths, kwargs)),
+    )
+
+    upload_datasets(promote_only=True, run_id="run-123", version="1.73.0")
+
+    assert validate_calls == []
+    assert promote_calls == [
+        (
+            "hf",
+            expected_repo_paths,
+            {
+                "version": "1.73.0",
+                "hf_repo_name": upload_module.HF_REPO_NAME,
+                "hf_repo_type": upload_module.HF_REPO_TYPE,
+                "run_id": "run-123",
+            },
+        ),
+        (
+            "gcs",
+            expected_repo_paths,
+            {
+                "version": "1.73.0",
+                "gcs_bucket_name": upload_module.GCS_BUCKET_NAME,
+                "hf_repo_name": upload_module.HF_REPO_NAME,
+                "hf_repo_type": upload_module.HF_REPO_TYPE,
+                "run_id": "run-123",
+            },
+        ),
+    ]
+    assert publish_calls == [
+        (
+            expected_repo_paths,
+            {
+                "version": "1.73.0",
+                "hf_repo_name": upload_module.HF_REPO_NAME,
+                "hf_repo_type": upload_module.HF_REPO_TYPE,
+                "create_tag": True,
+            },
+        )
+    ]
+    assert upload_manifest_calls == [
+        {
+            "version": "1.73.0",
+            "blob_names": expected_repo_paths,
+            "hf_info": upload_module.HFVersionInfo(
+                repo=upload_module.HF_REPO_NAME,
+                commit="1.73.0",
+            ),
+        }
+    ]
+    assert cleanup_calls == [
+        (
+            expected_repo_paths,
+            {
+                "version": "1.73.0",
+                "hf_repo_name": upload_module.HF_REPO_NAME,
+                "hf_repo_type": upload_module.HF_REPO_TYPE,
+                "run_id": "run-123",
+            },
+        )
+    ]

--- a/tests/unit/test_upload_completed_datasets.py
+++ b/tests/unit/test_upload_completed_datasets.py
@@ -223,6 +223,11 @@ def test_upload_datasets_stages_then_promotes_release(tmp_path, monkeypatch):
             ([(Path(path), repo_path) for path, repo_path in files_with_paths], kwargs)
         ),
     )
+    monkeypatch.setattr(
+        upload_module,
+        "should_finalize_local_area_release",
+        lambda **kwargs: (False, ["national/", "states/", "districts/", "cities/"]),
+    )
     cleanup_calls = []
     monkeypatch.setattr(
         upload_module,
@@ -230,13 +235,12 @@ def test_upload_datasets_stages_then_promotes_release(tmp_path, monkeypatch):
         lambda rel_paths, **kwargs: cleanup_calls.append((rel_paths, kwargs)),
     )
 
-    built_manifest = SimpleNamespace(version="1.73.0")
     build_manifest_calls = []
     upload_manifest_calls = []
     monkeypatch.setattr(
         upload_module,
         "build_manifest",
-        lambda **kwargs: build_manifest_calls.append(kwargs) or built_manifest,
+        lambda **kwargs: build_manifest_calls.append(kwargs),
     )
     monkeypatch.setattr(
         upload_module,
@@ -284,18 +288,9 @@ def test_upload_datasets_stages_then_promotes_release(tmp_path, monkeypatch):
         ),
     ]
     assert [repo_path for _, repo_path in publish_calls[0][0]] == expected_repo_paths
-    assert publish_calls[0][1]["create_tag"] is True
-    assert build_manifest_calls == [
-        {
-            "version": "1.73.0",
-            "blob_names": expected_repo_paths,
-            "hf_info": upload_module.HFVersionInfo(
-                repo=upload_module.HF_REPO_NAME,
-                commit="1.73.0",
-            ),
-        }
-    ]
-    assert upload_manifest_calls == [built_manifest]
+    assert publish_calls[0][1]["create_tag"] is False
+    assert build_manifest_calls == []
+    assert upload_manifest_calls == []
     assert cleanup_calls == [
         (
             expected_repo_paths,
@@ -391,8 +386,8 @@ def test_upload_datasets_promote_only_uses_staged_artifacts(tmp_path, monkeypatc
     )
     monkeypatch.setattr(
         upload_module,
-        "build_manifest",
-        lambda **kwargs: kwargs,
+        "should_finalize_local_area_release",
+        lambda **kwargs: (False, ["national/", "states/", "districts/", "cities/"]),
     )
     upload_manifest_calls = []
     monkeypatch.setattr(
@@ -440,20 +435,11 @@ def test_upload_datasets_promote_only_uses_staged_artifacts(tmp_path, monkeypatc
                 "version": "1.73.0",
                 "hf_repo_name": upload_module.HF_REPO_NAME,
                 "hf_repo_type": upload_module.HF_REPO_TYPE,
-                "create_tag": True,
+                "create_tag": False,
             },
         )
     ]
-    assert upload_manifest_calls == [
-        {
-            "version": "1.73.0",
-            "blob_names": expected_repo_paths,
-            "hf_info": upload_module.HFVersionInfo(
-                repo=upload_module.HF_REPO_NAME,
-                commit="1.73.0",
-            ),
-        }
-    ]
+    assert upload_manifest_calls == []
     assert cleanup_calls == [
         (
             expected_repo_paths,

--- a/tests/unit/test_upload_completed_datasets.py
+++ b/tests/unit/test_upload_completed_datasets.py
@@ -225,8 +225,11 @@ def test_upload_datasets_stages_then_promotes_release(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(
         upload_module,
-        "should_finalize_local_area_release",
-        lambda **kwargs: (False, ["national/", "states/", "districts/", "cities/"]),
+        "preflight_release_manifest_publish",
+        lambda *args, **kwargs: (
+            False,
+            ["national/", "states/", "districts/", "cities/"],
+        ),
     )
     cleanup_calls = []
     monkeypatch.setattr(
@@ -386,8 +389,11 @@ def test_upload_datasets_promote_only_uses_staged_artifacts(tmp_path, monkeypatc
     )
     monkeypatch.setattr(
         upload_module,
-        "should_finalize_local_area_release",
-        lambda **kwargs: (False, ["national/", "states/", "districts/", "cities/"]),
+        "preflight_release_manifest_publish",
+        lambda *args, **kwargs: (
+            False,
+            ["national/", "states/", "districts/", "cities/"],
+        ),
     )
     upload_manifest_calls = []
     monkeypatch.setattr(
@@ -451,3 +457,39 @@ def test_upload_datasets_promote_only_uses_staged_artifacts(tmp_path, monkeypatc
             },
         )
     ]
+
+
+def test_promote_datasets_preflight_failure_stops_before_production_writes(
+    tmp_path, monkeypatch
+):
+    files = _prepare_release_files(tmp_path, monkeypatch)
+    files_with_repo_paths = [
+        (files["cps"], "cps_2024.h5"),
+        (files["db"], "policy_data.db"),
+    ]
+    promote_calls = []
+
+    monkeypatch.setattr(upload_module.metadata, "version", lambda _: "1.73.0")
+    monkeypatch.setattr(
+        upload_module,
+        "preflight_release_manifest_publish",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("blocked")),
+    )
+    monkeypatch.setattr(
+        upload_module,
+        "promote_staging_to_production_hf",
+        lambda *args, **kwargs: promote_calls.append(("hf", args, kwargs)),
+    )
+    monkeypatch.setattr(
+        upload_module,
+        "upload_from_hf_staging_to_gcs",
+        lambda *args, **kwargs: promote_calls.append(("gcs", args, kwargs)),
+    )
+
+    with pytest.raises(RuntimeError, match="blocked"):
+        upload_module.promote_datasets(
+            version="1.73.0",
+            files_with_repo_paths=files_with_repo_paths,
+        )
+
+    assert promote_calls == []


### PR DESCRIPTION
## Summary
- add a canonical release manifest builder for US data artifacts
- publish the manifest alongside national and local-area uploads
- add focused tests around release-manifest generation

Refs #724.