### PR TITLE
Add CTC artifact comparison diagnostics to national validation

### DIFF
--- a/changelog.d/725.added.md
+++ b/changelog.d/725.added.md
@@ -1,0 +1,1 @@
+Add comparison-mode CTC diagnostics to `validate_national_h5`, including child-count and child-age drift reporting between national artifacts.

--- a/policyengine_us_data/calibration/validate_national_h5.py
+++ b/policyengine_us_data/calibration/validate_national_h5.py
@@ -61,6 +61,12 @@ REFERENCES = {
 }
 
 DEFAULT_HF_PATH = "hf://policyengine/policyengine-us-data/national/US.h5"
+ARTIFACT_CTC_SUMMARY_VARIABLES = [
+    "ctc_qualifying_children",
+    "ctc",
+    "refundable_ctc",
+    "non_refundable_ctc",
+]
 
 COUNT_VARS = {
     "person_count",
@@ -216,9 +222,181 @@ def build_canonical_ctc_reform_summary(
 
 def _format_canonical_ctc_reform_summary(table: pd.DataFrame) -> str:
     display = table.copy()
-    for column in ("baseline", "reformed", "delta"):
+    numeric_columns = [
+        column
+        for column in display.columns
+        if column != "variable" and pd.api.types.is_numeric_dtype(display[column])
+    ]
+    for column in numeric_columns:
         display[column] = display[column].map(lambda value: f"${value / 1e9:,.1f}B")
     return display.to_string(index=False)
+
+
+def build_artifact_ctc_summary(
+    reference_sim,
+    candidate_sim,
+    *,
+    period: int = 2025,
+) -> pd.DataFrame:
+    rows = []
+    for variable in ARTIFACT_CTC_SUMMARY_VARIABLES:
+        reference = float(reference_sim.calculate(variable, period=period).sum())
+        candidate = float(candidate_sim.calculate(variable, period=period).sum())
+        rows.append(
+            {
+                "variable": variable,
+                "reference": reference,
+                "candidate": candidate,
+                "delta": candidate - reference,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _format_artifact_ctc_summary(table: pd.DataFrame) -> str:
+    display = table.copy()
+    for column in ("reference", "candidate", "delta"):
+        display[column] = display.apply(
+            lambda row: (
+                f"{row[column] / 1e6:,.2f}M"
+                if row["variable"] in COUNT_VARS
+                else f"${row[column] / 1e9:,.1f}B"
+            ),
+            axis=1,
+        )
+    return display.to_string(index=False)
+
+
+def get_artifact_ctc_comparison_outputs(
+    reference_sim,
+    candidate_sim,
+    *,
+    period: int = 2025,
+) -> dict[str, str]:
+    outputs = {
+        "CURRENT-LAW CTC TOTAL DELTAS VS COMPARISON DATASET": (
+            _format_artifact_ctc_summary(
+                build_artifact_ctc_summary(
+                    reference_sim,
+                    candidate_sim,
+                    period=period,
+                )
+            )
+        )
+    }
+
+    delta_tables = _subtract_diagnostic_tables(
+        create_ctc_diagnostic_tables(reference_sim, period=period),
+        create_ctc_diagnostic_tables(candidate_sim, period=period),
+    )
+    section_names = {
+        "by_agi_band": "CURRENT-LAW CTC DIAGNOSTIC DELTAS BY AGI BAND",
+        "by_filing_status": "CURRENT-LAW CTC DIAGNOSTIC DELTAS BY FILING STATUS",
+        "by_agi_band_and_filing_status": (
+            "CURRENT-LAW CTC DIAGNOSTIC DELTAS BY AGI BAND AND FILING STATUS"
+        ),
+        "by_child_count": "CURRENT-LAW CTC DIAGNOSTIC DELTAS BY QUALIFYING-CHILD COUNT",
+        "by_child_age": "CURRENT-LAW CTC DIAGNOSTIC DELTAS BY QUALIFYING-CHILD AGE",
+    }
+    for name, table in delta_tables.items():
+        if name in section_names:
+            outputs[section_names[name]] = format_ctc_diagnostic_table(table)
+
+    return outputs
+
+
+def _build_canonical_ctc_reform_comparison_summary(
+    reference_summary: pd.DataFrame,
+    candidate_summary: pd.DataFrame,
+) -> pd.DataFrame:
+    merged = reference_summary.merge(
+        candidate_summary,
+        on="variable",
+        suffixes=("_reference", "_candidate"),
+    )
+    comparison = pd.DataFrame(
+        {
+            "variable": merged["variable"],
+            "reference_baseline": merged["baseline_reference"],
+            "candidate_baseline": merged["baseline_candidate"],
+            "baseline_delta": (
+                merged["baseline_candidate"] - merged["baseline_reference"]
+            ),
+            "reference_reformed": merged["reformed_reference"],
+            "candidate_reformed": merged["reformed_candidate"],
+            "reformed_delta": (
+                merged["reformed_candidate"] - merged["reformed_reference"]
+            ),
+            "reference_delta": merged["delta_reference"],
+            "candidate_delta": merged["delta_candidate"],
+            "delta_drift": merged["delta_candidate"] - merged["delta_reference"],
+        }
+    )
+    return comparison
+
+
+def get_canonical_ctc_reform_comparison_outputs(
+    reference_dataset_path: str | None = None,
+    candidate_dataset_path: str | None = None,
+    *,
+    reference_baseline_sim=None,
+    candidate_baseline_sim=None,
+    reference_reformed_sim=None,
+    candidate_reformed_sim=None,
+    period: int = 2025,
+) -> dict[str, str]:
+    from policyengine_us import Microsimulation
+
+    if reference_baseline_sim is None:
+        if reference_dataset_path is None:
+            raise ValueError(
+                "reference_dataset_path is required when reference_baseline_sim is not provided"
+            )
+        reference_baseline_sim = Microsimulation(dataset=reference_dataset_path)
+    if candidate_baseline_sim is None:
+        if candidate_dataset_path is None:
+            raise ValueError(
+                "candidate_dataset_path is required when candidate_baseline_sim is not provided"
+            )
+        candidate_baseline_sim = Microsimulation(dataset=candidate_dataset_path)
+
+    canonical_reform = _create_canonical_ctc_reform()
+    if reference_reformed_sim is None:
+        if reference_dataset_path is None:
+            raise ValueError(
+                "reference_dataset_path is required when reference_reformed_sim is not provided"
+            )
+        reference_reformed_sim = Microsimulation(
+            dataset=reference_dataset_path,
+            reform=canonical_reform,
+        )
+    if candidate_reformed_sim is None:
+        if candidate_dataset_path is None:
+            raise ValueError(
+                "candidate_dataset_path is required when candidate_reformed_sim is not provided"
+            )
+        candidate_reformed_sim = Microsimulation(
+            dataset=candidate_dataset_path,
+            reform=canonical_reform,
+        )
+
+    comparison = _build_canonical_ctc_reform_comparison_summary(
+        build_canonical_ctc_reform_summary(
+            reference_baseline_sim,
+            reference_reformed_sim,
+            period=period,
+        ),
+        build_canonical_ctc_reform_summary(
+            candidate_baseline_sim,
+            candidate_reformed_sim,
+            period=period,
+        ),
+    )
+    return {
+        "CANONICAL CTC REFORM DRIFT VS COMPARISON DATASET": (
+            _format_canonical_ctc_reform_summary(comparison)
+        )
+    }
 
 
 def _subtract_diagnostic_tables(
@@ -337,15 +515,35 @@ def main(argv=None):
         default=DEFAULT_HF_PATH,
         help=f"HF path to US.h5 (default: {DEFAULT_HF_PATH})",
     )
+    parser.add_argument(
+        "--compare-h5-path",
+        default=None,
+        help="Optional local path to comparison US.h5",
+    )
+    parser.add_argument(
+        "--compare-hf-path",
+        default=None,
+        help="Optional HF path to comparison US.h5",
+    )
     args = parser.parse_args(argv)
 
     dataset_path = args.h5_path or args.hf_path
     resolved_dataset_path = resolve_dataset_path(dataset_path)
+    comparison_dataset_path = args.compare_h5_path or args.compare_hf_path
+    resolved_comparison_dataset_path = (
+        resolve_dataset_path(comparison_dataset_path)
+        if comparison_dataset_path is not None
+        else None
+    )
 
     from policyengine_us import Microsimulation
 
     print(f"Loading {dataset_path}...")
     sim = Microsimulation(dataset=resolved_dataset_path)
+    comparison_sim = None
+    if resolved_comparison_dataset_path is not None:
+        print(f"Loading comparison dataset {comparison_dataset_path}...")
+        comparison_sim = Microsimulation(dataset=resolved_comparison_dataset_path)
 
     n_hh = sim.calculate("household_id", map_to="household").shape[0]
     print(f"Households in file: {n_hh:,}")
@@ -416,6 +614,27 @@ def main(argv=None):
         print(section_name)
         print("=" * 70)
         print(section_output)
+
+    if comparison_sim is not None:
+        for section_name, section_output in get_artifact_ctc_comparison_outputs(
+            comparison_sim,
+            sim,
+        ).items():
+            print("\n" + "=" * 70)
+            print(section_name)
+            print("=" * 70)
+            print(section_output)
+
+        for section_name, section_output in get_canonical_ctc_reform_comparison_outputs(
+            reference_dataset_path=resolved_comparison_dataset_path,
+            candidate_dataset_path=resolved_dataset_path,
+            reference_baseline_sim=comparison_sim,
+            candidate_baseline_sim=sim,
+        ).items():
+            print("\n" + "=" * 70)
+            print(section_name)
+            print("=" * 70)
+            print(section_output)
 
     print("\n" + "=" * 70)
     print("STRUCTURAL CHECKS")

--- a/tests/unit/calibration/test_validate_national_h5.py
+++ b/tests/unit/calibration/test_validate_national_h5.py
@@ -3,7 +3,10 @@ import os
 import pandas as pd
 
 from policyengine_us_data.calibration.validate_national_h5 import (
+    build_artifact_ctc_summary,
     build_canonical_ctc_reform_summary,
+    get_artifact_ctc_comparison_outputs,
+    get_canonical_ctc_reform_comparison_outputs,
     get_ctc_diagnostic_outputs,
     get_reference_values,
     resolve_dataset_path,
@@ -150,3 +153,148 @@ def test_build_canonical_ctc_reform_summary_reports_level_and_delta():
     assert summary.loc["refundable_ctc", "delta"] == 30.0
     assert summary.loc["non_refundable_ctc", "delta"] == 0.0
     assert summary.loc["household_net_income", "delta"] == 55.0
+
+
+def test_build_artifact_ctc_summary_reports_level_and_delta():
+    reference = _FakeSummarySim(
+        {
+            "ctc_qualifying_children": pd.Series([1.0, 2.0]).to_numpy(),
+            "ctc": pd.Series([90.0]).to_numpy(),
+            "refundable_ctc": pd.Series([40.0]).to_numpy(),
+            "non_refundable_ctc": pd.Series([50.0]).to_numpy(),
+        }
+    )
+    candidate = _FakeSummarySim(
+        {
+            "ctc_qualifying_children": pd.Series([1.0, 4.0]).to_numpy(),
+            "ctc": pd.Series([120.0]).to_numpy(),
+            "refundable_ctc": pd.Series([70.0]).to_numpy(),
+            "non_refundable_ctc": pd.Series([50.0]).to_numpy(),
+        }
+    )
+
+    summary = build_artifact_ctc_summary(
+        reference,
+        candidate,
+        period=2025,
+    ).set_index("variable")
+
+    assert summary.loc["ctc_qualifying_children", "reference"] == 3.0
+    assert summary.loc["ctc_qualifying_children", "candidate"] == 5.0
+    assert summary.loc["ctc_qualifying_children", "delta"] == 2.0
+    assert summary.loc["ctc", "delta"] == 30.0
+    assert summary.loc["refundable_ctc", "delta"] == 30.0
+    assert summary.loc["non_refundable_ctc", "delta"] == 0.0
+
+
+def test_artifact_ctc_comparison_outputs_include_child_composition_sections(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "policyengine_us_data.calibration.validate_national_h5.create_ctc_diagnostic_tables",
+        lambda sim, period=None: {
+            "by_agi_band": pd.DataFrame({"group": ["<$1"], "ctc": [1.0 if sim == "reference" else 3.0]}),
+            "by_filing_status": pd.DataFrame(
+                {"group": ["Single"], "ctc": [2.0 if sim == "reference" else 5.0]}
+            ),
+            "by_agi_band_and_filing_status": pd.DataFrame(
+                {
+                    "agi_band": ["<$1"],
+                    "filing_status": ["Single"],
+                    "ctc": [4.0 if sim == "reference" else 9.0],
+                }
+            ),
+            "by_child_count": pd.DataFrame({"group": ["1"], "ctc": [6.0 if sim == "reference" else 8.0]}),
+            "by_child_age": pd.DataFrame(
+                {"group": ["Under 6"], "ctc_qualifying_children": [7.0 if sim == "reference" else 10.0]}
+            ),
+        },
+    )
+    monkeypatch.setattr(
+        "policyengine_us_data.calibration.validate_national_h5.format_ctc_diagnostic_table",
+        lambda table: f"formatted:{list(table.columns)}:{table.iloc[0].to_dict()}",
+    )
+    monkeypatch.setattr(
+        "policyengine_us_data.calibration.validate_national_h5._format_artifact_ctc_summary",
+        lambda table: f"summary:{table.to_dict(orient='records')}",
+    )
+    monkeypatch.setattr(
+        "policyengine_us_data.calibration.validate_national_h5.build_artifact_ctc_summary",
+        lambda reference_sim, candidate_sim, period=2025: pd.DataFrame(
+            [
+                {
+                    "variable": "ctc_qualifying_children",
+                    "reference": 3.0,
+                    "candidate": 5.0,
+                    "delta": 2.0,
+                }
+            ]
+        ),
+    )
+
+    outputs = get_artifact_ctc_comparison_outputs("reference", "candidate")
+
+    assert outputs == {
+        "CURRENT-LAW CTC TOTAL DELTAS VS COMPARISON DATASET": (
+            "summary:[{'variable': 'ctc_qualifying_children', 'reference': 3.0, "
+            "'candidate': 5.0, 'delta': 2.0}]"
+        ),
+        "CURRENT-LAW CTC DIAGNOSTIC DELTAS BY AGI BAND": (
+            "formatted:['group', 'ctc']:{'group': '<$1', 'ctc': 2.0}"
+        ),
+        "CURRENT-LAW CTC DIAGNOSTIC DELTAS BY FILING STATUS": (
+            "formatted:['group', 'ctc']:{'group': 'Single', 'ctc': 3.0}"
+        ),
+        "CURRENT-LAW CTC DIAGNOSTIC DELTAS BY AGI BAND AND FILING STATUS": (
+            "formatted:['agi_band', 'filing_status', 'ctc']:{'agi_band': '<$1', "
+            "'filing_status': 'Single', 'ctc': 5.0}"
+        ),
+        "CURRENT-LAW CTC DIAGNOSTIC DELTAS BY QUALIFYING-CHILD COUNT": (
+            "formatted:['group', 'ctc']:{'group': '1', 'ctc': 2.0}"
+        ),
+        "CURRENT-LAW CTC DIAGNOSTIC DELTAS BY QUALIFYING-CHILD AGE": (
+            "formatted:['group', 'ctc_qualifying_children']:{'group': 'Under 6', "
+            "'ctc_qualifying_children': 3.0}"
+        ),
+    }
+
+
+def test_canonical_ctc_reform_comparison_outputs_report_dataset_drift(monkeypatch):
+    monkeypatch.setattr(
+        "policyengine_us_data.calibration.validate_national_h5._format_canonical_ctc_reform_summary",
+        lambda table: f"formatted:{table.to_dict(orient='records')}",
+    )
+    monkeypatch.setattr(
+        "policyengine_us_data.calibration.validate_national_h5.build_canonical_ctc_reform_summary",
+        lambda baseline_sim, reformed_sim, period=2025: pd.DataFrame(
+            [
+                {
+                    "variable": "household_net_income",
+                    "baseline": 10.0 if baseline_sim == "reference_base" else 12.0,
+                    "reformed": 20.0 if reformed_sim == "reference_reform" else 25.0,
+                    "delta": 10.0 if baseline_sim == "reference_base" else 13.0,
+                }
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        "policyengine_us_data.calibration.validate_national_h5.get_canonical_ctc_reform_outputs",
+        lambda dataset_path, baseline_sim=None, period=2025: {},
+    )
+
+    outputs = get_canonical_ctc_reform_comparison_outputs(
+        reference_baseline_sim="reference_base",
+        candidate_baseline_sim="candidate_base",
+        reference_reformed_sim="reference_reform",
+        candidate_reformed_sim="candidate_reform",
+    )
+
+    assert outputs == {
+        "CANONICAL CTC REFORM DRIFT VS COMPARISON DATASET": (
+            "formatted:[{'variable': 'household_net_income', 'reference_baseline': 10.0, "
+            "'candidate_baseline': 12.0, 'baseline_delta': 2.0, "
+            "'reference_reformed': 20.0, 'candidate_reformed': 25.0, "
+            "'reformed_delta': 5.0, 'reference_delta': 10.0, "
+            "'candidate_delta': 13.0, 'delta_drift': 3.0}]"
+        )
+    }

--- a/tests/unit/calibration/test_validate_national_h5.py
+++ b/tests/unit/calibration/test_validate_national_h5.py
@@ -193,7 +193,9 @@ def test_artifact_ctc_comparison_outputs_include_child_composition_sections(
     monkeypatch.setattr(
         "policyengine_us_data.calibration.validate_national_h5.create_ctc_diagnostic_tables",
         lambda sim, period=None: {
-            "by_agi_band": pd.DataFrame({"group": ["<$1"], "ctc": [1.0 if sim == "reference" else 3.0]}),
+            "by_agi_band": pd.DataFrame(
+                {"group": ["<$1"], "ctc": [1.0 if sim == "reference" else 3.0]}
+            ),
             "by_filing_status": pd.DataFrame(
                 {"group": ["Single"], "ctc": [2.0 if sim == "reference" else 5.0]}
             ),
@@ -204,9 +206,14 @@ def test_artifact_ctc_comparison_outputs_include_child_composition_sections(
                     "ctc": [4.0 if sim == "reference" else 9.0],
                 }
             ),
-            "by_child_count": pd.DataFrame({"group": ["1"], "ctc": [6.0 if sim == "reference" else 8.0]}),
+            "by_child_count": pd.DataFrame(
+                {"group": ["1"], "ctc": [6.0 if sim == "reference" else 8.0]}
+            ),
             "by_child_age": pd.DataFrame(
-                {"group": ["Under 6"], "ctc_qualifying_children": [7.0 if sim == "reference" else 10.0]}
+                {
+                    "group": ["Under 6"],
+                    "ctc_qualifying_children": [7.0 if sim == "reference" else 10.0],
+                }
             ),
         },
     )


### PR DESCRIPTION
## Summary
- add compare-mode support to `validate_national_h5` for artifact-to-artifact CTC comparisons
- report current-law CTC total drift plus AGI, filing-status, child-count, and child-age diagnostic deltas
- report canonical CTC reform drift between two national artifacts
- add focused unit coverage and a changelog fragment

## Why
This implements the validation half of #725. We can already compare aggregate CTC totals, but recent adjacent artifacts showed that CTC reform sensitivity can move because the child composition moves even when top-line current-law totals stay close.

Using the new comparison output on adjacent staged national artifacts showed:
- total `ctc_qualifying_children` moved only about `-570k`
- but the mix shifted materially from 1- and 2-child units toward 3+ child units
- the biggest shifts were compositional inside low/mid AGI and filing-status cells

That is exactly the failure mode we need the validator to surface.

## Issue tracking
- Closes #725
- Follow-on sourcing issue for external child-composition benchmarks: #729

## Testing
- `uv run pytest tests/unit/calibration/test_validate_national_h5.py -q`
- `uv run pytest tests/unit/calibration/test_ctc_diagnostics.py -q`
- `uv run ruff check policyengine_us_data/calibration/validate_national_h5.py tests/unit/calibration/test_validate_national_h5.py`
- `uv run python -m policyengine_us_data.calibration.validate_national_h5 --help`
