### PR TITLE
Add external CTC child benchmarks to national validation

### DIFF
--- a/changelog.d/729.added.md
+++ b/changelog.d/729.added.md
@@ -1,0 +1,1 @@
+Add public IRS benchmark checks for `ctc_qualifying_children` and contextual AGI and filing-status child-mix comparisons in `validate_national_h5`.

--- a/policyengine_us_data/calibration/validate_national_h5.py
+++ b/policyengine_us_data/calibration/validate_national_h5.py
@@ -14,6 +14,7 @@ Usage:
 import argparse
 import os
 
+import numpy as np
 import pandas as pd
 
 from policyengine_us_data.calibration.ctc_diagnostics import (
@@ -61,12 +62,63 @@ REFERENCES = {
 }
 
 DEFAULT_HF_PATH = "hf://policyengine/policyengine-us-data/national/US.h5"
+PUB_4801_2022_CTC_QUALIFYING_CHILDREN = 63_622_000.0
 ARTIFACT_CTC_SUMMARY_VARIABLES = [
     "ctc_qualifying_children",
     "ctc",
     "refundable_ctc",
     "non_refundable_ctc",
 ]
+ADVANCE_CTC_2021_AGI_BANDS = [
+    (-np.inf, 1.0, "No adjusted gross income [4]"),
+    (1.0, 10_000.0, "$1 under $10,000"),
+    (10_000.0, 20_000.0, "$10,000 under $20,000"),
+    (20_000.0, 30_000.0, "$20,000 under $30,000"),
+    (30_000.0, 40_000.0, "$30,000 under $40,000"),
+    (40_000.0, 50_000.0, "$40,000 under $50,000"),
+    (50_000.0, 60_000.0, "$50,000 under $60,000"),
+    (60_000.0, 75_000.0, "$60,000 under $75,000"),
+    (75_000.0, 100_000.0, "$75,000 under $100,000"),
+    (100_000.0, 200_000.0, "$100,000 under $200,000"),
+    (200_000.0, 400_000.0, "$200,000 under $400,000"),
+    (400_000.0, np.inf, "$400,000 or more"),
+]
+ADVANCE_CTC_2021_AGI_REFERENCE_ROWS = [
+    ("No adjusted gross income [4]", 349_933.0),
+    ("$1 under $10,000", 3_604_619.0),
+    ("$10,000 under $20,000", 6_379_391.0),
+    ("$20,000 under $30,000", 7_419_453.0),
+    ("$30,000 under $40,000", 6_689_905.0),
+    ("$40,000 under $50,000", 5_093_918.0),
+    ("$50,000 under $60,000", 4_008_971.0),
+    ("$60,000 under $75,000", 4_943_145.0),
+    ("$75,000 under $100,000", 6_522_488.0),
+    ("$100,000 under $200,000", 12_149_615.0),
+    ("$200,000 under $400,000", 4_174_996.0),
+    ("$400,000 or more", 639_657.0),
+]
+ADVANCE_CTC_2021_FILING_STATUS_REFERENCE_ROWS = [
+    ("Single [4]", 3_362_687.0),
+    ("Married filing a joint return", 35_165_385.0),
+    ("Married filing separate returns", 1_038_058.0),
+    ("Head of household", 22_346_185.0),
+    ("Qualifying Widow/Widower", 63_776.0),
+]
+ADVANCE_CTC_2021_FILING_STATUS_ORDER = [
+    "Single [4]",
+    "Head of household",
+    "Married filing a joint return",
+    "Married filing separate returns",
+    "Qualifying Widow/Widower",
+    "Other",
+]
+ADVANCE_CTC_2021_FILING_STATUS_MAP = {
+    "SINGLE": "Single [4]",
+    "HEAD_OF_HOUSEHOLD": "Head of household",
+    "JOINT": "Married filing a joint return",
+    "SEPARATE": "Married filing separate returns",
+    "SURVIVING_SPOUSE": "Qualifying Widow/Widower",
+}
 
 COUNT_VARS = {
     "person_count",
@@ -161,6 +213,10 @@ CANONICAL_CTC_REFORM_DICT = {
 def get_reference_values(reference_year: int = 2024):
     """Return national validation references for the current production year."""
     references = dict(REFERENCES)
+    references["ctc_qualifying_children"] = (
+        PUB_4801_2022_CTC_QUALIFYING_CHILDREN,
+        "IRS Pub. 4801 2022 63.6M",
+    )
     for variable in ("refundable_ctc", "non_refundable_ctc"):
         target = get_national_geography_soi_target(
             variable,
@@ -171,6 +227,163 @@ def get_reference_values(reference_year: int = 2024):
             f"IRS SOI {target['source_year']} ${target['amount'] / 1e9:.1f}B",
         )
     return references
+
+
+def _build_reference_share_table(
+    rows: list[tuple[str, float]],
+) -> pd.DataFrame:
+    table = pd.DataFrame(rows, columns=["group", "reference_children_2021"])
+    table["reference_share_2021"] = (
+        table["reference_children_2021"] / table["reference_children_2021"].sum()
+    )
+    return table
+
+
+def _get_advance_ctc_agi_reference() -> pd.DataFrame:
+    return _build_reference_share_table(ADVANCE_CTC_2021_AGI_REFERENCE_ROWS)
+
+
+def _get_advance_ctc_filing_status_reference() -> pd.DataFrame:
+    return _build_reference_share_table(ADVANCE_CTC_2021_FILING_STATUS_REFERENCE_ROWS)
+
+
+def _assign_advance_ctc_agi_bands(
+    adjusted_gross_income: np.ndarray,
+) -> pd.Categorical:
+    labels = [label for _, _, label in ADVANCE_CTC_2021_AGI_BANDS]
+    agi_band = np.full(len(adjusted_gross_income), labels[-1], dtype=object)
+    for lower, upper, label in ADVANCE_CTC_2021_AGI_BANDS:
+        mask = (adjusted_gross_income >= lower) & (adjusted_gross_income < upper)
+        agi_band[mask] = label
+    return pd.Categorical(agi_band, categories=labels, ordered=True)
+
+
+def _normalize_advance_ctc_filing_status(
+    filing_status: pd.Series,
+) -> pd.Categorical:
+    labels = [
+        ADVANCE_CTC_2021_FILING_STATUS_MAP.get(str(value), "Other")
+        for value in filing_status.astype(str)
+    ]
+    return pd.Categorical(
+        labels,
+        categories=ADVANCE_CTC_2021_FILING_STATUS_ORDER,
+        ordered=True,
+    )
+
+
+def _build_external_share_comparison(
+    reference: pd.DataFrame,
+    simulated: pd.DataFrame,
+) -> pd.DataFrame:
+    comparison = reference.merge(simulated, on="group", how="left")
+    comparison["simulated_children"] = comparison["simulated_children"].fillna(0.0)
+    comparison["simulated_share"] = comparison["simulated_share"].fillna(0.0)
+    comparison["share_delta_pp"] = (
+        comparison["simulated_share"] - comparison["reference_share_2021"]
+    ) * 100
+    return comparison
+
+
+def build_advance_ctc_agi_share_comparison(
+    sim,
+    *,
+    period: int = 2025,
+) -> pd.DataFrame:
+    adjusted_gross_income = sim.calculate(
+        "adjusted_gross_income", period=period
+    ).values.astype(float)
+    ctc_qualifying_children = sim.calculate(
+        "ctc_qualifying_children", period=period
+    ).values.astype(float)
+    tax_unit_weight = sim.calculate("tax_unit_weight", period=period).values.astype(
+        float
+    )
+
+    frame = pd.DataFrame(
+        {
+            "group": _assign_advance_ctc_agi_bands(adjusted_gross_income),
+            "simulated_children": ctc_qualifying_children * tax_unit_weight,
+        }
+    )
+    simulated = (
+        frame.groupby("group", observed=False)["simulated_children"].sum().reset_index()
+    )
+    total = simulated["simulated_children"].sum()
+    simulated["simulated_share"] = (
+        simulated["simulated_children"] / total if total else 0.0
+    )
+    return _build_external_share_comparison(
+        _get_advance_ctc_agi_reference(),
+        simulated,
+    )
+
+
+def build_advance_ctc_filing_status_share_comparison(
+    sim,
+    *,
+    period: int = 2025,
+) -> pd.DataFrame:
+    filing_status = pd.Series(sim.calculate("filing_status", period=period).values)
+    ctc_qualifying_children = sim.calculate(
+        "ctc_qualifying_children", period=period
+    ).values.astype(float)
+    tax_unit_weight = sim.calculate("tax_unit_weight", period=period).values.astype(
+        float
+    )
+
+    frame = pd.DataFrame(
+        {
+            "group": _normalize_advance_ctc_filing_status(filing_status),
+            "simulated_children": ctc_qualifying_children * tax_unit_weight,
+        }
+    )
+    simulated = (
+        frame.groupby("group", observed=False)["simulated_children"].sum().reset_index()
+    )
+    total = simulated["simulated_children"].sum()
+    simulated["simulated_share"] = (
+        simulated["simulated_children"] / total if total else 0.0
+    )
+    return _build_external_share_comparison(
+        _get_advance_ctc_filing_status_reference(),
+        simulated,
+    )
+
+
+def _format_external_share_comparison(table: pd.DataFrame) -> str:
+    display = table.copy()
+    for column in ("simulated_children", "reference_children_2021"):
+        display[column] = display[column].map(lambda value: f"{value / 1e6:,.2f}M")
+    for column in ("simulated_share", "reference_share_2021"):
+        display[column] = display[column].map(lambda value: f"{value * 100:,.1f}%")
+    display["share_delta_pp"] = display["share_delta_pp"].map(
+        lambda value: f"{value:+.1f}pp"
+    )
+    return display.to_string(index=False)
+
+
+def get_external_ctc_benchmark_outputs(
+    sim,
+    *,
+    period: int = 2025,
+) -> dict[str, str]:
+    """Return contextual external CTC child-mix benchmarks from public IRS data."""
+    return {
+        "CTC QUALIFYING-CHILD SHARE VS 2021 ADVANCE CTC ADMIN DATA BY AGI BAND": (
+            _format_external_share_comparison(
+                build_advance_ctc_agi_share_comparison(sim, period=period)
+            )
+        ),
+        "CTC QUALIFYING-CHILD SHARE VS 2021 ADVANCE CTC ADMIN DATA BY FILING STATUS": (
+            _format_external_share_comparison(
+                build_advance_ctc_filing_status_share_comparison(
+                    sim,
+                    period=period,
+                )
+            )
+        ),
+    }
 
 
 def get_ctc_diagnostic_outputs(sim) -> dict[str, str]:
@@ -601,6 +814,12 @@ def main(argv=None):
             print(f"  {var}: {err}")
 
     for section_name, section_output in get_ctc_diagnostic_outputs(sim).items():
+        print("\n" + "=" * 70)
+        print(section_name)
+        print("=" * 70)
+        print(section_output)
+
+    for section_name, section_output in get_external_ctc_benchmark_outputs(sim).items():
         print("\n" + "=" * 70)
         print(section_name)
         print("=" * 70)

--- a/tests/unit/calibration/test_validate_national_h5.py
+++ b/tests/unit/calibration/test_validate_national_h5.py
@@ -1,14 +1,18 @@
 import os
 
 import pandas as pd
+import pytest
 
 from policyengine_us_data.calibration.validate_national_h5 import (
     VARIABLES,
+    build_advance_ctc_agi_share_comparison,
+    build_advance_ctc_filing_status_share_comparison,
     build_artifact_ctc_summary,
     build_canonical_ctc_reform_summary,
     get_artifact_ctc_comparison_outputs,
     get_canonical_ctc_reform_comparison_outputs,
     get_ctc_diagnostic_outputs,
+    get_external_ctc_benchmark_outputs,
     get_reference_values,
     resolve_dataset_path,
 )
@@ -38,6 +42,10 @@ def test_reference_values_use_irs_ctc_component_targets(monkeypatch):
     assert references["non_refundable_ctc"] == (
         81_600_000_000.0,
         "IRS SOI 2022 $81.6B",
+    )
+    assert references["ctc_qualifying_children"] == (
+        63_622_000.0,
+        "IRS Pub. 4801 2022 63.6M",
     )
 
 
@@ -191,6 +199,108 @@ def test_build_artifact_ctc_summary_reports_level_and_delta():
     assert summary.loc["ctc", "delta"] == 30.0
     assert summary.loc["refundable_ctc", "delta"] == 30.0
     assert summary.loc["non_refundable_ctc", "delta"] == 0.0
+
+
+def test_build_advance_ctc_agi_share_comparison_reports_share_deltas(monkeypatch):
+    monkeypatch.setattr(
+        "policyengine_us_data.calibration.validate_national_h5._get_advance_ctc_agi_reference",
+        lambda: pd.DataFrame(
+            [
+                {
+                    "group": "No adjusted gross income [4]",
+                    "reference_children_2021": 5.0,
+                    "reference_share_2021": 0.25,
+                },
+                {
+                    "group": "$1 under $10,000",
+                    "reference_children_2021": 15.0,
+                    "reference_share_2021": 0.75,
+                },
+            ]
+        ),
+    )
+    sim = _FakeSummarySim(
+        {
+            "adjusted_gross_income": pd.Series([0.0, 5_000.0]).to_numpy(),
+            "tax_unit_weight": pd.Series([1.0, 1.0]).to_numpy(),
+            "ctc_qualifying_children": pd.Series([2.0, 2.0]).to_numpy(),
+        }
+    )
+
+    summary = build_advance_ctc_agi_share_comparison(sim).set_index("group")
+
+    assert summary.loc["No adjusted gross income [4]", "simulated_children"] == 2.0
+    assert summary.loc["No adjusted gross income [4]", "simulated_share"] == 0.5
+    assert summary.loc["No adjusted gross income [4]", "share_delta_pp"] == 25.0
+    assert summary.loc["$1 under $10,000", "simulated_children"] == 2.0
+    assert summary.loc["$1 under $10,000", "simulated_share"] == 0.5
+    assert summary.loc["$1 under $10,000", "share_delta_pp"] == -25.0
+
+
+def test_build_advance_ctc_filing_status_share_comparison_reports_share_deltas(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "policyengine_us_data.calibration.validate_national_h5._get_advance_ctc_filing_status_reference",
+        lambda: pd.DataFrame(
+            [
+                {
+                    "group": "Single [4]",
+                    "reference_children_2021": 1.0,
+                    "reference_share_2021": 0.2,
+                },
+                {
+                    "group": "Married filing a joint return",
+                    "reference_children_2021": 4.0,
+                    "reference_share_2021": 0.8,
+                },
+            ]
+        ),
+    )
+    sim = _FakeSummarySim(
+        {
+            "filing_status": pd.Series(["SINGLE", "JOINT"]).to_numpy(),
+            "tax_unit_weight": pd.Series([1.0, 1.0]).to_numpy(),
+            "ctc_qualifying_children": pd.Series([3.0, 1.0]).to_numpy(),
+        }
+    )
+
+    summary = build_advance_ctc_filing_status_share_comparison(sim).set_index("group")
+
+    assert summary.loc["Single [4]", "simulated_children"] == 3.0
+    assert summary.loc["Single [4]", "simulated_share"] == 0.75
+    assert summary.loc["Single [4]", "share_delta_pp"] == pytest.approx(55.0)
+    assert summary.loc["Married filing a joint return", "simulated_children"] == 1.0
+    assert summary.loc["Married filing a joint return", "simulated_share"] == 0.25
+    assert summary.loc["Married filing a joint return", "share_delta_pp"] == (
+        pytest.approx(-55.0)
+    )
+
+
+def test_external_ctc_benchmark_outputs_include_share_sections(monkeypatch):
+    monkeypatch.setattr(
+        "policyengine_us_data.calibration.validate_national_h5.build_advance_ctc_agi_share_comparison",
+        lambda sim, period=2025: pd.DataFrame([{"group": "A", "simulated_share": 0.5}]),
+    )
+    monkeypatch.setattr(
+        "policyengine_us_data.calibration.validate_national_h5.build_advance_ctc_filing_status_share_comparison",
+        lambda sim, period=2025: pd.DataFrame([{"group": "B", "simulated_share": 0.4}]),
+    )
+    monkeypatch.setattr(
+        "policyengine_us_data.calibration.validate_national_h5._format_external_share_comparison",
+        lambda table: f"formatted:{table.to_dict(orient='records')}",
+    )
+
+    outputs = get_external_ctc_benchmark_outputs(object())
+
+    assert outputs == {
+        "CTC QUALIFYING-CHILD SHARE VS 2021 ADVANCE CTC ADMIN DATA BY AGI BAND": (
+            "formatted:[{'group': 'A', 'simulated_share': 0.5}]"
+        ),
+        "CTC QUALIFYING-CHILD SHARE VS 2021 ADVANCE CTC ADMIN DATA BY FILING STATUS": (
+            "formatted:[{'group': 'B', 'simulated_share': 0.4}]"
+        ),
+    }
 
 
 def test_artifact_ctc_comparison_outputs_include_child_composition_sections(


### PR DESCRIPTION
## Summary
- add an exact 2022 IRS Publication 4801 benchmark for `ctc_qualifying_children`
- add contextual public IRS benchmark comparisons for qualifying-child shares by AGI band and filing status
- keep these external comparisons clearly separate from hard current-law pass/fail references
- add focused unit coverage and a changelog fragment

## Why
Recent CTC follow-up work showed that the remaining instability is compositional. We now have a better validator for artifact-to-artifact drift in #731, but we still need some source-backed external anchors for the child composition itself.

This PR adds the public-source pieces that look defensible now:
- exact total `ctc_qualifying_children` from 2022 Publication 4801 Schedule 8812 line 4 amounts
- contextual 2021 advance CTC admin-share comparisons by AGI band and filing status

It deliberately does **not** add the 2021 under-6 split as a hard target because that source is tied to the ARPA/advance-CTC under-18 concept rather than the current-law under-17 concept used by `ctc_qualifying_child`.

## Issue tracking
- Progress on #729
- Related blocked sourcing issue: #717

## Testing
- `uv run pytest tests/unit/calibration/test_validate_national_h5.py -q`
- `uv run ruff check policyengine_us_data/calibration/validate_national_h5.py tests/unit/calibration/test_validate_national_h5.py`
- `uv run ruff format --check policyengine_us_data/calibration/validate_national_h5.py tests/unit/calibration/test_validate_national_h5.py`
- `uv run python -m policyengine_us_data.calibration.validate_national_h5 --help`
