### PR TITLE
Publish TRACE TRO declarations for US data releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,3 +153,29 @@ make documentation
 ```
 
 Note: The Makefile uses the older `jb` command syntax which may not work with Jupyter Book 2. Use `myst start` or `jupyter book start docs` instead.
+
+## TRACE provenance output
+
+Each US data release now publishes both:
+
+- `release_manifest.json`
+- `trace.tro.jsonld`
+
+The release manifest remains the operational source of truth for:
+
+- published artifact paths and checksums
+- build IDs and timestamps
+- build-time `policyengine-us` provenance
+
+`trace.tro.jsonld` is a generated TRACE declaration built from that manifest. It gives a
+standards-based provenance export over the same release artifacts, including a
+composition fingerprint across the release manifest and the artifacts it describes.
+
+Important boundary:
+
+- the TRACE file does not replace the release manifest
+- the TRACE file does not decide model/data compatibility
+
+For the broader certified-bundle architecture, see
+[`policyengine.py` release bundles](https://github.com/PolicyEngine/policyengine.py/blob/main/docs/release-bundles.md)
+and the official [TRACE specification](https://transparency-certified.github.io/trace-specification/docs/specifications/).

--- a/README.md
+++ b/README.md
@@ -171,6 +171,15 @@ The release manifest remains the operational source of truth for:
 standards-based provenance export over the same release artifacts, including a
 composition fingerprint across the release manifest and the artifacts it describes.
 
+The TRO uses the canonical [TROv 0.1 vocabulary](https://w3id.org/trace/trov/0.1/) and
+surfaces PolicyEngine-specific build provenance under the `https://policyengine.org/trace/0.1#`
+extension namespace. Structured fields on the performance node
+(`pe:dataBuildFingerprint`, `pe:builtWithModelVersion`, `pe:builtWithModelGitSha`,
+`pe:dataBuildId`, `pe:emittedIn`) let a verifier cross-check this TRO against the
+certified-bundle TRO emitted by `policyengine.py` without parsing prose.
+
+The emitted TRO is validated against `policyengine_us_data/schemas/trace_tro.schema.json`.
+
 Important boundary:
 
 - the TRACE file does not replace the release manifest

--- a/changelog.d/codex-trace-tro-export-release-manifest.changed.md
+++ b/changelog.d/codex-trace-tro-export-release-manifest.changed.md
@@ -1,0 +1,1 @@
+Publish TRACE TRO declarations alongside US data release manifests on Hugging Face.

--- a/changelog.d/codex-trace-tro-export-release-manifest.changed.md
+++ b/changelog.d/codex-trace-tro-export-release-manifest.changed.md
@@ -1,1 +1,1 @@
-Publish TRACE TRO declarations alongside US data release manifests on Hugging Face.
+Publish TRACE TRO declarations alongside US data release manifests on Hugging Face. The TRO uses canonical TROv 0.1 vocabulary, exposes structured `pe:*` build provenance fields (model version, git sha, data-build fingerprint, CI emission context), and ships with a JSON schema for downstream validation.

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -491,14 +491,11 @@ def add_marketplace_plan_benchmark_ratio(self):
         map_to="tax_unit",
         period=period,
     ).values
-    takes_up_aca = (
-        baseline.calculate(
-            "takes_up_aca_if_eligible",
-            map_to="tax_unit",
-            period=period,
-        )
-        .values.astype(bool)
-    )
+    takes_up_aca = baseline.calculate(
+        "takes_up_aca_if_eligible",
+        map_to="tax_unit",
+        period=period,
+    ).values.astype(bool)
 
     data["selected_marketplace_plan_benchmark_ratio"] = (
         compute_marketplace_plan_benchmark_ratio(

--- a/policyengine_us_data/schemas/trace_tro.schema.json
+++ b/policyengine_us_data/schemas/trace_tro.schema.json
@@ -1,0 +1,222 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://policyengine.org/schemas/policyengine-us-data/trace_tro/0.1.json",
+  "title": "PolicyEngine US data release TRACE TRO",
+  "description": "JSON Schema for a TRACE Transparent Research Object emitted alongside a policyengine-us-data release. Uses the canonical TROv 0.1 vocabulary with the PolicyEngine extension namespace.",
+  "type": "object",
+  "required": ["@context", "@graph"],
+  "properties": {
+    "@context": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["trov", "schema", "pe"],
+        "properties": {
+          "trov": {
+            "type": "string",
+            "const": "https://w3id.org/trace/trov/0.1#"
+          },
+          "schema": {
+            "type": "string",
+            "const": "https://schema.org/"
+          },
+          "pe": {
+            "type": "string",
+            "const": "https://policyengine.org/trace/0.1#"
+          }
+        }
+      }
+    },
+    "@graph": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/troNode" }
+    }
+  },
+  "$defs": {
+    "sha256Hex": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "trovHash": {
+      "type": "object",
+      "required": ["trov:hashAlgorithm", "trov:hashValue"],
+      "properties": {
+        "trov:hashAlgorithm": { "type": "string", "const": "sha256" },
+        "trov:hashValue": { "$ref": "#/$defs/sha256Hex" }
+      }
+    },
+    "typeStringOrArray": {
+      "oneOf": [
+        { "type": "string" },
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        }
+      ]
+    },
+    "artifact": {
+      "type": "object",
+      "required": ["@id", "@type", "trov:hash"],
+      "properties": {
+        "@id": { "type": "string" },
+        "@type": { "const": "trov:ResearchArtifact" },
+        "schema:name": { "type": "string" },
+        "trov:hash": { "$ref": "#/$defs/trovHash" },
+        "trov:mimeType": { "type": "string" }
+      }
+    },
+    "artifactLocation": {
+      "type": "object",
+      "required": ["@id", "@type", "trov:artifact", "trov:path"],
+      "properties": {
+        "@id": { "type": "string" },
+        "@type": { "const": "trov:ArtifactLocation" },
+        "trov:artifact": {
+          "type": "object",
+          "required": ["@id"],
+          "properties": { "@id": { "type": "string" } }
+        },
+        "trov:path": { "type": "string", "minLength": 1 }
+      }
+    },
+    "troNode": {
+      "type": "object",
+      "required": [
+        "@id",
+        "@type",
+        "schema:name",
+        "trov:wasAssembledBy",
+        "trov:hasComposition",
+        "trov:hasArrangement",
+        "trov:hasPerformance"
+      ],
+      "properties": {
+        "@id": { "type": "string" },
+        "@type": {
+          "oneOf": [
+            { "const": "trov:TransparentResearchObject" },
+            {
+              "type": "array",
+              "minItems": 1,
+              "contains": { "const": "trov:TransparentResearchObject" },
+              "items": { "type": "string" }
+            }
+          ]
+        },
+        "trov:vocabularyVersion": { "type": "string" },
+        "schema:name": { "type": "string", "minLength": 1 },
+        "schema:description": { "type": "string" },
+        "schema:dateCreated": { "type": "string" },
+        "schema:creator": {},
+        "trov:wasAssembledBy": {
+          "type": "object",
+          "required": ["@id", "@type", "schema:name"],
+          "properties": {
+            "@id": { "type": "string" },
+            "@type": { "$ref": "#/$defs/typeStringOrArray" },
+            "schema:name": { "type": "string" }
+          }
+        },
+        "trov:createdWith": {
+          "type": "object",
+          "required": ["@type", "schema:name"],
+          "properties": {
+            "@type": { "const": "schema:SoftwareApplication" },
+            "schema:name": { "type": "string" },
+            "schema:softwareVersion": { "type": "string" }
+          }
+        },
+        "trov:hasComposition": { "$ref": "#/$defs/composition" },
+        "trov:hasArrangement": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/arrangement" }
+        },
+        "trov:hasPerformance": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/performance" }
+        }
+      }
+    },
+    "composition": {
+      "type": "object",
+      "required": ["@id", "@type", "trov:hasFingerprint", "trov:hasArtifact"],
+      "properties": {
+        "@id": { "type": "string" },
+        "@type": { "const": "trov:ArtifactComposition" },
+        "trov:hasFingerprint": {
+          "type": "object",
+          "required": ["@id", "@type", "trov:hash"],
+          "properties": {
+            "@id": { "type": "string" },
+            "@type": { "const": "trov:CompositionFingerprint" },
+            "trov:hash": { "$ref": "#/$defs/trovHash" }
+          }
+        },
+        "trov:hasArtifact": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/artifact" }
+        }
+      }
+    },
+    "arrangement": {
+      "type": "object",
+      "required": ["@id", "@type", "trov:hasArtifactLocation"],
+      "properties": {
+        "@id": { "type": "string" },
+        "@type": { "const": "trov:ArtifactArrangement" },
+        "rdfs:comment": { "type": "string" },
+        "trov:hasArtifactLocation": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/artifactLocation" }
+        }
+      }
+    },
+    "performance": {
+      "type": "object",
+      "required": [
+        "@id",
+        "@type",
+        "trov:wasConductedBy",
+        "trov:contributedToArrangement",
+        "pe:emittedIn",
+        "pe:dataBuildId"
+      ],
+      "properties": {
+        "@id": { "type": "string" },
+        "@type": { "const": "trov:TrustedResearchPerformance" },
+        "rdfs:comment": { "type": "string" },
+        "trov:wasConductedBy": {
+          "type": "object",
+          "required": ["@id"],
+          "properties": { "@id": { "type": "string" } }
+        },
+        "trov:contributedToArrangement": {
+          "type": "object",
+          "required": ["@id"],
+          "properties": { "@id": { "type": "string" } }
+        },
+        "trov:startedAtTime": { "type": "string" },
+        "trov:endedAtTime": { "type": "string" },
+        "pe:emittedIn": {
+          "type": "string",
+          "enum": ["local", "github-actions"]
+        },
+        "pe:ciRunUrl": { "type": "string", "format": "uri" },
+        "pe:ciGitSha": { "type": "string" },
+        "pe:ciGitRef": { "type": "string" },
+        "pe:dataBuildId": { "type": "string" },
+        "pe:builtWithModelPackageName": { "type": "string" },
+        "pe:builtWithModelVersion": { "type": "string" },
+        "pe:builtWithModelGitSha": { "type": "string" },
+        "pe:dataBuildFingerprint": { "type": "string" }
+      }
+    }
+  }
+}

--- a/policyengine_us_data/tests/test_release_manifest.py
+++ b/policyengine_us_data/tests/test_release_manifest.py
@@ -11,6 +11,7 @@ from policyengine_us_data.utils.release_manifest import (
     RELEASE_MANIFEST_SCHEMA_VERSION,
     build_release_manifest,
 )
+from policyengine_us_data.utils.trace_tro import TRACE_TRO_FILENAME
 
 
 def _write_file(path: Path, content: bytes) -> Path:
@@ -181,6 +182,8 @@ def test_upload_files_to_hf_adds_release_manifest_operations(tmp_path):
     assert "enhanced_cps_2024.h5" in operation_paths
     assert "release_manifest.json" in operation_paths
     assert "releases/1.73.0/release_manifest.json" in operation_paths
+    assert TRACE_TRO_FILENAME in operation_paths
+    assert f"releases/1.73.0/{TRACE_TRO_FILENAME}" in operation_paths
 
     release_ops = [
         operation
@@ -189,6 +192,14 @@ def test_upload_files_to_hf_adds_release_manifest_operations(tmp_path):
     ]
     assert len(release_ops) == 2
     for operation in release_ops:
+        assert isinstance(operation, CommitOperationAdd)
+        assert isinstance(operation.path_or_fileobj, BytesIO)
+
+    trace_ops = [
+        operation for operation in operations if operation.path_in_repo.endswith(".jsonld")
+    ]
+    assert len(trace_ops) == 2
+    for operation in trace_ops:
         assert isinstance(operation, CommitOperationAdd)
         assert isinstance(operation.path_or_fileobj, BytesIO)
 

--- a/policyengine_us_data/tests/test_release_manifest.py
+++ b/policyengine_us_data/tests/test_release_manifest.py
@@ -196,7 +196,9 @@ def test_upload_files_to_hf_adds_release_manifest_operations(tmp_path):
         assert isinstance(operation.path_or_fileobj, BytesIO)
 
     trace_ops = [
-        operation for operation in operations if operation.path_in_repo.endswith(".jsonld")
+        operation
+        for operation in operations
+        if operation.path_in_repo.endswith(".jsonld")
     ]
     assert len(trace_ops) == 2
     for operation in trace_ops:

--- a/policyengine_us_data/tests/test_trace_tro.py
+++ b/policyengine_us_data/tests/test_trace_tro.py
@@ -1,0 +1,90 @@
+import hashlib
+import json
+from pathlib import Path
+
+from policyengine_us_data.utils.release_manifest import build_release_manifest
+from policyengine_us_data.utils.trace_tro import (
+    TRACE_TRO_FILENAME,
+    build_trace_tro_from_release_manifest,
+    compute_trace_composition_fingerprint,
+    serialize_trace_tro,
+)
+
+
+def _write_file(path: Path, content: bytes) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path
+
+
+def test_compute_trace_composition_fingerprint_is_order_independent():
+    a = "b" * 64
+    b = "a" * 64
+
+    assert compute_trace_composition_fingerprint([a, b]) == (
+        compute_trace_composition_fingerprint([b, a])
+    )
+
+
+def test_build_trace_tro_from_release_manifest_tracks_artifacts(tmp_path):
+    national_path = _write_file(tmp_path / "enhanced_cps_2024.h5", b"national")
+    state_path = _write_file(tmp_path / "AL.h5", b"state")
+
+    manifest = build_release_manifest(
+        files_with_repo_paths=[
+            (national_path, "enhanced_cps_2024.h5"),
+            (state_path, "states/AL.h5"),
+        ],
+        version="1.73.0",
+        repo_id="policyengine/policyengine-us-data",
+        model_package_version="1.634.4",
+        model_package_git_sha="deadbeef",
+        model_package_data_build_fingerprint="sha256:fingerprint",
+        created_at="2026-04-10T12:00:00Z",
+    )
+
+    tro = build_trace_tro_from_release_manifest(manifest)
+    root = tro["@graph"][0]
+    composition = root["trov:hasComposition"]
+    artifacts = composition["trov:hasArtifact"]
+    arrangement = root["trov:hasArrangement"][0]
+    performance = root["trov:hasPerformance"][0]
+
+    assert tro["@context"][0]["trov"] == "https://w3id.org/trace/trov/0.1#"
+    assert root["schema:name"] == "policyengine-us-data 1.73.0 release TRO"
+    assert root["trov:wasAssembledBy"]["schema:name"] == (
+        "PolicyEngine US data release pipeline"
+    )
+    assert len(artifacts) == 3
+    assert arrangement["trov:hasArtifactLocation"][-1]["trov:path"] == "release_manifest.json"
+    assert performance["trov:contributedToArrangement"]["trov:arrangement"] == {
+        "@id": "arrangement/0"
+    }
+
+    manifest_hash = hashlib.sha256(
+        (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    ).hexdigest()
+    assert artifacts[-1]["trov:hash"]["trov:hashValue"] == manifest_hash
+
+    expected_fingerprint = compute_trace_composition_fingerprint(
+        [artifact["trov:hash"]["trov:hashValue"] for artifact in artifacts]
+    )
+    assert (
+        composition["trov:hasFingerprint"]["trov:hash"]["trov:hashValue"]
+        == expected_fingerprint
+    )
+
+
+def test_serialize_trace_tro_is_deterministic(tmp_path):
+    dataset_path = _write_file(tmp_path / "enhanced_cps_2024.h5", b"national")
+    manifest = build_release_manifest(
+        files_with_repo_paths=[(dataset_path, "enhanced_cps_2024.h5")],
+        version="1.73.0",
+        repo_id="policyengine/policyengine-us-data",
+        created_at="2026-04-10T12:00:00Z",
+    )
+
+    tro = build_trace_tro_from_release_manifest(manifest)
+
+    assert serialize_trace_tro(tro) == serialize_trace_tro(tro)
+    assert TRACE_TRO_FILENAME == "trace.tro.jsonld"

--- a/policyengine_us_data/tests/test_trace_tro.py
+++ b/policyengine_us_data/tests/test_trace_tro.py
@@ -56,7 +56,10 @@ def test_build_trace_tro_from_release_manifest_tracks_artifacts(tmp_path):
         "PolicyEngine US data release pipeline"
     )
     assert len(artifacts) == 3
-    assert arrangement["trov:hasArtifactLocation"][-1]["trov:path"] == "release_manifest.json"
+    assert (
+        arrangement["trov:hasArtifactLocation"][-1]["trov:path"]
+        == "release_manifest.json"
+    )
     assert performance["trov:contributedToArrangement"]["trov:arrangement"] == {
         "@id": "arrangement/0"
     }

--- a/policyengine_us_data/tests/test_trace_tro.py
+++ b/policyengine_us_data/tests/test_trace_tro.py
@@ -2,10 +2,15 @@ import hashlib
 import json
 from pathlib import Path
 
+import pytest
+
 from policyengine_us_data.utils.release_manifest import build_release_manifest
 from policyengine_us_data.utils.trace_tro import (
+    POLICYENGINE_TRACE_NAMESPACE,
     TRACE_TRO_FILENAME,
+    TRACE_TROV_NAMESPACE,
     build_trace_tro_from_release_manifest,
+    canonical_json_bytes,
     compute_trace_composition_fingerprint,
     serialize_trace_tro,
 )
@@ -17,20 +22,11 @@ def _write_file(path: Path, content: bytes) -> Path:
     return path
 
 
-def test_compute_trace_composition_fingerprint_is_order_independent():
-    a = "b" * 64
-    b = "a" * 64
-
-    assert compute_trace_composition_fingerprint([a, b]) == (
-        compute_trace_composition_fingerprint([b, a])
-    )
-
-
-def test_build_trace_tro_from_release_manifest_tracks_artifacts(tmp_path):
+def _build_manifest(tmp_path: Path, **overrides):
     national_path = _write_file(tmp_path / "enhanced_cps_2024.h5", b"national")
     state_path = _write_file(tmp_path / "AL.h5", b"state")
 
-    manifest = build_release_manifest(
+    defaults = dict(
         files_with_repo_paths=[
             (national_path, "enhanced_cps_2024.h5"),
             (state_path, "states/AL.h5"),
@@ -42,15 +38,46 @@ def test_build_trace_tro_from_release_manifest_tracks_artifacts(tmp_path):
         model_package_data_build_fingerprint="sha256:fingerprint",
         created_at="2026-04-10T12:00:00Z",
     )
+    defaults.update(overrides)
+    return build_release_manifest(**defaults)
+
+
+def test_compute_trace_composition_fingerprint_is_order_independent():
+    a = "b" * 64
+    b = "a" * 64
+
+    assert compute_trace_composition_fingerprint([a, b]) == (
+        compute_trace_composition_fingerprint([b, a])
+    )
+
+
+def test_compute_trace_composition_fingerprint_uses_newline_separator():
+    """Matches policyengine.py's canonical fingerprint algorithm."""
+    a = "a" * 64
+    b = "b" * 64
+
+    expected = hashlib.sha256(f"{a}\n{b}".encode("utf-8")).hexdigest()
+    assert compute_trace_composition_fingerprint([b, a]) == expected
+
+
+def test_build_trace_tro_uses_canonical_trov_namespace(tmp_path):
+    manifest = _build_manifest(tmp_path)
+
+    tro = build_trace_tro_from_release_manifest(manifest)
+
+    assert tro["@context"][0]["trov"] == TRACE_TROV_NAMESPACE
+    assert tro["@context"][0]["pe"] == POLICYENGINE_TRACE_NAMESPACE
+
+
+def test_build_trace_tro_from_release_manifest_tracks_artifacts(tmp_path):
+    manifest = _build_manifest(tmp_path)
 
     tro = build_trace_tro_from_release_manifest(manifest)
     root = tro["@graph"][0]
     composition = root["trov:hasComposition"]
     artifacts = composition["trov:hasArtifact"]
     arrangement = root["trov:hasArrangement"][0]
-    performance = root["trov:hasPerformance"][0]
 
-    assert tro["@context"][0]["trov"] == "https://w3id.org/trace/trov/0.1#"
     assert root["schema:name"] == "policyengine-us-data 1.73.0 release TRO"
     assert root["trov:wasAssembledBy"]["schema:name"] == (
         "PolicyEngine US data release pipeline"
@@ -60,9 +87,6 @@ def test_build_trace_tro_from_release_manifest_tracks_artifacts(tmp_path):
         arrangement["trov:hasArtifactLocation"][-1]["trov:path"]
         == "release_manifest.json"
     )
-    assert performance["trov:contributedToArrangement"]["trov:arrangement"] == {
-        "@id": "arrangement/0"
-    }
 
     manifest_hash = hashlib.sha256(
         (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode("utf-8")
@@ -78,16 +102,125 @@ def test_build_trace_tro_from_release_manifest_tracks_artifacts(tmp_path):
     )
 
 
-def test_serialize_trace_tro_is_deterministic(tmp_path):
-    dataset_path = _write_file(tmp_path / "enhanced_cps_2024.h5", b"national")
-    manifest = build_release_manifest(
-        files_with_repo_paths=[(dataset_path, "enhanced_cps_2024.h5")],
-        version="1.73.0",
-        repo_id="policyengine/policyengine-us-data",
-        created_at="2026-04-10T12:00:00Z",
+def test_performance_links_arrangement_directly(tmp_path):
+    """TROv 0.1 has no ArrangementBinding; contributedToArrangement is a direct link."""
+    manifest = _build_manifest(tmp_path)
+
+    tro = build_trace_tro_from_release_manifest(manifest)
+    performance = tro["@graph"][0]["trov:hasPerformance"][0]
+
+    assert performance["trov:contributedToArrangement"] == {"@id": "arrangement/1"}
+    assert "trov:arrangement" not in performance["trov:contributedToArrangement"]
+
+
+def test_performance_exposes_structured_build_metadata(tmp_path):
+    manifest = _build_manifest(tmp_path)
+
+    tro = build_trace_tro_from_release_manifest(manifest)
+    performance = tro["@graph"][0]["trov:hasPerformance"][0]
+
+    assert performance["pe:builtWithModelPackageName"] == "policyengine-us"
+    assert performance["pe:builtWithModelVersion"] == "1.634.4"
+    assert performance["pe:builtWithModelGitSha"] == "deadbeef"
+    assert performance["pe:dataBuildFingerprint"] == "sha256:fingerprint"
+    assert performance["pe:dataBuildId"] == "policyengine-us-data-1.73.0"
+
+
+def test_performance_omits_missing_build_metadata(tmp_path):
+    manifest = _build_manifest(
+        tmp_path,
+        model_package_version=None,
+        model_package_git_sha=None,
+        model_package_data_build_fingerprint=None,
     )
 
     tro = build_trace_tro_from_release_manifest(manifest)
+    performance = tro["@graph"][0]["trov:hasPerformance"][0]
 
-    assert serialize_trace_tro(tro) == serialize_trace_tro(tro)
+    assert "pe:builtWithModelVersion" not in performance
+    assert "pe:builtWithModelGitSha" not in performance
+    assert "pe:dataBuildFingerprint" not in performance
+
+
+def test_performance_records_local_emission(tmp_path, monkeypatch):
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    manifest = _build_manifest(tmp_path)
+
+    tro = build_trace_tro_from_release_manifest(manifest)
+    performance = tro["@graph"][0]["trov:hasPerformance"][0]
+
+    assert performance["pe:emittedIn"] == "local"
+    assert "pe:ciRunUrl" not in performance
+
+
+def test_performance_records_github_actions_emission(tmp_path, monkeypatch):
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.com")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "PolicyEngine/policyengine-us-data")
+    monkeypatch.setenv("GITHUB_RUN_ID", "1234567890")
+    monkeypatch.setenv("GITHUB_SHA", "abc123")
+    monkeypatch.setenv("GITHUB_REF", "refs/heads/main")
+    manifest = _build_manifest(tmp_path)
+
+    tro = build_trace_tro_from_release_manifest(manifest)
+    performance = tro["@graph"][0]["trov:hasPerformance"][0]
+
+    assert performance["pe:emittedIn"] == "github-actions"
+    assert performance["pe:ciRunUrl"] == (
+        "https://github.com/PolicyEngine/policyengine-us-data/actions/runs/1234567890"
+    )
+    assert performance["pe:ciGitSha"] == "abc123"
+    assert performance["pe:ciGitRef"] == "refs/heads/main"
+
+
+def test_index_numbering_is_consistent(tmp_path):
+    manifest = _build_manifest(tmp_path)
+
+    tro = build_trace_tro_from_release_manifest(manifest)
+    root = tro["@graph"][0]
+    arrangement = root["trov:hasArrangement"][0]
+    performance = root["trov:hasPerformance"][0]
+
+    assert root["trov:hasComposition"]["@id"] == "composition/1"
+    assert arrangement["@id"] == "arrangement/1"
+    assert performance["@id"] == "trp/1"
+    assert arrangement["trov:hasArtifactLocation"][0]["@id"].startswith(
+        "arrangement/1/location/"
+    )
+
+
+def test_build_trace_tro_is_deterministic(tmp_path, monkeypatch):
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    manifest = _build_manifest(tmp_path)
+
+    tro_a = build_trace_tro_from_release_manifest(manifest)
+    tro_b = build_trace_tro_from_release_manifest(manifest)
+
+    assert serialize_trace_tro(tro_a) == serialize_trace_tro(tro_b)
+
+
+def test_canonical_json_bytes_match_serialize(tmp_path):
+    """A caller recomputing the TRO hash from dict form must get the same bytes."""
+    manifest = _build_manifest(tmp_path)
+
+    tro = build_trace_tro_from_release_manifest(manifest)
+
+    assert canonical_json_bytes(tro) == serialize_trace_tro(tro)
+
+
+def test_trace_tro_filename_is_stable():
     assert TRACE_TRO_FILENAME == "trace.tro.jsonld"
+
+
+def test_tro_validates_against_shipped_schema(tmp_path):
+    """The emitted TRO must pass the packaged JSON schema."""
+    jsonschema = pytest.importorskip("jsonschema")
+    manifest = _build_manifest(tmp_path)
+
+    tro = build_trace_tro_from_release_manifest(manifest)
+
+    schema_path = (
+        Path(__file__).resolve().parents[1] / "schemas" / "trace_tro.schema.json"
+    )
+    schema = json.loads(schema_path.read_text())
+    jsonschema.validate(instance=tro, schema=schema)

--- a/policyengine_us_data/utils/data_upload.py
+++ b/policyengine_us_data/utils/data_upload.py
@@ -29,6 +29,11 @@ from policyengine_us_data.utils.release_manifest import (
     build_release_manifest,
     serialize_release_manifest,
 )
+from policyengine_us_data.utils.trace_tro import (
+    TRACE_TRO_FILENAME,
+    build_trace_tro_from_release_manifest,
+    serialize_trace_tro,
+)
 
 DEFAULT_HF_TIMEOUT = 300
 MAX_RETRIES = 5
@@ -282,6 +287,9 @@ def create_release_manifest_commit_operations(
         existing_manifest=existing_manifest,
     )
     manifest_payload = serialize_release_manifest(manifest)
+    trace_tro_payload = serialize_trace_tro(
+        build_trace_tro_from_release_manifest(manifest)
+    )
 
     operations = [
         CommitOperationAdd(
@@ -291,6 +299,14 @@ def create_release_manifest_commit_operations(
         CommitOperationAdd(
             path_in_repo=f"releases/{version}/{RELEASE_MANIFEST_PATH}",
             path_or_fileobj=BytesIO(manifest_payload),
+        ),
+        CommitOperationAdd(
+            path_in_repo=TRACE_TRO_FILENAME,
+            path_or_fileobj=BytesIO(trace_tro_payload),
+        ),
+        CommitOperationAdd(
+            path_in_repo=f"releases/{version}/{TRACE_TRO_FILENAME}",
+            path_or_fileobj=BytesIO(trace_tro_payload),
         ),
     ]
     return manifest, operations

--- a/policyengine_us_data/utils/trace_tro.py
+++ b/policyengine_us_data/utils/trace_tro.py
@@ -52,7 +52,9 @@ def build_trace_tro_from_release_manifest(
     data_package = manifest["data_package"]
     created_at = manifest.get("created_at") or manifest.get("build", {}).get("built_at")
     build = manifest.get("build", {})
-    build_id = build.get("build_id") or f"{data_package['name']}-{data_package['version']}"
+    build_id = (
+        build.get("build_id") or f"{data_package['name']}-{data_package['version']}"
+    )
     built_with_model = build.get("built_with_model_package") or {}
     artifact_items = sorted(manifest.get("artifacts", {}).items())
 

--- a/policyengine_us_data/utils/trace_tro.py
+++ b/policyengine_us_data/utils/trace_tro.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Iterable, Mapping
+
+TRACE_TRO_FILENAME = "trace.tro.jsonld"
+TRACE_TROV_VERSION = "0.1"
+TRACE_CONTEXT = [
+    {
+        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+        "trov": "https://w3id.org/trace/trov/0.1#",
+        "schema": "https://schema.org/",
+    }
+]
+
+
+def _hash_object(value: str) -> dict[str, str]:
+    return {
+        "trov:hashAlgorithm": "sha256",
+        "trov:hashValue": value,
+    }
+
+
+def _artifact_mime_type(path_in_repo: str) -> str | None:
+    suffix = path_in_repo.rsplit(".", 1)[-1].lower() if "." in path_in_repo else ""
+    return {
+        "h5": "application/x-hdf5",
+        "db": "application/vnd.sqlite3",
+        "json": "application/json",
+        "jsonld": "application/ld+json",
+        "npy": "application/octet-stream",
+        "npz": "application/octet-stream",
+        "csv": "text/csv",
+    }.get(suffix)
+
+
+def compute_trace_composition_fingerprint(
+    artifact_hashes: Iterable[str],
+) -> str:
+    digest = hashlib.sha256()
+    digest.update("".join(sorted(artifact_hashes)).encode("utf-8"))
+    return digest.hexdigest()
+
+
+def build_trace_tro_from_release_manifest(
+    manifest: Mapping,
+    *,
+    release_manifest_path: str = "release_manifest.json",
+) -> dict:
+    data_package = manifest["data_package"]
+    created_at = manifest.get("created_at") or manifest.get("build", {}).get("built_at")
+    build = manifest.get("build", {})
+    build_id = build.get("build_id") or f"{data_package['name']}-{data_package['version']}"
+    built_with_model = build.get("built_with_model_package") or {}
+    artifact_items = sorted(manifest.get("artifacts", {}).items())
+
+    composition_artifacts = []
+    arrangement_locations = []
+    artifact_hashes = []
+
+    for index, (_, artifact) in enumerate(artifact_items):
+        artifact_id = f"composition/1/artifact/{index}"
+        artifact_hashes.append(artifact["sha256"])
+        artifact_entry = {
+            "@id": artifact_id,
+            "@type": "trov:ResearchArtifact",
+            "trov:hash": _hash_object(artifact["sha256"]),
+        }
+        mime_type = _artifact_mime_type(artifact["path"])
+        if mime_type is not None:
+            artifact_entry["trov:mimeType"] = mime_type
+        composition_artifacts.append(artifact_entry)
+        arrangement_locations.append(
+            {
+                "@id": f"arrangement/0/location/{index}",
+                "@type": "trov:ArtifactLocation",
+                "trov:artifact": {"@id": artifact_id},
+                "trov:path": artifact["path"],
+            }
+        )
+
+    manifest_bytes = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode(
+        "utf-8"
+    )
+    release_manifest_hash = hashlib.sha256(manifest_bytes).hexdigest()
+    manifest_artifact_id = f"composition/1/artifact/{len(composition_artifacts)}"
+    artifact_hashes.append(release_manifest_hash)
+    composition_artifacts.append(
+        {
+            "@id": manifest_artifact_id,
+            "@type": "trov:ResearchArtifact",
+            "trov:hash": _hash_object(release_manifest_hash),
+            "trov:mimeType": "application/json",
+        }
+    )
+    arrangement_locations.append(
+        {
+            "@id": f"arrangement/0/location/{len(arrangement_locations)}",
+            "@type": "trov:ArtifactLocation",
+            "trov:artifact": {"@id": manifest_artifact_id},
+            "trov:path": release_manifest_path,
+        }
+    )
+
+    trs_description = {
+        "@id": "trs",
+        "@type": ["trov:TrustedResearchSystem", "schema:Organization"],
+        "schema:name": "PolicyEngine US data release pipeline",
+        "schema:description": (
+            "PolicyEngine build and release workflow for versioned US microdata artifacts."
+        ),
+    }
+
+    model_version = built_with_model.get("version")
+    model_name = built_with_model.get("name", "policyengine-us")
+    model_fingerprint = built_with_model.get("data_build_fingerprint")
+    description = (
+        f"TRACE TRO for {data_package['name']} {data_package['version']} "
+        f"covering immutable release artifacts and the accompanying release manifest."
+    )
+    if model_version:
+        description += f" Built with {model_name} {model_version}."
+    if model_fingerprint:
+        description += f" Data-build fingerprint: {model_fingerprint}."
+
+    return {
+        "@context": TRACE_CONTEXT,
+        "@graph": [
+            {
+                "@id": "tro",
+                "@type": ["trov:TransparentResearchObject", "schema:CreativeWork"],
+                "trov:vocabularyVersion": TRACE_TROV_VERSION,
+                "schema:creator": data_package["name"],
+                "schema:name": f"{data_package['name']} {data_package['version']} release TRO",
+                "schema:description": description,
+                "schema:dateCreated": created_at,
+                "trov:wasAssembledBy": trs_description,
+                "trov:createdWith": {
+                    "@type": "schema:SoftwareApplication",
+                    "schema:name": data_package["name"],
+                    "schema:softwareVersion": data_package["version"],
+                },
+                "trov:hasComposition": {
+                    "@id": "composition/1",
+                    "@type": "trov:ArtifactComposition",
+                    "trov:hasFingerprint": {
+                        "@id": "fingerprint",
+                        "@type": "trov:CompositionFingerprint",
+                        "trov:hash": _hash_object(
+                            compute_trace_composition_fingerprint(artifact_hashes)
+                        ),
+                    },
+                    "trov:hasArtifact": composition_artifacts,
+                },
+                "trov:hasArrangement": [
+                    {
+                        "@id": "arrangement/0",
+                        "@type": "trov:ArtifactArrangement",
+                        "rdfs:comment": (
+                            f"Immutable release artifact arrangement for build {build_id}"
+                        ),
+                        "trov:hasArtifactLocation": arrangement_locations,
+                    }
+                ],
+                "trov:hasPerformance": [
+                    {
+                        "@id": "trp/0",
+                        "@type": "trov:TrustedResearchPerformance",
+                        "rdfs:comment": (
+                            f"Publication of release build {build_id} for "
+                            f"{data_package['name']} {data_package['version']}"
+                        ),
+                        "trov:wasConductedBy": {"@id": "trs"},
+                        "trov:startedAtTime": build.get("built_at") or created_at,
+                        "trov:endedAtTime": created_at,
+                        "trov:contributedToArrangement": {
+                            "@id": "trp/0/binding/0",
+                            "@type": "trov:ArrangementBinding",
+                            "trov:arrangement": {"@id": "arrangement/0"},
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def serialize_trace_tro(tro: Mapping) -> bytes:
+    return (json.dumps(tro, indent=2, sort_keys=True) + "\n").encode("utf-8")

--- a/policyengine_us_data/utils/trace_tro.py
+++ b/policyengine_us_data/utils/trace_tro.py
@@ -1,19 +1,49 @@
+"""TRACE Transparent Research Object (TRO) export for US data releases.
+
+Emits JSON-LD conforming to the canonical TROv 0.1 vocabulary at
+``https://w3id.org/trace/trov/0.1#``. The TRO pins every artifact in the
+release (plus the release manifest itself) by sha256 and records
+PolicyEngine-specific build provenance under the ``pe:`` extension
+namespace so a verifier can cross-check against the certified-bundle TRO
+emitted by ``policyengine.py`` without parsing prose.
+"""
+
 from __future__ import annotations
 
 import hashlib
 import json
-from typing import Iterable, Mapping
+import os
+from typing import Any, Iterable, Mapping, Optional
 
 TRACE_TRO_FILENAME = "trace.tro.jsonld"
 TRACE_TROV_VERSION = "0.1"
-TRACE_CONTEXT = [
+
+TRACE_TROV_NAMESPACE = "https://w3id.org/trace/trov/0.1#"
+POLICYENGINE_TRACE_NAMESPACE = "https://policyengine.org/trace/0.1#"
+
+TRACE_CONTEXT: list[dict[str, str]] = [
     {
         "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
         "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-        "trov": "https://w3id.org/trace/trov/0.1#",
+        "trov": TRACE_TROV_NAMESPACE,
         "schema": "https://schema.org/",
+        "pe": POLICYENGINE_TRACE_NAMESPACE,
     }
 ]
+
+_COMPOSITION_ID = "composition/1"
+_ARRANGEMENT_ID = "arrangement/1"
+_PERFORMANCE_ID = "trp/1"
+
+_MIME_TYPES = {
+    "h5": "application/x-hdf5",
+    "db": "application/vnd.sqlite3",
+    "json": "application/json",
+    "jsonld": "application/ld+json",
+    "npy": "application/octet-stream",
+    "npz": "application/octet-stream",
+    "csv": "text/csv",
+}
 
 
 def _hash_object(value: str) -> dict[str, str]:
@@ -23,25 +53,131 @@ def _hash_object(value: str) -> dict[str, str]:
     }
 
 
-def _artifact_mime_type(path_in_repo: str) -> str | None:
+def _artifact_mime_type(path_in_repo: str) -> Optional[str]:
     suffix = path_in_repo.rsplit(".", 1)[-1].lower() if "." in path_in_repo else ""
-    return {
-        "h5": "application/x-hdf5",
-        "db": "application/vnd.sqlite3",
-        "json": "application/json",
-        "jsonld": "application/ld+json",
-        "npy": "application/octet-stream",
-        "npz": "application/octet-stream",
-        "csv": "text/csv",
-    }.get(suffix)
+    return _MIME_TYPES.get(suffix)
+
+
+def canonical_json_bytes(value: Mapping) -> bytes:
+    """Canonical JSON serialization used for every content hash.
+
+    Kept public so a third-party verifier can reproduce these bytes
+    exactly to recompute artifact hashes and the composition fingerprint.
+    """
+    return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8")
 
 
 def compute_trace_composition_fingerprint(
     artifact_hashes: Iterable[str],
 ) -> str:
+    """Fingerprint a composition by the sorted set of its artifact hashes.
+
+    Joins with ``\\n`` so the boundary between hashes is unambiguous even
+    if a future hash algorithm produces variable-length values. This
+    matches ``policyengine.py``'s fingerprint algorithm so a verifier can
+    recompute fingerprints across data-side and bundle-side TROs.
+    """
+    sorted_hashes = sorted(artifact_hashes)
     digest = hashlib.sha256()
-    digest.update("".join(sorted(artifact_hashes)).encode("utf-8"))
+    digest.update("\n".join(sorted_hashes).encode("utf-8"))
     return digest.hexdigest()
+
+
+def _emission_context() -> dict[str, str]:
+    """Attestation metadata about where and how the TRO was emitted.
+
+    Always includes ``pe:emittedIn`` so a verifier can distinguish a CI
+    build from a laptop build without inferring from the absence of
+    optional fields.
+    """
+    context: dict[str, str] = {}
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        context["pe:emittedIn"] = "github-actions"
+        server = os.environ.get("GITHUB_SERVER_URL")
+        repo = os.environ.get("GITHUB_REPOSITORY")
+        run_id = os.environ.get("GITHUB_RUN_ID")
+        if server and repo and run_id:
+            context["pe:ciRunUrl"] = f"{server}/{repo}/actions/runs/{run_id}"
+        sha = os.environ.get("GITHUB_SHA")
+        if sha:
+            context["pe:ciGitSha"] = sha
+        ref = os.environ.get("GITHUB_REF")
+        if ref:
+            context["pe:ciGitRef"] = ref
+    else:
+        context["pe:emittedIn"] = "local"
+    return context
+
+
+def _build_artifact_entry(
+    artifact_id: str,
+    sha256: str,
+    *,
+    mime_type: Optional[str] = None,
+    name: Optional[str] = None,
+) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "@id": artifact_id,
+        "@type": "trov:ResearchArtifact",
+        "trov:hash": _hash_object(sha256),
+    }
+    if mime_type is not None:
+        entry["trov:mimeType"] = mime_type
+    if name is not None:
+        entry["schema:name"] = name
+    return entry
+
+
+def _build_location_entry(
+    location_id: str, artifact_id: str, path: str
+) -> dict[str, Any]:
+    return {
+        "@id": location_id,
+        "@type": "trov:ArtifactLocation",
+        "trov:artifact": {"@id": artifact_id},
+        "trov:path": path,
+    }
+
+
+def _build_performance(
+    *,
+    build_id: str,
+    data_package: Mapping[str, str],
+    built_with_model: Mapping[str, Any],
+    started_at: Optional[str],
+    ended_at: Optional[str],
+) -> dict[str, Any]:
+    performance: dict[str, Any] = {
+        "@id": _PERFORMANCE_ID,
+        "@type": "trov:TrustedResearchPerformance",
+        "rdfs:comment": (
+            f"Publication of release build {build_id} for "
+            f"{data_package['name']} {data_package['version']}"
+        ),
+        "trov:wasConductedBy": {"@id": "trs"},
+        "trov:contributedToArrangement": {"@id": _ARRANGEMENT_ID},
+        "pe:dataBuildId": build_id,
+    }
+    if started_at is not None:
+        performance["trov:startedAtTime"] = started_at
+    if ended_at is not None:
+        performance["trov:endedAtTime"] = ended_at
+
+    model_name = built_with_model.get("name")
+    if model_name:
+        performance["pe:builtWithModelPackageName"] = model_name
+    model_version = built_with_model.get("version")
+    if model_version:
+        performance["pe:builtWithModelVersion"] = model_version
+    model_git_sha = built_with_model.get("git_sha")
+    if model_git_sha:
+        performance["pe:builtWithModelGitSha"] = model_git_sha
+    model_fingerprint = built_with_model.get("data_build_fingerprint")
+    if model_fingerprint:
+        performance["pe:dataBuildFingerprint"] = model_fingerprint
+
+    performance.update(_emission_context())
+    return performance
 
 
 def build_trace_tro_from_release_manifest(
@@ -49,6 +185,14 @@ def build_trace_tro_from_release_manifest(
     *,
     release_manifest_path: str = "release_manifest.json",
 ) -> dict:
+    """Build a TRACE TRO from a PolicyEngine US data release manifest.
+
+    Artifacts in the composition: every file listed in the release
+    manifest's ``artifacts`` block, plus the canonical release manifest
+    bytes themselves. Every artifact hash feeds into the composition
+    fingerprint, and build-time ``policyengine-us`` provenance is
+    surfaced as structured ``pe:*`` fields on the performance node.
+    """
     data_package = manifest["data_package"]
     created_at = manifest.get("created_at") or manifest.get("build", {}).get("built_at")
     build = manifest.get("build", {})
@@ -58,52 +202,48 @@ def build_trace_tro_from_release_manifest(
     built_with_model = build.get("built_with_model_package") or {}
     artifact_items = sorted(manifest.get("artifacts", {}).items())
 
-    composition_artifacts = []
-    arrangement_locations = []
-    artifact_hashes = []
+    composition_artifacts: list[dict[str, Any]] = []
+    arrangement_locations: list[dict[str, Any]] = []
+    artifact_hashes: list[str] = []
 
-    for index, (_, artifact) in enumerate(artifact_items):
-        artifact_id = f"composition/1/artifact/{index}"
+    for index, (artifact_key, artifact) in enumerate(artifact_items):
+        artifact_id = f"{_COMPOSITION_ID}/artifact/{index}"
         artifact_hashes.append(artifact["sha256"])
-        artifact_entry = {
-            "@id": artifact_id,
-            "@type": "trov:ResearchArtifact",
-            "trov:hash": _hash_object(artifact["sha256"]),
-        }
-        mime_type = _artifact_mime_type(artifact["path"])
-        if mime_type is not None:
-            artifact_entry["trov:mimeType"] = mime_type
-        composition_artifacts.append(artifact_entry)
+        composition_artifacts.append(
+            _build_artifact_entry(
+                artifact_id,
+                artifact["sha256"],
+                mime_type=_artifact_mime_type(artifact["path"]),
+                name=artifact_key,
+            )
+        )
         arrangement_locations.append(
-            {
-                "@id": f"arrangement/0/location/{index}",
-                "@type": "trov:ArtifactLocation",
-                "trov:artifact": {"@id": artifact_id},
-                "trov:path": artifact["path"],
-            }
+            _build_location_entry(
+                f"{_ARRANGEMENT_ID}/location/{index}",
+                artifact_id,
+                artifact["path"],
+            )
         )
 
-    manifest_bytes = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode(
-        "utf-8"
-    )
+    manifest_bytes = canonical_json_bytes(manifest)
     release_manifest_hash = hashlib.sha256(manifest_bytes).hexdigest()
-    manifest_artifact_id = f"composition/1/artifact/{len(composition_artifacts)}"
+    manifest_index = len(composition_artifacts)
+    manifest_artifact_id = f"{_COMPOSITION_ID}/artifact/{manifest_index}"
     artifact_hashes.append(release_manifest_hash)
     composition_artifacts.append(
-        {
-            "@id": manifest_artifact_id,
-            "@type": "trov:ResearchArtifact",
-            "trov:hash": _hash_object(release_manifest_hash),
-            "trov:mimeType": "application/json",
-        }
+        _build_artifact_entry(
+            manifest_artifact_id,
+            release_manifest_hash,
+            mime_type="application/json",
+            name="release_manifest.json",
+        )
     )
     arrangement_locations.append(
-        {
-            "@id": f"arrangement/0/location/{len(arrangement_locations)}",
-            "@type": "trov:ArtifactLocation",
-            "trov:artifact": {"@id": manifest_artifact_id},
-            "trov:path": release_manifest_path,
-        }
+        _build_location_entry(
+            f"{_ARRANGEMENT_ID}/location/{manifest_index}",
+            manifest_artifact_id,
+            release_manifest_path,
+        )
     )
 
     trs_description = {
@@ -115,79 +255,64 @@ def build_trace_tro_from_release_manifest(
         ),
     }
 
-    model_version = built_with_model.get("version")
-    model_name = built_with_model.get("name", "policyengine-us")
-    model_fingerprint = built_with_model.get("data_build_fingerprint")
     description = (
         f"TRACE TRO for {data_package['name']} {data_package['version']} "
         f"covering immutable release artifacts and the accompanying release manifest."
     )
-    if model_version:
-        description += f" Built with {model_name} {model_version}."
-    if model_fingerprint:
-        description += f" Data-build fingerprint: {model_fingerprint}."
 
-    return {
-        "@context": TRACE_CONTEXT,
-        "@graph": [
-            {
-                "@id": "tro",
-                "@type": ["trov:TransparentResearchObject", "schema:CreativeWork"],
-                "trov:vocabularyVersion": TRACE_TROV_VERSION,
-                "schema:creator": data_package["name"],
-                "schema:name": f"{data_package['name']} {data_package['version']} release TRO",
-                "schema:description": description,
-                "schema:dateCreated": created_at,
-                "trov:wasAssembledBy": trs_description,
-                "trov:createdWith": {
-                    "@type": "schema:SoftwareApplication",
-                    "schema:name": data_package["name"],
-                    "schema:softwareVersion": data_package["version"],
-                },
-                "trov:hasComposition": {
-                    "@id": "composition/1",
-                    "@type": "trov:ArtifactComposition",
-                    "trov:hasFingerprint": {
-                        "@id": "fingerprint",
-                        "@type": "trov:CompositionFingerprint",
-                        "trov:hash": _hash_object(
-                            compute_trace_composition_fingerprint(artifact_hashes)
-                        ),
-                    },
-                    "trov:hasArtifact": composition_artifacts,
-                },
-                "trov:hasArrangement": [
-                    {
-                        "@id": "arrangement/0",
-                        "@type": "trov:ArtifactArrangement",
-                        "rdfs:comment": (
-                            f"Immutable release artifact arrangement for build {build_id}"
-                        ),
-                        "trov:hasArtifactLocation": arrangement_locations,
-                    }
-                ],
-                "trov:hasPerformance": [
-                    {
-                        "@id": "trp/0",
-                        "@type": "trov:TrustedResearchPerformance",
-                        "rdfs:comment": (
-                            f"Publication of release build {build_id} for "
-                            f"{data_package['name']} {data_package['version']}"
-                        ),
-                        "trov:wasConductedBy": {"@id": "trs"},
-                        "trov:startedAtTime": build.get("built_at") or created_at,
-                        "trov:endedAtTime": created_at,
-                        "trov:contributedToArrangement": {
-                            "@id": "trp/0/binding/0",
-                            "@type": "trov:ArrangementBinding",
-                            "trov:arrangement": {"@id": "arrangement/0"},
-                        },
-                    }
-                ],
-            }
-        ],
+    composition = {
+        "@id": _COMPOSITION_ID,
+        "@type": "trov:ArtifactComposition",
+        "trov:hasFingerprint": {
+            "@id": f"{_COMPOSITION_ID}/fingerprint",
+            "@type": "trov:CompositionFingerprint",
+            "trov:hash": _hash_object(
+                compute_trace_composition_fingerprint(artifact_hashes)
+            ),
+        },
+        "trov:hasArtifact": composition_artifacts,
     }
+
+    arrangement = {
+        "@id": _ARRANGEMENT_ID,
+        "@type": "trov:ArtifactArrangement",
+        "rdfs:comment": (
+            f"Immutable release artifact arrangement for build {build_id}"
+        ),
+        "trov:hasArtifactLocation": arrangement_locations,
+    }
+
+    performance = _build_performance(
+        build_id=build_id,
+        data_package=data_package,
+        built_with_model=built_with_model,
+        started_at=build.get("built_at") or created_at,
+        ended_at=created_at,
+    )
+
+    tro_node: dict[str, Any] = {
+        "@id": "tro",
+        "@type": ["trov:TransparentResearchObject", "schema:CreativeWork"],
+        "trov:vocabularyVersion": TRACE_TROV_VERSION,
+        "schema:creator": data_package["name"],
+        "schema:name": f"{data_package['name']} {data_package['version']} release TRO",
+        "schema:description": description,
+        "trov:wasAssembledBy": trs_description,
+        "trov:createdWith": {
+            "@type": "schema:SoftwareApplication",
+            "schema:name": data_package["name"],
+            "schema:softwareVersion": data_package["version"],
+        },
+        "trov:hasComposition": composition,
+        "trov:hasArrangement": [arrangement],
+        "trov:hasPerformance": [performance],
+    }
+    if created_at is not None:
+        tro_node["schema:dateCreated"] = created_at
+
+    return {"@context": TRACE_CONTEXT, "@graph": [tro_node]}
 
 
 def serialize_trace_tro(tro: Mapping) -> bytes:
-    return (json.dumps(tro, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    """Serialize a TRO with the same canonical JSON used for hashing."""
+    return canonical_json_bytes(tro)


### PR DESCRIPTION
## Summary
- add a TRACE TRO builder for US data release manifests
- upload `trace.tro.jsonld` alongside the floating and versioned release manifests
- add focused regression coverage for TRO generation and HF commit operations

## Testing
- PYTHONPATH=/Users/maxghenis/PolicyEngine/_codex_prs/policyengine-us-data-trace-tro-export-release-manifest /Users/maxghenis/PolicyEngine/policyengine-us-data/.venv/bin/pytest /Users/maxghenis/PolicyEngine/_codex_prs/policyengine-us-data-trace-tro-export-release-manifest/policyengine_us_data/tests/test_release_manifest.py /Users/maxghenis/PolicyEngine/_codex_prs/policyengine-us-data-trace-tro-export-release-manifest/policyengine_us_data/tests/test_trace_tro.py
- /Users/maxghenis/PolicyEngine/policyengine-us-data/.venv/bin/python -m ruff check policyengine_us_data/utils/data_upload.py policyengine_us_data/utils/release_manifest.py policyengine_us_data/utils/trace_tro.py policyengine_us_data/tests/test_release_manifest.py policyengine_us_data/tests/test_trace_tro.py