### PR TITLE
Add TANF administrative calibration targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ database:
 	python policyengine_us_data/db/etl_age.py --year $(YEAR)
 	python policyengine_us_data/db/etl_medicaid.py --year $(YEAR)
 	python policyengine_us_data/db/etl_snap.py --year $(YEAR)
+	python policyengine_us_data/db/etl_tanf.py --year $(YEAR)
 	python policyengine_us_data/db/etl_state_income_tax.py --year $(YEAR)
 	python policyengine_us_data/db/etl_irs_soi.py --year $(YEAR)
 	python policyengine_us_data/db/etl_pregnancy.py --year $(YEAR)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@ which installs the development dependencies in a reference-only manner (so that 
 to the package code will be reflected immediately); `policyengine-us-data` is a dev package
 and not intended for direct access.
 
+## Pull Requests
+
+PRs must come from branches pushed to `PolicyEngine/policyengine-us-data`, not from
+personal forks. The PR workflow hard-fails fork-based PRs before the real test suite
+runs because the required secrets are unavailable there.
+
+Before opening a PR, push the current branch to the upstream repo:
+
+```bash
+make push-pr-branch
+```
+
+That target pushes the current branch to the `upstream` remote and sets tracking so
+`gh pr create` opens the PR from `PolicyEngine/policyengine-us-data`.
+
 ## SSA Data Sources
 
 The following SSA data sources are used in this project:

--- a/changelog.d/codex-tanf-state-targets.added.md
+++ b/changelog.d/codex-tanf-state-targets.added.md
@@ -1,1 +1,1 @@
-Added HHS ACF TANF caseload and basic-assistance ETL targets, populated baseline CPS `spm_unit_assets`, and aligned TANF calibration totals to FY2024 administrative data.
+Added HHS ACF TANF caseload and cash-assistance ETL targets, exposed baseline CPS liquid-asset inputs, and aligned TANF calibration totals to FY2024 administrative data.

--- a/changelog.d/codex-tanf-state-targets.added.md
+++ b/changelog.d/codex-tanf-state-targets.added.md
@@ -1,0 +1,1 @@
+Added HHS ACF TANF caseload and basic-assistance ETL targets, populated baseline CPS `spm_unit_assets`, and aligned TANF calibration totals to FY2024 administrative data.

--- a/policyengine_us_data/calibration/target_config.yaml
+++ b/policyengine_us_data/calibration/target_config.yaml
@@ -51,8 +51,13 @@ include:
   # REMOVED: is_pregnant — 100% unachievable across all 51 state geos
   - variable: snap
     geo_level: state
+  - variable: tanf
+    geo_level: state
   - variable: adjusted_gross_income
     geo_level: state
+  - variable: spm_unit_count
+    geo_level: state
+    domain_variable: tanf
 
   # === STATE — fine AGI bracket targets (stubs 9/10 from in55cmcsv) ===
   - variable: person_count
@@ -127,6 +132,9 @@ include:
     geo_level: national
   - variable: tanf
     geo_level: national
+  - variable: spm_unit_count
+    geo_level: national
+    domain_variable: tanf
   - variable: tip_income
     geo_level: national
   - variable: unemployment_compensation

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -106,6 +106,55 @@ def _open_dataset_read_only(dataset_source):
         yield store
 
 
+def derive_spm_unit_assets(
+    person_spm_unit_ids,
+    spm_unit_ids,
+    bank_account_assets,
+    stock_assets,
+    bond_assets,
+    assessed_property_value=None,
+):
+    """Aggregate modeled person-level assets to the SPM-unit entity.
+
+    This intentionally stays conservative for baseline CPS construction:
+    liquid financial assets are always included, while real property is only
+    included if a compatible person-level array is explicitly supplied.
+    """
+
+    person_spm_unit_ids = np.asarray(person_spm_unit_ids, dtype=np.int64)
+    spm_unit_ids = np.asarray(spm_unit_ids, dtype=np.int64)
+    person_asset_totals = (
+        np.asarray(bank_account_assets, dtype=np.float32)
+        + np.asarray(stock_assets, dtype=np.float32)
+        + np.asarray(bond_assets, dtype=np.float32)
+    )
+    if assessed_property_value is not None:
+        person_asset_totals = person_asset_totals + np.asarray(
+            assessed_property_value,
+            dtype=np.float32,
+        )
+
+    spm_unit_index = {int(spm_unit_id): i for i, spm_unit_id in enumerate(spm_unit_ids)}
+    missing_spm_unit_ids = {
+        int(spm_unit_id)
+        for spm_unit_id in np.unique(person_spm_unit_ids)
+        if int(spm_unit_id) not in spm_unit_index
+    }
+    if missing_spm_unit_ids:
+        raise ValueError(
+            "Person SPM unit ids missing from SPM-unit entity ids: "
+            f"{sorted(missing_spm_unit_ids)[:10]}"
+        )
+
+    result = np.zeros(len(spm_unit_ids), dtype=np.float32)
+    spm_unit_positions = np.array(
+        [spm_unit_index[int(spm_unit_id)] for spm_unit_id in person_spm_unit_ids],
+        dtype=np.int64,
+    )
+    np.add.at(result, spm_unit_positions, person_asset_totals)
+    return result
+
+
 class CPS(Dataset):
     name = "cps"
     label = "CPS"
@@ -1534,8 +1583,6 @@ def add_ssn_card_type(
         }
     )
 
-    final_counts = pd.Series(ssn_card_type).value_counts().sort_index()
-
     # ============================================================================
     # PROBABILISTIC FAMILY CORRELATION ADJUSTMENT
     # ============================================================================
@@ -1558,8 +1605,6 @@ def add_ssn_card_type(
         f"Current undocumented: {current_undocumented:,.0f}, Target: {undocumented_target:,.0f}"
     )
     print(f"Additional undocumented needed: {undocumented_needed:,.0f}")
-
-    families_adjusted = 0
 
     if undocumented_needed > 0:
         # Identify households with mixed status (code 0 + code 3 members)
@@ -1584,7 +1629,6 @@ def add_ssn_card_type(
         # Randomly select from eligible code 3 members in mixed households to hit target
         if len(mixed_household_candidates) > 0:
             mixed_household_candidates = np.array(mixed_household_candidates)
-            candidate_weights = person_weights[mixed_household_candidates]
 
             # Use probabilistic selection to hit target
             selected_indices = select_random_subset_to_target(
@@ -1596,7 +1640,6 @@ def add_ssn_card_type(
 
             if len(selected_indices) > 0:
                 ssn_card_type[selected_indices] = 0
-                families_adjusted = len(selected_indices)
                 print(
                     f"Selected {len(selected_indices)} people from {len(mixed_household_candidates)} candidates in mixed households"
                 )
@@ -1735,7 +1778,7 @@ def add_ssn_card_type(
     # Save as immigration_status_str since that's what PolicyEngine expects
     cps["immigration_status_str"] = immigration_status.astype("S")
     # Final population summary
-    print(f"\nFinal populations:")
+    print("\nFinal populations:")
     code_to_str = {
         0: "NONE",  # Likely undocumented immigrants
         1: "CITIZEN",  # US citizens
@@ -1877,6 +1920,8 @@ def _update_documentation_with_numbers(log_df, docs_dir):
 
 
 def add_tips(self, cps: h5py.File):
+    person_spm_unit_ids = np.asarray(cps["person_spm_unit_id"], dtype=np.int64)
+    spm_unit_ids = np.asarray(cps["spm_unit_id"], dtype=np.int64)
     self.save_dataset(cps)
     from policyengine_us import Microsimulation
 
@@ -1947,13 +1992,21 @@ def add_tips(self, cps: h5py.File):
     cps["bank_account_assets"] = asset_predictions.bank_account_assets.values
     cps["stock_assets"] = asset_predictions.stock_assets.values
     cps["bond_assets"] = asset_predictions.bond_assets.values
+    spm_unit_assets = derive_spm_unit_assets(
+        person_spm_unit_ids=person_spm_unit_ids,
+        spm_unit_ids=spm_unit_ids,
+        bank_account_assets=cps["bank_account_assets"].values,
+        stock_assets=cps["stock_assets"].values,
+        bond_assets=cps["bond_assets"].values,
+    )
 
     # Drop temporary columns used only for imputation
     # is_married is person-level here but policyengine-us defines it at Family
     # level, so we must not save it
     cps = cps.drop(columns=["is_married", "is_under_18", "is_under_6"], errors="ignore")
-
-    self.save_dataset(cps)
+    data_to_save = {column: cps[column].values for column in cps.columns}
+    data_to_save["spm_unit_assets"] = spm_unit_assets
+    self.save_dataset(data_to_save)
 
 
 def add_org_labor_market_inputs(cps: h5py.File) -> None:

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -105,6 +105,7 @@ def _open_dataset_read_only(dataset_source):
     with closing(dataset.load()) as store:
         yield store
 
+
 class CPS(Dataset):
     name = "cps"
     label = "CPS"

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -105,56 +105,6 @@ def _open_dataset_read_only(dataset_source):
     with closing(dataset.load()) as store:
         yield store
 
-
-def derive_spm_unit_assets(
-    person_spm_unit_ids,
-    spm_unit_ids,
-    bank_account_assets,
-    stock_assets,
-    bond_assets,
-    assessed_property_value=None,
-):
-    """Aggregate modeled person-level assets to the SPM-unit entity.
-
-    This intentionally stays conservative for baseline CPS construction:
-    liquid financial assets are always included, while real property is only
-    included if a compatible person-level array is explicitly supplied.
-    """
-
-    person_spm_unit_ids = np.asarray(person_spm_unit_ids, dtype=np.int64)
-    spm_unit_ids = np.asarray(spm_unit_ids, dtype=np.int64)
-    person_asset_totals = (
-        np.asarray(bank_account_assets, dtype=np.float32)
-        + np.asarray(stock_assets, dtype=np.float32)
-        + np.asarray(bond_assets, dtype=np.float32)
-    )
-    if assessed_property_value is not None:
-        person_asset_totals = person_asset_totals + np.asarray(
-            assessed_property_value,
-            dtype=np.float32,
-        )
-
-    spm_unit_index = {int(spm_unit_id): i for i, spm_unit_id in enumerate(spm_unit_ids)}
-    missing_spm_unit_ids = {
-        int(spm_unit_id)
-        for spm_unit_id in np.unique(person_spm_unit_ids)
-        if int(spm_unit_id) not in spm_unit_index
-    }
-    if missing_spm_unit_ids:
-        raise ValueError(
-            "Person SPM unit ids missing from SPM-unit entity ids: "
-            f"{sorted(missing_spm_unit_ids)[:10]}"
-        )
-
-    result = np.zeros(len(spm_unit_ids), dtype=np.float32)
-    spm_unit_positions = np.array(
-        [spm_unit_index[int(spm_unit_id)] for spm_unit_id in person_spm_unit_ids],
-        dtype=np.int64,
-    )
-    np.add.at(result, spm_unit_positions, person_asset_totals)
-    return result
-
-
 class CPS(Dataset):
     name = "cps"
     label = "CPS"
@@ -1920,8 +1870,6 @@ def _update_documentation_with_numbers(log_df, docs_dir):
 
 
 def add_tips(self, cps: h5py.File):
-    person_spm_unit_ids = np.asarray(cps["person_spm_unit_id"], dtype=np.int64)
-    spm_unit_ids = np.asarray(cps["spm_unit_id"], dtype=np.int64)
     self.save_dataset(cps)
     from policyengine_us import Microsimulation
 
@@ -1992,21 +1940,12 @@ def add_tips(self, cps: h5py.File):
     cps["bank_account_assets"] = asset_predictions.bank_account_assets.values
     cps["stock_assets"] = asset_predictions.stock_assets.values
     cps["bond_assets"] = asset_predictions.bond_assets.values
-    spm_unit_assets = derive_spm_unit_assets(
-        person_spm_unit_ids=person_spm_unit_ids,
-        spm_unit_ids=spm_unit_ids,
-        bank_account_assets=cps["bank_account_assets"].values,
-        stock_assets=cps["stock_assets"].values,
-        bond_assets=cps["bond_assets"].values,
-    )
 
     # Drop temporary columns used only for imputation
     # is_married is person-level here but policyengine-us defines it at Family
     # level, so we must not save it
     cps = cps.drop(columns=["is_married", "is_under_18", "is_under_6"], errors="ignore")
-    data_to_save = {column: cps[column].values for column in cps.columns}
-    data_to_save["spm_unit_assets"] = spm_unit_assets
-    self.save_dataset(data_to_save)
+    self.save_dataset(cps)
 
 
 def add_org_labor_market_inputs(cps: h5py.File) -> None:

--- a/policyengine_us_data/db/DATABASE_GUIDE.md
+++ b/policyengine_us_data/db/DATABASE_GUIDE.md
@@ -29,10 +29,11 @@ make database-refresh   # Force re-download all sources and rebuild
 | 4 | `etl_age.py` | Census ACS 1-year | Age distribution: 18 bins x 488 geographies |
 | 5 | `etl_medicaid.py` | Census ACS + CMS | Medicaid enrollment (admin state-level, survey district-level) |
 | 6 | `etl_snap.py` | USDA FNS + Census ACS | SNAP participation (admin state-level, survey district-level) |
-| 7 | `etl_state_income_tax.py` | Census STC | State income tax collections (Census STC FY2023 `T40`, downloaded and cached) |
-| 8 | `etl_irs_soi.py` | IRS | Tax variables, EITC by child count, AGI brackets, conditional strata |
-| 9 | `etl_pregnancy.py` | CDC VSRR + Census ACS | Pregnancy prevalence by state (provisional birth counts) |
-| 10 | `validate_database.py` | No | Checks all target variables exist in policyengine-us |
+| 7 | `etl_tanf.py` | HHS ACF | TANF caseload families and basic-assistance spending (FY2024) |
+| 8 | `etl_state_income_tax.py` | Census STC | State income tax collections (Census STC FY2023 `T40`, downloaded and cached) |
+| 9 | `etl_irs_soi.py` | IRS | Tax variables, EITC by child count, AGI brackets, conditional strata |
+| 10 | `etl_pregnancy.py` | CDC VSRR + Census ACS | Pregnancy prevalence by state (provisional birth counts) |
+| 11 | `validate_database.py` | No | Checks all target variables exist in policyengine-us |
 
 ### Raw Input Caching
 

--- a/policyengine_us_data/db/DATABASE_GUIDE.md
+++ b/policyengine_us_data/db/DATABASE_GUIDE.md
@@ -29,7 +29,7 @@ make database-refresh   # Force re-download all sources and rebuild
 | 4 | `etl_age.py` | Census ACS 1-year | Age distribution: 18 bins x 488 geographies |
 | 5 | `etl_medicaid.py` | Census ACS + CMS | Medicaid enrollment (admin state-level, survey district-level) |
 | 6 | `etl_snap.py` | USDA FNS + Census ACS | SNAP participation (admin state-level, survey district-level) |
-| 7 | `etl_tanf.py` | HHS ACF | TANF caseload families and basic-assistance spending (FY2024) |
+| 7 | `etl_tanf.py` | HHS ACF | TANF caseload families and cash-assistance spending (FY2024) |
 | 8 | `etl_state_income_tax.py` | Census STC | State income tax collections (Census STC FY2023 `T40`, downloaded and cached) |
 | 9 | `etl_irs_soi.py` | IRS | Tax variables, EITC by child count, AGI brackets, conditional strata |
 | 10 | `etl_pregnancy.py` | CDC VSRR + Census ACS | Pregnancy prevalence by state (provisional birth counts) |

--- a/policyengine_us_data/db/create_field_valid_values.py
+++ b/policyengine_us_data/db/create_field_valid_values.py
@@ -75,6 +75,8 @@ def populate_field_valid_values(session: Session) -> None:
         ("source", "Census ACS S2201", "survey"),
         ("source", "Census STC", "administrative"),
         ("source", "CDC VSRR Natality", "administrative"),
+        ("source", "HHS ACF TANF Caseload", "administrative"),
+        ("source", "HHS ACF TANF Financial", "administrative"),
         ("source", "PolicyEngine", "hardcoded"),
     ]
 

--- a/policyengine_us_data/db/etl_national_targets.py
+++ b/policyengine_us_data/db/etl_national_targets.py
@@ -204,13 +204,6 @@ def extract_national_targets(year: int = DEFAULT_YEAR):
             "year": HARDCODED_YEAR,
         },
         {
-            "variable": "tanf",
-            "value": 9e9,
-            "source": "HHS/ACF",
-            "notes": "TANF cash assistance",
-            "year": HARDCODED_YEAR,
-        },
-        {
             "variable": "real_estate_taxes",
             "value": 500e9,
             "source": "Census Bureau",

--- a/policyengine_us_data/db/etl_tanf.py
+++ b/policyengine_us_data/db/etl_tanf.py
@@ -18,6 +18,7 @@ from policyengine_us_data.utils.raw_cache import is_cached, load_bytes, save_byt
 
 logger = logging.getLogger(__name__)
 
+ACF_DATA_YEAR = 2024
 CASELOAD_PAGE_URL = "https://www.acf.hhs.gov/ofa/data/tanf-caseload-data-2024"
 FINANCIAL_PAGE_URL = "https://www.acf.hhs.gov/ofa/data/tanf-financial-data-fy-2024"
 CASELOAD_URL_PATTERN = re.compile(
@@ -26,6 +27,14 @@ CASELOAD_URL_PATTERN = re.compile(
 FINANCIAL_URL_PATTERN = re.compile(
     r"https://acf\.gov/sites/default/files/documents/ofa/fy-\d{4}-tanf-moe-financial-data\.xlsx"
 )
+
+
+def _validate_supported_year(year: int) -> None:
+    if year != ACF_DATA_YEAR:
+        raise ValueError(
+            "TANF administrative calibration targets are currently available only "
+            f"for FY{ACF_DATA_YEAR}; got year={year}"
+        )
 
 
 def _download_acf_excel(page_url: str, cache_file: str, url_pattern: re.Pattern) -> bytes:
@@ -57,9 +66,10 @@ def _download_acf_excel(page_url: str, cache_file: str, url_pattern: re.Pattern)
 
 
 def extract_tanf_caseload_data(year: int) -> pd.DataFrame:
+    _validate_supported_year(year)
     workbook = _download_acf_excel(
         CASELOAD_PAGE_URL,
-        f"tanf_caseload_{year}.xlsx",
+        f"tanf_caseload_{ACF_DATA_YEAR}.xlsx",
         CASELOAD_URL_PATTERN,
     )
     return pd.read_excel(io.BytesIO(workbook), sheet_name="TFam", header=3)
@@ -99,9 +109,10 @@ def transform_tanf_caseload_data(raw_df: pd.DataFrame) -> tuple[float, pd.DataFr
 def extract_tanf_financial_data(
     year: int,
 ) -> tuple[pd.DataFrame, dict[str, pd.DataFrame]]:
+    _validate_supported_year(year)
     workbook = _download_acf_excel(
         FINANCIAL_PAGE_URL,
-        f"tanf_financial_{year}.xlsx",
+        f"tanf_financial_{ACF_DATA_YEAR}.xlsx",
         FINANCIAL_URL_PATTERN,
     )
     xls = pd.ExcelFile(io.BytesIO(workbook))
@@ -121,7 +132,7 @@ def extract_tanf_financial_data(
     return national_df, state_sheets
 
 
-def _extract_basic_assistance_all_funds(df: pd.DataFrame) -> float:
+def _extract_cash_assistance_all_funds(df: pd.DataFrame) -> float:
     normalized = df.copy()
     normalized.columns = [
         re.sub(r"\s+", " ", str(column)).strip() for column in normalized.columns
@@ -139,10 +150,15 @@ def _extract_basic_assistance_all_funds(df: pd.DataFrame) -> float:
 
     mask = (
         normalized[spending_category_column].astype(str).str.strip()
-        == "Basic Assistance"
+        == (
+            "Basic Assistance (excluding Relative Foster Care Maintenance Payments "
+            "and Adoption and Guardianship Subsidies)"
+        )
     )
     if not mask.any():
-        raise ValueError("Could not locate Basic Assistance row in TANF financial workbook")
+        raise ValueError(
+            "Could not locate narrow Basic Assistance row in TANF financial workbook"
+        )
 
     value = (
         normalized.loc[mask, "All Funds"]
@@ -158,7 +174,7 @@ def transform_tanf_financial_data(
     national_df: pd.DataFrame,
     state_sheets: dict[str, pd.DataFrame],
 ) -> tuple[float, pd.DataFrame]:
-    national_spending = _extract_basic_assistance_all_funds(national_df)
+    national_spending = _extract_cash_assistance_all_funds(national_df)
 
     state_rows = []
     for state_name, df in state_sheets.items():
@@ -166,7 +182,7 @@ def transform_tanf_financial_data(
             {
                 "state": state_name,
                 "state_fips": int(STATE_NAME_TO_FIPS[state_name]),
-                "tanf": _extract_basic_assistance_all_funds(df),
+                "tanf": _extract_cash_assistance_all_funds(df),
             }
         )
 
@@ -217,7 +233,10 @@ def load_tanf_data(
                 value=national_families,
                 active=True,
                 source="HHS ACF TANF Caseload",
-                notes=f"Average monthly TANF recipient families | Source: ACF TFam FY{year}",
+                notes=(
+                    "Average monthly TANF recipient families | "
+                    f"Source: ACF TFam FY{ACF_DATA_YEAR}"
+                ),
             ),
             Target(
                 variable="tanf",
@@ -226,8 +245,9 @@ def load_tanf_data(
                 active=True,
                 source="HHS ACF TANF Financial",
                 notes=(
-                    "Basic assistance all funds | "
-                    f"Source: ACF TANF & MOE Financial Data FY{year}"
+                    "Basic assistance excluding relative foster care maintenance "
+                    "payments and adoption and guardianship subsidies | "
+                    f"Source: ACF TANF & MOE Financial Data FY{ACF_DATA_YEAR}"
                 ),
             ),
         ]
@@ -259,7 +279,10 @@ def load_tanf_data(
                     value=float(row.recipient_families),
                     active=True,
                     source="HHS ACF TANF Caseload",
-                    notes=f"Average monthly TANF recipient families | Source: ACF TFam FY{year}",
+                    notes=(
+                        "Average monthly TANF recipient families | "
+                        f"Source: ACF TFam FY{ACF_DATA_YEAR}"
+                    ),
                 ),
                 Target(
                     variable="tanf",
@@ -268,8 +291,9 @@ def load_tanf_data(
                     active=True,
                     source="HHS ACF TANF Financial",
                     notes=(
-                        "Basic assistance all funds | "
-                        f"Source: ACF TANF & MOE Financial Data FY{year}"
+                        "Basic assistance excluding relative foster care maintenance "
+                        "payments and adoption and guardianship subsidies | "
+                        f"Source: ACF TANF & MOE Financial Data FY{ACF_DATA_YEAR}"
                     ),
                 ),
             ]

--- a/policyengine_us_data/db/etl_tanf.py
+++ b/policyengine_us_data/db/etl_tanf.py
@@ -1,0 +1,302 @@
+import io
+import logging
+import re
+
+import pandas as pd
+import requests
+from sqlmodel import Session, create_engine
+
+from policyengine_us_data.storage import STORAGE_FOLDER
+from policyengine_us_data.db.create_database_tables import (
+    Stratum,
+    StratumConstraint,
+    Target,
+)
+from policyengine_us_data.utils.census import STATE_NAME_TO_FIPS
+from policyengine_us_data.utils.db import etl_argparser, get_geographic_strata
+from policyengine_us_data.utils.raw_cache import is_cached, load_bytes, save_bytes
+
+logger = logging.getLogger(__name__)
+
+CASELOAD_PAGE_URL = "https://www.acf.hhs.gov/ofa/data/tanf-caseload-data-2024"
+FINANCIAL_PAGE_URL = "https://www.acf.hhs.gov/ofa/data/tanf-financial-data-fy-2024"
+CASELOAD_URL_PATTERN = re.compile(
+    r"https://acf\.gov/sites/default/files/documents/ofa/fy\d{4}_tanf_caseload\.xlsx"
+)
+FINANCIAL_URL_PATTERN = re.compile(
+    r"https://acf\.gov/sites/default/files/documents/ofa/fy-\d{4}-tanf-moe-financial-data\.xlsx"
+)
+
+
+def _download_acf_excel(page_url: str, cache_file: str, url_pattern: re.Pattern) -> bytes:
+    if is_cached(cache_file):
+        logger.info("Using cached %s", cache_file)
+        return load_bytes(cache_file)
+
+    session = requests.Session()
+    session.headers.update(
+        {
+            "User-Agent": (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0 Safari/537.36"
+            )
+        }
+    )
+
+    page_response = session.get(page_url, timeout=30)
+    page_response.raise_for_status()
+    match = url_pattern.search(page_response.text)
+    if match is None:
+        raise ValueError(f"Could not find TANF workbook URL on {page_url}")
+
+    workbook_url = match.group(0)
+    workbook_response = session.get(workbook_url, timeout=60)
+    workbook_response.raise_for_status()
+    save_bytes(cache_file, workbook_response.content)
+    return workbook_response.content
+
+
+def extract_tanf_caseload_data(year: int) -> pd.DataFrame:
+    workbook = _download_acf_excel(
+        CASELOAD_PAGE_URL,
+        f"tanf_caseload_{year}.xlsx",
+        CASELOAD_URL_PATTERN,
+    )
+    return pd.read_excel(io.BytesIO(workbook), sheet_name="TFam", header=3)
+
+
+def transform_tanf_caseload_data(raw_df: pd.DataFrame) -> tuple[float, pd.DataFrame]:
+    df = raw_df.copy()
+    non_empty_columns = [column for column in df.columns if df[column].notna().any()]
+    if len(non_empty_columns) < 2:
+        raise ValueError("Unexpected TANF caseload workbook shape")
+
+    state_column = non_empty_columns[0]
+    value_column = non_empty_columns[-1]
+    df = df[[state_column, value_column]].rename(
+        columns={state_column: "state", value_column: "recipient_families"}
+    )
+    df["state"] = df["state"].astype(str).str.strip()
+    df["recipient_families"] = pd.to_numeric(
+        df["recipient_families"],
+        errors="coerce",
+    )
+    df = df.dropna(subset=["recipient_families"])
+
+    national_rows = df["state"].str.contains("U.S.", regex=False, na=False)
+    if not national_rows.any():
+        raise ValueError("Could not locate U.S. totals row in TANF caseload workbook")
+    national_families = float(df.loc[national_rows, "recipient_families"].iloc[0])
+
+    state_df = df.loc[df["state"].isin(STATE_NAME_TO_FIPS.keys())].copy()
+    state_df["state_fips"] = state_df["state"].map(STATE_NAME_TO_FIPS).astype(int)
+    state_df["ucgid_str"] = state_df["state_fips"].map(lambda fips: f"0400000US{fips:02d}")
+    return national_families, state_df[
+        ["state", "state_fips", "ucgid_str", "recipient_families"]
+    ].sort_values("state_fips")
+
+
+def extract_tanf_financial_data(
+    year: int,
+) -> tuple[pd.DataFrame, dict[str, pd.DataFrame]]:
+    workbook = _download_acf_excel(
+        FINANCIAL_PAGE_URL,
+        f"tanf_financial_{year}.xlsx",
+        FINANCIAL_URL_PATTERN,
+    )
+    xls = pd.ExcelFile(io.BytesIO(workbook))
+    national_df = pd.read_excel(
+        xls,
+        sheet_name="A.1 Fed & State by Category",
+        header=1,
+    )
+    state_sheets = {}
+    for state_name in STATE_NAME_TO_FIPS:
+        sheet_name = "DC" if state_name == "District of Columbia" else state_name
+        state_sheets[state_name] = pd.read_excel(
+            xls,
+            sheet_name=sheet_name,
+            header=1,
+        )
+    return national_df, state_sheets
+
+
+def _extract_basic_assistance_all_funds(df: pd.DataFrame) -> float:
+    normalized = df.copy()
+    normalized.columns = [
+        re.sub(r"\s+", " ", str(column)).strip() for column in normalized.columns
+    ]
+    spending_category_column = next(
+        (
+            column
+            for column in normalized.columns
+            if column.lower().startswith("spending category")
+        ),
+        None,
+    )
+    if spending_category_column is None or "All Funds" not in normalized.columns:
+        raise ValueError("Unexpected TANF financial workbook columns")
+
+    mask = (
+        normalized[spending_category_column].astype(str).str.strip()
+        == "Basic Assistance"
+    )
+    if not mask.any():
+        raise ValueError("Could not locate Basic Assistance row in TANF financial workbook")
+
+    value = (
+        normalized.loc[mask, "All Funds"]
+        .astype(str)
+        .str.replace(",", "", regex=False)
+        .pipe(pd.to_numeric, errors="coerce")
+        .iloc[0]
+    )
+    return float(value)
+
+
+def transform_tanf_financial_data(
+    national_df: pd.DataFrame,
+    state_sheets: dict[str, pd.DataFrame],
+) -> tuple[float, pd.DataFrame]:
+    national_spending = _extract_basic_assistance_all_funds(national_df)
+
+    state_rows = []
+    for state_name, df in state_sheets.items():
+        state_rows.append(
+            {
+                "state": state_name,
+                "state_fips": int(STATE_NAME_TO_FIPS[state_name]),
+                "tanf": _extract_basic_assistance_all_funds(df),
+            }
+        )
+
+    state_df = pd.DataFrame(state_rows).sort_values("state_fips").reset_index(drop=True)
+    return national_spending, state_df
+
+
+def load_tanf_data(
+    national_families: float,
+    national_spending: float,
+    state_caseload_df: pd.DataFrame,
+    state_financial_df: pd.DataFrame,
+    year: int,
+) -> None:
+    database_url = f"sqlite:///{STORAGE_FOLDER / 'calibration' / 'policy_data.db'}"
+    engine = create_engine(database_url)
+
+    state_df = state_caseload_df.merge(
+        state_financial_df,
+        on=["state", "state_fips"],
+        how="inner",
+        validate="one_to_one",
+    )
+    if len(state_df) != len(STATE_NAME_TO_FIPS):
+        raise ValueError(
+            "Merged TANF caseload/financial targets do not cover all states: "
+            f"{len(state_df)} rows"
+        )
+
+    with Session(engine) as session:
+        geo_strata = get_geographic_strata(session)
+
+        national_stratum = Stratum(
+            parent_stratum_id=geo_strata["national"],
+            notes="National TANF recipient families",
+        )
+        national_stratum.constraints_rel = [
+            StratumConstraint(
+                constraint_variable="tanf",
+                operation=">",
+                value="0",
+            )
+        ]
+        national_stratum.targets_rel = [
+            Target(
+                variable="spm_unit_count",
+                period=year,
+                value=national_families,
+                active=True,
+                source="HHS ACF TANF Caseload",
+                notes=f"Average monthly TANF recipient families | Source: ACF TFam FY{year}",
+            ),
+            Target(
+                variable="tanf",
+                period=year,
+                value=national_spending,
+                active=True,
+                source="HHS ACF TANF Financial",
+                notes=(
+                    "Basic assistance all funds | "
+                    f"Source: ACF TANF & MOE Financial Data FY{year}"
+                ),
+            ),
+        ]
+        session.add(national_stratum)
+        session.flush()
+
+        for row in state_df.itertuples(index=False):
+            parent_stratum_id = geo_strata["state"][int(row.state_fips)]
+            state_stratum = Stratum(
+                parent_stratum_id=parent_stratum_id,
+                notes=f"State FIPS {int(row.state_fips)} TANF recipient families",
+            )
+            state_stratum.constraints_rel = [
+                StratumConstraint(
+                    constraint_variable="state_fips",
+                    operation="==",
+                    value=str(int(row.state_fips)),
+                ),
+                StratumConstraint(
+                    constraint_variable="tanf",
+                    operation=">",
+                    value="0",
+                ),
+            ]
+            state_stratum.targets_rel = [
+                Target(
+                    variable="spm_unit_count",
+                    period=year,
+                    value=float(row.recipient_families),
+                    active=True,
+                    source="HHS ACF TANF Caseload",
+                    notes=f"Average monthly TANF recipient families | Source: ACF TFam FY{year}",
+                ),
+                Target(
+                    variable="tanf",
+                    period=year,
+                    value=float(row.tanf),
+                    active=True,
+                    source="HHS ACF TANF Financial",
+                    notes=(
+                        "Basic assistance all funds | "
+                        f"Source: ACF TANF & MOE Financial Data FY{year}"
+                    ),
+                ),
+            ]
+            session.add(state_stratum)
+
+        session.commit()
+
+
+def main():
+    _, year = etl_argparser("ETL for TANF administrative calibration targets")
+    caseload_raw = extract_tanf_caseload_data(year)
+    national_families, state_caseload_df = transform_tanf_caseload_data(caseload_raw)
+
+    financial_national_df, financial_state_sheets = extract_tanf_financial_data(year)
+    national_spending, state_financial_df = transform_tanf_financial_data(
+        financial_national_df,
+        financial_state_sheets,
+    )
+
+    load_tanf_data(
+        national_families=national_families,
+        national_spending=national_spending,
+        state_caseload_df=state_caseload_df,
+        state_financial_df=state_financial_df,
+        year=year,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/policyengine_us_data/db/etl_tanf.py
+++ b/policyengine_us_data/db/etl_tanf.py
@@ -37,7 +37,9 @@ def _validate_supported_year(year: int) -> None:
         )
 
 
-def _download_acf_excel(page_url: str, cache_file: str, url_pattern: re.Pattern) -> bytes:
+def _download_acf_excel(
+    page_url: str, cache_file: str, url_pattern: re.Pattern
+) -> bytes:
     if is_cached(cache_file):
         logger.info("Using cached %s", cache_file)
         return load_bytes(cache_file)
@@ -100,7 +102,9 @@ def transform_tanf_caseload_data(raw_df: pd.DataFrame) -> tuple[float, pd.DataFr
 
     state_df = df.loc[df["state"].isin(STATE_NAME_TO_FIPS.keys())].copy()
     state_df["state_fips"] = state_df["state"].map(STATE_NAME_TO_FIPS).astype(int)
-    state_df["ucgid_str"] = state_df["state_fips"].map(lambda fips: f"0400000US{fips:02d}")
+    state_df["ucgid_str"] = state_df["state_fips"].map(
+        lambda fips: f"0400000US{fips:02d}"
+    )
     return national_families, state_df[
         ["state", "state_fips", "ucgid_str", "recipient_families"]
     ].sort_values("state_fips")
@@ -148,12 +152,9 @@ def _extract_cash_assistance_all_funds(df: pd.DataFrame) -> float:
     if spending_category_column is None or "All Funds" not in normalized.columns:
         raise ValueError("Unexpected TANF financial workbook columns")
 
-    mask = (
-        normalized[spending_category_column].astype(str).str.strip()
-        == (
-            "Basic Assistance (excluding Relative Foster Care Maintenance Payments "
-            "and Adoption and Guardianship Subsidies)"
-        )
+    mask = normalized[spending_category_column].astype(str).str.strip() == (
+        "Basic Assistance (excluding Relative Foster Care Maintenance Payments "
+        "and Adoption and Guardianship Subsidies)"
     )
     if not mask.any():
         raise ValueError(

--- a/policyengine_us_data/storage/calibration_targets/pull_hardcoded_targets.py
+++ b/policyengine_us_data/storage/calibration_targets/pull_hardcoded_targets.py
@@ -16,7 +16,7 @@ HARD_CODED_TOTALS = {
     "child_support_received": 33e9,
     "spm_unit_capped_work_childcare_expenses": 348e9,
     "spm_unit_capped_housing_subsidy": 35e9,
-    "tanf": 9e9,
+    "tanf": 8_186_013_422.99,
     # Alimony could be targeted via SOI
     "alimony_income": 13e9,
     "alimony_expense": 13e9,

--- a/policyengine_us_data/storage/calibration_targets/pull_hardcoded_targets.py
+++ b/policyengine_us_data/storage/calibration_targets/pull_hardcoded_targets.py
@@ -16,7 +16,7 @@ HARD_CODED_TOTALS = {
     "child_support_received": 33e9,
     "spm_unit_capped_work_childcare_expenses": 348e9,
     "spm_unit_capped_housing_subsidy": 35e9,
-    "tanf": 8_186_013_422.99,
+    "tanf": 7_788_317_474.55,
     # Alimony could be targeted via SOI
     "alimony_income": 13e9,
     "alimony_expense": 13e9,

--- a/policyengine_us_data/utils/loss.py
+++ b/policyengine_us_data/utils/loss.py
@@ -38,7 +38,7 @@ HARD_CODED_TOTALS = {
     "child_support_received": 33e9,
     "spm_unit_capped_work_childcare_expenses": 348e9,
     "spm_unit_capped_housing_subsidy": 35e9,
-    "tanf": 8_186_013_422.99,
+    "tanf": 7_788_317_474.55,
     # Alimony could be targeted via SOI
     "alimony_income": 13e9,
     "alimony_expense": 13e9,

--- a/policyengine_us_data/utils/loss.py
+++ b/policyengine_us_data/utils/loss.py
@@ -38,7 +38,7 @@ HARD_CODED_TOTALS = {
     "child_support_received": 33e9,
     "spm_unit_capped_work_childcare_expenses": 348e9,
     "spm_unit_capped_housing_subsidy": 35e9,
-    "tanf": 9e9,
+    "tanf": 8_186_013_422.99,
     # Alimony could be targeted via SOI
     "alimony_income": 13e9,
     "alimony_expense": 13e9,

--- a/tests/integration/test_cps_generation.py
+++ b/tests/integration/test_cps_generation.py
@@ -1,20 +1,6 @@
 import pandas as pd
 
 
-def test_derive_spm_unit_assets_sums_person_level_assets():
-    from policyengine_us_data.datasets.cps.cps import derive_spm_unit_assets
-
-    result = derive_spm_unit_assets(
-        person_spm_unit_ids=[101, 101, 202],
-        spm_unit_ids=[101, 202],
-        bank_account_assets=[100.0, 300.0, 50.0],
-        stock_assets=[50.0, 200.0, 80.0],
-        bond_assets=[10.0, 25.0, 0.0],
-    )
-
-    assert result.tolist() == [685.0, 130.0]
-
-
 def test_add_tips_derives_tipped_status_from_raw_cps(monkeypatch):
     import policyengine_us
     import policyengine_us_data.datasets.sipp as sipp_module
@@ -101,4 +87,6 @@ def test_add_tips_derives_tipped_status_from_raw_cps(monkeypatch):
     )
 
     assert dataset.saved_dataset["tip_income"].tolist() == [100.0, 0.0]
-    assert dataset.saved_dataset["spm_unit_assets"].tolist() == [0.0, 0.0]
+    assert dataset.saved_dataset["bank_account_assets"].tolist() == [0.0, 0.0]
+    assert dataset.saved_dataset["stock_assets"].tolist() == [0.0, 0.0]
+    assert dataset.saved_dataset["bond_assets"].tolist() == [0.0, 0.0]

--- a/tests/integration/test_cps_generation.py
+++ b/tests/integration/test_cps_generation.py
@@ -1,6 +1,20 @@
 import pandas as pd
 
 
+def test_derive_spm_unit_assets_sums_person_level_assets():
+    from policyengine_us_data.datasets.cps.cps import derive_spm_unit_assets
+
+    result = derive_spm_unit_assets(
+        person_spm_unit_ids=[101, 101, 202],
+        spm_unit_ids=[101, 202],
+        bank_account_assets=[100.0, 300.0, 50.0],
+        stock_assets=[50.0, 200.0, 80.0],
+        bond_assets=[10.0, 25.0, 0.0],
+    )
+
+    assert result.tolist() == [685.0, 130.0]
+
+
 def test_add_tips_derives_tipped_status_from_raw_cps(monkeypatch):
     import policyengine_us
     import policyengine_us_data.datasets.sipp as sipp_module
@@ -78,6 +92,13 @@ def test_add_tips_derives_tipped_status_from_raw_cps(monkeypatch):
     monkeypatch.setattr(sipp_module, "get_asset_model", lambda: FakeAssetModel())
 
     dataset = FakeDataset()
-    add_tips(dataset, {})
+    add_tips(
+        dataset,
+        {
+            "person_spm_unit_id": [101, 202],
+            "spm_unit_id": [101, 202],
+        },
+    )
 
     assert dataset.saved_dataset["tip_income"].tolist() == [100.0, 0.0]
+    assert dataset.saved_dataset["spm_unit_assets"].tolist() == [0.0, 0.0]

--- a/tests/integration/test_database_build.py
+++ b/tests/integration/test_database_build.py
@@ -222,11 +222,11 @@ def test_tanf_targets(built_db):
     tanf_targets = {(geo, variable): value for geo, variable, value in rows}
 
     assert tanf_targets[("US", "spm_unit_count")] == pytest.approx(841_208.666667)
-    assert tanf_targets[("US", "tanf")] == pytest.approx(8_186_013_422.99)
+    assert tanf_targets[("US", "tanf")] == pytest.approx(7_788_317_474.55)
     assert tanf_targets[("6", "spm_unit_count")] == pytest.approx(290_247.75)
-    assert tanf_targets[("6", "tanf")] == pytest.approx(3_908_497_323.43)
+    assert tanf_targets[("6", "tanf")] == pytest.approx(3_742_540_224.36)
     assert tanf_targets[("11", "spm_unit_count")] == pytest.approx(5_056.25)
-    assert tanf_targets[("11", "tanf")] == pytest.approx(51_920_224.78)
+    assert tanf_targets[("11", "tanf")] == pytest.approx(45_666_113.50)
 
 
 def test_congressional_district_strata(built_db):

--- a/tests/integration/test_database_build.py
+++ b/tests/integration/test_database_build.py
@@ -28,6 +28,7 @@ PIPELINE_SCRIPTS = [
     ("db/etl_age.py", ["--year", "2024"]),
     ("db/etl_medicaid.py", ["--year", "2024"]),
     ("db/etl_snap.py", ["--year", "2024"]),
+    ("db/etl_tanf.py", ["--year", "2024"]),
     ("db/etl_state_income_tax.py", ["--year", "2024"]),
     ("db/etl_irs_soi.py", ["--year", "2024"]),
     ("db/etl_pregnancy.py", ["--year", "2024"]),
@@ -193,6 +194,39 @@ def test_state_income_tax_targets(built_db):
 
     tn_val = state_totals.get("47")
     assert tn_val == 2_926_000
+
+
+def test_tanf_targets(built_db):
+    """TANF recipient-family and spending targets should load from ACF files."""
+    conn = sqlite3.connect(str(built_db))
+    rows = conn.execute("""
+        SELECT
+            COALESCE(state_sc.value, 'US') AS geography,
+            t.variable,
+            t.value
+        FROM targets t
+        JOIN strata s
+            ON t.stratum_id = s.stratum_id
+        JOIN stratum_constraints tanf_sc
+            ON s.stratum_id = tanf_sc.stratum_id
+        LEFT JOIN stratum_constraints state_sc
+            ON s.stratum_id = state_sc.stratum_id
+           AND state_sc.constraint_variable = 'state_fips'
+        WHERE tanf_sc.constraint_variable = 'tanf'
+          AND tanf_sc.operation = '>'
+          AND tanf_sc.value = '0'
+          AND t.variable IN ('spm_unit_count', 'tanf')
+    """).fetchall()
+    conn.close()
+
+    tanf_targets = {(geo, variable): value for geo, variable, value in rows}
+
+    assert tanf_targets[("US", "spm_unit_count")] == pytest.approx(841_208.666667)
+    assert tanf_targets[("US", "tanf")] == pytest.approx(8_186_013_422.99)
+    assert tanf_targets[("6", "spm_unit_count")] == pytest.approx(290_247.75)
+    assert tanf_targets[("6", "tanf")] == pytest.approx(3_908_497_323.43)
+    assert tanf_targets[("11", "spm_unit_count")] == pytest.approx(5_056.25)
+    assert tanf_targets[("11", "tanf")] == pytest.approx(51_920_224.78)
 
 
 def test_congressional_district_strata(built_db):

--- a/tests/unit/calibration/test_loss_targets.py
+++ b/tests/unit/calibration/test_loss_targets.py
@@ -127,4 +127,4 @@ def test_add_ctc_targets(monkeypatch):
 
 
 def test_tanf_hardcoded_target_uses_fy2024_basic_assistance_total():
-    assert HARD_CODED_TOTALS["tanf"] == pytest.approx(8_186_013_422.99)
+    assert HARD_CODED_TOTALS["tanf"] == pytest.approx(7_788_317_474.55)

--- a/tests/unit/calibration/test_loss_targets.py
+++ b/tests/unit/calibration/test_loss_targets.py
@@ -8,6 +8,7 @@ from policyengine_us_data.utils.loss import (
     _get_medicaid_national_targets,
     _load_aca_spending_and_enrollment_targets,
     _load_medicaid_enrollment_targets,
+    HARD_CODED_TOTALS,
 )
 
 
@@ -123,3 +124,7 @@ def test_add_ctc_targets(monkeypatch):
         loss_matrix["nation/irs/non_refundable_ctc_count"],
         np.array([1.0, 1.0, 0.0], dtype=np.float32),
     )
+
+
+def test_tanf_hardcoded_target_uses_fy2024_basic_assistance_total():
+    assert HARD_CODED_TOTALS["tanf"] == pytest.approx(8_186_013_422.99)

--- a/tests/unit/calibration/test_target_config.py
+++ b/tests/unit/calibration/test_target_config.py
@@ -206,6 +206,29 @@ class TestLoadTargetConfig:
             "geo_level": "district",
         } in include_rules
 
+    def test_training_config_includes_tanf_state_and_national_count_targets(self):
+        config = load_target_config(
+            str(
+                Path(__file__).resolve().parents[3]
+                / "policyengine_us_data"
+                / "calibration"
+                / "target_config.yaml"
+            )
+        )
+
+        include_rules = config["include"]
+        assert {"variable": "tanf", "geo_level": "state"} in include_rules
+        assert {
+            "variable": "spm_unit_count",
+            "geo_level": "state",
+            "domain_variable": "tanf",
+        } in include_rules
+        assert {
+            "variable": "spm_unit_count",
+            "geo_level": "national",
+            "domain_variable": "tanf",
+        } in include_rules
+
 
 class TestCalibrationPackageRoundTrip:
     def test_round_trip(self, sample_targets, tmp_path):

--- a/tests/unit/test_etl_tanf.py
+++ b/tests/unit/test_etl_tanf.py
@@ -84,9 +84,9 @@ def test_transform_tanf_financial_data_extracts_cash_assistance_totals():
     assert state_df.loc[state_df["state_fips"] == 6, "tanf"].iloc[0] == pytest.approx(
         3_742_540_224.36
     )
-    assert state_df.loc[state_df["state_fips"] == 11, "tanf"].iloc[
-        0
-    ] == pytest.approx(45_666_113.50)
+    assert state_df.loc[state_df["state_fips"] == 11, "tanf"].iloc[0] == pytest.approx(
+        45_666_113.50
+    )
 
 
 def test_validate_supported_year_rejects_non_2024():

--- a/tests/unit/test_etl_tanf.py
+++ b/tests/unit/test_etl_tanf.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pytest
 
 from policyengine_us_data.db.etl_tanf import (
+    _validate_supported_year,
     transform_tanf_caseload_data,
     transform_tanf_financial_data,
 )
@@ -33,24 +34,43 @@ def test_transform_tanf_caseload_data_extracts_national_and_state_rows():
     ] == pytest.approx(5_056.25)
 
 
-def test_transform_tanf_financial_data_extracts_basic_assistance_totals():
+def test_transform_tanf_financial_data_extracts_cash_assistance_totals():
     national_df = pd.DataFrame(
         {
-            "Spending Category": ["Basic Assistance", "Work Supports"],
-            "All Funds": ["8,186,013,422.99", "123.45"],
+            "Spending Category": [
+                "Basic Assistance",
+                (
+                    "Basic Assistance (excluding Relative Foster Care Maintenance "
+                    "Payments and Adoption and Guardianship Subsidies)"
+                ),
+                "Work Supports",
+            ],
+            "All Funds": ["8,186,013,422.99", "7,788,317,474.55", "123.45"],
         }
     )
     state_sheets = {
         "California": pd.DataFrame(
             {
-                "Spending Category": ["Basic Assistance"],
-                "All Funds": ["3,908,497,323.43"],
+                "Spending Category": [
+                    "Basic Assistance",
+                    (
+                        "Basic Assistance (excluding Relative Foster Care Maintenance "
+                        "Payments and Adoption and Guardianship Subsidies)"
+                    ),
+                ],
+                "All Funds": ["3,908,497,323.43", "3,742,540,224.36"],
             }
         ),
         "District of Columbia": pd.DataFrame(
             {
-                "Spending Category": ["Basic Assistance"],
-                "All Funds": ["51,920,224.78"],
+                "Spending Category": [
+                    "Basic Assistance",
+                    (
+                        "Basic Assistance (excluding Relative Foster Care Maintenance "
+                        "Payments and Adoption and Guardianship Subsidies)"
+                    ),
+                ],
+                "All Funds": ["51,920,224.78", "45,666,113.50"],
             }
         ),
     }
@@ -60,10 +80,15 @@ def test_transform_tanf_financial_data_extracts_basic_assistance_totals():
         state_sheets,
     )
 
-    assert national_spending == pytest.approx(8_186_013_422.99)
+    assert national_spending == pytest.approx(7_788_317_474.55)
     assert state_df.loc[state_df["state_fips"] == 6, "tanf"].iloc[0] == pytest.approx(
-        3_908_497_323.43
+        3_742_540_224.36
     )
     assert state_df.loc[state_df["state_fips"] == 11, "tanf"].iloc[
         0
-    ] == pytest.approx(51_920_224.78)
+    ] == pytest.approx(45_666_113.50)
+
+
+def test_validate_supported_year_rejects_non_2024():
+    with pytest.raises(ValueError, match="FY2024"):
+        _validate_supported_year(2025)

--- a/tests/unit/test_etl_tanf.py
+++ b/tests/unit/test_etl_tanf.py
@@ -1,0 +1,69 @@
+import pandas as pd
+import pytest
+
+from policyengine_us_data.db.etl_tanf import (
+    transform_tanf_caseload_data,
+    transform_tanf_financial_data,
+)
+
+
+def test_transform_tanf_caseload_data_extracts_national_and_state_rows():
+    raw_df = pd.DataFrame(
+        {
+            "State": [
+                "Alabama",
+                "California",
+                "District of Columbia",
+                "U.S. Totals",
+                "Footnote",
+            ],
+            "FY2024": [8_500.0, 290_247.75, 5_056.25, 841_208.666667, None],
+        }
+    )
+
+    national_families, state_df = transform_tanf_caseload_data(raw_df)
+
+    assert national_families == pytest.approx(841_208.666667)
+    assert list(state_df["state_fips"]) == [1, 6, 11]
+    assert state_df.loc[state_df["state_fips"] == 6, "recipient_families"].iloc[
+        0
+    ] == pytest.approx(290_247.75)
+    assert state_df.loc[state_df["state_fips"] == 11, "recipient_families"].iloc[
+        0
+    ] == pytest.approx(5_056.25)
+
+
+def test_transform_tanf_financial_data_extracts_basic_assistance_totals():
+    national_df = pd.DataFrame(
+        {
+            "Spending Category": ["Basic Assistance", "Work Supports"],
+            "All Funds": ["8,186,013,422.99", "123.45"],
+        }
+    )
+    state_sheets = {
+        "California": pd.DataFrame(
+            {
+                "Spending Category": ["Basic Assistance"],
+                "All Funds": ["3,908,497,323.43"],
+            }
+        ),
+        "District of Columbia": pd.DataFrame(
+            {
+                "Spending Category": ["Basic Assistance"],
+                "All Funds": ["51,920,224.78"],
+            }
+        ),
+    }
+
+    national_spending, state_df = transform_tanf_financial_data(
+        national_df,
+        state_sheets,
+    )
+
+    assert national_spending == pytest.approx(8_186_013_422.99)
+    assert state_df.loc[state_df["state_fips"] == 6, "tanf"].iloc[0] == pytest.approx(
+        3_908_497_323.43
+    )
+    assert state_df.loc[state_df["state_fips"] == 11, "tanf"].iloc[
+        0
+    ] == pytest.approx(51_920_224.78)


### PR DESCRIPTION
## Summary
This PR adds TANF administrative calibration targets from HHS ACF FY2024 data and wires them into the US data build.

It does four things:
- adds a new TANF ETL that reads the official FY2024 ACF caseload and TANF/MOE financial workbooks
- loads national and state TANF recipient-family counts plus TANF cash-assistance spending into the calibration database and target config
- exposes baseline CPS liquid-asset inputs (`bank_account_assets`, `stock_assets`, `bond_assets`) so follow-up state-specific resource modeling can use explicit asset types instead of survey-reported placeholders
- documents in `README.md` that PRs must come from upstream branches, not forks, because `check-fork` hard-fails otherwise

## Details
The new ETL pulls:
- average monthly TANF recipient families from the FY2024 ACF caseload workbook
- cash-assistance spending from the FY2024 TANF/MOE financial workbook, using the narrower row that excludes relative foster care maintenance payments and adoption/guardianship subsidies

Those targets are added at:
- national `tanf`
- national `spm_unit_count` with `domain_variable: tanf`
- state `tanf`
- state `spm_unit_count` with `domain_variable: tanf`

The old hardcoded national TANF total is removed from `etl_national_targets.py`, and the remaining legacy fallback is aligned to the same FY2024 ACF cash-assistance total.

## Scope boundary
This PR does **not** publish a generic `spm_unit_assets` aggregate. That would be too semantically broad for the current data, because this branch only exposes liquid-asset inputs and many downstream rules still interpret `spm_unit_assets` as broader countable resources.

It also intentionally does **not** add state-specific TANF take-up priors. Full-take-up profiling still leaves structural eligibility misses in some states, so inferred state take-up rates are not yet credible. That follow-up belongs after the remaining eligibility/application-month modeling work.

For now, this PR stays on the calibration/data side:
- administrative TANF count and spending targets
- person-level liquid-asset inputs for future state-specific counted-asset formulas

Related context:
- PolicyEngine/policyengine-us-data#535
- PolicyEngine/policyengine-us#7988
- PolicyEngine/policyengine-us#7989

## Verification
- `uv run pytest -q tests/unit/test_etl_tanf.py tests/unit/calibration/test_target_config.py tests/unit/calibration/test_loss_targets.py tests/integration/test_cps_generation.py tests/integration/test_database_build.py`
- `uv run ruff check policyengine_us_data/db/etl_tanf.py policyengine_us_data/storage/calibration_targets/pull_hardcoded_targets.py policyengine_us_data/utils/loss.py tests/unit/test_etl_tanf.py tests/unit/calibration/test_loss_targets.py tests/integration/test_cps_generation.py tests/integration/test_database_build.py`

Two fresh independent review passes after the follow-up patch found no remaining actionable issues.
