### PR TITLE
Add SIPP vehicle asset inputs to CPS

### DIFF
--- a/changelog.d/codex-tanf-vehicle-signals.added.md
+++ b/changelog.d/codex-tanf-vehicle-signals.added.md
@@ -1,0 +1,1 @@
+Add SIPP-imputed household vehicle count and value inputs to CPS generation and source imputation so TANF and other asset-tested programs no longer default those vehicle signals to zero.

--- a/policyengine_us_data/calibration/source_impute.py
+++ b/policyengine_us_data/calibration/source_impute.py
@@ -8,7 +8,8 @@ financial predictors.
 Sources and variables:
     ACS  -> rent, real_estate_taxes  (with state predictor)
     SIPP -> tip_income, bank_account_assets, stock_assets,
-            bond_assets  (no state predictor)
+            bond_assets, household_vehicles_owned,
+            household_vehicles_value  (no state predictor)
     ORG  -> hourly_wage, is_paid_hourly,
             is_union_member_or_covered
     SCF  -> net_worth, auto_loan_balance, auto_loan_interest
@@ -32,12 +33,19 @@ from policyengine_us_data.datasets.cps.tipped_occupation import (
     derive_any_treasury_tipped_occupation_code,
     derive_is_tipped_occupation,
 )
+from policyengine_us_data.datasets.sipp.sipp import (
+    VEHICLE_MODEL_PREDICTORS,
+    build_vehicle_training_frame,
+)
 
 from policyengine_us_data.datasets.org import (
     ORG_BOOL_VARIABLES,
     ORG_IMPUTED_VARIABLES,
     build_org_receiver_frame,
     predict_org_features,
+)
+from policyengine_us_data.utils.asset_imputation import (
+    build_household_vehicle_receiver,
 )
 
 logger = logging.getLogger(__name__)
@@ -52,6 +60,8 @@ SIPP_IMPUTED_VARIABLES = [
     "bank_account_assets",
     "stock_assets",
     "bond_assets",
+    "household_vehicles_owned",
+    "household_vehicles_value",
 ]
 
 SCF_IMPUTED_VARIABLES = [
@@ -357,7 +367,7 @@ def _impute_sipp(
     time_period: int,
     dataset_path: Optional[str] = None,
 ) -> Dict[str, Dict[int, np.ndarray]]:
-    """Impute tip_income and liquid assets from SIPP.
+    """Impute tip_income, liquid assets, and vehicle signals from SIPP.
 
     Args:
         data: CPS data dict.
@@ -620,6 +630,96 @@ def _impute_sipp(
         gc.collect()
 
         logger.info("SIPP asset imputation complete")
+
+        vehicle_train = build_vehicle_training_frame()
+        vehicle_train = vehicle_train.loc[
+            rng.choice(
+                vehicle_train.index,
+                size=min(20_000, len(vehicle_train)),
+                replace=True,
+                p=(
+                    vehicle_train.household_weight
+                    / vehicle_train.household_weight.sum()
+                ),
+            )
+        ]
+
+        cps_vehicle_df = _build_cps_receiver(
+            data,
+            time_period,
+            dataset_path,
+            [
+                "employment_income",
+                "interest_income",
+                "dividend_income",
+                "rental_income",
+                "age",
+                "is_male",
+                "is_household_head",
+            ],
+        )
+        cps_vehicle_df["person_household_id"] = data["person_household_id"][
+            time_period
+        ].astype(np.int64)
+        if "is_male" in cps_vehicle_df.columns:
+            cps_vehicle_df["is_female"] = (
+                ~cps_vehicle_df["is_male"].astype(bool)
+            ).astype(np.float32)
+        else:
+            cps_vehicle_df["is_female"] = 0.0
+        if "is_married" in data:
+            cps_vehicle_df["is_married"] = data["is_married"][time_period].astype(
+                np.float32
+            )
+        else:
+            cps_vehicle_df["is_married"] = 0.0
+        for cap_var in [
+            "interest_income",
+            "dividend_income",
+            "rental_income",
+            "is_household_head",
+        ]:
+            if cap_var not in cps_vehicle_df.columns:
+                cps_vehicle_df[cap_var] = 0.0
+
+        vehicle_receiver = build_household_vehicle_receiver(
+            cps_vehicle_df,
+            tenure_type=data.get("tenure_type", {}).get(time_period),
+        )
+
+        qrf = QRF()
+        logger.info(
+            "SIPP vehicle QRF: %d train, %d test",
+            len(vehicle_train),
+            len(vehicle_receiver),
+        )
+        fitted = qrf.fit(
+            X_train=vehicle_train,
+            predictors=VEHICLE_MODEL_PREDICTORS,
+            imputed_variables=[
+                "household_vehicles_owned",
+                "household_vehicles_value",
+            ],
+        )
+        vehicle_preds = fitted.predict(X_test=vehicle_receiver)
+        data["household_vehicles_owned"] = {
+            time_period: np.clip(
+                np.rint(vehicle_preds["household_vehicles_owned"].values),
+                0,
+                None,
+            ).astype(np.int32)
+        }
+        data["household_vehicles_value"] = {
+            time_period: np.clip(
+                vehicle_preds["household_vehicles_value"].values,
+                0,
+                None,
+            ).astype(np.float32)
+        }
+        del fitted, vehicle_preds
+        gc.collect()
+
+        logger.info("SIPP vehicle imputation complete")
 
     except (FileNotFoundError, KeyError, ValueError, OSError) as e:
         logger.warning(

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -212,13 +212,24 @@ def add_rent(self, cps: h5py.File, person: DataFrame, household: DataFrame):
         }
     ).astype("S")
     if self.file_path.exists():
-        with h5py.File(self.file_path, "r") as _f:
-            stale_keys = [k for k in _f.keys() if k not in cps]
-            if stale_keys:
-                logging.warning(
-                    f"Stale H5 at {self.file_path} has {len(stale_keys)} "
-                    f"extra vars before first save: {stale_keys[:5]}"
-                )
+        try:
+            with pd.HDFStore(self.file_path, mode="r") as store:
+                stale_keys = [
+                    key.lstrip("/")
+                    for key in store.keys()
+                    if key.lstrip("/") not in cps
+                ]
+                if stale_keys:
+                    logging.warning(
+                        f"Stale H5 at {self.file_path} has {len(stale_keys)} "
+                        f"extra vars before first save: {stale_keys[:5]}"
+                    )
+        except (BlockingIOError, OSError, ValueError) as error:
+            logging.warning(
+                "Unable to inspect stale H5 at %s before replacement: %s",
+                self.file_path,
+                error,
+            )
         self.file_path.unlink()
     self.save_dataset(cps)
 

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -38,6 +38,9 @@ from policyengine_us_data.utils.takeup import (
     assign_takeup_with_reported_anchors,
     reported_subsidized_marketplace_by_tax_unit,
 )
+from policyengine_us_data.utils.asset_imputation import (
+    build_household_vehicle_receiver,
+)
 from policyengine_us_data.utils.policyengine import (
     supports_medicare_enrollment_input,
     supports_modeled_medicare_part_b_inputs,
@@ -2013,11 +2016,43 @@ def add_tips(self, cps: h5py.File):
     cps["stock_assets"] = asset_predictions.stock_assets.values
     cps["bond_assets"] = asset_predictions.bond_assets.values
 
+    from policyengine_us_data.datasets.sipp import get_vehicle_model
+
+    vehicle_model = get_vehicle_model()
+    cps["is_household_head"] = np.asarray(
+        existing_data["is_household_head"],
+        dtype=bool,
+    )
+    household_vehicle_receiver = build_household_vehicle_receiver(
+        cps,
+        tenure_type=existing_data.get("tenure_type"),
+    )
+    vehicle_predictions = vehicle_model.predict(
+        X_test=household_vehicle_receiver,
+        mean_quantile=0.5,
+    )
+    household_vehicle_data = {
+        "household_vehicles_owned": np.clip(
+            np.rint(vehicle_predictions.household_vehicles_owned.values),
+            0,
+            None,
+        ).astype(np.int32),
+        "household_vehicles_value": np.clip(
+            vehicle_predictions.household_vehicles_value.values,
+            0,
+            None,
+        ).astype(np.float32),
+    }
+
     # Drop temporary columns used only for imputation
     # is_married is person-level here but policyengine-us defines it at Family
     # level, so we must not save it
-    cps = cps.drop(columns=["is_married", "is_under_18", "is_under_6"], errors="ignore")
+    cps = cps.drop(
+        columns=["is_married", "is_under_18", "is_under_6", "is_household_head"],
+        errors="ignore",
+    )
     self.save_dataset(cps)
+    self.save_dataset(household_vehicle_data)
 
 
 def add_org_labor_market_inputs(cps: h5py.File) -> None:

--- a/policyengine_us_data/datasets/sipp/__init__.py
+++ b/policyengine_us_data/datasets/sipp/__init__.py
@@ -3,4 +3,7 @@ from .sipp import (
     get_tip_model,
     train_asset_model,
     get_asset_model,
+    build_vehicle_training_frame,
+    train_vehicle_model,
+    get_vehicle_model,
 )

--- a/policyengine_us_data/datasets/sipp/sipp.py
+++ b/policyengine_us_data/datasets/sipp/sipp.py
@@ -20,6 +20,19 @@ TIP_MODEL_PREDICTORS = [
     "is_tipped_occupation",
 ]
 
+VEHICLE_MODEL_PREDICTORS = [
+    "household_employment_income",
+    "household_interest_income",
+    "household_dividend_income",
+    "household_rental_income",
+    "reference_age",
+    "reference_is_female",
+    "reference_is_married",
+    "count_under_18",
+    "household_size",
+    "is_homeowner",
+]
+
 
 def train_tip_model():
     DOWNLOAD_FULL_SIPP = False
@@ -196,6 +209,24 @@ ASSET_COLUMNS = [
     "RSSI_YRYN",  # Received SSI in at least one month
 ]
 
+VEHICLE_COLUMNS = [
+    "SSUID",
+    "PNUM",
+    "MONTHCODE",
+    "WPFINWGT",
+    "TAGE",
+    "ESEX",
+    "EMS",
+    "TPTOTINC",
+    "TINC_BANK",
+    "TINC_STMF",
+    "TINC_BOND",
+    "TINC_RENT",
+    "TVEH_NUM",
+    "THVAL_VEH",
+    "THVAL_HOME",
+]
+
 
 def train_asset_model():
     """Train QRF model for liquid asset categories using SIPP 2023 data.
@@ -310,6 +341,126 @@ def get_asset_model() -> QRF:
 
     if not model_path.exists():
         model = train_asset_model()
+
+        with open(model_path, "wb") as f:
+            pickle.dump(model, f)
+    else:
+        with open(model_path, "rb") as f:
+            model = pickle.load(f)
+
+    return model
+
+
+def build_vehicle_training_frame() -> pd.DataFrame:
+    """Build a household-level SIPP frame for vehicle asset imputation."""
+    hf_hub_download(
+        repo_id="PolicyEngine/policyengine-us-data",
+        filename="pu2023.csv",
+        repo_type="model",
+        local_dir=STORAGE_FOLDER,
+    )
+
+    df = pd.read_csv(
+        STORAGE_FOLDER / "pu2023.csv",
+        delimiter="|",
+        usecols=VEHICLE_COLUMNS,
+    )
+    df = df[df.MONTHCODE == 12].copy()
+
+    df["employment_income"] = df.TPTOTINC.fillna(0) * 12
+    df["interest_income"] = (df["TINC_BANK"].fillna(0) + df["TINC_BOND"].fillna(0)) * 12
+    df["dividend_income"] = df["TINC_STMF"].fillna(0) * 12
+    df["rental_income"] = df["TINC_RENT"].fillna(0) * 12
+    df["is_under_18"] = df["TAGE"].fillna(0) < 18
+
+    grouped = df.groupby("SSUID")
+
+    reference_idx = grouped["TAGE"].idxmax()
+    reference_people = (
+        df.loc[reference_idx, ["SSUID", "TAGE", "ESEX", "EMS"]]
+        .rename(
+            columns={
+                "TAGE": "reference_age",
+                "ESEX": "reference_sex",
+                "EMS": "reference_marital_status",
+            }
+        )
+        .set_index("SSUID")
+    )
+
+    household = pd.DataFrame(
+        {
+            "household_id": grouped["SSUID"].first(),
+            "household_weight": grouped["WPFINWGT"].first().fillna(0),
+            "household_employment_income": grouped["employment_income"].sum(),
+            "household_interest_income": grouped["interest_income"].sum(),
+            "household_dividend_income": grouped["dividend_income"].sum(),
+            "household_rental_income": grouped["rental_income"].sum(),
+            "count_under_18": grouped["is_under_18"].sum(),
+            "household_size": grouped.size(),
+            "household_vehicles_owned": grouped["TVEH_NUM"].max().fillna(0),
+            "household_vehicles_value": grouped["THVAL_VEH"].first().fillna(0),
+            "is_homeowner": (grouped["THVAL_HOME"].first().fillna(0) > 0).astype(
+                np.float32
+            ),
+        }
+    ).reset_index(drop=True)
+
+    household = household.merge(
+        reference_people,
+        left_on="household_id",
+        right_index=True,
+        how="left",
+    )
+    household["reference_is_female"] = (
+        household["reference_sex"].fillna(1) == 2
+    ).astype(np.float32)
+    household["reference_is_married"] = (
+        household["reference_marital_status"].fillna(0) == 1
+    ).astype(np.float32)
+
+    household = household.drop(
+        columns=["reference_sex", "reference_marital_status"],
+        errors="ignore",
+    )
+    household = household.fillna(0)
+    return household
+
+
+def train_vehicle_model():
+    """Train a household-level vehicle asset model from SIPP 2023."""
+    sipp = build_vehicle_training_frame()
+    sipp = sipp[~sipp.isna().any(axis=1)]
+    # Seed the weighted resample so the vehicle-model training frame (and
+    # the pickled QRF) is deterministic across rebuilds of the cache.
+    vehicle_rng = seeded_rng("sipp_vehicle_model_training_sample")
+    sipp = sipp.loc[
+        vehicle_rng.choice(
+            sipp.index,
+            size=min(20_000, len(sipp)),
+            replace=True,
+            p=sipp.household_weight / sipp.household_weight.sum(),
+        )
+    ]
+
+    model = QRF()
+    model = model.fit(
+        X_train=sipp,
+        predictors=VEHICLE_MODEL_PREDICTORS,
+        imputed_variables=[
+            "household_vehicles_owned",
+            "household_vehicles_value",
+        ],
+    )
+    return model
+
+
+def get_vehicle_model() -> QRF:
+    """Get or train the household vehicle imputation model."""
+    model_path = STORAGE_FOLDER / "household_vehicle_assets.pkl"
+
+    if not model_path.exists():
+        model = train_vehicle_model()
 
         with open(model_path, "wb") as f:
             pickle.dump(model, f)

--- a/policyengine_us_data/utils/asset_imputation.py
+++ b/policyengine_us_data/utils/asset_imputation.py
@@ -1,0 +1,105 @@
+import numpy as np
+import pandas as pd
+
+
+def build_household_vehicle_receiver(
+    person_df: pd.DataFrame,
+    tenure_type: np.ndarray | None = None,
+) -> pd.DataFrame:
+    """Build household-level predictors for vehicle asset imputation.
+
+    The donor model is household-level, so we aggregate CPS person-level
+    predictors into one row per household and anchor demographic predictors
+    on the household head when available.
+    """
+    if (
+        "household_id" not in person_df.columns
+        and "person_household_id" in person_df.columns
+    ):
+        person_df = person_df.rename(columns={"person_household_id": "household_id"})
+
+    work = person_df.copy()
+
+    for col in [
+        "employment_income",
+        "interest_income",
+        "dividend_income",
+        "rental_income",
+        "age",
+        "is_female",
+        "is_married",
+    ]:
+        if col not in work.columns:
+            work[col] = 0.0
+
+    work["is_under_18"] = work["age"] < 18
+
+    household_agg = (
+        work.groupby("household_id")
+        .agg(
+            household_employment_income=("employment_income", "sum"),
+            household_interest_income=("interest_income", "sum"),
+            household_dividend_income=("dividend_income", "sum"),
+            household_rental_income=("rental_income", "sum"),
+            count_under_18=("is_under_18", "sum"),
+            household_size=("household_id", "size"),
+        )
+        .reset_index()
+    )
+
+    if "is_household_head" in work.columns:
+        heads = work[work["is_household_head"].astype(bool)].copy()
+    else:
+        heads = work.groupby("household_id", as_index=False).first()
+
+    heads = (
+        heads.sort_values("household_id")
+        .drop_duplicates("household_id")
+        .loc[:, ["household_id", "age", "is_female", "is_married"]]
+        .rename(
+            columns={
+                "age": "reference_age",
+                "is_female": "reference_is_female",
+                "is_married": "reference_is_married",
+            }
+        )
+    )
+
+    receiver = household_agg.merge(heads, on="household_id", how="left")
+
+    if tenure_type is not None:
+        tenure = pd.Series(tenure_type)
+        receiver["is_homeowner"] = (
+            tenure.astype(str)
+            .isin(
+                [
+                    "OWNED_OUTRIGHT",
+                    "OWNED_WITH_MORTGAGE",
+                    "b'OWNED_OUTRIGHT'",
+                    "b'OWNED_WITH_MORTGAGE'",
+                ]
+            )
+            .astype(np.float32)
+        )
+    else:
+        receiver["is_homeowner"] = 0.0
+
+    for col in [
+        "reference_age",
+        "reference_is_female",
+        "reference_is_married",
+        "count_under_18",
+        "household_size",
+    ]:
+        receiver[col] = receiver[col].fillna(0).astype(np.float32)
+
+    for col in [
+        "household_employment_income",
+        "household_interest_income",
+        "household_dividend_income",
+        "household_rental_income",
+        "is_homeowner",
+    ]:
+        receiver[col] = receiver[col].fillna(0).astype(np.float32)
+
+    return receiver

--- a/tests/integration/test_cps_generation.py
+++ b/tests/integration/test_cps_generation.py
@@ -47,6 +47,8 @@ def test_add_tips_derives_tipped_status_from_raw_cps(monkeypatch):
                 "age": [30, 45],
                 "household_weight": [1.0, 1.0],
                 "is_female": [False, True],
+                "is_household_head": [True, True],
+                "tenure_type": [b"OWNED_WITH_MORTGAGE", b"RENTED"],
             }
 
         def save_dataset(self, data):
@@ -78,8 +80,19 @@ def test_add_tips_derives_tipped_status_from_raw_cps(monkeypatch):
                 }
             )
 
+    class FakeVehicleModel:
+        def predict(self, X_test, mean_quantile):
+            assert X_test["household_id"].tolist() == [10, 20]
+            return pd.DataFrame(
+                {
+                    "household_vehicles_owned": [2.0, 1.0],
+                    "household_vehicles_value": [18_000.0, 7_500.0],
+                }
+            )
+
     monkeypatch.setattr(sipp_module, "get_tip_model", lambda: FakeTipModel())
     monkeypatch.setattr(sipp_module, "get_asset_model", lambda: FakeAssetModel())
+    monkeypatch.setattr(sipp_module, "get_vehicle_model", lambda: FakeVehicleModel())
 
     dataset = FakeDataset()
     add_tips(
@@ -94,6 +107,11 @@ def test_add_tips_derives_tipped_status_from_raw_cps(monkeypatch):
     assert dataset.saved_dataset["bank_account_assets"].tolist() == [0.0, 0.0]
     assert dataset.saved_dataset["stock_assets"].tolist() == [0.0, 0.0]
     assert dataset.saved_dataset["bond_assets"].tolist() == [0.0, 0.0]
+    assert dataset.saved_dataset["household_vehicles_owned"].tolist() == [2, 1]
+    assert dataset.saved_dataset["household_vehicles_value"].tolist() == [
+        18_000.0,
+        7_500.0,
+    ]
 
 
 def test_add_rent_requests_person_level_frames(monkeypatch, tmp_path):

--- a/tests/unit/calibration/test_source_impute.py
+++ b/tests/unit/calibration/test_source_impute.py
@@ -57,6 +57,8 @@ def _make_data_dict(n_persons=20, time_period=2024):
         "bank_account_assets": {time_period: np.zeros(n_persons)},
         "stock_assets": {time_period: np.zeros(n_persons)},
         "bond_assets": {time_period: np.zeros(n_persons)},
+        "household_vehicles_owned": {time_period: np.zeros(n_hh, dtype=np.int32)},
+        "household_vehicles_value": {time_period: np.zeros(n_hh, dtype=np.float32)},
         "hourly_wage": {time_period: np.zeros(n_persons)},
         "is_paid_hourly": {time_period: np.zeros(n_persons, dtype=bool)},
         "is_union_member_or_covered": {
@@ -78,6 +80,8 @@ class TestConstants:
         assert "bank_account_assets" in SIPP_IMPUTED_VARIABLES
         assert "stock_assets" in SIPP_IMPUTED_VARIABLES
         assert "bond_assets" in SIPP_IMPUTED_VARIABLES
+        assert "household_vehicles_owned" in SIPP_IMPUTED_VARIABLES
+        assert "household_vehicles_value" in SIPP_IMPUTED_VARIABLES
 
     def test_scf_variables_defined(self):
         assert "net_worth" in SCF_IMPUTED_VARIABLES

--- a/tests/unit/datasets/test_cps_file_handles.py
+++ b/tests/unit/datasets/test_cps_file_handles.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 import policyengine_us_data.datasets.cps.cps as cps_module
 from policyengine_us_data.datasets.cps.cps import (
+    add_rent,
     add_auto_loan_interest_and_net_worth,
     add_previous_year_income,
 )
@@ -234,3 +235,107 @@ def test_add_auto_loan_interest_and_net_worth_uses_outer_receiver_data(monkeypat
     np.testing.assert_array_equal(
         dataset.saved_dataset["auto_loan_interest"], [200.0, 100.0]
     )
+
+
+def test_add_rent_replaces_existing_hdf_using_read_only_hdfstore(
+    tmp_path, monkeypatch
+):
+    existing_path = tmp_path / "existing_cps.h5"
+    with pd.HDFStore(existing_path, mode="w") as store:
+        store["stale_var"] = pd.Series([1, 2, 3])
+
+    real_hdfstore = pd.HDFStore
+    opened_modes = []
+
+    def recording_hdfstore(path, mode="a", *args, **kwargs):
+        opened_modes.append(mode)
+        return real_hdfstore(path, mode=mode, *args, **kwargs)
+
+    def fail_h5py_file(*args, **kwargs):
+        raise AssertionError("add_rent should not reopen the existing H5 with h5py")
+
+    class FakeQRF:
+        def fit(self, X_train, predictors, imputed_variables):
+            return self
+
+        def predict(self, X_test):
+            return pd.DataFrame(
+                {
+                    "rent": np.full(len(X_test), 1_000.0),
+                    "real_estate_taxes": np.full(len(X_test), 250.0),
+                }
+            )
+
+    class FakeMicrosimulation:
+        def __init__(self, dataset):
+            self.dataset = dataset
+
+        def calculate_dataframe(
+            self, columns, period=None, map_to=None, use_weights=True
+        ):
+            if "rent" in columns:
+                df = pd.DataFrame(
+                    {
+                        "is_household_head": np.ones(10_000, dtype=bool),
+                        "age": np.full(10_000, 40),
+                        "is_male": np.zeros(10_000, dtype=bool),
+                        "tenure_type": ["RENTED"] * 10_000,
+                        "employment_income": np.full(10_000, 30_000.0),
+                        "self_employment_income": np.zeros(10_000),
+                        "social_security": np.zeros(10_000),
+                        "pension_income": np.zeros(10_000),
+                        "state_code_str": ["CA"] * 10_000,
+                        "household_size": np.ones(10_000),
+                        "rent": np.full(10_000, 1_200.0),
+                        "real_estate_taxes": np.zeros(10_000),
+                    }
+                )
+            else:
+                df = pd.DataFrame(
+                    {
+                        "is_household_head": [True],
+                        "age": [40],
+                        "is_male": [False],
+                        "tenure_type": ["RENTED"],
+                        "employment_income": [30_000.0],
+                        "self_employment_income": [0.0],
+                        "social_security": [0.0],
+                        "pension_income": [0.0],
+                        "state_code_str": ["CA"],
+                        "household_size": [1],
+                    }
+                )
+            return df[columns]
+
+    class FakeDataset:
+        def __init__(self):
+            self.file_path = existing_path
+            self.saved = []
+
+        def save_dataset(self, data):
+            self.saved.append(data)
+
+    monkeypatch.setattr(cps_module.pd, "HDFStore", recording_hdfstore)
+    monkeypatch.setattr(cps_module.h5py, "File", fail_h5py_file)
+    monkeypatch.setattr(cps_module, "QRF", FakeQRF)
+
+    import policyengine_us
+    import policyengine_us_data.datasets.acs.acs as acs_module
+
+    monkeypatch.setattr(policyengine_us, "Microsimulation", FakeMicrosimulation)
+    monkeypatch.setattr(acs_module, "ACS_2022", object())
+
+    dataset = FakeDataset()
+    cps = {
+        "age": np.array([40], dtype=np.int32),
+        "spm_unit_capped_housing_subsidy_reported": np.array([0.0]),
+    }
+    person = pd.DataFrame({"dummy": [1]})
+    household = pd.DataFrame({"H_TENURE": [2]})
+
+    add_rent(dataset, cps, person, household)
+
+    assert opened_modes == ["r"]
+    assert not existing_path.exists()
+    np.testing.assert_array_equal(cps["rent"], np.array([1_000.0]))
+    np.testing.assert_array_equal(cps["real_estate_taxes"], np.array([250.0]))

--- a/tests/unit/datasets/test_cps_file_handles.py
+++ b/tests/unit/datasets/test_cps_file_handles.py
@@ -237,9 +237,7 @@ def test_add_auto_loan_interest_and_net_worth_uses_outer_receiver_data(monkeypat
     )
 
 
-def test_add_rent_replaces_existing_hdf_using_read_only_hdfstore(
-    tmp_path, monkeypatch
-):
+def test_add_rent_replaces_existing_hdf_using_read_only_hdfstore(tmp_path, monkeypatch):
     existing_path = tmp_path / "existing_cps.h5"
     with pd.HDFStore(existing_path, mode="w") as store:
         store["stale_var"] = pd.Series([1, 2, 3])

--- a/tests/unit/test_asset_imputation.py
+++ b/tests/unit/test_asset_imputation.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pandas as pd
+
+from policyengine_us_data.utils.asset_imputation import (
+    build_household_vehicle_receiver,
+)
+
+
+def test_build_household_vehicle_receiver_aggregates_person_inputs():
+    person_df = pd.DataFrame(
+        {
+            "household_id": [10, 10, 20],
+            "employment_income": [20_000.0, 5_000.0, 30_000.0],
+            "interest_income": [100.0, 50.0, 25.0],
+            "dividend_income": [10.0, 0.0, 5.0],
+            "rental_income": [0.0, 200.0, 0.0],
+            "age": [42, 12, 35],
+            "is_female": [1.0, 1.0, 0.0],
+            "is_married": [1.0, 0.0, 0.0],
+            "is_household_head": [True, False, True],
+        }
+    )
+
+    receiver = build_household_vehicle_receiver(
+        person_df,
+        tenure_type=np.array([b"OWNED_WITH_MORTGAGE", b"RENTED"]),
+    )
+
+    assert receiver["household_id"].tolist() == [10, 20]
+    assert receiver["household_employment_income"].tolist() == [25_000.0, 30_000.0]
+    assert receiver["household_interest_income"].tolist() == [150.0, 25.0]
+    assert receiver["household_dividend_income"].tolist() == [10.0, 5.0]
+    assert receiver["household_rental_income"].tolist() == [200.0, 0.0]
+    assert receiver["count_under_18"].tolist() == [1.0, 0.0]
+    assert receiver["household_size"].tolist() == [2.0, 1.0]
+    assert receiver["reference_age"].tolist() == [42.0, 35.0]
+    assert receiver["reference_is_female"].tolist() == [1.0, 0.0]
+    assert receiver["reference_is_married"].tolist() == [1.0, 0.0]
+    assert receiver["is_homeowner"].tolist() == [1.0, 0.0]


### PR DESCRIPTION
## Summary
- add SIPP-based household vehicle count/value imputation for CPS generation
- extend source-impute to rebuild the same household vehicle signals in the enhanced calibration pipeline
- add focused tests for the shared household receiver builder and the CPS/source-impute wiring

## Why
Current CPS/ECPS baselines leave `household_vehicles_owned` and `household_vehicles_value` at zero. That weakens TANF and other asset-tested program logic in states that use vehicle exclusions or countable vehicle value.

This PR fixes the zero-input problem with the smallest credible donor-backed signal:
- SIPP `TVEH_NUM` for vehicle count
- SIPP household totals `THVAL_VEH` for vehicle value

## Validation
- `uv run pytest -q tests/unit/test_asset_imputation.py tests/unit/calibration/test_source_impute.py tests/integration/test_cps_generation.py`
- `uv run ruff format --check policyengine_us_data/utils/asset_imputation.py policyengine_us_data/datasets/sipp/sipp.py policyengine_us_data/calibration/source_impute.py policyengine_us_data/datasets/cps/cps.py tests/unit/test_asset_imputation.py tests/unit/calibration/test_source_impute.py tests/integration/test_cps_generation.py`
- `uv run ruff check policyengine_us_data/utils/asset_imputation.py policyengine_us_data/datasets/sipp/sipp.py policyengine_us_data/calibration/source_impute.py tests/unit/test_asset_imputation.py tests/unit/calibration/test_source_impute.py tests/integration/test_cps_generation.py`

## Follow-up
This does not yet add non-home real-property signals or vehicle-equity-specific inputs. It just gets the vehicle-count/value layer off zero so the policy side can use a real baseline.
