### PR TITLE
Add household asset equity signals

### DIFF
--- a/changelog.d/codex-household-asset-equity-signals.added.md
+++ b/changelog.d/codex-household-asset-equity-signals.added.md
@@ -1,0 +1,1 @@
+Adds SIPP-based household vehicle debt/equity and non-home asset signals to CPS/source-imputed datasets.

--- a/changelog.d/codex-tanf-vehicle-signals.added.md
+++ b/changelog.d/codex-tanf-vehicle-signals.added.md
@@ -1,0 +1,1 @@
+Add SIPP-imputed household vehicle count and value inputs to CPS generation and source imputation so TANF and other asset-tested programs no longer default those vehicle signals to zero.

--- a/policyengine_us_data/calibration/source_impute.py
+++ b/policyengine_us_data/calibration/source_impute.py
@@ -8,7 +8,8 @@ financial predictors.
 Sources and variables:
     ACS  -> rent, real_estate_taxes  (with state predictor)
     SIPP -> tip_income, bank_account_assets, stock_assets,
-            bond_assets  (no state predictor)
+            bond_assets, household_vehicles_owned,
+            household_vehicles_value  (no state predictor)
     ORG  -> hourly_wage, is_paid_hourly,
             is_union_member_or_covered
     SCF  -> net_worth, auto_loan_balance, auto_loan_interest
@@ -32,12 +33,19 @@ from policyengine_us_data.datasets.cps.tipped_occupation import (
     derive_any_treasury_tipped_occupation_code,
     derive_is_tipped_occupation,
 )
+from policyengine_us_data.datasets.sipp.sipp import (
+    VEHICLE_MODEL_PREDICTORS,
+    build_vehicle_training_frame,
+)
 
 from policyengine_us_data.datasets.org import (
     ORG_BOOL_VARIABLES,
     ORG_IMPUTED_VARIABLES,
     build_org_receiver_frame,
     predict_org_features,
+)
+from policyengine_us_data.utils.asset_imputation import (
+    build_household_vehicle_receiver,
 )
 
 logger = logging.getLogger(__name__)
@@ -52,6 +60,8 @@ SIPP_IMPUTED_VARIABLES = [
     "bank_account_assets",
     "stock_assets",
     "bond_assets",
+    "household_vehicles_owned",
+    "household_vehicles_value",
 ]
 
 SCF_IMPUTED_VARIABLES = [
@@ -355,7 +365,7 @@ def _impute_sipp(
     time_period: int,
     dataset_path: Optional[str] = None,
 ) -> Dict[str, Dict[int, np.ndarray]]:
-    """Impute tip_income and liquid assets from SIPP.
+    """Impute tip_income, liquid assets, and vehicle signals from SIPP.
 
     Args:
         data: CPS data dict.
@@ -618,6 +628,96 @@ def _impute_sipp(
         gc.collect()
 
         logger.info("SIPP asset imputation complete")
+
+        vehicle_train = build_vehicle_training_frame()
+        vehicle_train = vehicle_train.loc[
+            rng.choice(
+                vehicle_train.index,
+                size=min(20_000, len(vehicle_train)),
+                replace=True,
+                p=(
+                    vehicle_train.household_weight
+                    / vehicle_train.household_weight.sum()
+                ),
+            )
+        ]
+
+        cps_vehicle_df = _build_cps_receiver(
+            data,
+            time_period,
+            dataset_path,
+            [
+                "employment_income",
+                "interest_income",
+                "dividend_income",
+                "rental_income",
+                "age",
+                "is_male",
+                "is_household_head",
+            ],
+        )
+        cps_vehicle_df["person_household_id"] = data["person_household_id"][
+            time_period
+        ].astype(np.int64)
+        if "is_male" in cps_vehicle_df.columns:
+            cps_vehicle_df["is_female"] = (
+                ~cps_vehicle_df["is_male"].astype(bool)
+            ).astype(np.float32)
+        else:
+            cps_vehicle_df["is_female"] = 0.0
+        if "is_married" in data:
+            cps_vehicle_df["is_married"] = data["is_married"][time_period].astype(
+                np.float32
+            )
+        else:
+            cps_vehicle_df["is_married"] = 0.0
+        for cap_var in [
+            "interest_income",
+            "dividend_income",
+            "rental_income",
+            "is_household_head",
+        ]:
+            if cap_var not in cps_vehicle_df.columns:
+                cps_vehicle_df[cap_var] = 0.0
+
+        vehicle_receiver = build_household_vehicle_receiver(
+            cps_vehicle_df,
+            tenure_type=data.get("tenure_type", {}).get(time_period),
+        )
+
+        qrf = QRF()
+        logger.info(
+            "SIPP vehicle QRF: %d train, %d test",
+            len(vehicle_train),
+            len(vehicle_receiver),
+        )
+        fitted = qrf.fit(
+            X_train=vehicle_train,
+            predictors=VEHICLE_MODEL_PREDICTORS,
+            imputed_variables=[
+                "household_vehicles_owned",
+                "household_vehicles_value",
+            ],
+        )
+        vehicle_preds = fitted.predict(X_test=vehicle_receiver)
+        data["household_vehicles_owned"] = {
+            time_period: np.clip(
+                np.rint(vehicle_preds["household_vehicles_owned"].values),
+                0,
+                None,
+            ).astype(np.int32)
+        }
+        data["household_vehicles_value"] = {
+            time_period: np.clip(
+                vehicle_preds["household_vehicles_value"].values,
+                0,
+                None,
+            ).astype(np.float32)
+        }
+        del fitted, vehicle_preds
+        gc.collect()
+
+        logger.info("SIPP vehicle imputation complete")
 
     except (FileNotFoundError, KeyError, ValueError, OSError) as e:
         logger.warning(

--- a/policyengine_us_data/calibration/source_impute.py
+++ b/policyengine_us_data/calibration/source_impute.py
@@ -9,7 +9,10 @@ Sources and variables:
     ACS  -> rent, real_estate_taxes  (with state predictor)
     SIPP -> tip_income, bank_account_assets, stock_assets,
             bond_assets, household_vehicles_owned,
-            household_vehicles_value  (no state predictor)
+            household_vehicles_value, household_vehicles_debt,
+            household_vehicles_equity, household_other_real_estate_*,
+            household_rental_property_*, household_business_assets_*
+            (no state predictor)
     ORG  -> hourly_wage, is_paid_hourly,
             is_union_member_or_covered
     SCF  -> net_worth, auto_loan_balance, auto_loan_interest
@@ -34,7 +37,9 @@ from policyengine_us_data.datasets.cps.tipped_occupation import (
     derive_is_tipped_occupation,
 )
 from policyengine_us_data.datasets.sipp.sipp import (
+    NONLIQUID_ASSET_MODEL_PREDICTORS,
     VEHICLE_MODEL_PREDICTORS,
+    build_nonliquid_asset_training_frame,
     build_vehicle_training_frame,
 )
 
@@ -45,7 +50,7 @@ from policyengine_us_data.datasets.org import (
     predict_org_features,
 )
 from policyengine_us_data.utils.asset_imputation import (
-    build_household_vehicle_receiver,
+    build_household_asset_receiver,
 )
 
 logger = logging.getLogger(__name__)
@@ -62,6 +67,17 @@ SIPP_IMPUTED_VARIABLES = [
     "bond_assets",
     "household_vehicles_owned",
     "household_vehicles_value",
+    "household_vehicles_debt",
+    "household_vehicles_equity",
+    "household_other_real_estate_value",
+    "household_other_real_estate_debt",
+    "household_other_real_estate_equity",
+    "household_rental_property_value",
+    "household_rental_property_debt",
+    "household_rental_property_equity",
+    "household_business_assets_value",
+    "household_business_assets_debt",
+    "household_business_assets_equity",
 ]
 
 SCF_IMPUTED_VARIABLES = [
@@ -629,20 +645,7 @@ def _impute_sipp(
 
         logger.info("SIPP asset imputation complete")
 
-        vehicle_train = build_vehicle_training_frame()
-        vehicle_train = vehicle_train.loc[
-            rng.choice(
-                vehicle_train.index,
-                size=min(20_000, len(vehicle_train)),
-                replace=True,
-                p=(
-                    vehicle_train.household_weight
-                    / vehicle_train.household_weight.sum()
-                ),
-            )
-        ]
-
-        cps_vehicle_df = _build_cps_receiver(
+        household_asset_train = _build_cps_receiver(
             data,
             time_period,
             dataset_path,
@@ -656,40 +659,53 @@ def _impute_sipp(
                 "is_household_head",
             ],
         )
-        cps_vehicle_df["person_household_id"] = data["person_household_id"][
+        household_asset_train["person_household_id"] = data["person_household_id"][
             time_period
         ].astype(np.int64)
-        if "is_male" in cps_vehicle_df.columns:
-            cps_vehicle_df["is_female"] = (
-                ~cps_vehicle_df["is_male"].astype(bool)
+        if "is_male" in household_asset_train.columns:
+            household_asset_train["is_female"] = (
+                ~household_asset_train["is_male"].astype(bool)
             ).astype(np.float32)
         else:
-            cps_vehicle_df["is_female"] = 0.0
+            household_asset_train["is_female"] = 0.0
         if "is_married" in data:
-            cps_vehicle_df["is_married"] = data["is_married"][time_period].astype(
-                np.float32
-            )
+            household_asset_train["is_married"] = data["is_married"][
+                time_period
+            ].astype(np.float32)
         else:
-            cps_vehicle_df["is_married"] = 0.0
+            household_asset_train["is_married"] = 0.0
         for cap_var in [
             "interest_income",
             "dividend_income",
             "rental_income",
             "is_household_head",
         ]:
-            if cap_var not in cps_vehicle_df.columns:
-                cps_vehicle_df[cap_var] = 0.0
+            if cap_var not in household_asset_train.columns:
+                household_asset_train[cap_var] = 0.0
 
-        vehicle_receiver = build_household_vehicle_receiver(
-            cps_vehicle_df,
+        household_asset_receiver = build_household_asset_receiver(
+            household_asset_train,
             tenure_type=data.get("tenure_type", {}).get(time_period),
         )
+
+        vehicle_train = build_vehicle_training_frame()
+        vehicle_train = vehicle_train.loc[
+            rng.choice(
+                vehicle_train.index,
+                size=min(20_000, len(vehicle_train)),
+                replace=True,
+                p=(
+                    vehicle_train.household_weight
+                    / vehicle_train.household_weight.sum()
+                ),
+            )
+        ]
 
         qrf = QRF()
         logger.info(
             "SIPP vehicle QRF: %d train, %d test",
             len(vehicle_train),
-            len(vehicle_receiver),
+            len(household_asset_receiver),
         )
         fitted = qrf.fit(
             X_train=vehicle_train,
@@ -697,9 +713,10 @@ def _impute_sipp(
             imputed_variables=[
                 "household_vehicles_owned",
                 "household_vehicles_value",
+                "household_vehicles_debt",
             ],
         )
-        vehicle_preds = fitted.predict(X_test=vehicle_receiver)
+        vehicle_preds = fitted.predict(X_test=household_asset_receiver)
         data["household_vehicles_owned"] = {
             time_period: np.clip(
                 np.rint(vehicle_preds["household_vehicles_owned"].values),
@@ -714,10 +731,82 @@ def _impute_sipp(
                 None,
             ).astype(np.float32)
         }
+        data["household_vehicles_debt"] = {
+            time_period: np.clip(
+                vehicle_preds["household_vehicles_debt"].values,
+                0,
+                None,
+            ).astype(np.float32)
+        }
+        data["household_vehicles_equity"] = {
+            time_period: np.clip(
+                data["household_vehicles_value"][time_period]
+                - data["household_vehicles_debt"][time_period],
+                0,
+                None,
+            ).astype(np.float32)
+        }
         del fitted, vehicle_preds
         gc.collect()
 
         logger.info("SIPP vehicle imputation complete")
+
+        nonliquid_asset_train = build_nonliquid_asset_training_frame()
+        nonliquid_asset_train = nonliquid_asset_train.loc[
+            rng.choice(
+                nonliquid_asset_train.index,
+                size=min(20_000, len(nonliquid_asset_train)),
+                replace=True,
+                p=(
+                    nonliquid_asset_train.household_weight
+                    / nonliquid_asset_train.household_weight.sum()
+                ),
+            )
+        ]
+
+        qrf = QRF()
+        logger.info(
+            "SIPP non-liquid asset QRF: %d train, %d test",
+            len(nonliquid_asset_train),
+            len(household_asset_receiver),
+        )
+        fitted = qrf.fit(
+            X_train=nonliquid_asset_train,
+            predictors=NONLIQUID_ASSET_MODEL_PREDICTORS,
+            imputed_variables=[
+                "household_other_real_estate_value",
+                "household_other_real_estate_debt",
+                "household_rental_property_value",
+                "household_rental_property_debt",
+                "household_business_assets_value",
+                "household_business_assets_debt",
+            ],
+        )
+        nonliquid_asset_preds = fitted.predict(X_test=household_asset_receiver)
+        for prefix in [
+            "household_other_real_estate",
+            "household_rental_property",
+            "household_business_assets",
+        ]:
+            value = np.clip(
+                nonliquid_asset_preds[f"{prefix}_value"].values,
+                0,
+                None,
+            ).astype(np.float32)
+            debt = np.clip(
+                nonliquid_asset_preds[f"{prefix}_debt"].values,
+                0,
+                None,
+            ).astype(np.float32)
+            data[f"{prefix}_value"] = {time_period: value}
+            data[f"{prefix}_debt"] = {time_period: debt}
+            data[f"{prefix}_equity"] = {
+                time_period: np.clip(value - debt, 0, None).astype(np.float32)
+            }
+        del fitted, nonliquid_asset_preds
+        gc.collect()
+
+        logger.info("SIPP non-liquid asset imputation complete")
 
     except (FileNotFoundError, KeyError, ValueError, OSError) as e:
         logger.warning(

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -1886,25 +1886,57 @@ def _update_documentation_with_numbers(log_df, docs_dir):
 
 def add_tips(self, cps: h5py.File):
     self.save_dataset(cps)
-    from policyengine_us import Microsimulation
 
     existing_data = self.load_dataset()
-    sim = Microsimulation(dataset=self)
-    cps = sim.calculate_dataframe(
-        [
-            "person_id",
-            "household_id",
-            "employment_income",
-            "interest_income",
-            "dividend_income",
-            "rental_income",
-            "age",
-            "household_weight",
-            "is_female",
-        ],
-        2025,
+    person_household_id = np.asarray(
+        existing_data.get(
+            "person_household_id",
+            existing_data.get("household_id"),
+        )
     )
-    cps = pd.DataFrame(cps)
+    cps = pd.DataFrame(
+        {
+            "person_id": np.asarray(existing_data["person_id"]),
+            "household_id": person_household_id,
+            "employment_income": np.asarray(existing_data["employment_income"]),
+            "interest_income": np.asarray(
+                existing_data.get(
+                    "interest_income",
+                    np.zeros(len(person_household_id), dtype=np.float32),
+                )
+            ),
+            "dividend_income": np.asarray(
+                existing_data.get(
+                    "dividend_income",
+                    np.zeros(len(person_household_id), dtype=np.float32),
+                )
+            ),
+            "rental_income": np.asarray(
+                existing_data.get(
+                    "rental_income",
+                    np.zeros(len(person_household_id), dtype=np.float32),
+                )
+            ),
+            "age": np.asarray(existing_data["age"]),
+            "is_female": np.asarray(existing_data["is_female"]),
+        }
+    )
+    household_weight = existing_data.get("household_weight")
+    if household_weight is not None:
+        household_weight = np.asarray(household_weight)
+        if len(household_weight) == len(cps):
+            cps["household_weight"] = household_weight
+        else:
+            household_ids = np.asarray(existing_data["household_id"])
+            household_weight_map = dict(zip(household_ids, household_weight))
+            cps["household_weight"] = (
+                pd.Series(person_household_id)
+                .map(household_weight_map)
+                .fillna(0)
+                .values
+            )
+    else:
+        cps["household_weight"] = 0.0
 
     # Get is_married from raw CPS data (A_MARITL codes: 1,2 = married)
     # Note: is_married in policyengine-us is Family-level, but we need

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -212,13 +212,24 @@ def add_rent(self, cps: h5py.File, person: DataFrame, household: DataFrame):
         }
     ).astype("S")
     if self.file_path.exists():
-        with h5py.File(self.file_path, "r") as _f:
-            stale_keys = [k for k in _f.keys() if k not in cps]
-            if stale_keys:
-                logging.warning(
-                    f"Stale H5 at {self.file_path} has {len(stale_keys)} "
-                    f"extra vars before first save: {stale_keys[:5]}"
-                )
+        try:
+            with pd.HDFStore(self.file_path, mode="r") as store:
+                stale_keys = [
+                    key.lstrip("/")
+                    for key in store.keys()
+                    if key.lstrip("/") not in cps
+                ]
+                if stale_keys:
+                    logging.warning(
+                        f"Stale H5 at {self.file_path} has {len(stale_keys)} "
+                        f"extra vars before first save: {stale_keys[:5]}"
+                    )
+        except (BlockingIOError, OSError, ValueError) as error:
+            logging.warning(
+                "Unable to inspect stale H5 at %s before replacement: %s",
+                self.file_path,
+                error,
+            )
         self.file_path.unlink()
     self.save_dataset(cps)
 

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -38,6 +38,9 @@ from policyengine_us_data.utils.takeup import (
     assign_takeup_with_reported_anchors,
     reported_subsidized_marketplace_by_tax_unit,
 )
+from policyengine_us_data.utils.asset_imputation import (
+    build_household_vehicle_receiver,
+)
 from policyengine_us_data.utils.policyengine import (
     supports_medicare_enrollment_input,
     supports_modeled_medicare_part_b_inputs,
@@ -1874,6 +1877,7 @@ def add_tips(self, cps: h5py.File):
     self.save_dataset(cps)
     from policyengine_us import Microsimulation
 
+    existing_data = self.load_dataset()
     sim = Microsimulation(dataset=self)
     cps = sim.calculate_dataframe(
         [
@@ -1942,11 +1946,43 @@ def add_tips(self, cps: h5py.File):
     cps["stock_assets"] = asset_predictions.stock_assets.values
     cps["bond_assets"] = asset_predictions.bond_assets.values
 
+    from policyengine_us_data.datasets.sipp import get_vehicle_model
+
+    vehicle_model = get_vehicle_model()
+    cps["is_household_head"] = np.asarray(
+        existing_data["is_household_head"],
+        dtype=bool,
+    )
+    household_vehicle_receiver = build_household_vehicle_receiver(
+        cps,
+        tenure_type=existing_data.get("tenure_type"),
+    )
+    vehicle_predictions = vehicle_model.predict(
+        X_test=household_vehicle_receiver,
+        mean_quantile=0.5,
+    )
+    household_vehicle_data = {
+        "household_vehicles_owned": np.clip(
+            np.rint(vehicle_predictions.household_vehicles_owned.values),
+            0,
+            None,
+        ).astype(np.int32),
+        "household_vehicles_value": np.clip(
+            vehicle_predictions.household_vehicles_value.values,
+            0,
+            None,
+        ).astype(np.float32),
+    }
+
     # Drop temporary columns used only for imputation
     # is_married is person-level here but policyengine-us defines it at Family
     # level, so we must not save it
-    cps = cps.drop(columns=["is_married", "is_under_18", "is_under_6"], errors="ignore")
+    cps = cps.drop(
+        columns=["is_married", "is_under_18", "is_under_6", "is_household_head"],
+        errors="ignore",
+    )
     self.save_dataset(cps)
+    self.save_dataset(household_vehicle_data)
 
 
 def add_org_labor_market_inputs(cps: h5py.File) -> None:

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -39,7 +39,7 @@ from policyengine_us_data.utils.takeup import (
     reported_subsidized_marketplace_by_tax_unit,
 )
 from policyengine_us_data.utils.asset_imputation import (
-    build_household_vehicle_receiver,
+    build_household_asset_receiver,
 )
 from policyengine_us_data.utils.policyengine import (
     supports_medicare_enrollment_input,
@@ -1989,19 +1989,23 @@ def add_tips(self, cps: h5py.File):
     cps["stock_assets"] = asset_predictions.stock_assets.values
     cps["bond_assets"] = asset_predictions.bond_assets.values
 
-    from policyengine_us_data.datasets.sipp import get_vehicle_model
+    from policyengine_us_data.datasets.sipp import (
+        get_nonliquid_asset_model,
+        get_vehicle_model,
+    )
 
+    # Impute household vehicle and non-home asset signals from SIPP
     vehicle_model = get_vehicle_model()
     cps["is_household_head"] = np.asarray(
         existing_data["is_household_head"],
         dtype=bool,
     )
-    household_vehicle_receiver = build_household_vehicle_receiver(
+    household_asset_receiver = build_household_asset_receiver(
         cps,
         tenure_type=existing_data.get("tenure_type"),
     )
     vehicle_predictions = vehicle_model.predict(
-        X_test=household_vehicle_receiver,
+        X_test=household_asset_receiver,
         mean_quantile=0.5,
     )
     household_vehicle_data = {
@@ -2015,7 +2019,45 @@ def add_tips(self, cps: h5py.File):
             0,
             None,
         ).astype(np.float32),
+        "household_vehicles_debt": np.clip(
+            vehicle_predictions.household_vehicles_debt.values,
+            0,
+            None,
+        ).astype(np.float32),
     }
+    household_vehicle_data["household_vehicles_equity"] = np.clip(
+        household_vehicle_data["household_vehicles_value"]
+        - household_vehicle_data["household_vehicles_debt"],
+        0,
+        None,
+    ).astype(np.float32)
+
+    nonliquid_asset_model = get_nonliquid_asset_model()
+    nonliquid_asset_predictions = nonliquid_asset_model.predict(
+        X_test=household_asset_receiver,
+        mean_quantile=0.5,
+    )
+    for prefix in [
+        "household_other_real_estate",
+        "household_rental_property",
+        "household_business_assets",
+    ]:
+        household_vehicle_data[f"{prefix}_value"] = np.clip(
+            nonliquid_asset_predictions[f"{prefix}_value"].values,
+            0,
+            None,
+        ).astype(np.float32)
+        household_vehicle_data[f"{prefix}_debt"] = np.clip(
+            nonliquid_asset_predictions[f"{prefix}_debt"].values,
+            0,
+            None,
+        ).astype(np.float32)
+        household_vehicle_data[f"{prefix}_equity"] = np.clip(
+            household_vehicle_data[f"{prefix}_value"]
+            - household_vehicle_data[f"{prefix}_debt"],
+            0,
+            None,
+        ).astype(np.float32)
 
     # Drop temporary columns used only for imputation
     # is_married is person-level here but policyengine-us defines it at Family

--- a/policyengine_us_data/datasets/sipp/__init__.py
+++ b/policyengine_us_data/datasets/sipp/__init__.py
@@ -3,4 +3,7 @@ from .sipp import (
     get_tip_model,
     train_asset_model,
     get_asset_model,
+    build_vehicle_training_frame,
+    train_vehicle_model,
+    get_vehicle_model,
 )

--- a/policyengine_us_data/datasets/sipp/__init__.py
+++ b/policyengine_us_data/datasets/sipp/__init__.py
@@ -6,4 +6,7 @@ from .sipp import (
     build_vehicle_training_frame,
     train_vehicle_model,
     get_vehicle_model,
+    build_nonliquid_asset_training_frame,
+    train_nonliquid_asset_model,
+    get_nonliquid_asset_model,
 )

--- a/policyengine_us_data/datasets/sipp/sipp.py
+++ b/policyengine_us_data/datasets/sipp/sipp.py
@@ -32,6 +32,8 @@ VEHICLE_MODEL_PREDICTORS = [
     "is_homeowner",
 ]
 
+NONLIQUID_ASSET_MODEL_PREDICTORS = VEHICLE_MODEL_PREDICTORS
+
 
 def train_tip_model():
     DOWNLOAD_FULL_SIPP = False
@@ -205,7 +207,30 @@ VEHICLE_COLUMNS = [
     "TINC_RENT",
     "TVEH_NUM",
     "THVAL_VEH",
+    "THDEBT_VEH",
     "THVAL_HOME",
+]
+
+NONLIQUID_ASSET_COLUMNS = [
+    "SSUID",
+    "PNUM",
+    "MONTHCODE",
+    "WPFINWGT",
+    "TAGE",
+    "ESEX",
+    "EMS",
+    "TPTOTINC",
+    "TINC_BANK",
+    "TINC_STMF",
+    "TINC_BOND",
+    "TINC_RENT",
+    "THVAL_HOME",
+    "THVAL_RE",
+    "THDEBT_RE",
+    "THVAL_RENT",
+    "THDEBT_RENT",
+    "THVAL_BUS",
+    "THDEBT_BUS",
 ]
 
 
@@ -330,22 +355,8 @@ def get_asset_model() -> QRF:
     return model
 
 
-def build_vehicle_training_frame() -> pd.DataFrame:
-    """Build a household-level SIPP frame for vehicle asset imputation."""
-    hf_hub_download(
-        repo_id="PolicyEngine/policyengine-us-data",
-        filename="pu2023.csv",
-        repo_type="model",
-        local_dir=STORAGE_FOLDER,
-    )
-
-    df = pd.read_csv(
-        STORAGE_FOLDER / "pu2023.csv",
-        delimiter="|",
-        usecols=VEHICLE_COLUMNS,
-    )
-    df = df[df.MONTHCODE == 12].copy()
-
+def _build_household_sipp_asset_predictor_frame(df: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate person-level SIPP records to a household asset predictor frame."""
     df["employment_income"] = df.TPTOTINC.fillna(0) * 12
     df["interest_income"] = (df["TINC_BANK"].fillna(0) + df["TINC_BOND"].fillna(0)) * 12
     df["dividend_income"] = df["TINC_STMF"].fillna(0) * 12
@@ -377,8 +388,6 @@ def build_vehicle_training_frame() -> pd.DataFrame:
             "household_rental_income": grouped["rental_income"].sum(),
             "count_under_18": grouped["is_under_18"].sum(),
             "household_size": grouped.size(),
-            "household_vehicles_owned": grouped["TVEH_NUM"].max().fillna(0),
-            "household_vehicles_value": grouped["THVAL_VEH"].first().fillna(0),
             "is_homeowner": (grouped["THVAL_HOME"].first().fillna(0) > 0).astype(
                 np.float32
             ),
@@ -406,6 +415,84 @@ def build_vehicle_training_frame() -> pd.DataFrame:
     return household
 
 
+def build_vehicle_training_frame() -> pd.DataFrame:
+    """Build a household-level SIPP frame for vehicle asset imputation."""
+    hf_hub_download(
+        repo_id="PolicyEngine/policyengine-us-data",
+        filename="pu2023.csv",
+        repo_type="model",
+        local_dir=STORAGE_FOLDER,
+    )
+
+    df = pd.read_csv(
+        STORAGE_FOLDER / "pu2023.csv",
+        delimiter="|",
+        usecols=VEHICLE_COLUMNS,
+    )
+    df = df[df.MONTHCODE == 12].copy()
+
+    household = _build_household_sipp_asset_predictor_frame(df)
+    grouped = df.groupby("SSUID")
+    household["household_vehicles_owned"] = grouped["TVEH_NUM"].max().fillna(0).values
+    household["household_vehicles_value"] = (
+        grouped["THVAL_VEH"].first().fillna(0).values
+    )
+    household["household_vehicles_debt"] = (
+        grouped["THDEBT_VEH"].first().fillna(0).values
+    )
+    household["household_vehicles_equity"] = np.clip(
+        household["household_vehicles_value"] - household["household_vehicles_debt"],
+        0,
+        None,
+    )
+    return household
+
+
+def build_nonliquid_asset_training_frame() -> pd.DataFrame:
+    """Build a household-level SIPP frame for non-home asset imputation."""
+    hf_hub_download(
+        repo_id="PolicyEngine/policyengine-us-data",
+        filename="pu2023.csv",
+        repo_type="model",
+        local_dir=STORAGE_FOLDER,
+    )
+
+    df = pd.read_csv(
+        STORAGE_FOLDER / "pu2023.csv",
+        delimiter="|",
+        usecols=NONLIQUID_ASSET_COLUMNS,
+    )
+    df = df[df.MONTHCODE == 12].copy()
+
+    household = _build_household_sipp_asset_predictor_frame(df)
+    grouped = df.groupby("SSUID")
+    for prefix, value_col, debt_col in [
+        (
+            "household_other_real_estate",
+            "THVAL_RE",
+            "THDEBT_RE",
+        ),
+        (
+            "household_rental_property",
+            "THVAL_RENT",
+            "THDEBT_RENT",
+        ),
+        (
+            "household_business_assets",
+            "THVAL_BUS",
+            "THDEBT_BUS",
+        ),
+    ]:
+        household[f"{prefix}_value"] = grouped[value_col].first().fillna(0).values
+        household[f"{prefix}_debt"] = grouped[debt_col].first().fillna(0).values
+        household[f"{prefix}_equity"] = np.clip(
+            household[f"{prefix}_value"] - household[f"{prefix}_debt"],
+            0,
+            None,
+        )
+    return household
+
+
 def train_vehicle_model():
     """Train a household-level vehicle asset model from SIPP 2023."""
     sipp = build_vehicle_training_frame()
@@ -426,6 +513,7 @@ def train_vehicle_model():
         imputed_variables=[
             "household_vehicles_owned",
             "household_vehicles_value",
+            "household_vehicles_debt",
         ],
     )
     return model
@@ -433,10 +521,55 @@ def train_vehicle_model():
 
 def get_vehicle_model() -> QRF:
     """Get or train the household vehicle imputation model."""
-    model_path = STORAGE_FOLDER / "household_vehicle_assets.pkl"
+    model_path = STORAGE_FOLDER / "household_vehicle_assets_v2.pkl"
 
     if not model_path.exists():
         model = train_vehicle_model()
+
+        with open(model_path, "wb") as f:
+            pickle.dump(model, f)
+    else:
+        with open(model_path, "rb") as f:
+            model = pickle.load(f)
+
+    return model
+
+
+def train_nonliquid_asset_model():
+    """Train a household-level non-home asset model from SIPP 2023."""
+    sipp = build_nonliquid_asset_training_frame()
+    sipp = sipp[~sipp.isna().any(axis=1)]
+    sipp = sipp.loc[
+        np.random.choice(
+            sipp.index,
+            size=min(20_000, len(sipp)),
+            replace=True,
+            p=sipp.household_weight / sipp.household_weight.sum(),
+        )
+    ]
+
+    model = QRF()
+    model = model.fit(
+        X_train=sipp,
+        predictors=NONLIQUID_ASSET_MODEL_PREDICTORS,
+        imputed_variables=[
+            "household_other_real_estate_value",
+            "household_other_real_estate_debt",
+            "household_rental_property_value",
+            "household_rental_property_debt",
+            "household_business_assets_value",
+            "household_business_assets_debt",
+        ],
+    )
+    return model
+
+
+def get_nonliquid_asset_model() -> QRF:
+    """Get or train the household non-home asset imputation model."""
+    model_path = STORAGE_FOLDER / "household_nonliquid_assets_v1.pkl"
+
+    if not model_path.exists():
+        model = train_nonliquid_asset_model()
 
         with open(model_path, "wb") as f:
             pickle.dump(model, f)

--- a/policyengine_us_data/datasets/sipp/sipp.py
+++ b/policyengine_us_data/datasets/sipp/sipp.py
@@ -19,6 +19,19 @@ TIP_MODEL_PREDICTORS = [
     "is_tipped_occupation",
 ]
 
+VEHICLE_MODEL_PREDICTORS = [
+    "household_employment_income",
+    "household_interest_income",
+    "household_dividend_income",
+    "household_rental_income",
+    "reference_age",
+    "reference_is_female",
+    "reference_is_married",
+    "count_under_18",
+    "household_size",
+    "is_homeowner",
+]
+
 
 def train_tip_model():
     DOWNLOAD_FULL_SIPP = False
@@ -177,6 +190,24 @@ ASSET_COLUMNS = [
     "RSSI_YRYN",  # Received SSI in at least one month
 ]
 
+VEHICLE_COLUMNS = [
+    "SSUID",
+    "PNUM",
+    "MONTHCODE",
+    "WPFINWGT",
+    "TAGE",
+    "ESEX",
+    "EMS",
+    "TPTOTINC",
+    "TINC_BANK",
+    "TINC_STMF",
+    "TINC_BOND",
+    "TINC_RENT",
+    "TVEH_NUM",
+    "THVAL_VEH",
+    "THVAL_HOME",
+]
+
 
 def train_asset_model():
     """Train QRF model for liquid asset categories using SIPP 2023 data.
@@ -289,6 +320,123 @@ def get_asset_model() -> QRF:
 
     if not model_path.exists():
         model = train_asset_model()
+
+        with open(model_path, "wb") as f:
+            pickle.dump(model, f)
+    else:
+        with open(model_path, "rb") as f:
+            model = pickle.load(f)
+
+    return model
+
+
+def build_vehicle_training_frame() -> pd.DataFrame:
+    """Build a household-level SIPP frame for vehicle asset imputation."""
+    hf_hub_download(
+        repo_id="PolicyEngine/policyengine-us-data",
+        filename="pu2023.csv",
+        repo_type="model",
+        local_dir=STORAGE_FOLDER,
+    )
+
+    df = pd.read_csv(
+        STORAGE_FOLDER / "pu2023.csv",
+        delimiter="|",
+        usecols=VEHICLE_COLUMNS,
+    )
+    df = df[df.MONTHCODE == 12].copy()
+
+    df["employment_income"] = df.TPTOTINC.fillna(0) * 12
+    df["interest_income"] = (df["TINC_BANK"].fillna(0) + df["TINC_BOND"].fillna(0)) * 12
+    df["dividend_income"] = df["TINC_STMF"].fillna(0) * 12
+    df["rental_income"] = df["TINC_RENT"].fillna(0) * 12
+    df["is_under_18"] = df["TAGE"].fillna(0) < 18
+
+    grouped = df.groupby("SSUID")
+
+    reference_idx = grouped["TAGE"].idxmax()
+    reference_people = (
+        df.loc[reference_idx, ["SSUID", "TAGE", "ESEX", "EMS"]]
+        .rename(
+            columns={
+                "TAGE": "reference_age",
+                "ESEX": "reference_sex",
+                "EMS": "reference_marital_status",
+            }
+        )
+        .set_index("SSUID")
+    )
+
+    household = pd.DataFrame(
+        {
+            "household_id": grouped["SSUID"].first(),
+            "household_weight": grouped["WPFINWGT"].first().fillna(0),
+            "household_employment_income": grouped["employment_income"].sum(),
+            "household_interest_income": grouped["interest_income"].sum(),
+            "household_dividend_income": grouped["dividend_income"].sum(),
+            "household_rental_income": grouped["rental_income"].sum(),
+            "count_under_18": grouped["is_under_18"].sum(),
+            "household_size": grouped.size(),
+            "household_vehicles_owned": grouped["TVEH_NUM"].max().fillna(0),
+            "household_vehicles_value": grouped["THVAL_VEH"].first().fillna(0),
+            "is_homeowner": (grouped["THVAL_HOME"].first().fillna(0) > 0).astype(
+                np.float32
+            ),
+        }
+    ).reset_index(drop=True)
+
+    household = household.merge(
+        reference_people,
+        left_on="household_id",
+        right_index=True,
+        how="left",
+    )
+    household["reference_is_female"] = (
+        household["reference_sex"].fillna(1) == 2
+    ).astype(np.float32)
+    household["reference_is_married"] = (
+        household["reference_marital_status"].fillna(0) == 1
+    ).astype(np.float32)
+
+    household = household.drop(
+        columns=["reference_sex", "reference_marital_status"],
+        errors="ignore",
+    )
+    household = household.fillna(0)
+    return household
+
+
+def train_vehicle_model():
+    """Train a household-level vehicle asset model from SIPP 2023."""
+    sipp = build_vehicle_training_frame()
+    sipp = sipp[~sipp.isna().any(axis=1)]
+    sipp = sipp.loc[
+        np.random.choice(
+            sipp.index,
+            size=min(20_000, len(sipp)),
+            replace=True,
+            p=sipp.household_weight / sipp.household_weight.sum(),
+        )
+    ]
+
+    model = QRF()
+    model = model.fit(
+        X_train=sipp,
+        predictors=VEHICLE_MODEL_PREDICTORS,
+        imputed_variables=[
+            "household_vehicles_owned",
+            "household_vehicles_value",
+        ],
+    )
+    return model
+
+
+def get_vehicle_model() -> QRF:
+    """Get or train the household vehicle imputation model."""
+    model_path = STORAGE_FOLDER / "household_vehicle_assets.pkl"
+
+    if not model_path.exists():
+        model = train_vehicle_model()
 
         with open(model_path, "wb") as f:
             pickle.dump(model, f)

--- a/policyengine_us_data/utils/asset_imputation.py
+++ b/policyengine_us_data/utils/asset_imputation.py
@@ -1,0 +1,105 @@
+import numpy as np
+import pandas as pd
+
+
+def build_household_vehicle_receiver(
+    person_df: pd.DataFrame,
+    tenure_type: np.ndarray | None = None,
+) -> pd.DataFrame:
+    """Build household-level predictors for vehicle asset imputation.
+
+    The donor model is household-level, so we aggregate CPS person-level
+    predictors into one row per household and anchor demographic predictors
+    on the household head when available.
+    """
+    if (
+        "household_id" not in person_df.columns
+        and "person_household_id" in person_df.columns
+    ):
+        person_df = person_df.rename(columns={"person_household_id": "household_id"})
+
+    work = person_df.copy()
+
+    for col in [
+        "employment_income",
+        "interest_income",
+        "dividend_income",
+        "rental_income",
+        "age",
+        "is_female",
+        "is_married",
+    ]:
+        if col not in work.columns:
+            work[col] = 0.0
+
+    work["is_under_18"] = work["age"] < 18
+
+    household_agg = (
+        work.groupby("household_id")
+        .agg(
+            household_employment_income=("employment_income", "sum"),
+            household_interest_income=("interest_income", "sum"),
+            household_dividend_income=("dividend_income", "sum"),
+            household_rental_income=("rental_income", "sum"),
+            count_under_18=("is_under_18", "sum"),
+            household_size=("household_id", "size"),
+        )
+        .reset_index()
+    )
+
+    if "is_household_head" in work.columns:
+        heads = work[work["is_household_head"].astype(bool)].copy()
+    else:
+        heads = work.groupby("household_id", as_index=False).first()
+
+    heads = (
+        heads.sort_values("household_id")
+        .drop_duplicates("household_id")
+        .loc[:, ["household_id", "age", "is_female", "is_married"]]
+        .rename(
+            columns={
+                "age": "reference_age",
+                "is_female": "reference_is_female",
+                "is_married": "reference_is_married",
+            }
+        )
+    )
+
+    receiver = household_agg.merge(heads, on="household_id", how="left")
+
+    if tenure_type is not None:
+        tenure = pd.Series(tenure_type)
+        receiver["is_homeowner"] = (
+            tenure.astype(str)
+            .isin(
+                [
+                    "OWNED_OUTRIGHT",
+                    "OWNED_WITH_MORTGAGE",
+                    "b'OWNED_OUTRIGHT'",
+                    "b'OWNED_WITH_MORTGAGE'",
+                ]
+            )
+            .astype(np.float32)
+        )
+    else:
+        receiver["is_homeowner"] = 0.0
+
+    for col in [
+        "reference_age",
+        "reference_is_female",
+        "reference_is_married",
+        "count_under_18",
+        "household_size",
+    ]:
+        receiver[col] = receiver[col].fillna(0).astype(np.float32)
+
+    for col in [
+        "household_employment_income",
+        "household_interest_income",
+        "household_dividend_income",
+        "household_rental_income",
+        "is_homeowner",
+    ]:
+        receiver[col] = receiver[col].fillna(0).astype(np.float32)
+
+    return receiver

--- a/policyengine_us_data/utils/asset_imputation.py
+++ b/policyengine_us_data/utils/asset_imputation.py
@@ -2,16 +2,11 @@ import numpy as np
 import pandas as pd
 
 
-def build_household_vehicle_receiver(
+def build_household_asset_receiver(
     person_df: pd.DataFrame,
     tenure_type: np.ndarray | None = None,
 ) -> pd.DataFrame:
-    """Build household-level predictors for vehicle asset imputation.
-
-    The donor model is household-level, so we aggregate CPS person-level
-    predictors into one row per household and anchor demographic predictors
-    on the household head when available.
-    """
+    """Build household-level predictors for SIPP household asset imputation."""
     if (
         "household_id" not in person_df.columns
         and "person_household_id" in person_df.columns
@@ -103,3 +98,14 @@ def build_household_vehicle_receiver(
         receiver[col] = receiver[col].fillna(0).astype(np.float32)
 
     return receiver
+
+
+def build_household_vehicle_receiver(
+    person_df: pd.DataFrame,
+    tenure_type: np.ndarray | None = None,
+) -> pd.DataFrame:
+    """Backward-compatible alias for the household asset receiver."""
+    return build_household_asset_receiver(
+        person_df=person_df,
+        tenure_type=tenure_type,
+    )

--- a/tests/integration/test_cps_generation.py
+++ b/tests/integration/test_cps_generation.py
@@ -81,12 +81,32 @@ def test_add_tips_derives_tipped_status_from_raw_cps(monkeypatch):
                 {
                     "household_vehicles_owned": [2.0, 1.0],
                     "household_vehicles_value": [18_000.0, 7_500.0],
+                    "household_vehicles_debt": [6_000.0, 500.0],
+                }
+            )
+
+    class FakeNonliquidAssetModel:
+        def predict(self, X_test, mean_quantile):
+            assert X_test["household_id"].tolist() == [10, 20]
+            return pd.DataFrame(
+                {
+                    "household_other_real_estate_value": [25_000.0, 0.0],
+                    "household_other_real_estate_debt": [5_000.0, 0.0],
+                    "household_rental_property_value": [40_000.0, 0.0],
+                    "household_rental_property_debt": [10_000.0, 0.0],
+                    "household_business_assets_value": [8_000.0, 2_000.0],
+                    "household_business_assets_debt": [1_000.0, 500.0],
                 }
             )
 
     monkeypatch.setattr(sipp_module, "get_tip_model", lambda: FakeTipModel())
     monkeypatch.setattr(sipp_module, "get_asset_model", lambda: FakeAssetModel())
     monkeypatch.setattr(sipp_module, "get_vehicle_model", lambda: FakeVehicleModel())
+    monkeypatch.setattr(
+        sipp_module,
+        "get_nonliquid_asset_model",
+        lambda: FakeNonliquidAssetModel(),
+    )
 
     dataset = FakeDataset()
     add_tips(
@@ -105,4 +125,32 @@ def test_add_tips_derives_tipped_status_from_raw_cps(monkeypatch):
     assert dataset.saved_dataset["household_vehicles_value"].tolist() == [
         18_000.0,
         7_500.0,
+    ]
+    assert dataset.saved_dataset["household_vehicles_debt"].tolist() == [
+        6_000.0,
+        500.0,
+    ]
+    assert dataset.saved_dataset["household_vehicles_equity"].tolist() == [
+        12_000.0,
+        7_000.0,
+    ]
+    assert dataset.saved_dataset["household_other_real_estate_value"].tolist() == [
+        25_000.0,
+        0.0,
+    ]
+    assert dataset.saved_dataset["household_other_real_estate_debt"].tolist() == [
+        5_000.0,
+        0.0,
+    ]
+    assert dataset.saved_dataset["household_other_real_estate_equity"].tolist() == [
+        20_000.0,
+        0.0,
+    ]
+    assert dataset.saved_dataset["household_rental_property_equity"].tolist() == [
+        30_000.0,
+        0.0,
+    ]
+    assert dataset.saved_dataset["household_business_assets_equity"].tolist() == [
+        7_000.0,
+        1_500.0,
     ]

--- a/tests/integration/test_cps_generation.py
+++ b/tests/integration/test_cps_generation.py
@@ -2,7 +2,6 @@ import pandas as pd
 
 
 def test_add_tips_derives_tipped_status_from_raw_cps(monkeypatch):
-    import policyengine_us
     import policyengine_us_data.datasets.sipp as sipp_module
     from policyengine_us_data.datasets.cps.cps import add_tips
 
@@ -35,6 +34,15 @@ def test_add_tips_derives_tipped_status_from_raw_cps(monkeypatch):
             self.raw_cps = FakeRawCPS()
             self.saved_dataset = None
             self.base_dataset = {
+                "person_id": [1, 2],
+                "person_household_id": [10, 20],
+                "employment_income": [25_000.0, 30_000.0],
+                "interest_income": [0.0, 0.0],
+                "dividend_income": [0.0, 0.0],
+                "rental_income": [0.0, 0.0],
+                "age": [30, 45],
+                "household_weight": [1.0, 1.0],
+                "is_female": [False, True],
                 "is_household_head": [True, True],
                 "tenure_type": [b"OWNED_WITH_MORTGAGE", b"RENTED"],
             }
@@ -50,26 +58,6 @@ def test_add_tips_derives_tipped_status_from_raw_cps(monkeypatch):
 
         def load_dataset(self):
             return self.base_dataset
-
-    class FakeMicrosimulation:
-        def __init__(self, dataset):
-            self.dataset = dataset
-
-        def calculate_dataframe(self, columns, year):
-            base = pd.DataFrame(
-                {
-                    "person_id": [1, 2],
-                    "household_id": [10, 20],
-                    "employment_income": [25_000, 30_000],
-                    "interest_income": [0.0, 0.0],
-                    "dividend_income": [0.0, 0.0],
-                    "rental_income": [0.0, 0.0],
-                    "age": [30, 45],
-                    "household_weight": [1.0, 1.0],
-                    "is_female": [False, True],
-                }
-            )
-            return base[columns]
 
     class FakeTipModel:
         def predict(self, X_test, mean_quantile):
@@ -96,7 +84,6 @@ def test_add_tips_derives_tipped_status_from_raw_cps(monkeypatch):
                 }
             )
 
-    monkeypatch.setattr(policyengine_us, "Microsimulation", FakeMicrosimulation)
     monkeypatch.setattr(sipp_module, "get_tip_model", lambda: FakeTipModel())
     monkeypatch.setattr(sipp_module, "get_asset_model", lambda: FakeAssetModel())
     monkeypatch.setattr(sipp_module, "get_vehicle_model", lambda: FakeVehicleModel())

--- a/tests/integration/test_cps_generation.py
+++ b/tests/integration/test_cps_generation.py
@@ -34,9 +34,22 @@ def test_add_tips_derives_tipped_status_from_raw_cps(monkeypatch):
         def __init__(self):
             self.raw_cps = FakeRawCPS()
             self.saved_dataset = None
+            self.base_dataset = {
+                "is_household_head": [True, True],
+                "tenure_type": [b"OWNED_WITH_MORTGAGE", b"RENTED"],
+            }
 
         def save_dataset(self, data):
-            self.saved_dataset = data
+            if self.saved_dataset is None:
+                self.saved_dataset = {}
+            if hasattr(data, "items"):
+                for key, value in data.items():
+                    self.saved_dataset[key] = (
+                        value.values if hasattr(value, "values") else value
+                    )
+
+        def load_dataset(self):
+            return self.base_dataset
 
     class FakeMicrosimulation:
         def __init__(self, dataset):
@@ -73,9 +86,20 @@ def test_add_tips_derives_tipped_status_from_raw_cps(monkeypatch):
                 }
             )
 
+    class FakeVehicleModel:
+        def predict(self, X_test, mean_quantile):
+            assert X_test["household_id"].tolist() == [10, 20]
+            return pd.DataFrame(
+                {
+                    "household_vehicles_owned": [2.0, 1.0],
+                    "household_vehicles_value": [18_000.0, 7_500.0],
+                }
+            )
+
     monkeypatch.setattr(policyengine_us, "Microsimulation", FakeMicrosimulation)
     monkeypatch.setattr(sipp_module, "get_tip_model", lambda: FakeTipModel())
     monkeypatch.setattr(sipp_module, "get_asset_model", lambda: FakeAssetModel())
+    monkeypatch.setattr(sipp_module, "get_vehicle_model", lambda: FakeVehicleModel())
 
     dataset = FakeDataset()
     add_tips(
@@ -90,3 +114,8 @@ def test_add_tips_derives_tipped_status_from_raw_cps(monkeypatch):
     assert dataset.saved_dataset["bank_account_assets"].tolist() == [0.0, 0.0]
     assert dataset.saved_dataset["stock_assets"].tolist() == [0.0, 0.0]
     assert dataset.saved_dataset["bond_assets"].tolist() == [0.0, 0.0]
+    assert dataset.saved_dataset["household_vehicles_owned"].tolist() == [2, 1]
+    assert dataset.saved_dataset["household_vehicles_value"].tolist() == [
+        18_000.0,
+        7_500.0,
+    ]

--- a/tests/unit/calibration/test_source_impute.py
+++ b/tests/unit/calibration/test_source_impute.py
@@ -59,6 +59,35 @@ def _make_data_dict(n_persons=20, time_period=2024):
         "bond_assets": {time_period: np.zeros(n_persons)},
         "household_vehicles_owned": {time_period: np.zeros(n_hh, dtype=np.int32)},
         "household_vehicles_value": {time_period: np.zeros(n_hh, dtype=np.float32)},
+        "household_vehicles_debt": {time_period: np.zeros(n_hh, dtype=np.float32)},
+        "household_vehicles_equity": {time_period: np.zeros(n_hh, dtype=np.float32)},
+        "household_other_real_estate_value": {
+            time_period: np.zeros(n_hh, dtype=np.float32)
+        },
+        "household_other_real_estate_debt": {
+            time_period: np.zeros(n_hh, dtype=np.float32)
+        },
+        "household_other_real_estate_equity": {
+            time_period: np.zeros(n_hh, dtype=np.float32)
+        },
+        "household_rental_property_value": {
+            time_period: np.zeros(n_hh, dtype=np.float32)
+        },
+        "household_rental_property_debt": {
+            time_period: np.zeros(n_hh, dtype=np.float32)
+        },
+        "household_rental_property_equity": {
+            time_period: np.zeros(n_hh, dtype=np.float32)
+        },
+        "household_business_assets_value": {
+            time_period: np.zeros(n_hh, dtype=np.float32)
+        },
+        "household_business_assets_debt": {
+            time_period: np.zeros(n_hh, dtype=np.float32)
+        },
+        "household_business_assets_equity": {
+            time_period: np.zeros(n_hh, dtype=np.float32)
+        },
         "hourly_wage": {time_period: np.zeros(n_persons)},
         "is_paid_hourly": {time_period: np.zeros(n_persons, dtype=bool)},
         "is_union_member_or_covered": {
@@ -82,6 +111,17 @@ class TestConstants:
         assert "bond_assets" in SIPP_IMPUTED_VARIABLES
         assert "household_vehicles_owned" in SIPP_IMPUTED_VARIABLES
         assert "household_vehicles_value" in SIPP_IMPUTED_VARIABLES
+        assert "household_vehicles_debt" in SIPP_IMPUTED_VARIABLES
+        assert "household_vehicles_equity" in SIPP_IMPUTED_VARIABLES
+        assert "household_other_real_estate_value" in SIPP_IMPUTED_VARIABLES
+        assert "household_other_real_estate_debt" in SIPP_IMPUTED_VARIABLES
+        assert "household_other_real_estate_equity" in SIPP_IMPUTED_VARIABLES
+        assert "household_rental_property_value" in SIPP_IMPUTED_VARIABLES
+        assert "household_rental_property_debt" in SIPP_IMPUTED_VARIABLES
+        assert "household_rental_property_equity" in SIPP_IMPUTED_VARIABLES
+        assert "household_business_assets_value" in SIPP_IMPUTED_VARIABLES
+        assert "household_business_assets_debt" in SIPP_IMPUTED_VARIABLES
+        assert "household_business_assets_equity" in SIPP_IMPUTED_VARIABLES
 
     def test_scf_variables_defined(self):
         assert "net_worth" in SCF_IMPUTED_VARIABLES

--- a/tests/unit/calibration/test_source_impute.py
+++ b/tests/unit/calibration/test_source_impute.py
@@ -57,6 +57,8 @@ def _make_data_dict(n_persons=20, time_period=2024):
         "bank_account_assets": {time_period: np.zeros(n_persons)},
         "stock_assets": {time_period: np.zeros(n_persons)},
         "bond_assets": {time_period: np.zeros(n_persons)},
+        "household_vehicles_owned": {time_period: np.zeros(n_hh, dtype=np.int32)},
+        "household_vehicles_value": {time_period: np.zeros(n_hh, dtype=np.float32)},
         "hourly_wage": {time_period: np.zeros(n_persons)},
         "is_paid_hourly": {time_period: np.zeros(n_persons, dtype=bool)},
         "is_union_member_or_covered": {
@@ -78,6 +80,8 @@ class TestConstants:
         assert "bank_account_assets" in SIPP_IMPUTED_VARIABLES
         assert "stock_assets" in SIPP_IMPUTED_VARIABLES
         assert "bond_assets" in SIPP_IMPUTED_VARIABLES
+        assert "household_vehicles_owned" in SIPP_IMPUTED_VARIABLES
+        assert "household_vehicles_value" in SIPP_IMPUTED_VARIABLES
 
     def test_scf_variables_defined(self):
         assert "net_worth" in SCF_IMPUTED_VARIABLES

--- a/tests/unit/datasets/test_cps_file_handles.py
+++ b/tests/unit/datasets/test_cps_file_handles.py
@@ -237,9 +237,7 @@ def test_add_auto_loan_interest_and_net_worth_uses_outer_receiver_data(monkeypat
     )
 
 
-def test_add_rent_replaces_existing_hdf_using_read_only_hdfstore(
-    tmp_path, monkeypatch
-):
+def test_add_rent_replaces_existing_hdf_using_read_only_hdfstore(tmp_path, monkeypatch):
     existing_path = tmp_path / "existing_cps.h5"
     with pd.HDFStore(existing_path, mode="w") as store:
         store["stale_var"] = pd.Series([1, 2, 3])

--- a/tests/unit/datasets/test_cps_file_handles.py
+++ b/tests/unit/datasets/test_cps_file_handles.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 import policyengine_us_data.datasets.cps.cps as cps_module
 from policyengine_us_data.datasets.cps.cps import (
+    add_rent,
     add_auto_loan_interest_and_net_worth,
     add_previous_year_income,
 )
@@ -234,3 +235,105 @@ def test_add_auto_loan_interest_and_net_worth_uses_outer_receiver_data(monkeypat
     np.testing.assert_array_equal(
         dataset.saved_dataset["auto_loan_interest"], [200.0, 100.0]
     )
+
+
+def test_add_rent_replaces_existing_hdf_using_read_only_hdfstore(
+    tmp_path, monkeypatch
+):
+    existing_path = tmp_path / "existing_cps.h5"
+    with pd.HDFStore(existing_path, mode="w") as store:
+        store["stale_var"] = pd.Series([1, 2, 3])
+
+    real_hdfstore = pd.HDFStore
+    opened_modes = []
+
+    def recording_hdfstore(path, mode="a", *args, **kwargs):
+        opened_modes.append(mode)
+        return real_hdfstore(path, mode=mode, *args, **kwargs)
+
+    def fail_h5py_file(*args, **kwargs):
+        raise AssertionError("add_rent should not reopen the existing H5 with h5py")
+
+    class FakeQRF:
+        def fit(self, X_train, predictors, imputed_variables):
+            return self
+
+        def predict(self, X_test):
+            return pd.DataFrame(
+                {
+                    "rent": np.full(len(X_test), 1_000.0),
+                    "real_estate_taxes": np.full(len(X_test), 250.0),
+                }
+            )
+
+    class FakeMicrosimulation:
+        def __init__(self, dataset):
+            self.dataset = dataset
+
+        def calculate_dataframe(self, columns):
+            if "rent" in columns:
+                df = pd.DataFrame(
+                    {
+                        "is_household_head": np.ones(10_000, dtype=bool),
+                        "age": np.full(10_000, 40),
+                        "is_male": np.zeros(10_000, dtype=bool),
+                        "tenure_type": ["RENTED"] * 10_000,
+                        "employment_income": np.full(10_000, 30_000.0),
+                        "self_employment_income": np.zeros(10_000),
+                        "social_security": np.zeros(10_000),
+                        "pension_income": np.zeros(10_000),
+                        "state_code_str": ["CA"] * 10_000,
+                        "household_size": np.ones(10_000),
+                        "rent": np.full(10_000, 1_200.0),
+                        "real_estate_taxes": np.zeros(10_000),
+                    }
+                )
+            else:
+                df = pd.DataFrame(
+                    {
+                        "is_household_head": [True],
+                        "age": [40],
+                        "is_male": [False],
+                        "tenure_type": ["RENTED"],
+                        "employment_income": [30_000.0],
+                        "self_employment_income": [0.0],
+                        "social_security": [0.0],
+                        "pension_income": [0.0],
+                        "state_code_str": ["CA"],
+                        "household_size": [1],
+                    }
+                )
+            return df[columns]
+
+    class FakeDataset:
+        def __init__(self):
+            self.file_path = existing_path
+            self.saved = []
+
+        def save_dataset(self, data):
+            self.saved.append(data)
+
+    monkeypatch.setattr(cps_module.pd, "HDFStore", recording_hdfstore)
+    monkeypatch.setattr(cps_module.h5py, "File", fail_h5py_file)
+    monkeypatch.setattr(cps_module, "QRF", FakeQRF)
+
+    import policyengine_us
+    import policyengine_us_data.datasets.acs.acs as acs_module
+
+    monkeypatch.setattr(policyengine_us, "Microsimulation", FakeMicrosimulation)
+    monkeypatch.setattr(acs_module, "ACS_2022", object())
+
+    dataset = FakeDataset()
+    cps = {
+        "age": np.array([40], dtype=np.int32),
+        "spm_unit_capped_housing_subsidy_reported": np.array([0.0]),
+    }
+    person = pd.DataFrame({"dummy": [1]})
+    household = pd.DataFrame({"H_TENURE": [2]})
+
+    add_rent(dataset, cps, person, household)
+
+    assert opened_modes == ["r"]
+    assert not existing_path.exists()
+    np.testing.assert_array_equal(cps["rent"], np.array([1_000.0]))
+    np.testing.assert_array_equal(cps["real_estate_taxes"], np.array([250.0]))

--- a/tests/unit/test_asset_imputation.py
+++ b/tests/unit/test_asset_imputation.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pandas as pd
+
+from policyengine_us_data.utils.asset_imputation import (
+    build_household_vehicle_receiver,
+)
+
+
+def test_build_household_vehicle_receiver_aggregates_person_inputs():
+    person_df = pd.DataFrame(
+        {
+            "household_id": [10, 10, 20],
+            "employment_income": [20_000.0, 5_000.0, 30_000.0],
+            "interest_income": [100.0, 50.0, 25.0],
+            "dividend_income": [10.0, 0.0, 5.0],
+            "rental_income": [0.0, 200.0, 0.0],
+            "age": [42, 12, 35],
+            "is_female": [1.0, 1.0, 0.0],
+            "is_married": [1.0, 0.0, 0.0],
+            "is_household_head": [True, False, True],
+        }
+    )
+
+    receiver = build_household_vehicle_receiver(
+        person_df,
+        tenure_type=np.array([b"OWNED_WITH_MORTGAGE", b"RENTED"]),
+    )
+
+    assert receiver["household_id"].tolist() == [10, 20]
+    assert receiver["household_employment_income"].tolist() == [25_000.0, 30_000.0]
+    assert receiver["household_interest_income"].tolist() == [150.0, 25.0]
+    assert receiver["household_dividend_income"].tolist() == [10.0, 5.0]
+    assert receiver["household_rental_income"].tolist() == [200.0, 0.0]
+    assert receiver["count_under_18"].tolist() == [1.0, 0.0]
+    assert receiver["household_size"].tolist() == [2.0, 1.0]
+    assert receiver["reference_age"].tolist() == [42.0, 35.0]
+    assert receiver["reference_is_female"].tolist() == [1.0, 0.0]
+    assert receiver["reference_is_married"].tolist() == [1.0, 0.0]
+    assert receiver["is_homeowner"].tolist() == [1.0, 0.0]

--- a/tests/unit/test_asset_imputation.py
+++ b/tests/unit/test_asset_imputation.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 
 from policyengine_us_data.utils.asset_imputation import (
+    build_household_asset_receiver,
     build_household_vehicle_receiver,
 )
 
@@ -37,3 +38,9 @@ def test_build_household_vehicle_receiver_aggregates_person_inputs():
     assert receiver["reference_is_female"].tolist() == [1.0, 0.0]
     assert receiver["reference_is_married"].tolist() == [1.0, 0.0]
     assert receiver["is_homeowner"].tolist() == [1.0, 0.0]
+
+    generic_receiver = build_household_asset_receiver(
+        person_df,
+        tenure_type=np.array([b"OWNED_WITH_MORTGAGE", b"RENTED"]),
+    )
+    pd.testing.assert_frame_equal(receiver, generic_receiver)


### PR DESCRIPTION
## Summary
- add reusable household asset receiver logic for CPS/SIPP asset imputation
- impute vehicle debt/equity plus other real estate, rental property, and business asset value/debt/equity from SIPP
- carry the new household asset signals through CPS generation and source-impute tests

## Notes
- stacked on top of #751
- focused local validation passed: asset/source-impute/CPS generation/file-handle slice