### PR TITLE
Fix DC SNAP state target drop caused by FIPS int/string mismatch

### DIFF
--- a/changelog.d/fix-dc-snap-fips-coercion.fixed.md
+++ b/changelog.d/fix-dc-snap-fips-coercion.fixed.md
@@ -1,0 +1,1 @@
+Fix DC SNAP state calibration target drop caused by int/string FIPS mismatch in utils/loss.py.

--- a/policyengine_us_data/utils/loss.py
+++ b/policyengine_us_data/utils/loss.py
@@ -1129,7 +1129,6 @@ def _add_snap_metric_columns(
 
     state = sim.calculate("state_code", map_to="person").values
     state = sim.map_result(state, "person", "household", how="value_from_first_person")
-    STATE_ABBR_TO_FIPS["DC"] = 11
     state_fips = pd.Series(state).apply(lambda s: STATE_ABBR_TO_FIPS[s])
 
     for _, r in snap_targets.iterrows():

--- a/tests/unit/test_state_fips.py
+++ b/tests/unit/test_state_fips.py
@@ -1,0 +1,43 @@
+"""Tests for the shared STATE_ABBR_TO_FIPS dict used across calibration code."""
+
+import pytest
+
+
+def test_dc_fips_is_string():
+    """DC's FIPS in the canonical dict is a string '11' (matches GEO_ID suffix)."""
+    from policyengine_us_data.storage.calibration_targets.pull_soi_targets import (
+        STATE_ABBR_TO_FIPS,
+    )
+
+    assert STATE_ABBR_TO_FIPS["DC"] == "11"
+    assert isinstance(STATE_ABBR_TO_FIPS["DC"], str)
+
+
+def test_all_state_fips_are_strings():
+    """All entries in STATE_ABBR_TO_FIPS are strings — downstream code compares
+    against ``r.GEO_ID[-2:]`` which is a string slice, so any int entry would
+    silently fail comparison and drop that state's targets."""
+    from policyengine_us_data.storage.calibration_targets.pull_soi_targets import (
+        STATE_ABBR_TO_FIPS,
+    )
+
+    for abbr, fips in STATE_ABBR_TO_FIPS.items():
+        assert isinstance(fips, str), f"{abbr} FIPS {fips!r} is not a string"
+        assert len(fips) == 2, f"{abbr} FIPS {fips!r} is not a 2-character string"
+
+
+def test_loss_module_does_not_mutate_state_fips_on_import():
+    """Regression for the DC SNAP calibration drop bug.
+
+    Previously ``_add_snap_metric_columns`` wrote ``STATE_ABBR_TO_FIPS["DC"] = 11``
+    (int) inline, corrupting the shared dict the moment the function ran. The fix
+    removed that line. Even at import time the dict should be untouched.
+    """
+    from policyengine_us_data.storage.calibration_targets.pull_soi_targets import (
+        STATE_ABBR_TO_FIPS,
+    )
+
+    before = dict(STATE_ABBR_TO_FIPS)
+    import policyengine_us_data.utils.loss  # noqa: F401
+
+    assert STATE_ABBR_TO_FIPS == before


### PR DESCRIPTION
## Summary

`_add_snap_metric_columns` in `policyengine_us_data/utils/loss.py` wrote
`STATE_ABBR_TO_FIPS["DC"] = 11` (int) before looking up each household's FIPS string for the SNAP-by-state calibration targets. A few lines later:

```python
state_fips = pd.Series(state).apply(lambda s: STATE_ABBR_TO_FIPS[s])
...
in_state = state_fips == r.GEO_ID[-2:]       # r.GEO_ID[-2:] is a str like "11"
```

Because `int(11) != "11"`, every DC household silently failed the comparison and the DC SNAP state-level calibration targets were effectively dropped.

Worse: `STATE_ABBR_TO_FIPS` is a module-level dict imported from `storage/calibration_targets/pull_soi_targets.py`. DC is already defined there as the string `"11"`, so the assignment both broke this loop *and* corrupted the shared dict for every downstream consumer (e.g. `db/etl_irs_soi.py`, `storage/calibration_targets/pull_soi_targets.py::FIPS_TO_STATE_ABBR`) the moment this function ran.

## Fix

Delete the line. DC is already present as `"11"` in the canonical dict.

```diff
     state = sim.map_result(state, "person", "household", how="value_from_first_person")
-    STATE_ABBR_TO_FIPS["DC"] = 11
     state_fips = pd.Series(state).apply(lambda s: STATE_ABBR_TO_FIPS[s])
```

## Regression test

Added `tests/unit/test_state_fips.py` with three assertions:

- `test_dc_fips_is_string`: DC is `"11"` (string).
- `test_all_state_fips_are_strings`: every entry is a 2-character string.
- `test_loss_module_does_not_mutate_state_fips_on_import`: importing `utils.loss` leaves the shared dict untouched.

## Test plan

- [x] `tests/unit/test_state_fips.py` — 3/3 passed.
- [ ] CI passes.
