### PR TITLE
Exclude SIPP allocation flags from tip income sum (closes #524)

### DIFF
--- a/changelog.d/fix-sipp-tip-txamt-regex.fixed.md
+++ b/changelog.d/fix-sipp-tip-txamt-regex.fixed.md
@@ -1,0 +1,1 @@
+Limit SIPP tip income imputation to TJB*_TXAMT dollar-amount columns, excluding AJB*_TXAMT allocation flags. Fixes #524.

--- a/policyengine_us_data/datasets/sipp/sipp.py
+++ b/policyengine_us_data/datasets/sipp/sipp.py
@@ -77,9 +77,12 @@ def train_tip_model():
         df = pd.read_csv(
             STORAGE_FOLDER / "pu2023_slim.csv",
         )
-    # Sum tip columns (AJB*_TXAMT + TJB*_TXAMT) across all jobs.
+    # Sum tip dollar-amount columns (TJB*_TXAMT) across all jobs.
+    # Previously used `str.contains("TXAMT")`, which also picked up
+    # AJB*_TXAMT Census allocation flags (small ints 0/1/2 indicating
+    # imputation status) and added them to the dollar totals.
     df["tip_income"] = (
-        df[df.columns[df.columns.str.contains("TXAMT")]].fillna(0).sum(axis=1) * 12
+        df[df.columns[df.columns.str.match(r"TJB\d_TXAMT")]].fillna(0).sum(axis=1) * 12
     )
     df["employment_income"] = df.TPTOTINC * 12
     df["is_under_18"] = (df.TAGE < 18) & (df.MONTHCODE == 12)

--- a/tests/unit/datasets/test_sipp_tip_columns.py
+++ b/tests/unit/datasets/test_sipp_tip_columns.py
@@ -1,0 +1,51 @@
+"""Regression test for SIPP tip income column matching.
+
+Previously `str.contains("TXAMT")` matched both `TJB*_TXAMT` (dollar
+amounts) and `AJB*_TXAMT` (Census allocation flags). The fix narrows
+to `TJB\\d_TXAMT` (dollar-amount columns only).
+"""
+
+import pandas as pd
+
+
+def test_tip_regex_matches_dollar_amounts_only():
+    # SIPP column naming: TJB<N>_TXAMT is the dollar amount for job N,
+    # AJB<N>_TXAMT is the allocation flag for the same field.
+    # Include several distractors that the old `contains("TXAMT")` regex
+    # would have caught.
+    columns = pd.Index(
+        [
+            "TJB1_TXAMT",
+            "TJB2_TXAMT",
+            "AJB1_TXAMT",  # allocation flag — should NOT be summed
+            "AJB2_TXAMT",  # allocation flag — should NOT be summed
+            "SOME_TXAMT_OTHER",  # unrelated non-numbered column
+            "TPTOTINC",  # unrelated
+        ]
+    )
+
+    matches = columns[columns.str.match(r"TJB\d_TXAMT")]
+
+    assert list(matches) == ["TJB1_TXAMT", "TJB2_TXAMT"]
+
+
+def test_tip_sum_excludes_allocation_flags():
+    df = pd.DataFrame(
+        {
+            "TJB1_TXAMT": [100.0, 200.0],
+            "TJB2_TXAMT": [50.0, 75.0],
+            "AJB1_TXAMT": [1, 2],  # allocation flags: small ints
+            "AJB2_TXAMT": [0, 1],
+        }
+    )
+    # Mirror the sipp.py computation using the new regex.
+    tip_income_monthly = (
+        df[df.columns[df.columns.str.match(r"TJB\d_TXAMT")]].fillna(0).sum(axis=1)
+    )
+    assert list(tip_income_monthly) == [150.0, 275.0]
+
+    # Sanity check: the buggy regex would have included AJB flags.
+    buggy_tip_income_monthly = (
+        df[df.columns[df.columns.str.contains("TXAMT")]].fillna(0).sum(axis=1)
+    )
+    assert list(buggy_tip_income_monthly) == [151.0, 278.0]


### PR DESCRIPTION
## Summary

Fixes [#524](https://github.com/PolicyEngine/policyengine-us-data/issues/524).

`sipp.py` computed tip income by summing every column containing `"TXAMT"`, which matched both:

- `TJB<n>_TXAMT` — the per-job tip **dollar amounts** (the intended source)
- `AJB<n>_TXAMT` — Census allocation flags (small integers 0/1/2 indicating whether the value was imputed)

Allocation-flag integers were added to dollar totals. The effect is small (the flags range 0–2, so typical inflation per job is <$3/month × 12 = <$36/year) but incorrect.

## Fix

```python
# before
df["tip_income"] = (
    df[df.columns[df.columns.str.contains("TXAMT")]].fillna(0).sum(axis=1) * 12
)

# after — match dollar-amount columns only
df["tip_income"] = (
    df[df.columns[df.columns.str.match(r"TJB\d_TXAMT")]].fillna(0).sum(axis=1)
    * 12
)
```

Implements the fix proposed in #524 verbatim.

## Regression tests

New `tests/unit/datasets/test_sipp_tip_columns.py`:
- `test_tip_regex_matches_dollar_amounts_only` — the new regex matches `TJB1_TXAMT`/`TJB2_TXAMT` but excludes `AJB1_TXAMT`, `AJB2_TXAMT`, `SOME_TXAMT_OTHER`, and `TPTOTINC`.
- `test_tip_sum_excludes_allocation_flags` — row-sum check: with dollar amounts [100, 50]/[200, 75] and allocation flags [1, 0]/[2, 1], the new filter yields 150/275 while the old `contains("TXAMT")` would have yielded 151/278.

## Test plan

- [x] 2 new unit tests pass.
- [ ] CI passes.
