### PR TITLE
Seed numpy before EnhancedCPS initial weight jitter

### DIFF
--- a/changelog.d/fix-enhanced-cps-unseeded-jitter.fixed.md
+++ b/changelog.d/fix-enhanced-cps-unseeded-jitter.fixed.md
@@ -1,0 +1,1 @@
+Seed numpy before the EnhancedCPS/ReweightedCPS initial weight jitter so calibrated weights are reproducible across runs.

--- a/policyengine_us_data/datasets/cps/enhanced_cps.py
+++ b/policyengine_us_data/datasets/cps/enhanced_cps.py
@@ -222,6 +222,12 @@ class EnhancedCPS(Dataset):
         base_year = int(sim.default_calculation_period)
         data["household_weight"] = {}
         original_weights = sim.calculate("household_weight")
+        # Seed before the initial weight jitter so the L0 optimizer's
+        # starting point is reproducible across runs. `reweight()` re-seeds
+        # inside, but that happens AFTER this perturbation, so without
+        # this call the jitter (and hence the final calibrated weights)
+        # differ run-to-run.
+        set_seeds(1456)
         original_weights = original_weights.values + np.random.normal(
             1, 0.1, len(original_weights)
         )
@@ -358,6 +364,9 @@ class ReweightedCPS_2024(Dataset):
         sim = Microsimulation(dataset=self.input_dataset)
         data = sim.dataset.load_dataset()
         original_weights = sim.calculate("household_weight")
+        # Seed before the jitter so the starting weights (and the final
+        # reweighted result) are reproducible across runs.
+        set_seeds(1456)
         original_weights = original_weights.values + np.random.normal(
             1, 0.1, len(original_weights)
         )

--- a/tests/unit/datasets/test_enhanced_cps_seeding.py
+++ b/tests/unit/datasets/test_enhanced_cps_seeding.py
@@ -1,0 +1,60 @@
+"""Regression test ensuring the initial weight jitter in EnhancedCPS is seeded.
+
+Previously ``np.random.normal(1, 0.1, ...)`` ran with whatever numpy global
+state the process happened to be in. ``reweight()`` re-seeds, but only
+afterwards, so the final L0 weights differed run to run even with
+``seed=1456`` inside ``reweight``.
+
+Fix: call ``set_seeds(1456)`` right before the jitter in
+``EnhancedCPS.generate`` and ``ReweightedCPS_2024.generate``.
+"""
+
+import numpy as np
+
+from policyengine_us_data.utils.seed import set_seeds
+
+
+def _mock_jitter(n: int = 10) -> np.ndarray:
+    """Mirror the enhanced_cps perturbation shape."""
+    return np.random.normal(1, 0.1, n)
+
+
+def test_set_seeds_makes_numpy_normal_reproducible():
+    set_seeds(1456)
+    a = _mock_jitter()
+    set_seeds(1456)
+    b = _mock_jitter()
+    assert np.array_equal(a, b)
+
+
+def test_unseeded_numpy_normal_is_non_reproducible():
+    """Sanity check: without set_seeds in between, two consecutive draws differ."""
+    np.random.seed(None)  # reset to fresh entropy
+    a = _mock_jitter()
+    # Don't reseed — same process draws again, distinct state.
+    b = _mock_jitter()
+    assert not np.array_equal(a, b)
+
+
+def test_enhanced_cps_sources_call_set_seeds_before_jitter():
+    """The fix places ``set_seeds(1456)`` immediately before
+    ``np.random.normal`` in both generate() methods. Verify the file
+    preserves that invariant so regressions are caught by lint.
+    """
+    import policyengine_us_data.datasets.cps.enhanced_cps as ec
+
+    source = open(ec.__file__).read()
+    # Split into the two generate() bodies. Both must contain the
+    # set_seeds call before the np.random.normal call.
+    # The simplest invariant: every occurrence of np.random.normal
+    # must be preceded (within the previous 5 non-blank lines) by a
+    # set_seeds(...) call.
+    lines = source.splitlines()
+    normal_indices = [i for i, line in enumerate(lines) if "np.random.normal" in line]
+    assert normal_indices, "Expected at least one np.random.normal site"
+    for idx in normal_indices:
+        window = "\n".join(lines[max(0, idx - 5) : idx])
+        assert "set_seeds(" in window, (
+            f"np.random.normal on line {idx + 1} is not preceded by set_seeds("
+            f") within the previous 5 lines; window was:\n{window}"
+        )


### PR DESCRIPTION
## Summary

`EnhancedCPS.generate()` and `ReweightedCPS_2024.generate()` start by perturbing the original household weights:

```python
original_weights = original_weights.values + np.random.normal(
    1, 0.1, len(original_weights)
)
```

This `np.random.normal` call uses numpy's global RNG, seeded by whatever the process happens to have. `reweight()` *does* call `set_seeds(seed)` internally — but only after the perturbation, so by then the damage is done: the L0 optimizer started from a different point each run, and the final calibrated weights differed run-to-run despite the `seed=1456` argument suggesting reproducibility.

## Fix

Call `set_seeds(1456)` immediately before the jitter in both `generate()` methods. `set_seeds` already covers `random`, `numpy`, and `torch`, so all downstream randomness is deterministic from this point until `reweight` re-seeds with the same value.

```python
# before
original_weights = original_weights.values + np.random.normal(
    1, 0.1, len(original_weights)
)

# after
set_seeds(1456)
original_weights = original_weights.values + np.random.normal(
    1, 0.1, len(original_weights)
)
```

## Regression tests

`tests/unit/datasets/test_enhanced_cps_seeding.py` (3 tests):

- `test_set_seeds_makes_numpy_normal_reproducible` — set_seeds(1456) followed by np.random.normal yields identical draws twice.
- `test_unseeded_numpy_normal_is_non_reproducible` — sanity check that successive draws without re-seeding do diverge (pins the bug premise).
- `test_enhanced_cps_sources_call_set_seeds_before_jitter` — source-code invariant: every `np.random.normal` call in `enhanced_cps.py` is preceded by `set_seeds(` within the previous 5 lines.

## Test plan

- [x] 3 unit tests pass.
- [ ] CI passes.
