### PR TITLE
Align state AGI-band convention with main SOI loop

### DIFF
--- a/changelog.d/fix-agi-band-boundary-convention.fixed.md
+++ b/changelog.d/fix-agi-band-boundary-convention.fixed.md
@@ -1,0 +1,1 @@
+Use the [lower, upper) AGI-band boundary convention in the state AGI metric loop, matching the main SOI loop in build_loss_matrix.

--- a/policyengine_us_data/utils/loss.py
+++ b/policyengine_us_data/utils/loss.py
@@ -1033,7 +1033,10 @@ def _add_agi_metric_columns(
         band = get_agi_band_label(lower, upper)
 
         in_state = state == r.GEO_NAME
-        in_band = (agi > lower) & (agi <= upper)
+        # Use the same [lower, upper) boundary convention as the main SOI
+        # loop in build_loss_matrix() (the SOI targets use half-open bands
+        # starting at the lower bound).
+        in_band = (agi >= lower) & (agi < upper)
 
         if r.IS_COUNT:
             metric = (in_state & in_band & (agi > 0)).astype(float)


### PR DESCRIPTION
## Summary

Two loops in `policyengine_us_data/utils/loss.py` read AGI buckets from the same SOI CSV but disagree on the boundary convention.

The main SOI loop in `build_loss_matrix` (line 425) uses `[lower, upper)` — left-inclusive, right-exclusive:

```python
mask = (
    (agi >= row["AGI lower bound"])
    * (agi < row["AGI upper bound"])
    * filer
) > 0
```

The state AGI helper `_add_state_agi_metric_columns` (line 1036) used the **opposite** convention — left-exclusive, right-inclusive:

```python
in_band = (agi > lower) & (agi <= upper)
```

The underlying SOI data is published on the `[lower, upper)` half-open convention, so the state-band loop misclassified records sitting exactly on bucket boundaries.

## Fix

Match the main loop's convention:

```diff
-        in_band = (agi > lower) & (agi <= upper)
+        in_band = (agi >= lower) & (agi < upper)
```

## Impact

Affects only records whose AGI is exactly at a bucket boundary (e.g. `10_000.0`, `25_000.0`). A handful of synthetic records with boundary-exact AGI used to be counted in the wrong bucket for state-level calibration.

## Test plan

- [ ] CI passes.
