### PR TITLE
Combine chained AGI bound filters in soi validation helper

### DIFF
--- a/changelog.d/fix-soi-pandas-chained-indexing.fixed.md
+++ b/changelog.d/fix-soi-pandas-chained-indexing.fixed.md
@@ -1,0 +1,1 @@
+Combine AGI bound filters into a single boolean mask in compare_soi_replication_to_soi to avoid chained-indexing misalignment.

--- a/policyengine_us_data/utils/soi.py
+++ b/policyengine_us_data/utils/soi.py
@@ -288,8 +288,9 @@ def compare_soi_replication_to_soi(df, soi):
         if row.Variable not in df.columns:
             continue
 
-        subset = df[df.adjusted_gross_income >= row["AGI lower bound"]][
-            df.adjusted_gross_income < row["AGI upper bound"]
+        subset = df[
+            (df.adjusted_gross_income >= row["AGI lower bound"])
+            & (df.adjusted_gross_income < row["AGI upper bound"])
         ]
 
         variable = row["Variable"]


### PR DESCRIPTION
## Summary

`compare_soi_replication_to_soi` in `policyengine_us_data/utils/soi.py` (line 291-293) filtered the dataframe with a chained indexer:

```python
subset = df[df.adjusted_gross_income >= row["AGI lower bound"]][
    df.adjusted_gross_income < row["AGI upper bound"]
]
```

The inner `[...]` returns a shorter dataframe, but the outer `[...]` takes a boolean mask built from **the original `df.adjusted_gross_income`** (which still has the original length). Applying a mask of one length to a dataframe of another length is misaligned — on modern pandas (≥1.0) this raises `IndexingError` or silently returns the wrong rows.

## Fix

Combine the two conditions into a single `&`-composed mask so both filters see the same index:

```python
subset = df[
    (df.adjusted_gross_income >= row["AGI lower bound"])
    & (df.adjusted_gross_income < row["AGI upper bound"])
]
```

## Impact

This helper is the SOI replication validator — it's only used for diagnostic comparison against published SOI tables, not for the main calibration path. But on any modern pandas it would either error or silently miscount bands where rows get dropped, masking discrepancies.

## Test plan

- [ ] CI passes.
