### PR TITLE
Prefix state ACA spending calibration label with state/

### DIFF
--- a/changelog.d/fix-state-aca-spending-label-prefix.fixed.md
+++ b/changelog.d/fix-state-aca-spending-label-prefix.fixed.md
@@ -1,0 +1,1 @@
+Re-prefix state ACA spending calibration label with state/ (was nation/) so reweight() correctly classifies it as a state target.

--- a/policyengine_us_data/utils/loss.py
+++ b/policyengine_us_data/utils/loss.py
@@ -816,8 +816,10 @@ def build_loss_matrix(dataset: type, time_period):
         # ACA PTC amounts for every household (2025)
         aca_value = sim.calculate("aca_ptc", map_to="household", period=2025).values
 
-        # Add a loss-matrix entry and matching target
-        label = f"nation/irs/aca_spending/{row['state'].lower()}"
+        # Add a loss-matrix entry and matching target. Prefix `state/`
+        # so `reweight()` correctly classifies this as a state-level
+        # (non-national) target via `startswith("nation/")`.
+        label = f"state/irs/aca_spending/{row['state'].lower()}"
         loss_matrix[label] = aca_value * in_state
         annual_target = row["spending"]
         if any(loss_matrix[label].isna()):


### PR DESCRIPTION
## Summary

`_add_aca_and_medicaid_metric_columns` at `utils/loss.py:820` labels the per-state ACA spending target `nation/irs/aca_spending/{state}` — starting with `nation/` even though every row is specific to one state.

`reweight()` at `datasets/cps/enhanced_cps.py:115` classifies targets via `columns.str.startswith("nation/")` and normalises nation vs state rows by their relative counts:

```python
is_national = loss_matrix.columns.str.startswith("nation/")
nation_normalisation_factor = is_national * (1 / is_national.sum())
state_normalisation_factor = ~is_national * (1 / (~is_national).sum())
```

So the ~50 per-state ACA-spending rows were being pooled with true national targets, diluting the national-normalisation weight for real national targets.

## Fix

```diff
-        label = f"nation/irs/aca_spending/{row['state'].lower()}"
+        label = f"state/irs/aca_spending/{row['state'].lower()}"
```

Matches the sibling state labels (`state/irs/aca_enrollment/{state}` at line 849, `state/{GEO_NAME}/{VARIABLE}/{band}` for AGI, `{GEO_ID}/snap-cost` for SNAP).

## Context

Found during independent review of #778 (state Medicaid label prefix). While #778 was a naming-consistency fix that didn't actually change `reweight()` behavior (label started with `irs/`, correctly classified as state), this one genuinely affects calibration weighting because the label starts with `nation/`.

## Test plan

- [ ] CI passes.
