### PR TITLE
Filter SIPP tip-model training frame to MONTHCODE == 12

### DIFF
--- a/changelog.d/fix-sipp-monthcode-filter.fixed.md
+++ b/changelog.d/fix-sipp-monthcode-filter.fixed.md
@@ -1,0 +1,1 @@
+Filter SIPP tip-model training frame to `MONTHCODE == 12` before the weighted resample — `train_tip_model` previously sampled 10,000 rows from a 12×-bloated panel (one row per person per month, each annualized from that single month), so the QRF treated Jan-annualized and Dec-annualized rows as separate observations and mixed seasonal tip amounts with the annual figures.

--- a/policyengine_us_data/datasets/sipp/sipp.py
+++ b/policyengine_us_data/datasets/sipp/sipp.py
@@ -100,6 +100,18 @@ def train_tip_model():
         df["treasury_tipped_occupation_code"]
     )
 
+    # SIPP data are monthly (one row per person × MONTHCODE 1..12).
+    # tip_income and employment_income above were annualized as
+    # ``month_value * 12``, which is only right for a single reference
+    # month. Without this filter the training frame had 12 rows per
+    # person — each annualized from a different month — so the QRF
+    # treated Jan-income-annualized and Dec-income-annualized as
+    # separate observations and mixed seasonal tip amounts
+    # (restaurant, holiday) with the annual figures. Filter to
+    # December (end of year) so every training row represents one
+    # person-year.
+    df = df[df["MONTHCODE"] == 12]
+
     sipp = df[
         [
             "household_id",

--- a/tests/unit/datasets/test_sipp_monthcode_filter.py
+++ b/tests/unit/datasets/test_sipp_monthcode_filter.py
@@ -1,0 +1,89 @@
+"""Regression test for the SIPP tip-model MONTHCODE filter (N9).
+
+SIPP panels have one row per person per month. ``sipp.train_tip_model``
+annualizes tip and employment income as ``monthly_value * 12`` on every
+row, then samples training rows. Without a MONTHCODE filter the
+training frame contains 12 rows per person — each annualized from a
+different month — which inflates effective sample size and mixes
+seasonal tip values (restaurant, holiday) with the annual figures.
+
+Fix: filter to MONTHCODE == 12 (end of year) before sampling so every
+training row represents one person-year.
+
+This is a source-level regression test because train_tip_model itself
+downloads files from HF and trains a QRF.
+"""
+
+import ast
+from pathlib import Path
+
+import pandas as pd
+
+SIPP_SOURCE = (
+    Path(__file__).resolve().parent.parent.parent.parent
+    / "policyengine_us_data"
+    / "datasets"
+    / "sipp"
+    / "sipp.py"
+)
+
+
+def test_train_tip_model_filters_to_monthcode_12_before_sampling():
+    """The train_tip_model function body must filter ``MONTHCODE``
+    before the weighted resample so the training frame has one row
+    per person."""
+    src = SIPP_SOURCE.read_text()
+    tree = ast.parse(src)
+    fn = next(
+        (
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef) and node.name == "train_tip_model"
+        ),
+        None,
+    )
+    assert fn is not None
+    fn_src = ast.get_source_segment(src, fn)
+    assert fn_src is not None
+
+    # Must mention the MONTHCODE == 12 filter somewhere in the body.
+    assert 'df["MONTHCODE"] == 12' in fn_src or "df.MONTHCODE == 12" in fn_src, (
+        "train_tip_model must filter to MONTHCODE == 12 to avoid 12x "
+        "duplicate training rows per person; got:\n" + fn_src
+    )
+
+
+def test_monthcode_filter_collapses_to_one_row_per_person():
+    """Toy SIPP-shaped frame: one person with 12 monthly rows, the
+    MONTHCODE==12 filter must produce exactly 1 row (their December
+    values)."""
+    df = pd.DataFrame(
+        {
+            "SSUID": [1] * 12 + [2] * 12,
+            "PNUM": [100] * 12 + [200] * 12,
+            "MONTHCODE": list(range(1, 13)) * 2,
+            "TPTOTINC": [1000.0] * 24,
+        }
+    )
+    filtered = df[df["MONTHCODE"] == 12]
+    assert len(filtered) == 2  # one December row per person
+    assert set(filtered["SSUID"].tolist()) == {1, 2}
+
+
+def test_without_filter_there_are_12x_duplicate_rows_per_person():
+    """Pin the bug premise: without the filter the frame has 12
+    rows per person after the annualization."""
+    df = pd.DataFrame(
+        {
+            "SSUID": [1] * 12,
+            "PNUM": [100] * 12,
+            "MONTHCODE": list(range(1, 13)),
+            "TPTOTINC": [1000.0] * 12,
+        }
+    )
+    df["employment_income"] = df["TPTOTINC"] * 12
+    # Before the fix, every row in the training frame keyed on the
+    # (SSUID, PNUM) pair appeared 12 times. The filter is what brings
+    # it down to one row per person.
+    assert len(df) == 12
+    assert len(df[df["MONTHCODE"] == 12]) == 1


### PR DESCRIPTION
## Summary

SIPP panels have one row per person per month. In `train_tip_model`:

```python
df["tip_income"] = (
    df[df.columns[df.columns.str.contains("TXAMT")]].fillna(0).sum(axis=1) * 12
)
df["employment_income"] = df.TPTOTINC * 12
```

Those annualized columns were computed on **every** row (12 per person). A later block filters `is_under_18` / `is_under_6` to `MONTHCODE == 12`, but the annualized income rows were never pruned. The weighted `np.random.choice` then sampled 10,000 rows from a 12×-bloated panel, so the QRF:

- inflated effective sample size (12 duplicates per person), and
- mixed seasonal tip values (restaurant vs holiday month) with the annual figures because each Jan-annualized row disagreed with its Dec-annualized sibling.

Orthogonal to #524 / #773 (column selection). This is about **row selection**.

## Fix

Filter the frame to `MONTHCODE == 12` before slicing into the training frame and sampling:

```python
df = df[df["MONTHCODE"] == 12]
```

## Regression tests

New `tests/unit/datasets/test_sipp_monthcode_filter.py` (3 tests):

- `test_train_tip_model_filters_to_monthcode_12_before_sampling` — AST walk of the `train_tip_model` function body asserts the filter is present.
- `test_monthcode_filter_collapses_to_one_row_per_person` — toy 2-person × 12-month frame yields one row per person after filtering.
- `test_without_filter_there_are_12x_duplicate_rows_per_person` — pins the bug premise.

## Test plan

- [x] 3 unit tests pass.
- [ ] CI passes.
