### PR TITLE
Harden utils.raw_cache.cache_path against path traversal

### DIFF
--- a/changelog.d/fix-raw-cache-path-traversal.fixed.md
+++ b/changelog.d/fix-raw-cache-path-traversal.fixed.md
@@ -1,0 +1,1 @@
+Harden `utils.raw_cache.cache_path` against path traversal — reject absolute filenames, parent-directory (`..`) components, and any filename whose resolved path escapes `RAW_INPUTS_DIR`, so future ETL callers can't accidentally read or overwrite files outside the cache directory.

--- a/policyengine_us_data/utils/raw_cache.py
+++ b/policyengine_us_data/utils/raw_cache.py
@@ -14,7 +14,42 @@ REFRESH = os.environ.get("PE_REFRESH_RAW", "0") == "1"
 
 
 def cache_path(filename: str) -> Path:
-    return RAW_INPUTS_DIR / filename
+    """Return the absolute path of a raw-input cache file.
+
+    ``filename`` must be a plain relative path under
+    :data:`RAW_INPUTS_DIR` — no absolute paths and no parent-directory
+    (``..``) components. Without this guard a caller that builds
+    ``filename`` from a URL or any external input (for example
+    ``cache_path(url.split("/")[-1])`` in a future ETL script) could
+    escape ``RAW_INPUTS_DIR`` and either read or overwrite arbitrary
+    files elsewhere on the filesystem.
+
+    The resolve-and-check below fails closed if the resolved path is
+    not inside ``RAW_INPUTS_DIR``.
+    """
+    if not isinstance(filename, (str, os.PathLike)):
+        raise TypeError(
+            f"cache_path expects a string or PathLike filename; got {type(filename)!r}"
+        )
+    if filename == "" or filename is None:
+        raise ValueError("cache_path requires a non-empty filename")
+    path_filename = Path(filename)
+    if path_filename.is_absolute():
+        raise ValueError(f"cache_path refuses absolute filenames; got {filename!r}")
+    if ".." in path_filename.parts:
+        raise ValueError(
+            f"cache_path refuses filenames that traverse with '..'; got {filename!r}"
+        )
+    raw_inputs_dir_resolved = RAW_INPUTS_DIR.resolve()
+    candidate = (RAW_INPUTS_DIR / path_filename).resolve()
+    try:
+        candidate.relative_to(raw_inputs_dir_resolved)
+    except ValueError as exc:
+        raise ValueError(
+            f"cache_path refuses filenames that escape RAW_INPUTS_DIR "
+            f"({raw_inputs_dir_resolved}): got {filename!r} -> {candidate}"
+        ) from exc
+    return RAW_INPUTS_DIR / path_filename
 
 
 def is_cached(filename: str) -> bool:

--- a/tests/unit/test_raw_cache_path_traversal.py
+++ b/tests/unit/test_raw_cache_path_traversal.py
@@ -1,0 +1,79 @@
+"""Regression tests for ``utils.raw_cache.cache_path`` path-traversal
+guard (N12).
+
+Previously::
+
+    def cache_path(filename: str) -> Path:
+        return RAW_INPUTS_DIR / filename
+
+No validation that ``filename`` stays under ``RAW_INPUTS_DIR``. All
+current callers pass literal filenames, so the real-world risk is
+low, but a future ETL script building ``cache_path(url.split("/")[-1])``
+or similar would escape silently. Fail closed.
+"""
+
+import pytest
+
+from policyengine_us_data.utils import raw_cache
+
+
+def test_cache_path_accepts_plain_basenames():
+    result = raw_cache.cache_path("snap_state.csv")
+    assert result.name == "snap_state.csv"
+    assert result.parent == raw_cache.RAW_INPUTS_DIR
+
+
+def test_cache_path_accepts_nested_relative_paths_under_raw_inputs_dir():
+    result = raw_cache.cache_path("soi/raw/2024.csv")
+    assert result.parent.parent == raw_cache.RAW_INPUTS_DIR / "soi"
+
+
+def test_cache_path_rejects_parent_dot_dot_traversal():
+    with pytest.raises(ValueError, match=r"\.\."):
+        raw_cache.cache_path("../escape.csv")
+
+
+def test_cache_path_rejects_nested_parent_dot_dot_traversal():
+    with pytest.raises(ValueError):
+        raw_cache.cache_path("subdir/../../escape.csv")
+
+
+def test_cache_path_rejects_absolute_path():
+    with pytest.raises(ValueError, match="absolute"):
+        raw_cache.cache_path("/etc/passwd")
+
+
+def test_cache_path_rejects_empty_filename():
+    with pytest.raises(ValueError, match="non-empty"):
+        raw_cache.cache_path("")
+
+
+def test_cache_path_rejects_non_string_filenames():
+    with pytest.raises(TypeError):
+        raw_cache.cache_path(123)  # type: ignore[arg-type]
+
+
+def test_cache_path_rejects_escape_via_symlink_style_resolve(tmp_path, monkeypatch):
+    """An absolute ``file://``-like prefix (``/tmp/other/foo``) must
+    fail both the absolute-path guard and the resolve() containment
+    check."""
+    with pytest.raises(ValueError):
+        raw_cache.cache_path(str(tmp_path / "unreachable.csv"))
+
+
+def test_is_cached_refuses_traversal_filenames():
+    """The public wrappers inherit the guard via cache_path."""
+    with pytest.raises(ValueError):
+        raw_cache.is_cached("../escape.csv")
+
+
+def test_save_and_load_json_round_trip_under_raw_inputs_dir():
+    """Sanity: the guard does not break the happy path."""
+    filename = "test_raw_cache_path_traversal_roundtrip.json"
+    try:
+        raw_cache.save_json(filename, {"hello": "world"})
+        assert raw_cache.load_json(filename) == {"hello": "world"}
+    finally:
+        path = raw_cache.cache_path(filename)
+        if path.exists():
+            path.unlink()


### PR DESCRIPTION
## Summary

`policyengine_us_data/utils/raw_cache.py::cache_path` simply returned `RAW_INPUTS_DIR / filename` without any validation:

```python
def cache_path(filename: str) -> Path:
    return RAW_INPUTS_DIR / filename
```

Every current caller passes a literal filename so real-world risk today is low, but a new ETL script doing `cache_path(url.split("/")[-1])` or `cache_path(download_manifest[key])` would happily escape `RAW_INPUTS_DIR`. Trivial hardening, fails closed.

## Fix

`cache_path` now rejects:
- non-string / non-PathLike filenames (`TypeError`),
- empty / `None` filenames,
- absolute paths,
- any filename containing a `..` component,
- any filename whose `.resolve()`d path is not under `RAW_INPUTS_DIR.resolve()` (catch-all for symlinks and quirky inputs).

Happy-path behavior (plain basenames, nested relative paths) is unchanged, and `is_cached` / `save_json` / `save_bytes` / `load_json` / `load_bytes` inherit the guard via `cache_path`.

## Regression tests

New `tests/unit/test_raw_cache_path_traversal.py` (10 tests):

- Accepts `"snap_state.csv"`.
- Accepts `"soi/raw/2024.csv"` (nested relative).
- Rejects `"../escape.csv"`, `"subdir/../../escape.csv"`, `"/etc/passwd"`, `""`, `123`, absolute `tmp_path`-prefixed strings.
- `is_cached("../escape.csv")` raises.
- `save_json` / `load_json` round trip still works on happy-path filenames.

## Test plan

- [x] 10 unit tests pass.
- [ ] CI passes.
