### PR TITLE
Treat top healthcare age bucket as 80+ to cover 90+ population

### DIFF
--- a/changelog.d/fix-healthcare-90plus-target.fixed.md
+++ b/changelog.d/fix-healthcare-90plus-target.fixed.md
@@ -1,0 +1,1 @@
+Treat the top healthcare spending age bucket as unbounded (age >= 80) so the 90+ population is covered by an age-specific calibration target rather than only the national total.

--- a/policyengine_us_data/utils/loss.py
+++ b/policyengine_us_data/utils/loss.py
@@ -685,20 +685,31 @@ def build_loss_matrix(dataset: type, time_period):
     ).astype(float)
     targets_array.append(3e6)
 
-    # Healthcare spending by age
+    # Healthcare spending by age.
+    # Each row targets a decade of ages (lower_bound to lower_bound + 9).
+    # The top row is treated as unbounded (age >= lower_bound) so the
+    # 90+ population is constrained by an age-specific target rather than
+    # only by the national total. See issue #768.
 
     healthcare = pd.read_csv(CALIBRATION_FOLDER / "healthcare_spending.csv")
+    top_age_lower_bound = int(healthcare["age_10_year_lower_bound"].max())
 
     for _, row in healthcare.iterrows():
         age_lower_bound = int(row["age_10_year_lower_bound"])
-        in_age_range = (age >= age_lower_bound) * (age < age_lower_bound + 10)
+        is_top_bucket = age_lower_bound == top_age_lower_bound
+        if is_top_bucket:
+            in_age_range = age >= age_lower_bound
+            label_suffix = f"age_{age_lower_bound}_plus"
+        else:
+            in_age_range = (age >= age_lower_bound) * (age < age_lower_bound + 10)
+            label_suffix = f"age_{age_lower_bound}_to_{age_lower_bound + 9}"
         for expense_type in [
             "health_insurance_premiums_without_medicare_part_b",
             "over_the_counter_health_expenses",
             "other_medical_expenses",
             "medicare_part_b_premiums",
         ]:
-            label = f"nation/census/{expense_type}/age_{age_lower_bound}_to_{age_lower_bound + 9}"
+            label = f"nation/census/{expense_type}/{label_suffix}"
             value = sim.calculate(expense_type).values
             loss_matrix[label] = sim.map_result(
                 in_age_range * value, "person", "household"


### PR DESCRIPTION
## Summary

- Healthcare spending calibration targets are keyed to 10-year age bands. The top row (lower bound 80) previously only covered ages 80-89 due to the `(age >= lower) * (age < lower + 10)` loop condition in `build_loss_matrix()`.
- ~1.5-2M Americans aged 90+ (about 0.5% of the population, with high per-capita healthcare spending) were unconstrained by any age-specific target, bounded only by the national total.
- This change relabels the top bucket to `age >= lower_bound` semantics so 90+ spending is included in the band. Label changes from `age_80_to_89` to `age_80_plus`.

## Trade-off

The existing MEPS-derived CSV value represents 80-89 spending; national aggregate checks suggest there is a ~$9.5B gap for `health_insurance_premiums_without_medicare_part_b` (and smaller gaps for other expense types) that is presumably 90+ spending. Keeping the current CSV value therefore produces a slight under-target for the full 80+ band, but this is directionally better than leaving 90+ health spending totally unconstrained. Re-pulling MEPS 80+ values can be done in a follow-up.

## Test plan

- [x] `pytest tests/unit/ -x --maxfail=3` (778 passed, 3 skipped)
- [x] `ruff format` / `ruff check`

Closes #768

🤖 Generated with [Claude Code](https://claude.com/claude-code)