### PR TITLE
Add dataset READMEs with codebook links for CPS, SIPP, SCF, and ORG

### DIFF
--- a/changelog.d/dataset-readmes.added.md
+++ b/changelog.d/dataset-readmes.added.md
@@ -1,0 +1,1 @@
+Add README files with codebook and documentation links to the cps, sipp, scf, and org dataset folders.

--- a/policyengine_us_data/datasets/cps/README.md
+++ b/policyengine_us_data/datasets/cps/README.md
@@ -1,0 +1,47 @@
+# Current Population Survey (CPS ASEC)
+
+This folder contains the tooling that ingests the Census Bureau's Current
+Population Survey Annual Social and Economic Supplement (CPS ASEC) into
+PolicyEngine's US microdata pipeline (`census_cps.py`, `cps.py`,
+`enhanced_cps.py`, `extended_cps.py`, `small_enhanced_cps.py`, `takeup.py`,
+and `tipped_occupation.py`).
+
+The CPS ASEC is the Census Bureau / Bureau of Labor Statistics' primary
+source of annual demographic and income data for the US civilian
+noninstitutional population. PolicyEngine uses it as the demographic
+backbone of the Enhanced CPS; tax-return detail from the IRS PUF is then
+merged onto each CPS record.
+
+## Documentation
+
+The Census Bureau publishes a data dictionary and technical documentation
+for each ASEC vintage. These are the canonical reference for every
+variable name, code, and SPM/tax-unit construction used by the code in
+this folder:
+
+- [2023 ASEC data dictionary (full PDF)](https://www2.census.gov/programs-surveys/cps/datasets/2023/march/asec2023_ddl_pub_full.pdf)
+- [2024 ASEC data dictionary (full PDF)](https://www2.census.gov/programs-surveys/cps/datasets/2024/march/asec2024_ddl_pub_full.pdf)
+- [2025 ASEC data dictionary (full PDF)](https://www2.census.gov/programs-surveys/cps/datasets/2025/march/asec2025_ddl_pub_full.pdf)
+
+See also:
+
+- [CPS ASEC landing page](https://www.census.gov/programs-surveys/cps.html)
+- [CPS ASEC technical documentation](https://www.census.gov/programs-surveys/cps/technical-documentation.html)
+- [CPS ASEC public-use microdata datasets](https://www.census.gov/data/datasets/time-series/demo/cps/cps-asec.html)
+
+The exact Census URLs the pipeline downloads for each ASEC year are
+enumerated in `CPS_URL_BY_YEAR` inside `census_cps.py`.
+
+## Data products in this folder
+
+- `census_cps.py` — downloads and stages the raw ASEC person/family/
+  household tables from Census for a given ASEC year.
+- `cps.py` — derives the PolicyEngine `CPS` dataset (PolicyEngine variable
+  names, entity structure, SPM units, tax units) from the Census tables.
+- `enhanced_cps.py`, `extended_cps.py`, `small_enhanced_cps.py` —
+  downstream enhanced datasets that merge PUF-based tax-return detail and
+  imputed variables onto the CPS backbone.
+- `takeup.py` — program take-up anchoring against reported CPS recipiency.
+- `tipped_occupation.py` — Treasury tipped-occupation code derivation.
+- `imputation_parameters.yaml` — hyperparameters for QRF imputations used
+  by the enhanced CPS pipeline.

--- a/policyengine_us_data/datasets/org/README.md
+++ b/policyengine_us_data/datasets/org/README.md
@@ -1,0 +1,38 @@
+# CPS Outgoing Rotation Group (ORG)
+
+This folder contains the tooling that builds a labor-market donor frame
+from the CPS basic monthly public-use files (`org.py`).
+
+The CPS Outgoing Rotation Group (ORG) earnings questions are asked only
+of the one-quarter of the sample that is rotating out in a given month.
+Pooling the twelve monthly ORG samples for a year yields a donor frame
+PolicyEngine uses to impute wage, hourly-pay, and union variables onto
+the CPS ASEC records.
+
+The checked-in code does not vendor the donor file itself. Instead,
+`org.py` builds `census_cps_org_2024_wages.csv.gz` on demand by
+downloading the twelve official CPS basic monthly public-use CSVs for
+`ORG_YEAR` (currently 2024) directly from the Census Bureau and filtering
+each file to the ORG rotations.
+
+## Documentation
+
+The Census Bureau and BLS publish a data dictionary and users' guide for
+the CPS basic monthly public-use microdata. These are the canonical
+reference for every variable name and earnings-recipiency code used by
+the code in this folder:
+
+- [2024 CPS basic monthly public-use record layout (TXT)](https://www2.census.gov/programs-surveys/cps/datasets/2024/basic/2024_Basic_CPS_Public_Use_Record_Layout_plus_IO_Code_list.txt)
+- [CPS basic monthly documentation landing page](https://www.census.gov/data/datasets/time-series/demo/cps/cps-basic.html)
+
+See also:
+
+- [CPS technical documentation](https://www.census.gov/programs-surveys/cps/technical-documentation.html)
+
+## Data products in this folder
+
+- `org.py` — downloads the twelve monthly CSVs, filters to the MIS-4 and
+  MIS-8 outgoing rotations (`HRMIS`), and caches the combined ORG donor
+  frame. Trains a QRF model to impute `wage_income`, `hourly_wage`, and
+  union-coverage variables onto the CPS ASEC records used by the
+  Enhanced CPS pipeline.

--- a/policyengine_us_data/datasets/scf/README.md
+++ b/policyengine_us_data/datasets/scf/README.md
@@ -1,0 +1,33 @@
+# Survey of Consumer Finances (SCF)
+
+This folder contains the tooling that ingests the Federal Reserve Board's
+Survey of Consumer Finances (SCF) summary extract into PolicyEngine's US
+microdata pipeline (`fed_scf.py`, `scf.py`).
+
+The SCF is the Fed's triennial household-level survey of wealth, debt,
+and income. PolicyEngine uses the summary extract to inform net-worth
+and asset-related calibration targets.
+
+## Documentation
+
+The Federal Reserve Board publishes a codebook for each SCF survey wave
+describing every summary variable, derivation, and weight. These are the
+canonical reference for the code in this folder:
+
+- [2022 SCF main-survey codebook (TXT)](https://www.federalreserve.gov/econres/files/codebk2022.txt)
+- [2019 SCF main-survey codebook (TXT)](https://www.federalreserve.gov/econres/files/codebk2019.txt)
+- [2016 SCF main-survey codebook (TXT)](https://www.federalreserve.gov/econres/files/codebk2016.txt)
+- [SCF summary-extract variable-definition macro (bulletin.macro.txt)](https://www.federalreserve.gov/econres/files/bulletin.macro.txt)
+
+See also:
+
+- [SCF landing page](https://www.federalreserve.gov/econres/scfindex.htm)
+- [SCF documentation (working papers, methodology)](https://www.federalreserve.gov/econres/scf-documentation.htm)
+
+## Data products in this folder
+
+- `fed_scf.py` — downloads the Fed's SAS summary-extract ZIPs
+  (`SummarizedFedSCF_2016`, `SummarizedFedSCF_2019`, `SummarizedFedSCF_2022`)
+  and reads them into a pandas DataFrame.
+- `scf.py` — wraps the raw summary extract in a PolicyEngine `Dataset`
+  (`SCF`) with the standard ARRAYS format used downstream.

--- a/policyengine_us_data/datasets/sipp/README.md
+++ b/policyengine_us_data/datasets/sipp/README.md
@@ -1,0 +1,41 @@
+# Survey of Income and Program Participation (SIPP)
+
+This folder contains the tooling that uses the Census Bureau's Survey of
+Income and Program Participation (SIPP) as a donor source for imputations
+onto the CPS (`sipp.py`).
+
+PolicyEngine currently uses SIPP to train QRF imputation models for
+tip income (using the SIPP job-level tip-amount columns) and for
+household-level asset categories (bank, stock, bond, vehicle). These
+models are then applied to the CPS-based Enhanced CPS to obtain
+person-level tip income and household-level countable resources that the
+CPS itself does not capture.
+
+## Documentation
+
+The Census Bureau publishes a users' guide and data dictionary for each
+SIPP panel wave. These are the canonical reference for every variable
+name, value code, and weighting construct used by the code in this
+folder:
+
+- [SIPP 2023 public-use data dictionary (PDF)](https://www2.census.gov/programs-surveys/sipp/tech-documentation/data-dictionaries/2023/2023_SIPP_Data_Dictionary.pdf)
+- [SIPP 2023 users' guide (PDF, Aug 2026 revision)](https://www2.census.gov/programs-surveys/sipp/tech-documentation/methodology/2023_SIPP_Users_Guide_AUG26.pdf)
+
+See also:
+
+- [SIPP landing page](https://www.census.gov/programs-surveys/sipp.html)
+- [SIPP technical documentation](https://www.census.gov/programs-surveys/sipp/tech-documentation.html)
+- [SIPP public-use datasets](https://www.census.gov/programs-surveys/sipp/data/datasets.html)
+
+## Data products in this folder
+
+- `sipp.py` — trains and caches QRF imputation models (`get_tip_model`,
+  `get_asset_model`, `get_vehicle_model`) from SIPP 2023 person-month
+  data. The training frame is filtered to `MONTHCODE == 12` (December)
+  so every row represents one person-year rather than twelve annualized
+  months.
+
+The raw SIPP CSVs (`pu2023.csv` and the slim variant `pu2023_slim.csv`)
+are mirrored on the `PolicyEngine/policyengine-us-data` HuggingFace model
+repo and downloaded on demand when a training run is needed. They are
+not vendored in this Git repository.


### PR DESCRIPTION
## Summary

- Adds `README.md` files to `policyengine_us_data/datasets/{cps,sipp,scf,org}/` following the style of the existing `acs/README.md` and `puf/README.md` (the latter added in #789).
- Each README links to the canonical codebook / data dictionary / user's guide for the underlying source (Census Bureau CPS ASEC & SIPP & basic-monthly, Federal Reserve Board SCF) and briefly describes what the folder's Python modules produce.

Closes #221.

## Test plan

- [x] All URLs manually curled and returned HTTP 200 (CPS ASEC 2023/2024/2025, SIPP 2023 data dictionary + users' guide AUG26, SCF 2016/2019/2022 main-survey codebooks + bulletin.macro.txt, CPS basic 2024 record layout, landing pages).
- [ ] Docs build workflow passes (Markdown-only change under `policyengine_us_data/datasets/`).
