### PR TITLE
Impute selected_marketplace_plan_benchmark_ratio from CPS premiums

### DIFF
--- a/changelog.d/marketplace-plan-benchmark-ratio.added.md
+++ b/changelog.d/marketplace-plan-benchmark-ratio.added.md
@@ -1,0 +1,1 @@
+Added a Marketplace plan benchmark ratio imputation that populates `selected_marketplace_plan_benchmark_ratio` per tax unit by backing out the implied plan cost from CPS-reported private health premiums and PolicyEngine-computed PTC.

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -482,17 +482,23 @@ def add_marketplace_plan_benchmark_ratio(self):
     from policyengine_us import Microsimulation
 
     baseline = Microsimulation(dataset=self)
+    period = self.time_period
 
-    slcsp = baseline.calculate("slcsp", map_to="tax_unit").values
-    aca_ptc = baseline.calculate("aca_ptc", map_to="tax_unit").values
+    slcsp = baseline.calculate("slcsp", map_to="tax_unit", period=period).values
+    aca_ptc = baseline.calculate("aca_ptc", map_to="tax_unit", period=period).values
     reported_premium = baseline.calculate(
         "health_insurance_premiums_without_medicare_part_b",
         map_to="tax_unit",
+        period=period,
     ).values
-    takes_up_aca = baseline.calculate(
-        "takes_up_aca_if_eligible",
-        map_to="tax_unit",
-    ).values.astype(bool)
+    takes_up_aca = (
+        baseline.calculate(
+            "takes_up_aca_if_eligible",
+            map_to="tax_unit",
+            period=period,
+        )
+        .values.astype(bool)
+    )
 
     data["selected_marketplace_plan_benchmark_ratio"] = (
         compute_marketplace_plan_benchmark_ratio(

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -181,6 +181,8 @@ class CPS(Dataset):
         self.save_dataset(cps)
         logging.info("Adding takeup")
         add_takeup(self)
+        logging.info("Imputing Marketplace plan benchmark ratio")
+        add_marketplace_plan_benchmark_ratio(self)
         logging.info("Downsampling")
 
         # Downsample
@@ -446,6 +448,103 @@ def add_takeup(self):
     )
 
     self.save_dataset(data)
+
+
+def add_marketplace_plan_benchmark_ratio(self):
+    """Impute `selected_marketplace_plan_benchmark_ratio` per tax unit.
+
+    PolicyEngine-US's ACA PTC formulas assume the selected Marketplace plan
+    costs exactly the Second Lowest Cost Silver Plan (SLCSP). That under- or
+    over-states household out-of-pocket premium for the ~50% of Marketplace
+    enrollees who select Bronze or Gold / Platinum plans instead.
+
+    For tax units that CPS flags as taking up Marketplace coverage, back out
+    the implied plan-to-SLCSP ratio from:
+
+        reported_net_premium   ≈ selected_plan_cost − APTC
+        selected_plan_cost      = SLCSP × benchmark_ratio
+        → benchmark_ratio       = (reported_net_premium + computed_PTC) / SLCSP
+
+    The CPS private-health-premium field is net of APTC for subsidized
+    enrollees, so adding back PolicyEngine's computed PTC recovers the
+    sticker cost. Non-Marketplace tax units keep the default 1.0; the
+    ratio is only consumed through `selected_marketplace_plan_premium_proxy`,
+    which is zero when `takes_up_aca_if_eligible` is false, so the default
+    value does not affect their downstream calculations.
+
+    Ratios are clipped to [0.5, 1.5] to handle CPS reporting noise and
+    Marketplace-flag false positives. Outliers usually indicate the
+    household reported a private or employer premium rather than a true
+    Marketplace plan.
+    """
+    data = self.load_dataset()
+
+    from policyengine_us import Microsimulation
+
+    baseline = Microsimulation(dataset=self)
+
+    slcsp = baseline.calculate("slcsp", map_to="tax_unit").values
+    aca_ptc = baseline.calculate("aca_ptc", map_to="tax_unit").values
+    reported_premium = baseline.calculate(
+        "health_insurance_premiums_without_medicare_part_b",
+        map_to="tax_unit",
+    ).values
+    takes_up_aca = baseline.calculate(
+        "takes_up_aca_if_eligible",
+        map_to="tax_unit",
+    ).values.astype(bool)
+
+    data["selected_marketplace_plan_benchmark_ratio"] = (
+        compute_marketplace_plan_benchmark_ratio(
+            reported_premium=reported_premium,
+            aca_ptc=aca_ptc,
+            slcsp=slcsp,
+            takes_up_aca=takes_up_aca,
+        )
+    )
+
+    self.save_dataset(data)
+
+
+MARKETPLACE_PLAN_BENCHMARK_RATIO_MIN = 0.5
+MARKETPLACE_PLAN_BENCHMARK_RATIO_MAX = 1.5
+
+
+def compute_marketplace_plan_benchmark_ratio(
+    reported_premium: np.ndarray,
+    aca_ptc: np.ndarray,
+    slcsp: np.ndarray,
+    takes_up_aca: np.ndarray,
+) -> np.ndarray:
+    """Back out the Marketplace plan-to-SLCSP ratio per tax unit.
+
+    Returns 1.0 for tax units that don't take up Marketplace coverage or that
+    have no SLCSP (zero benchmark). Ratios for Marketplace takers are clipped
+    to ``[MARKETPLACE_PLAN_BENCHMARK_RATIO_MIN, MARKETPLACE_PLAN_BENCHMARK_RATIO_MAX]``.
+
+    Args:
+        reported_premium: CPS-reported annual private health insurance premium
+            (net of APTC for subsidized Marketplace takers), at the tax-unit
+            level in USD.
+        aca_ptc: PolicyEngine-computed annual advance premium tax credit at
+            the tax-unit level in USD.
+        slcsp: Second Lowest Cost Silver Plan annual premium at the tax-unit
+            level in USD.
+        takes_up_aca: Boolean array at the tax-unit level, True when the
+            household is modeled as taking up Marketplace coverage.
+
+    Returns:
+        Array of benchmark ratios (unitless), same shape as the inputs.
+    """
+    with np.errstate(divide="ignore", invalid="ignore"):
+        raw = (reported_premium + aca_ptc) / np.where(slcsp > 0, slcsp, 1.0)
+    clipped = np.clip(
+        raw,
+        MARKETPLACE_PLAN_BENCHMARK_RATIO_MIN,
+        MARKETPLACE_PLAN_BENCHMARK_RATIO_MAX,
+    )
+    applicable = takes_up_aca.astype(bool) & (slcsp > 0)
+    return np.where(applicable, clipped, 1.0)
 
 
 def uprate_cps_data(data, from_period, to_period):

--- a/tests/unit/datasets/test_marketplace_plan_benchmark_ratio.py
+++ b/tests/unit/datasets/test_marketplace_plan_benchmark_ratio.py
@@ -1,0 +1,113 @@
+"""Unit tests for the Marketplace plan benchmark ratio back-out."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from policyengine_us_data.datasets.cps.cps import (
+    MARKETPLACE_PLAN_BENCHMARK_RATIO_MAX,
+    MARKETPLACE_PLAN_BENCHMARK_RATIO_MIN,
+    compute_marketplace_plan_benchmark_ratio,
+)
+
+
+def test_silver_plan_back_out_yields_unit_ratio() -> None:
+    reported_premium = np.array([2_000.0])
+    aca_ptc = np.array([4_000.0])
+    slcsp = np.array([6_000.0])
+    takes_up_aca = np.array([True])
+
+    result = compute_marketplace_plan_benchmark_ratio(
+        reported_premium=reported_premium,
+        aca_ptc=aca_ptc,
+        slcsp=slcsp,
+        takes_up_aca=takes_up_aca,
+    )
+
+    np.testing.assert_allclose(result, [1.0])
+
+
+def test_bronze_plan_back_out_yields_sub_silver_ratio() -> None:
+    reported_premium = np.array([800.0])
+    aca_ptc = np.array([4_000.0])
+    slcsp = np.array([6_000.0])
+    takes_up_aca = np.array([True])
+
+    result = compute_marketplace_plan_benchmark_ratio(
+        reported_premium=reported_premium,
+        aca_ptc=aca_ptc,
+        slcsp=slcsp,
+        takes_up_aca=takes_up_aca,
+    )
+
+    np.testing.assert_allclose(result, [0.8])
+
+
+def test_gold_plan_back_out_yields_above_silver_ratio() -> None:
+    reported_premium = np.array([3_500.0])
+    aca_ptc = np.array([4_000.0])
+    slcsp = np.array([6_000.0])
+    takes_up_aca = np.array([True])
+
+    result = compute_marketplace_plan_benchmark_ratio(
+        reported_premium=reported_premium,
+        aca_ptc=aca_ptc,
+        slcsp=slcsp,
+        takes_up_aca=takes_up_aca,
+    )
+
+    np.testing.assert_allclose(result, [1.25])
+
+
+def test_non_marketplace_households_keep_default_ratio() -> None:
+    reported_premium = np.array([500.0, 2_000.0])
+    aca_ptc = np.array([0.0, 0.0])
+    slcsp = np.array([5_000.0, 6_000.0])
+    takes_up_aca = np.array([False, False])
+
+    result = compute_marketplace_plan_benchmark_ratio(
+        reported_premium=reported_premium,
+        aca_ptc=aca_ptc,
+        slcsp=slcsp,
+        takes_up_aca=takes_up_aca,
+    )
+
+    np.testing.assert_allclose(result, [1.0, 1.0])
+
+
+def test_zero_slcsp_returns_default_ratio_even_for_marketplace_taker() -> None:
+    reported_premium = np.array([1_000.0])
+    aca_ptc = np.array([0.0])
+    slcsp = np.array([0.0])
+    takes_up_aca = np.array([True])
+
+    result = compute_marketplace_plan_benchmark_ratio(
+        reported_premium=reported_premium,
+        aca_ptc=aca_ptc,
+        slcsp=slcsp,
+        takes_up_aca=takes_up_aca,
+    )
+
+    np.testing.assert_allclose(result, [1.0])
+
+
+def test_ratios_are_clipped_to_configured_window() -> None:
+    reported_premium = np.array([0.0, 10_000.0])
+    aca_ptc = np.array([0.0, 0.0])
+    slcsp = np.array([6_000.0, 6_000.0])
+    takes_up_aca = np.array([True, True])
+
+    result = compute_marketplace_plan_benchmark_ratio(
+        reported_premium=reported_premium,
+        aca_ptc=aca_ptc,
+        slcsp=slcsp,
+        takes_up_aca=takes_up_aca,
+    )
+
+    np.testing.assert_allclose(
+        result,
+        [
+            MARKETPLACE_PLAN_BENCHMARK_RATIO_MIN,
+            MARKETPLACE_PLAN_BENCHMARK_RATIO_MAX,
+        ],
+    )


### PR DESCRIPTION
Closes #800.

## Problem

\`selected_marketplace_plan_benchmark_ratio\` in policyengine-us is currently an input variable with \`default_value = 1.0\`. Nothing populates it, so PolicyEngine-US effectively assumes every Marketplace enrollee picks the benchmark silver plan. Real CMS data shows ~35% pick bronze and ~15% pick gold/platinum — the rules-based \`marketplace_net_premium\` (PolicyEngine/policyengine-us#8105) overstates OOP for bronze pickers and understates for gold pickers.

## Approach — CPS premium back-out

For each Marketplace-enrolled tax unit in CPS, back out the implied plan-to-SLCSP ratio from the accounting identity:

\`\`\`
reported_net_premium  ≈ selected_plan_cost − APTC
selected_plan_cost     = SLCSP × benchmark_ratio
→ benchmark_ratio      = (reported_net_premium + computed_PTC) / SLCSP
\`\`\`

CPS-reported premium is net of APTC for subsidized Marketplace takers, so adding back PolicyEngine's computed PTC recovers the sticker price. Dividing by SLCSP gives the ratio.

Ratios clipped to \`[0.5, 1.5]\` to handle reporting noise and Marketplace-flag false positives.

## Changes

- **New pure-function helper** \`compute_marketplace_plan_benchmark_ratio\` in \`policyengine_us_data/datasets/cps/cps.py\` — all the math, no Microsimulation, unit-testable.
- **New CPS-stage function** \`add_marketplace_plan_benchmark_ratio\` that loads the dataset, runs a Microsimulation to pull SLCSP / ACA PTC / reported premium / takeup, and writes the ratio back.
- Called in \`generate()\` immediately after \`add_takeup\` and before downsampling.
- **6 unit tests** covering silver / bronze / gold / non-taker / zero-SLCSP / clipping cases — synthetic inputs only, no H5 dependency.

## Relationship to #618

#618 (open, by @daphnehanse11) adds **state-level calibration targets** for total APTC-taking Marketplace tax units and the bronze-plan subset, from CMS 2024 OEP data. That constrains the aggregate weighted distribution.

This PR is complementary — it sets the **per-household ratio** so each household's computed \`marketplace_net_premium\` reflects the plan they actually picked. After both land, the state-level targets from #618 can validate that the aggregated ratio distribution lines up with CMS effectuated-plan metal shares.

## Caveats

- **Marketplace flag noise**: CPS respondents sometimes confuse Marketplace with employer / Medicaid coverage. The \`takes_up_aca_if_eligible\` gate filters most, and the [0.5, 1.5] clip catches the rest.
- **CSR silver variants**: cost-sharing-reduction silver plans have the same sticker premium but reduced deductibles/copays. The back-out correctly lands on ratio ≈ 1.0; plan-value differences are a separate MOOP question.
- **Non-takers / zero SLCSP**: keep the 1.0 default. These paths are zeroed out downstream by \`takes_up_aca_if_eligible\` gating inside \`selected_marketplace_plan_premium_proxy\`, so the default never leaks into calculated OOP.

## Testing

\`uv run pytest tests/unit/datasets/test_marketplace_plan_benchmark_ratio.py -v\` → **6/6 pass**.

## Test plan

- [x] Unit tests pass
- [x] \`ruff check\` clean on new code (pre-existing unrelated errors in cps.py are unchanged)
- [ ] CI passes
- [ ] Integration: verify weighted ratio distribution across Enhanced CPS approximately matches CMS metal-tier shares (manual check after data build)