### PR TITLE
Reformat cps.py to satisfy ruff format

### DIFF
--- a/changelog.d/fix-cps-py-formatting.fixed.md
+++ b/changelog.d/fix-cps-py-formatting.fixed.md
@@ -1,0 +1,1 @@
+Reformat `policyengine_us_data/datasets/cps/cps.py` to satisfy `ruff format` (unblocks the lint job that was failing on every PR).

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -491,14 +491,11 @@ def add_marketplace_plan_benchmark_ratio(self):
         map_to="tax_unit",
         period=period,
     ).values
-    takes_up_aca = (
-        baseline.calculate(
-            "takes_up_aca_if_eligible",
-            map_to="tax_unit",
-            period=period,
-        )
-        .values.astype(bool)
-    )
+    takes_up_aca = baseline.calculate(
+        "takes_up_aca_if_eligible",
+        map_to="tax_unit",
+        period=period,
+    ).values.astype(bool)
 
     data["selected_marketplace_plan_benchmark_ratio"] = (
         compute_marketplace_plan_benchmark_ratio(


### PR DESCRIPTION
## Summary
- `policyengine_us_data/datasets/cps/cps.py` drifted out of `ruff format` canonical form, which is failing the `lint` job on every open PR (and on `push.yaml` for `main`).
- Apply `ruff format` to bring it back into compliance.

## Test plan
- [x] `ruff format --check policyengine_us_data/datasets/cps/cps.py` passes locally
- [ ] CI lint job passes
