### PR TITLE
Clarify SIPP is public-use; only IRS-PUF is access-restricted

### DIFF
--- a/changelog.d/correct-sipp-licensing-language.fixed.md
+++ b/changelog.d/correct-sipp-licensing-language.fixed.md
@@ -1,0 +1,1 @@
+Clarified SIPP licensing language in `policyengine_us_data/datasets/sipp/README.md`: SIPP public-use data is unrestricted (no per-user license, agreement, or registration). Of the six upstream microdata sources the Enhanced CPS pipeline ingests (CPS, ACS, SCF, ORG, SIPP, IRS-PUF), only IRS-PUF has a genuine access restriction. Fixes #808.

--- a/policyengine_us_data/datasets/sipp/README.md
+++ b/policyengine_us_data/datasets/sipp/README.md
@@ -39,3 +39,22 @@ The raw SIPP CSVs (`pu2023.csv` and the slim variant `pu2023_slim.csv`)
 are mirrored on the `PolicyEngine/policyengine-us-data` HuggingFace model
 repo and downloaded on demand when a training run is needed. They are
 not vendored in this Git repository.
+
+## Licensing
+
+SIPP public-use files are, as the name implies, **public-use data** — no
+per-user license, data-use agreement, or registration is required to
+download or redistribute them. We mirror them on our HuggingFace model
+repo purely as a caching convenience (Census's own hosting is slow and
+occasionally unavailable), not to work around any access restriction.
+
+This matters because PolicyEngine's enhanced CPS pipeline ingests several
+different upstream microdata sources, and only **one** of them —
+**IRS Public Use File (PUF)** — has any genuine access restriction. PUF
+requires agreeing to IRS's terms of use before download, even though the
+file is itself intended for public release. CPS, ACS, SCF, ORG, and SIPP
+are all unrestricted public-use. If you are writing about the pipeline's
+licensing posture (for a paper, replication packet, or TRACE TRO), only
+IRS-PUF should appear in the restricted column.
+
+See issue #808 for the background on this correction.


### PR DESCRIPTION
## Summary
- Adds a \`Licensing\` section to \`policyengine_us_data/datasets/sipp/README.md\` clarifying that SIPP public-use data has no per-user license, agreement, or registration requirement.
- Of the six upstream microdata sources the Enhanced CPS pipeline ingests (CPS, ACS, SCF, ORG, SIPP, IRS-PUF), **only IRS-PUF** has a genuine access restriction.
- Makes it explicit that our HuggingFace mirror of \`pu2023.csv\` is a caching convenience, not an access-restriction workaround.

## Why
At the 2026-04-21 meeting with Lars Vilhuber (AEA Data Editor), John Sabelhaus, and the TRACE team, John (who co-built the Sabelhaus subsynthetic beta) corrected a claim Max had been making: that SIPP requires individual user licensing. The actual SIPP vintage we use is Census public-use SIPP; the subsynthetic beta is separate. Both are effectively unrestricted. Overstating restrictions matters because it distorts which pipeline inputs genuinely warrant institutional-certification framing under TRACE.

No pipeline or ingest code changes; this is purely a docs guardrail to prevent regressions in external-communication writeups.

## Test plan
- [x] \`grep\` for SIPP / licensing claims across the repo — no existing misclaims to fix
- [ ] Render the README to confirm the new Licensing section formats correctly

Fixes #808.

🤖 Generated with [Claude Code](https://claude.com/claude-code)