### PR TITLE
Construct CPS tax units from household records

### DIFF
--- a/policyengine_us_data/datasets/cps/census_cps.py
+++ b/policyengine_us_data/datasets/cps/census_cps.py
@@ -5,6 +5,9 @@ from io import BytesIO
 from zipfile import ZipFile
 import pandas as pd
 from policyengine_us_data.storage import STORAGE_FOLDER
+from policyengine_us_data.datasets.cps.tax_unit_construction import (
+    construct_tax_units,
+)
 
 
 OPTIONAL_PERSON_COLUMNS = {
@@ -26,6 +29,7 @@ OPTIONAL_PERSON_COLUMNS = {
     "NOW_CHAMPVA",
     "NOW_VACARE",
     "NOW_IHSFLG",
+    "PTOTVAL",
 }
 
 
@@ -58,6 +62,9 @@ class CensusCPS(Dataset):
 
     time_period: int
     """Year of the dataset."""
+
+    tax_unit_construction_mode: str = "policyengine"
+    """Mode used when constructing tax units from CPS person records."""
 
     def generate(self):
         if self._cps_download_url is None:
@@ -117,6 +124,7 @@ class CensusCPS(Dataset):
                         usecols=person_usecols,
                     ).fillna(0)
                 person = _fill_missing_optional_person_columns(person)
+                tax_unit = self._create_tax_unit_table(person)
                 storage["person"] = person
                 with zipfile.open(f"{file_prefix}ffpub{file_year_code}.csv") as f:
                     person_family_id = person.PH_SEQ * 10 + person.PF_SEQ
@@ -130,7 +138,7 @@ class CensusCPS(Dataset):
                     household_id = household.H_SEQ
                     household = household[household_id.isin(person_household_id)]
                     storage["household"] = household
-                storage["tax_unit"] = self._create_tax_unit_table(person)
+                storage["tax_unit"] = tax_unit
                 storage["spm_unit"] = self._create_spm_unit_table(
                     person, self.time_period
                 )
@@ -139,10 +147,20 @@ class CensusCPS(Dataset):
     def _cps_download_url(self) -> str:
         return CPS_URL_BY_YEAR.get(self.time_period)
 
-    def _create_tax_unit_table(self, person: pd.DataFrame) -> pd.DataFrame:
-        tax_unit_df = person[TAX_UNIT_COLUMNS].groupby(person.TAX_ID).sum()
-        tax_unit_df["TAX_ID"] = tax_unit_df.index
-        return tax_unit_df
+    def _create_tax_unit_table(
+        self,
+        person: pd.DataFrame,
+        mode: str | None = None,
+    ) -> pd.DataFrame:
+        person["CENSUS_TAX_ID"] = person["TAX_ID"]
+        mode = mode or self.tax_unit_construction_mode
+        constructed_person, tax_unit_df = construct_tax_units(
+            person=person,
+            year=self.time_period,
+            mode=mode,
+        )
+        person["TAX_ID"] = constructed_person["TAX_ID"].values
+        return tax_unit_df[["TAX_ID"]]
 
     def _create_spm_unit_table(
         self, person: pd.DataFrame, time_period: int
@@ -282,12 +300,18 @@ PERSON_COLUMNS = [
     "PF_SEQ",
     "P_SEQ",
     "TAX_ID",
+    "PECOHAB",
     "SPM_ID",
     "A_FNLWGT",
     "A_LINENO",
     "A_SPOUSE",
+    "A_EXPRRP",
+    "A_FAMREL",
+    "A_FAMTYP",
     "A_AGE",
     "A_SEX",
+    "A_ENRLW",
+    "A_FTPT",
     "PEDISEYE",
     "NOW_COV",
     "NOW_DIR",
@@ -318,6 +342,7 @@ PERSON_COLUMNS = [
     "LKWEEKS",  # Weeks looking for work during the year (Census variable)
     "ANN_VAL",
     "PNSN_VAL",
+    "PTOTVAL",
     "OI_OFF",
     "OI_VAL",
     "CSP_VAL",

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -3,7 +3,16 @@ from importlib.resources import files
 from policyengine_core.data import Dataset
 from policyengine_us_data.storage import STORAGE_FOLDER, DOCS_FOLDER
 import h5py
-from policyengine_us_data.datasets.cps.census_cps import *
+from policyengine_us_data.datasets.cps.census_cps import (
+    CensusCPS,
+    CensusCPS_2018,
+    CensusCPS_2019,
+    CensusCPS_2020,
+    CensusCPS_2021,
+    CensusCPS_2022,
+    CensusCPS_2023,
+    CensusCPS_2024,
+)
 from pandas import DataFrame, Series
 import numpy as np
 import pandas as pd
@@ -138,6 +147,7 @@ class CPS(Dataset):
             person, tax_unit, family, spm_unit, household = [
                 raw_data[entity] for entity in ENTITIES
             ]
+        _validate_raw_cps_schema(person, tax_unit, self.raw_cps.name)
 
         logging.info("Adding ID variables")
         add_id_variables(cps, person, tax_unit, family, spm_unit, household)
@@ -562,6 +572,33 @@ def uprate_cps_data(data, from_period, to_period):
     return data
 
 
+def _validate_raw_cps_schema(
+    person: DataFrame,
+    tax_unit: DataFrame,
+    raw_cps_name: str,
+) -> None:
+    required_person_columns = {
+        "CENSUS_TAX_ID",
+    }
+    required_tax_unit_columns = set()
+
+    missing_person = sorted(required_person_columns - set(person.columns))
+    missing_tax_unit = sorted(required_tax_unit_columns - set(tax_unit.columns))
+    if not missing_person and not missing_tax_unit:
+        return
+
+    missing_parts = []
+    if missing_person:
+        missing_parts.append("person: " + ", ".join(missing_person))
+    if missing_tax_unit:
+        missing_parts.append("tax_unit: " + ", ".join(missing_tax_unit))
+
+    raise ValueError(
+        f"Raw CPS dataset {raw_cps_name} is stale and must be regenerated; "
+        f"missing constructed tax-unit columns ({'; '.join(missing_parts)})."
+    )
+
+
 def add_id_variables(
     cps: h5py.File,
     person: DataFrame,
@@ -717,8 +754,12 @@ def add_personal_variables(cps: h5py.File, person: DataFrame) -> None:
     cps["is_surviving_spouse"] = person.A_MARITL == 4
     cps["is_separated"] = person.A_MARITL == 6
     # High school or college/university enrollment status.
-    cps["is_full_time_college_student"] = person.A_HSCOL == 2
-
+    if "A_FTPT" in person.columns:
+        cps["is_full_time_college_student"] = (person.A_HSCOL == 2) & (
+            person.A_FTPT == 1
+        )
+    else:
+        cps["is_full_time_college_student"] = person.A_HSCOL == 2
     cps["detailed_occupation_recode"] = person.POCCU2
     cps["treasury_tipped_occupation_code"] = derive_treasury_tipped_occupation_code(
         person.PEIOOCC

--- a/policyengine_us_data/datasets/cps/tax_unit_construction.py
+++ b/policyengine_us_data/datasets/cps/tax_unit_construction.py
@@ -1,0 +1,822 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from policyengine_us_data.datasets.cps.tax_unit_rule_helpers import (
+    REFERENCE_PERSON_CODES,
+    dependent_gross_income_limit,
+    qualifying_child_age_test,
+    reference_relationship_allows_qualifying_child,
+    reference_relationship_allows_qualifying_relative,
+    related_to_head_or_spouse as reference_related_to_head_or_spouse,
+)
+
+
+HEAD = "HEAD"
+SPOUSE = "SPOUSE"
+DEPENDENT = "DEPENDENT"
+
+POLICYENGINE_MODE = "policyengine"
+CENSUS_DOCUMENTED_MODE = "census_documented"
+SUPPORTED_TAX_UNIT_CONSTRUCTION_MODES = frozenset(
+    {
+        POLICYENGINE_MODE,
+        CENSUS_DOCUMENTED_MODE,
+    }
+)
+
+
+@dataclass(frozen=True)
+class _HouseholdPerson:
+    index: int
+    household_id: int
+    line_no: int
+    age: int
+    relationship_code: int | None
+    marital_status: int
+    spouse_line: int | None
+    parent_lines: tuple[int, ...]
+    gross_income: float
+    claimant_income: float
+    total_money_income: float
+    is_full_time_student: bool
+    is_permanently_disabled: bool
+
+    @property
+    def starts_base_unit(self) -> bool:
+        return self.age >= 18 or self.marital_status in {1, 2, 3, 4, 5, 6}
+
+    @property
+    def married_spouse_present(self) -> bool:
+        return self.marital_status in {1, 2} and self.spouse_line is not None
+
+
+@dataclass
+class _BaseTaxUnit:
+    key: tuple
+    household_id: int
+    head_index: int
+    spouse_index: int | None = None
+    claimant_lines: tuple[int, ...] = ()
+    claimant_income: float = 0.0
+    total_money_income: float = 0.0
+    head_age: int = 0
+
+
+@dataclass(frozen=True)
+class _ClaimCandidate:
+    unit_key: tuple
+    priority: int
+    score: tuple[Any, ...]
+
+
+def _to_optional_positive_int(value) -> int | None:
+    if pd.isna(value):
+        return None
+    value = int(value)
+    return value if value > 0 else None
+
+
+def _to_optional_parent_line(value) -> int | None:
+    if pd.isna(value):
+        return None
+    value = int(value)
+    return value if value > 0 else None
+
+
+def _positive_series(person: pd.DataFrame, column: str) -> np.ndarray:
+    if column not in person:
+        return np.zeros(len(person), dtype=float)
+    values = pd.to_numeric(person[column], errors="coerce").fillna(0).to_numpy(
+        dtype=float,
+        copy=False,
+    )
+    return np.maximum(values, 0)
+
+
+def estimate_dependent_gross_income(person: pd.DataFrame) -> np.ndarray:
+    return (
+        _positive_series(person, "WSAL_VAL")
+        + _positive_series(person, "SEMP_VAL")
+        + _positive_series(person, "FRSE_VAL")
+        + _positive_series(person, "INT_VAL")
+        + _positive_series(person, "DIV_VAL")
+        + _positive_series(person, "RNT_VAL")
+        + _positive_series(person, "CAP_VAL")
+        + _positive_series(person, "UC_VAL")
+        + _positive_series(person, "OI_VAL")
+        + _positive_series(person, "ANN_VAL")
+        + _positive_series(person, "PNSN_VAL")
+    )
+
+
+def _estimate_claimant_income(person: pd.DataFrame) -> np.ndarray:
+    return estimate_dependent_gross_income(person) + _positive_series(person, "SS_VAL")
+
+
+def _prepare_household_people(
+    household: pd.DataFrame,
+    household_id: int,
+) -> list[_HouseholdPerson]:
+    disability_flags = ["PEDISDRS", "PEDISEAR", "PEDISEYE", "PEDISOUT", "PEDISPHY", "PEDISREM"]
+    gross_income = estimate_dependent_gross_income(household)
+    claimant_income = _estimate_claimant_income(household)
+    total_money_income = (
+        pd.to_numeric(household["PTOTVAL"], errors="coerce")
+        .fillna(0)
+        .to_numpy(dtype=float, copy=False)
+        if "PTOTVAL" in household
+        else claimant_income.copy()
+    )
+    has_disability = (
+        pd.DataFrame(
+            {
+                flag: household[flag] if flag in household else 0
+                for flag in disability_flags
+            },
+            index=household.index,
+        )
+        .eq(1)
+        .any(axis=1)
+        .to_numpy()
+    )
+    enrolled = (
+        household["A_ENRLW"]
+        if "A_ENRLW" in household
+        else pd.Series(0, index=household.index)
+    )
+    full_time = (
+        household["A_FTPT"]
+        if "A_FTPT" in household
+        else pd.Series(0, index=household.index)
+    )
+    school_level = (
+        household["A_HSCOL"]
+        if "A_HSCOL" in household
+        else pd.Series(0, index=household.index)
+    )
+    enrolled_values = pd.to_numeric(enrolled, errors="coerce").fillna(0)
+    full_time_values = pd.to_numeric(full_time, errors="coerce").fillna(0)
+    school_level_values = pd.to_numeric(school_level, errors="coerce").fillna(0)
+    # Limit this to tax-unit construction: CPS TAX_ID behavior treats current
+    # high-school or college enrollment as strong student evidence for young
+    # adults even when the full-time flag is absent or part-time.
+    is_full_time_student = (
+        ((enrolled_values == 1) & (full_time_values == 1))
+        | ((enrolled_values == 1) & school_level_values.isin([1, 2]))
+    ).to_numpy()
+    people = []
+    for row_number, (index, row) in enumerate(household.iterrows()):
+        line_no = int(row["A_LINENO"])
+        parent_lines = tuple(
+            parent
+            for parent in (
+                _to_optional_parent_line(row.get("PEPAR1", 0)),
+                _to_optional_parent_line(row.get("PEPAR2", 0)),
+            )
+            if parent is not None
+        )
+        relationship_code = row.get("A_EXPRRP")
+        if pd.isna(relationship_code):
+            relationship_code = None
+        else:
+            relationship_code = int(relationship_code)
+        people.append(
+            _HouseholdPerson(
+                index=index,
+                household_id=household_id,
+                line_no=line_no,
+                age=int(row["A_AGE"]),
+                relationship_code=relationship_code,
+                marital_status=int(row.get("A_MARITL", 7)),
+                spouse_line=_to_optional_positive_int(row.get("A_SPOUSE", 0)),
+                parent_lines=parent_lines,
+                gross_income=float(gross_income[row_number]),
+                claimant_income=float(claimant_income[row_number]),
+                total_money_income=float(total_money_income[row_number]),
+                is_full_time_student=bool(is_full_time_student[row_number]),
+                is_permanently_disabled=bool(has_disability[row_number]),
+            )
+        )
+    return people
+
+
+def _choose_pair_head(
+    person_a: _HouseholdPerson,
+    person_b: _HouseholdPerson,
+) -> tuple[_HouseholdPerson, _HouseholdPerson]:
+    if person_a.relationship_code in {code.value for code in REFERENCE_PERSON_CODES}:
+        return person_a, person_b
+    if person_b.relationship_code in {code.value for code in REFERENCE_PERSON_CODES}:
+        return person_b, person_a
+    if person_a.age != person_b.age:
+        return (
+            (person_a, person_b)
+            if person_a.age > person_b.age
+            else (person_b, person_a)
+        )
+    return (
+        (person_a, person_b)
+        if person_a.line_no < person_b.line_no
+        else (person_b, person_a)
+    )
+
+
+def _build_base_tax_units(
+    people: list[_HouseholdPerson],
+) -> tuple[dict[tuple, _BaseTaxUnit], dict[int, tuple], tuple | None]:
+    by_line = {person.line_no: person for person in people}
+    paired_indices: set[int] = set()
+    units: dict[tuple, _BaseTaxUnit] = {}
+    base_unit_by_person: dict[int, tuple] = {}
+    reference_unit_key: tuple | None = None
+
+    married_pairs: set[tuple[int, int]] = set()
+    for person in people:
+        if not person.married_spouse_present:
+            continue
+        spouse = by_line.get(person.spouse_line)
+        if spouse is None or spouse.index == person.index or not spouse.married_spouse_present:
+            continue
+        married_pairs.add(tuple(sorted((person.line_no, spouse.line_no))))
+
+    for line_a, line_b in sorted(married_pairs):
+        person_a = by_line[line_a]
+        person_b = by_line[line_b]
+        head, spouse = _choose_pair_head(person_a, person_b)
+        key = ("pair", min(line_a, line_b), max(line_a, line_b))
+        unit = _BaseTaxUnit(
+            key=key,
+            household_id=head.household_id,
+            head_index=head.index,
+            spouse_index=spouse.index,
+            claimant_lines=(head.line_no, spouse.line_no),
+            claimant_income=head.claimant_income + spouse.claimant_income,
+            total_money_income=head.total_money_income + spouse.total_money_income,
+            head_age=head.age,
+        )
+        units[key] = unit
+        paired_indices.update({head.index, spouse.index})
+        base_unit_by_person[head.index] = key
+        base_unit_by_person[spouse.index] = key
+        if (
+            head.relationship_code in {code.value for code in REFERENCE_PERSON_CODES}
+            or spouse.relationship_code in {code.value for code in REFERENCE_PERSON_CODES}
+        ):
+            reference_unit_key = key
+
+    for person in people:
+        if person.index in paired_indices or not person.starts_base_unit:
+            continue
+        key = ("single", person.line_no)
+        units[key] = _BaseTaxUnit(
+            key=key,
+            household_id=person.household_id,
+            head_index=person.index,
+            claimant_lines=(person.line_no,),
+            claimant_income=person.claimant_income,
+            total_money_income=person.total_money_income,
+            head_age=person.age,
+        )
+        base_unit_by_person[person.index] = key
+        if person.relationship_code in {code.value for code in REFERENCE_PERSON_CODES}:
+            reference_unit_key = key
+
+    return units, base_unit_by_person, reference_unit_key
+
+
+def _parent_candidate_units(
+    person: _HouseholdPerson,
+    base_units: dict[tuple, _BaseTaxUnit],
+    eligible_units: set[tuple],
+) -> list[tuple]:
+    candidates = []
+    for unit_key in eligible_units:
+        unit = base_units[unit_key]
+        if any(parent_line in unit.claimant_lines for parent_line in person.parent_lines):
+            candidates.append(unit_key)
+    return candidates
+
+
+def _reference_candidate_unit(
+    person: _HouseholdPerson,
+    reference_unit_key: tuple | None,
+    base_unit_key: tuple | None,
+    eligible_units: set[tuple],
+) -> tuple | None:
+    if (
+        reference_unit_key is None
+        or reference_unit_key == base_unit_key
+        or reference_unit_key not in eligible_units
+    ):
+        return None
+    return reference_unit_key
+
+
+def _unit_income_score(
+    unit_key: tuple,
+    base_units: dict[tuple, _BaseTaxUnit],
+) -> tuple[float, int, int]:
+    unit = base_units[unit_key]
+    return (
+        unit.claimant_income,
+        unit.head_age,
+        -unit.claimant_lines[0],
+    )
+
+
+def _choose_best_candidate(candidates: list[_ClaimCandidate]) -> tuple | None:
+    if not candidates:
+        return None
+    return max(
+        candidates,
+        key=lambda candidate: (candidate.priority, candidate.score),
+    ).unit_key
+
+
+def _choose_best_parent_unit_by_total_money_income(
+    candidate_units: list[tuple],
+    base_units: dict[tuple, _BaseTaxUnit],
+) -> tuple | None:
+    if not candidate_units:
+        return None
+    return max(
+        candidate_units,
+        key=lambda key: (
+            base_units[key].total_money_income,
+            base_units[key].claimant_income,
+            base_units[key].head_age,
+            -base_units[key].claimant_lines[0],
+        ),
+    )
+
+
+def _choose_main_filing_unit(
+    base_units: dict[tuple, _BaseTaxUnit],
+    reference_unit_key: tuple | None,
+) -> tuple | None:
+    if reference_unit_key in base_units:
+        return reference_unit_key
+    if not base_units:
+        return None
+    return max(
+        base_units,
+        key=lambda key: (
+            base_units[key].total_money_income,
+            base_units[key].claimant_income,
+            base_units[key].head_age,
+            -base_units[key].claimant_lines[0],
+        ),
+    )
+
+
+def _select_claimant_unit(
+    person: _HouseholdPerson,
+    year: int,
+    base_units: dict[tuple, _BaseTaxUnit],
+    base_unit_key: tuple | None,
+    reference_unit_key: tuple | None,
+    eligible_units: set[tuple],
+) -> tuple | None:
+    parent_units = _parent_candidate_units(person, base_units, eligible_units)
+    age_eligible = qualifying_child_age_test(
+        age=person.age,
+        is_full_time_student=person.is_full_time_student,
+        is_permanently_disabled=person.is_permanently_disabled,
+    )
+
+    reference_unit = _reference_candidate_unit(
+        person,
+        reference_unit_key,
+        base_unit_key,
+        eligible_units,
+    )
+    candidates: list[_ClaimCandidate] = []
+
+    if age_eligible:
+        candidates.extend(
+            _ClaimCandidate(
+                unit_key=unit_key,
+                priority=100,
+                score=_unit_income_score(unit_key, base_units),
+            )
+            for unit_key in parent_units
+        )
+        if (
+            reference_unit is not None
+            and not person.starts_base_unit
+            and not person.parent_lines
+            and person.age < 15
+        ):
+            candidates.append(
+                _ClaimCandidate(
+                    unit_key=reference_unit,
+                    priority=80,
+                    score=_unit_income_score(reference_unit, base_units),
+                )
+            )
+        selected = _choose_best_candidate(candidates)
+        if selected is not None:
+            return selected
+
+    if person.gross_income >= dependent_gross_income_limit(year):
+        return None
+
+    if person.starts_base_unit:
+        return None
+
+    candidates.extend(
+        _ClaimCandidate(
+            unit_key=unit_key,
+            priority=60,
+            score=_unit_income_score(unit_key, base_units),
+        )
+        for unit_key in parent_units
+    )
+
+    if (
+        reference_unit is not None
+        and (
+            reference_relationship_allows_qualifying_relative(person.relationship_code)
+            or (not person.parent_lines and person.age < 15)
+        )
+        and person.age < 15
+    ):
+        candidates.append(
+            _ClaimCandidate(
+                unit_key=reference_unit,
+                priority=50,
+                score=_unit_income_score(reference_unit, base_units),
+            )
+        )
+
+    return _choose_best_candidate(candidates)
+
+
+def _determine_final_assignments_for_household_policyengine(
+    people: list[_HouseholdPerson],
+    year: int,
+) -> tuple[dict[int, tuple], dict[int, str], dict[tuple, str], dict[int, bool]]:
+    base_units, base_unit_by_person, reference_unit_key = _build_base_tax_units(people)
+    person_by_index = {person.index: person for person in people}
+
+    adult_claims: dict[int, tuple] = {}
+    adult_candidates = [
+        person
+        for person in people
+        if person.starts_base_unit and base_unit_by_person.get(person.index) in base_units
+        and base_units[base_unit_by_person[person.index]].spouse_index is None
+    ]
+    eligible_units = set(base_units)
+    for person in sorted(adult_candidates, key=lambda item: (item.age, item.line_no)):
+        unit_key = _select_claimant_unit(
+            person=person,
+            year=year,
+            base_units=base_units,
+            base_unit_key=base_unit_by_person.get(person.index),
+            reference_unit_key=reference_unit_key,
+            eligible_units=eligible_units,
+        )
+        if unit_key is not None:
+            adult_claims[person.index] = unit_key
+            claimed_person_unit_key = base_unit_by_person.get(person.index)
+            if claimed_person_unit_key is not None:
+                eligible_units.discard(claimed_person_unit_key)
+
+    def _resolve_surviving_unit(unit_key: tuple) -> tuple:
+        seen: set[tuple] = set()
+        current_unit_key = unit_key
+        while current_unit_key not in seen:
+            seen.add(current_unit_key)
+            unit = base_units[current_unit_key]
+            if unit.spouse_index is not None:
+                return current_unit_key
+            next_unit_key = adult_claims.get(unit.head_index)
+            if next_unit_key is None:
+                return current_unit_key
+            current_unit_key = next_unit_key
+        return current_unit_key
+
+    adult_claims = {
+        person_index: _resolve_surviving_unit(unit_key)
+        for person_index, unit_key in adult_claims.items()
+    }
+
+    surviving_units = {
+        unit_key
+        for unit_key, unit in base_units.items()
+        if unit.spouse_index is not None or unit.head_index not in adult_claims
+    }
+
+    child_claims: dict[int, tuple] = {}
+    child_candidates = [
+        person
+        for person in people
+        if not person.starts_base_unit and person.index not in adult_claims
+    ]
+    for person in sorted(child_candidates, key=lambda item: (item.age, item.line_no)):
+        unit_key = _select_claimant_unit(
+            person=person,
+            year=year,
+            base_units=base_units,
+            base_unit_key=base_unit_by_person.get(person.index),
+            reference_unit_key=reference_unit_key,
+            eligible_units=surviving_units,
+        )
+        if unit_key is not None:
+            child_claims[person.index] = unit_key
+
+    final_unit_key_by_person: dict[int, tuple] = {}
+    roles_by_person: dict[int, str] = {}
+    for unit_key, unit in base_units.items():
+        if unit.spouse_index is not None:
+            final_unit_key_by_person[unit.head_index] = unit_key
+            final_unit_key_by_person[unit.spouse_index] = unit_key
+            roles_by_person[unit.head_index] = HEAD
+            roles_by_person[unit.spouse_index] = SPOUSE
+            continue
+        if unit.head_index in adult_claims:
+            continue
+        final_unit_key_by_person[unit.head_index] = unit_key
+        roles_by_person[unit.head_index] = HEAD
+
+    for person_index, unit_key in adult_claims.items():
+        final_unit_key_by_person[person_index] = unit_key
+        roles_by_person[person_index] = DEPENDENT
+
+    for person_index, unit_key in child_claims.items():
+        final_unit_key_by_person[person_index] = unit_key
+        roles_by_person[person_index] = DEPENDENT
+
+    for person in people:
+        if person.index in final_unit_key_by_person:
+            continue
+        unit_key = ("single", person.line_no)
+        final_unit_key_by_person[person.index] = unit_key
+        roles_by_person[person.index] = HEAD
+
+    related_to_head_or_spouse: dict[int, bool] = {}
+    head_spouse_lines_by_unit: dict[tuple, set[int]] = {}
+    for person_index, unit_key in final_unit_key_by_person.items():
+        role = roles_by_person[person_index]
+        if role in {HEAD, SPOUSE}:
+            head_spouse_lines_by_unit.setdefault(unit_key, set()).add(
+                person_by_index[person_index].line_no
+            )
+
+    filing_status_by_unit: dict[tuple, str] = {}
+    unit_members: dict[tuple, list[_HouseholdPerson]] = {}
+    for person_index, unit_key in final_unit_key_by_person.items():
+        unit_members.setdefault(unit_key, []).append(person_by_index[person_index])
+
+    for unit_key, members in unit_members.items():
+        roles = {person.index: roles_by_person[person.index] for person in members}
+        has_spouse = any(role == SPOUSE for role in roles.values())
+        head = next(person for person in members if roles[person.index] == HEAD)
+        claimant_lines = head_spouse_lines_by_unit.get(unit_key, {head.line_no})
+
+        for person in members:
+            if roles[person.index] in {HEAD, SPOUSE}:
+                related_to_head_or_spouse[person.index] = True
+                continue
+            related_to_head_or_spouse[person.index] = any(
+                parent_line in claimant_lines for parent_line in person.parent_lines
+            ) or reference_related_to_head_or_spouse(person.relationship_code)
+
+        if has_spouse:
+            filing_status_by_unit[unit_key] = "JOINT"
+            continue
+
+        has_qualifying_child = any(
+            roles[person.index] == DEPENDENT
+            and (
+                any(parent_line in claimant_lines for parent_line in person.parent_lines)
+                or reference_relationship_allows_qualifying_child(
+                    person.relationship_code
+                )
+            )
+            and qualifying_child_age_test(
+                age=person.age,
+                is_full_time_student=person.is_full_time_student,
+                is_permanently_disabled=person.is_permanently_disabled,
+            )
+            for person in members
+        )
+        has_qualifying_relative = any(
+            roles[person.index] == DEPENDENT
+            and related_to_head_or_spouse[person.index]
+            and person.gross_income < dependent_gross_income_limit(year)
+            for person in members
+        )
+        has_head_of_household_person = has_qualifying_child or has_qualifying_relative
+
+        if head.marital_status == 4 and has_qualifying_child:
+            filing_status_by_unit[unit_key] = "SURVIVING_SPOUSE"
+        elif has_head_of_household_person and head.marital_status != 6:
+            filing_status_by_unit[unit_key] = "HEAD_OF_HOUSEHOLD"
+        elif has_head_of_household_person and head.marital_status == 6:
+            filing_status_by_unit[unit_key] = "HEAD_OF_HOUSEHOLD"
+        elif head.marital_status == 6:
+            filing_status_by_unit[unit_key] = "SEPARATE"
+        else:
+            filing_status_by_unit[unit_key] = "SINGLE"
+
+    return (
+        final_unit_key_by_person,
+        roles_by_person,
+        filing_status_by_unit,
+        related_to_head_or_spouse,
+    )
+
+
+def _determine_final_assignments_for_household_census_documented(
+    people: list[_HouseholdPerson],
+    year: int,
+) -> tuple[dict[int, tuple], dict[int, str], dict[tuple, str], dict[int, bool]]:
+    del year
+    # Follow the publicly documented Census tax-model flow: married + dependents
+    # + others, qualifying-child-only parent-pointer claims, and under-15
+    # no-parent fallback to the household's main filing unit.
+    base_units, _, reference_unit_key = _build_base_tax_units(people)
+    person_by_index = {person.index: person for person in people}
+    main_unit_key = _choose_main_filing_unit(base_units, reference_unit_key)
+
+    final_unit_key_by_person: dict[int, tuple] = {}
+    roles_by_person: dict[int, str] = {}
+
+    for unit_key, unit in base_units.items():
+        final_unit_key_by_person[unit.head_index] = unit_key
+        roles_by_person[unit.head_index] = HEAD
+        if unit.spouse_index is not None:
+            final_unit_key_by_person[unit.spouse_index] = unit_key
+            roles_by_person[unit.spouse_index] = SPOUSE
+
+    dependent_claims: dict[int, tuple] = {}
+    for person in sorted(people, key=lambda item: (item.age, item.line_no)):
+        if person.index in final_unit_key_by_person or person.married_spouse_present:
+            continue
+
+        age_eligible = qualifying_child_age_test(
+            age=person.age,
+            is_full_time_student=person.is_full_time_student,
+            is_permanently_disabled=person.is_permanently_disabled,
+        )
+        if person.parent_lines and age_eligible:
+            parent_units = [
+                unit_key
+                for unit_key, unit in base_units.items()
+                if any(parent_line in unit.claimant_lines for parent_line in person.parent_lines)
+            ]
+            unit_key = _choose_best_parent_unit_by_total_money_income(
+                parent_units,
+                base_units,
+            )
+            if unit_key is not None:
+                dependent_claims[person.index] = unit_key
+                continue
+
+        if not person.parent_lines and person.age < 15 and main_unit_key is not None:
+            dependent_claims[person.index] = main_unit_key
+
+    for person_index, unit_key in dependent_claims.items():
+        final_unit_key_by_person[person_index] = unit_key
+        roles_by_person[person_index] = DEPENDENT
+
+    for person in people:
+        if person.index in final_unit_key_by_person:
+            continue
+        unit_key = ("single", person.line_no)
+        final_unit_key_by_person[person.index] = unit_key
+        roles_by_person[person.index] = HEAD
+
+    related_to_head_or_spouse: dict[int, bool] = {}
+    unit_members: dict[tuple, list[_HouseholdPerson]] = {}
+    head_spouse_lines_by_unit: dict[tuple, set[int]] = {}
+    for person_index, unit_key in final_unit_key_by_person.items():
+        unit_members.setdefault(unit_key, []).append(person_by_index[person_index])
+        if roles_by_person[person_index] in {HEAD, SPOUSE}:
+            head_spouse_lines_by_unit.setdefault(unit_key, set()).add(
+                person_by_index[person_index].line_no
+            )
+
+    filing_status_by_unit: dict[tuple, str] = {}
+    for unit_key, members in unit_members.items():
+        roles = {person.index: roles_by_person[person.index] for person in members}
+        has_spouse = any(role == SPOUSE for role in roles.values())
+        has_dependents = any(role == DEPENDENT for role in roles.values())
+        claimant_lines = head_spouse_lines_by_unit.get(unit_key, set())
+
+        for person in members:
+            if roles[person.index] in {HEAD, SPOUSE}:
+                related_to_head_or_spouse[person.index] = True
+                continue
+            related_to_head_or_spouse[person.index] = any(
+                parent_line in claimant_lines for parent_line in person.parent_lines
+            ) or reference_related_to_head_or_spouse(person.relationship_code)
+
+        if has_spouse:
+            filing_status_by_unit[unit_key] = "JOINT"
+        elif has_dependents:
+            filing_status_by_unit[unit_key] = "HEAD_OF_HOUSEHOLD"
+        else:
+            filing_status_by_unit[unit_key] = "SINGLE"
+
+    return (
+        final_unit_key_by_person,
+        roles_by_person,
+        filing_status_by_unit,
+        related_to_head_or_spouse,
+    )
+
+
+def construct_tax_units(
+    person: pd.DataFrame,
+    year: int,
+    mode: str = POLICYENGINE_MODE,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    required_columns = {
+        "PH_SEQ",
+        "A_LINENO",
+        "A_AGE",
+        "A_MARITL",
+        "A_SPOUSE",
+        "PEPAR1",
+        "PEPAR2",
+        "A_EXPRRP",
+    }
+    missing = sorted(column for column in required_columns if column not in person.columns)
+    if missing:
+        raise KeyError(
+            "Missing required CPS columns for tax-unit construction: "
+            + ", ".join(missing)
+        )
+    if mode not in SUPPORTED_TAX_UNIT_CONSTRUCTION_MODES:
+        raise ValueError(
+            "Unsupported tax-unit construction mode "
+            f"{mode!r}. Expected one of: "
+            + ", ".join(sorted(SUPPORTED_TAX_UNIT_CONSTRUCTION_MODES))
+        )
+
+    person_assignments = pd.DataFrame(index=person.index)
+    unit_key_records: list[tuple] = []
+    unit_filing_records: list[str] = []
+
+    household_unit_keys: list[tuple] = []
+    household_roles: list[str] = []
+    household_related_flags: list[bool] = []
+
+    assignment_fn = (
+        _determine_final_assignments_for_household_policyengine
+        if mode == POLICYENGINE_MODE
+        else _determine_final_assignments_for_household_census_documented
+    )
+
+    for household_id, household in person.groupby("PH_SEQ", sort=False):
+        household_people = _prepare_household_people(household, int(household_id))
+        (
+            unit_key_by_person,
+            roles_by_person,
+            filing_status_by_unit,
+            related_to_head_or_spouse,
+        ) = assignment_fn(household_people, year)
+
+        for row_index in household.index:
+            unit_key = (int(household_id),) + tuple(unit_key_by_person[row_index])
+            household_unit_keys.append(unit_key)
+            household_roles.append(roles_by_person[row_index])
+            household_related_flags.append(related_to_head_or_spouse[row_index])
+
+        for unit_key, filing_status in filing_status_by_unit.items():
+            unit_key_records.append((int(household_id),) + tuple(unit_key))
+            unit_filing_records.append(filing_status)
+
+    dense_unit_ids = {
+        unit_key: unit_id
+        for unit_id, unit_key in enumerate(dict.fromkeys(household_unit_keys), start=1)
+    }
+    person_assignments["TAX_ID"] = np.array(
+        [dense_unit_ids[unit_key] for unit_key in household_unit_keys],
+        dtype=np.int64,
+    )
+    person_assignments["tax_unit_role_input"] = np.array(household_roles).astype("S")
+    person_assignments["is_related_to_head_or_spouse"] = np.array(
+        household_related_flags,
+        dtype=bool,
+    )
+
+    tax_unit = pd.DataFrame(
+        {
+            "TAX_ID": np.array(
+                [dense_unit_ids[unit_key] for unit_key in unit_key_records],
+                dtype=np.int64,
+            ),
+            "filing_status_input": np.array(unit_filing_records).astype("S"),
+        }
+    ).drop_duplicates("TAX_ID")
+    tax_unit = tax_unit.sort_values("TAX_ID").reset_index(drop=True)
+
+    return person_assignments, tax_unit

--- a/policyengine_us_data/datasets/cps/tax_unit_rule_helpers.py
+++ b/policyengine_us_data/datasets/cps/tax_unit_rule_helpers.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from enum import IntEnum
+from functools import lru_cache
+from importlib import resources
+
+import yaml
+
+try:
+    from policyengine_us.tools.tax_unit_construction import (
+        CPSRelationshipCode,
+        REFERENCE_PERSON_CODES,
+        REFERENCE_SPOUSE_CODES,
+        dependent_gross_income_limit,
+        qualifying_child_age_test,
+        reference_relationship_allows_qualifying_child,
+        reference_relationship_allows_qualifying_relative,
+        related_to_head_or_spouse,
+    )
+except ImportError:
+    # Temporary compatibility shim while policyengine-us-data can still run
+    # against released policyengine-us versions that do not yet expose the
+    # shared tax-unit helper module. Remove once the minimum dependency includes
+    # policyengine_us.tools.tax_unit_construction.
+    class CPSRelationshipCode(IntEnum):
+        REFERENCE_PERSON_WITH_RELATIVES = 1
+        REFERENCE_PERSON_WITHOUT_RELATIVES = 2
+        HUSBAND = 3
+        WIFE = 4
+        OWN_CHILD = 5
+        GRANDCHILD = 7
+        PARENT = 8
+        SIBLING = 9
+        OTHER_RELATIVE = 10
+        FOSTER_CHILD = 11
+        NONRELATIVE_WITH_RELATIVES = 12
+        PARTNER_OR_ROOMMATE = 13
+        NONRELATIVE_WITHOUT_RELATIVES = 14
+
+
+    REFERENCE_PERSON_CODES = frozenset(
+        {
+            CPSRelationshipCode.REFERENCE_PERSON_WITH_RELATIVES,
+            CPSRelationshipCode.REFERENCE_PERSON_WITHOUT_RELATIVES,
+        }
+    )
+
+    REFERENCE_SPOUSE_CODES = frozenset(
+        {
+            CPSRelationshipCode.HUSBAND,
+            CPSRelationshipCode.WIFE,
+        }
+    )
+
+    REFERENCE_QUALIFYING_CHILD_CODES = frozenset(
+        {
+            CPSRelationshipCode.OWN_CHILD,
+            CPSRelationshipCode.GRANDCHILD,
+            CPSRelationshipCode.SIBLING,
+            CPSRelationshipCode.FOSTER_CHILD,
+        }
+    )
+
+    REFERENCE_QUALIFYING_RELATIVE_CODES = frozenset(
+        {
+            CPSRelationshipCode.OWN_CHILD,
+            CPSRelationshipCode.GRANDCHILD,
+            CPSRelationshipCode.PARENT,
+            CPSRelationshipCode.SIBLING,
+            CPSRelationshipCode.OTHER_RELATIVE,
+            CPSRelationshipCode.FOSTER_CHILD,
+        }
+    )
+
+    def qualifying_child_age_test(
+        age: int | float,
+        is_full_time_student: bool = False,
+        is_permanently_disabled: bool = False,
+        non_student_age_limit: int = 19,
+        student_age_limit: int = 24,
+    ) -> bool:
+        if is_permanently_disabled:
+            return True
+        age_limit = (
+            student_age_limit if is_full_time_student else non_student_age_limit
+        )
+        return float(age) < age_limit
+
+
+    def _relationship_from_code(relationship_code: int | None):
+        if relationship_code is None:
+            return None
+        try:
+            return CPSRelationshipCode(int(relationship_code))
+        except ValueError:
+            return None
+
+
+    def reference_relationship_allows_qualifying_child(
+        relationship_code: int | None,
+    ) -> bool:
+        relationship = _relationship_from_code(relationship_code)
+        return relationship in REFERENCE_QUALIFYING_CHILD_CODES
+
+
+    def reference_relationship_allows_qualifying_relative(
+        relationship_code: int | None,
+    ) -> bool:
+        relationship = _relationship_from_code(relationship_code)
+        return relationship in REFERENCE_QUALIFYING_RELATIVE_CODES
+
+
+    def related_to_head_or_spouse(relationship_code: int | None) -> bool:
+        relationship = _relationship_from_code(relationship_code)
+        return relationship in (
+            REFERENCE_PERSON_CODES
+            | REFERENCE_SPOUSE_CODES
+            | REFERENCE_QUALIFYING_RELATIVE_CODES
+        )
+
+
+    @lru_cache(maxsize=None)
+    def dependent_gross_income_limit(year: int) -> float:
+        parameter_path = (
+            resources.files("policyengine_us")
+            / "parameters"
+            / "gov"
+            / "irs"
+            / "income"
+            / "exemption"
+            / "amount.yaml"
+        )
+        with parameter_path.open("r", encoding="utf-8") as f:
+            values = yaml.safe_load(f)["values"]
+
+        def _period_year(period) -> int:
+            if hasattr(period, "year"):
+                return int(period.year)
+            return int(str(period)[:4])
+
+        applicable_years = sorted(
+            _period_year(period) for period in values if _period_year(period) <= year
+        )
+        if not applicable_years:
+            raise ValueError(f"No dependent gross income limit configured for {year}.")
+
+        selected_year = applicable_years[-1]
+        for period, entry in values.items():
+            if _period_year(period) == selected_year:
+                return float(entry["value"])
+        raise ValueError(f"No dependent gross income limit configured for {year}.")

--- a/tests/integration/test_census_cps.py
+++ b/tests/integration/test_census_cps.py
@@ -81,3 +81,106 @@ def test_fill_missing_optional_person_columns_backfills_zeroes():
         assert column in filled.columns
     assert filled.loc[0, "NOW_COV"] == 1
     assert filled.loc[0, "NOW_MRKS"] == 0
+
+
+def test_create_tax_unit_table_preserves_census_tax_id_and_replaces_tax_id():
+    import pandas as pd
+
+    from policyengine_us_data.datasets.cps.census_cps import CensusCPS_2024
+
+    dataset = object.__new__(CensusCPS_2024)
+    person = pd.DataFrame(
+        {
+            "PH_SEQ": [1, 1],
+            "TAX_ID": [501, 999],
+            "A_LINENO": [1, 2],
+            "A_AGE": [40, 10],
+            "A_MARITL": [7, 7],
+            "A_SPOUSE": [0, 0],
+            "A_EXPRRP": [1, 5],
+            "PEPAR1": [-1, 1],
+            "PEPAR2": [-1, -1],
+            "PECOHAB": [-1, -1],
+            "A_ENRLW": [0, 0],
+            "A_FTPT": [0, 0],
+            "WSAL_VAL": [50_000, 0],
+            "SEMP_VAL": [0, 0],
+            "FRSE_VAL": [0, 0],
+            "INT_VAL": [0, 0],
+            "DIV_VAL": [0, 0],
+            "RNT_VAL": [0, 0],
+            "CAP_VAL": [0, 0],
+            "UC_VAL": [0, 0],
+            "OI_VAL": [0, 0],
+            "ANN_VAL": [0, 0],
+            "PNSN_VAL": [0, 0],
+            "PTOTVAL": [50_000, 0],
+            "SS_VAL": [0, 0],
+            "PEDISDRS": [0, 0],
+            "PEDISEAR": [0, 0],
+            "PEDISEYE": [0, 0],
+            "PEDISOUT": [0, 0],
+            "PEDISPHY": [0, 0],
+            "PEDISREM": [0, 0],
+        }
+    )
+
+    tax_unit = dataset._create_tax_unit_table(person)
+
+    assert person["CENSUS_TAX_ID"].tolist() == [501, 999]
+    assert person["TAX_ID"].tolist() == [1, 1]
+    assert "tax_unit_role_input" not in person
+    assert "is_related_to_head_or_spouse" not in person
+    assert tax_unit["TAX_ID"].tolist() == [1]
+    assert "filing_status_input" not in tax_unit
+
+
+def test_create_tax_unit_table_accepts_census_documented_mode():
+    import pandas as pd
+
+    from policyengine_us_data.datasets.cps.census_cps import CensusCPS_2024
+
+    dataset = object.__new__(CensusCPS_2024)
+    person = pd.DataFrame(
+        {
+            "PH_SEQ": [1, 1],
+            "TAX_ID": [501, 999],
+            "A_LINENO": [1, 2],
+            "A_AGE": [40, 12],
+            "A_MARITL": [7, 7],
+            "A_SPOUSE": [0, 0],
+            "A_EXPRRP": [1, 14],
+            "PEPAR1": [-1, -1],
+            "PEPAR2": [-1, -1],
+            "PECOHAB": [-1, -1],
+            "A_ENRLW": [0, 0],
+            "A_FTPT": [0, 0],
+            "WSAL_VAL": [50_000, 0],
+            "SEMP_VAL": [0, 0],
+            "FRSE_VAL": [0, 0],
+            "INT_VAL": [0, 0],
+            "DIV_VAL": [0, 0],
+            "RNT_VAL": [0, 0],
+            "CAP_VAL": [0, 0],
+            "UC_VAL": [0, 0],
+            "OI_VAL": [0, 0],
+            "ANN_VAL": [0, 0],
+            "PNSN_VAL": [0, 0],
+            "PTOTVAL": [50_000, 0],
+            "SS_VAL": [0, 0],
+            "PEDISDRS": [0, 0],
+            "PEDISEAR": [0, 0],
+            "PEDISEYE": [0, 0],
+            "PEDISOUT": [0, 0],
+            "PEDISPHY": [0, 0],
+            "PEDISREM": [0, 0],
+        }
+    )
+
+    tax_unit = dataset._create_tax_unit_table(person, mode="census_documented")
+
+    assert person["CENSUS_TAX_ID"].tolist() == [501, 999]
+    assert person["TAX_ID"].tolist() == [1, 1]
+    assert "tax_unit_role_input" not in person
+    assert "is_related_to_head_or_spouse" not in person
+    assert "filing_status_input" not in tax_unit

--- a/tests/integration/test_cps.py
+++ b/tests/integration/test_cps.py
@@ -94,6 +94,112 @@ def test_add_personal_variables_maps_current_health_coverage_flags():
     np.testing.assert_array_equal(cps["has_esi"], [False, True, False])
 
 
+def test_add_personal_variables_uses_full_time_flag():
+    from policyengine_us_data.datasets.cps.cps import add_personal_variables
+
+    person = pd.DataFrame(
+        {
+            "A_AGE": [19, 20, 45],
+            "A_SEX": [2, 1, 2],
+            "PEDISEYE": [0, 0, 0],
+            "PEDISDRS": [0, 0, 0],
+            "PEDISEAR": [0, 0, 0],
+            "PEDISOUT": [0, 0, 0],
+            "PEDISPHY": [0, 0, 0],
+            "PEDISREM": [0, 0, 0],
+            "PEPAR1": [0, 0, 0],
+            "PEPAR2": [0, 0, 0],
+            "PH_SEQ": [1, 1, 1],
+            "A_LINENO": [1, 2, 3],
+            "NOW_COV": [0, 0, 0],
+            "NOW_DIR": [0, 0, 0],
+            "NOW_MRK": [0, 0, 0],
+            "NOW_MRKS": [0, 0, 0],
+            "NOW_MRKUN": [0, 0, 0],
+            "NOW_NONM": [0, 0, 0],
+            "NOW_PRIV": [0, 0, 0],
+            "NOW_PUB": [0, 0, 0],
+            "NOW_GRP": [0, 0, 0],
+            "NOW_CAID": [0, 0, 0],
+            "NOW_MCAID": [0, 0, 0],
+            "NOW_PCHIP": [0, 0, 0],
+            "NOW_OTHMT": [0, 0, 0],
+            "NOW_MCARE": [0, 0, 0],
+            "NOW_MIL": [0, 0, 0],
+            "NOW_CHAMPVA": [0, 0, 0],
+            "NOW_VACARE": [0, 0, 0],
+            "NOW_IHSFLG": [0, 0, 0],
+            "PRDTRACE": [1, 2, 3],
+            "PRDTHSP": [0, 0, 0],
+            "A_MARITL": [7, 7, 7],
+            "A_HSCOL": [2, 2, 0],
+            "A_FTPT": [1, 0, 0],
+            "POCCU2": [39, 52, 29],
+            "PEIOOCC": [4040, 9999, 4020],
+        }
+    )
+    cps = {}
+
+    add_personal_variables(cps, person)
+
+    np.testing.assert_array_equal(
+        cps["is_full_time_college_student"],
+        [True, False, False],
+    )
+    assert "tax_unit_role_input" not in cps
+    assert "is_related_to_head_or_spouse" not in cps
+
+
+def test_add_id_variables_copies_constructed_tax_unit_ids_only():
+    from policyengine_us_data.datasets.cps.cps import add_id_variables
+
+    cps = {}
+    person = pd.DataFrame(
+        {
+            "PH_SEQ": [1, 1],
+            "PF_SEQ": [1, 1],
+            "P_SEQ": [1, 2],
+            "TAX_ID": [10, 10],
+            "SPM_ID": [20, 20],
+            "A_LINENO": [1, 2],
+            "A_SPOUSE": [0, 0],
+        }
+    )
+    tax_unit = pd.DataFrame({"TAX_ID": [10]})
+    family = pd.DataFrame({"FH_SEQ": [1], "FFPOS": [1]})
+    spm_unit = pd.DataFrame({"SPM_ID": [20]})
+    household = pd.DataFrame({"H_SEQ": [1], "HSUP_WGT": [12_345]})
+
+    add_id_variables(cps, person, tax_unit, family, spm_unit, household)
+
+    assert cps["person_tax_unit_id"].tolist() == [10, 10]
+    assert cps["tax_unit_id"].tolist() == [10]
+    assert "filing_status_input" not in cps
+
+
+def test_validate_raw_cps_schema_rejects_stale_raw_tables():
+    from policyengine_us_data.datasets.cps.cps import _validate_raw_cps_schema
+
+    person = pd.DataFrame({"PH_SEQ": [1], "TAX_ID": [1]})
+    tax_unit = pd.DataFrame({"TAX_ID": [1]})
+
+    with pytest.raises(ValueError) as error:
+        _validate_raw_cps_schema(person, tax_unit, "census_cps_2024")
+
+    message = str(error.value)
+    assert "census_cps_2024" in message
+    assert "CENSUS_TAX_ID" in message
+
+
+def test_validate_raw_cps_schema_accepts_constructed_tax_unit_id_column():
+    from policyengine_us_data.datasets.cps.cps import _validate_raw_cps_schema
+
+    person = pd.DataFrame({"CENSUS_TAX_ID": [123]})
+    tax_unit = pd.DataFrame({"TAX_ID": [1]})
+
+    _validate_raw_cps_schema(person, tax_unit, "census_cps_2024")
+
+
 # ── Sanity checks ─────────────────────────────────────────────
 
 

--- a/tests/unit/datasets/test_cps_tax_unit_construction.py
+++ b/tests/unit/datasets/test_cps_tax_unit_construction.py
@@ -1,0 +1,402 @@
+import numpy as np
+import pandas as pd
+
+from policyengine_us_data.datasets.cps.tax_unit_construction import construct_tax_units
+
+
+def _person_fixture(**overrides):
+    n = max((len(value) for value in overrides.values()), default=1)
+    defaults = {
+        "PH_SEQ": np.ones(n, dtype=int),
+        "A_LINENO": np.arange(1, n + 1, dtype=int),
+        "A_AGE": np.zeros(n, dtype=int),
+        "A_MARITL": np.full(n, 7, dtype=int),
+        "A_SPOUSE": np.zeros(n, dtype=int),
+        "PECOHAB": np.full(n, -1, dtype=int),
+        "PEPAR1": np.full(n, -1, dtype=int),
+        "PEPAR2": np.full(n, -1, dtype=int),
+        "A_EXPRRP": np.full(n, 14, dtype=int),
+        "A_ENRLW": np.zeros(n, dtype=int),
+        "A_FTPT": np.zeros(n, dtype=int),
+        "A_HSCOL": np.zeros(n, dtype=int),
+        "WSAL_VAL": np.zeros(n, dtype=float),
+        "SEMP_VAL": np.zeros(n, dtype=float),
+        "FRSE_VAL": np.zeros(n, dtype=float),
+        "INT_VAL": np.zeros(n, dtype=float),
+        "DIV_VAL": np.zeros(n, dtype=float),
+        "RNT_VAL": np.zeros(n, dtype=float),
+        "CAP_VAL": np.zeros(n, dtype=float),
+        "UC_VAL": np.zeros(n, dtype=float),
+        "OI_VAL": np.zeros(n, dtype=float),
+        "ANN_VAL": np.zeros(n, dtype=float),
+        "PNSN_VAL": np.zeros(n, dtype=float),
+        "PTOTVAL": np.zeros(n, dtype=float),
+        "SS_VAL": np.zeros(n, dtype=float),
+        "PEDISDRS": np.zeros(n, dtype=int),
+        "PEDISEAR": np.zeros(n, dtype=int),
+        "PEDISEYE": np.zeros(n, dtype=int),
+        "PEDISOUT": np.zeros(n, dtype=int),
+        "PEDISPHY": np.zeros(n, dtype=int),
+        "PEDISREM": np.zeros(n, dtype=int),
+    }
+    defaults.update(overrides)
+    return pd.DataFrame(defaults)
+
+
+def _decoded_roles(assignments: pd.DataFrame) -> list[str]:
+    return [value.decode() for value in assignments["tax_unit_role_input"].tolist()]
+
+
+def _decoded_statuses(tax_unit: pd.DataFrame) -> list[str]:
+    return [value.decode() for value in tax_unit["filing_status_input"].tolist()]
+
+
+def test_construct_tax_units_keeps_married_couple_and_child_together():
+    person = _person_fixture(
+        A_AGE=[40, 38, 8],
+        A_MARITL=[1, 1, 7],
+        A_SPOUSE=[2, 1, 0],
+        A_EXPRRP=[1, 4, 5],
+        PEPAR1=[-1, -1, 1],
+        PEPAR2=[-1, -1, 2],
+        WSAL_VAL=[60_000, 20_000, 0],
+    )
+
+    assignments, tax_unit = construct_tax_units(person, year=2024)
+
+    assert assignments["TAX_ID"].nunique() == 1
+    assert _decoded_roles(assignments) == ["HEAD", "SPOUSE", "DEPENDENT"]
+    assert _decoded_statuses(tax_unit) == ["JOINT"]
+
+
+def test_construct_tax_units_claims_low_income_full_time_student():
+    person = _person_fixture(
+        A_AGE=[45, 20],
+        A_EXPRRP=[1, 5],
+        PEPAR1=[-1, 1],
+        A_ENRLW=[0, 1],
+        A_FTPT=[0, 1],
+        WSAL_VAL=[70_000, 3_000],
+    )
+
+    assignments, tax_unit = construct_tax_units(person, year=2024)
+
+    assert assignments["TAX_ID"].nunique() == 1
+    assert _decoded_roles(assignments) == ["HEAD", "DEPENDENT"]
+    assert _decoded_statuses(tax_unit) == ["HEAD_OF_HOUSEHOLD"]
+
+
+def test_construct_tax_units_claims_enrolled_young_adult_student():
+    person = _person_fixture(
+        A_AGE=[45, 21],
+        A_EXPRRP=[1, 5],
+        PEPAR1=[-1, 1],
+        A_ENRLW=[0, 1],
+        A_FTPT=[0, 2],
+        A_HSCOL=[0, 2],
+        WSAL_VAL=[70_000, 12_000],
+    )
+
+    assignments, tax_unit = construct_tax_units(person, year=2024)
+
+    assert assignments["TAX_ID"].nunique() == 1
+    assert _decoded_roles(assignments) == ["HEAD", "DEPENDENT"]
+    assert _decoded_statuses(tax_unit) == ["HEAD_OF_HOUSEHOLD"]
+
+
+def test_construct_tax_units_leaves_low_income_nonstudent_adult_child_independent():
+    person = _person_fixture(
+        A_AGE=[45, 22],
+        A_EXPRRP=[1, 5],
+        PEPAR1=[-1, 1],
+        A_ENRLW=[0, 0],
+        A_FTPT=[0, 0],
+        WSAL_VAL=[70_000, 2_000],
+    )
+
+    assignments, tax_unit = construct_tax_units(person, year=2024)
+
+    assert assignments["TAX_ID"].nunique() == 2
+    assert _decoded_roles(assignments) == ["HEAD", "HEAD"]
+    assert sorted(_decoded_statuses(tax_unit)) == ["SINGLE", "SINGLE"]
+
+
+def test_construct_tax_units_leaves_zero_income_nonstudent_young_adult_child_independent():
+    person = _person_fixture(
+        A_AGE=[45, 22],
+        A_EXPRRP=[1, 5],
+        PEPAR1=[-1, 1],
+        A_ENRLW=[0, 0],
+        A_FTPT=[0, 0],
+        WSAL_VAL=[70_000, 0],
+    )
+
+    assignments, tax_unit = construct_tax_units(person, year=2024)
+
+    assert assignments["TAX_ID"].nunique() == 2
+    assert _decoded_roles(assignments) == ["HEAD", "HEAD"]
+    assert sorted(_decoded_statuses(tax_unit)) == ["SINGLE", "SINGLE"]
+
+
+def test_construct_tax_units_leaves_high_income_adult_child_independent():
+    person = _person_fixture(
+        A_AGE=[45, 22],
+        A_EXPRRP=[1, 5],
+        PEPAR1=[-1, 1],
+        WSAL_VAL=[70_000, 10_000],
+    )
+
+    assignments, tax_unit = construct_tax_units(person, year=2024)
+
+    assert assignments["TAX_ID"].nunique() == 2
+    assert _decoded_roles(assignments) == ["HEAD", "HEAD"]
+    assert sorted(_decoded_statuses(tax_unit)) == ["SINGLE", "SINGLE"]
+
+
+def test_construct_tax_units_assigns_child_to_higher_income_separated_parent():
+    person = _person_fixture(
+        A_AGE=[40, 38, 10],
+        A_MARITL=[6, 6, 7],
+        A_EXPRRP=[1, 13, 5],
+        PEPAR1=[-1, -1, 1],
+        PEPAR2=[-1, -1, 2],
+        WSAL_VAL=[50_000, 20_000, 0],
+    )
+
+    assignments, tax_unit = construct_tax_units(person, year=2024)
+
+    assert assignments["TAX_ID"].nunique() == 2
+    assert _decoded_roles(assignments) == ["HEAD", "HEAD", "DEPENDENT"]
+    child_unit = assignments.loc[2, "TAX_ID"]
+    assert child_unit == assignments.loc[0, "TAX_ID"]
+    assert sorted(_decoded_statuses(tax_unit)) == ["HEAD_OF_HOUSEHOLD", "SEPARATE"]
+
+
+def test_construct_tax_units_can_roll_child_of_claimed_adult_up_to_grandparent():
+    person = _person_fixture(
+        A_AGE=[70, 22, 4],
+        A_EXPRRP=[1, 5, 7],
+        PEPAR1=[-1, 1, 2],
+        A_ENRLW=[0, 1, 0],
+        A_FTPT=[0, 1, 0],
+        WSAL_VAL=[40_000, 2_000, 0],
+    )
+
+    assignments, tax_unit = construct_tax_units(person, year=2024)
+
+    assert assignments["TAX_ID"].nunique() == 1
+    assert _decoded_roles(assignments) == ["HEAD", "DEPENDENT", "DEPENDENT"]
+    assert _decoded_statuses(tax_unit) == ["HEAD_OF_HOUSEHOLD"]
+
+
+def test_construct_tax_units_handles_nonconsecutive_person_index():
+    person = _person_fixture(
+        A_AGE=[40, 10],
+        A_EXPRRP=[1, 5],
+        PEPAR1=[-1, 1],
+        WSAL_VAL=[50_000, 0],
+    )
+    person.index = [10, 20]
+
+    assignments, tax_unit = construct_tax_units(person, year=2024)
+
+    assert assignments.index.tolist() == [10, 20]
+    assert assignments["TAX_ID"].tolist() == [1, 1]
+    assert _decoded_roles(assignments) == ["HEAD", "DEPENDENT"]
+    assert _decoded_statuses(tax_unit) == ["HEAD_OF_HOUSEHOLD"]
+
+
+def test_construct_tax_units_allows_missing_optional_evidence_columns():
+    person = _person_fixture(
+        A_AGE=[40, 10],
+        A_EXPRRP=[1, 5],
+        PEPAR1=[-1, 1],
+    ).drop(
+        columns=[
+            "A_ENRLW",
+            "A_FTPT",
+            "A_HSCOL",
+            "PTOTVAL",
+            "PEDISDRS",
+            "PEDISEAR",
+            "PEDISEYE",
+            "PEDISOUT",
+            "PEDISPHY",
+            "PEDISREM",
+        ]
+    )
+
+    assignments, tax_unit = construct_tax_units(person, year=2024)
+
+    assert assignments["TAX_ID"].tolist() == [1, 1]
+    assert _decoded_roles(assignments) == ["HEAD", "DEPENDENT"]
+    assert _decoded_statuses(tax_unit) == ["HEAD_OF_HOUSEHOLD"]
+
+
+def test_construct_tax_units_collapses_transitive_adult_claim_chains():
+    person = _person_fixture(
+        A_AGE=[46, 69, 43],
+        A_MARITL=[5, 5, 7],
+        A_EXPRRP=[1, 10, 12],
+        PEPAR1=[-1, -1, 2],
+        WSAL_VAL=[0, 0, 0],
+        SEMP_VAL=[120_000, 0, 0],
+        A_ENRLW=[0, 0, 0],
+        A_FTPT=[0, 0, 0],
+    )
+
+    assignments, tax_unit = construct_tax_units(person, year=2024)
+
+    assert assignments["TAX_ID"].tolist() == [1, 2, 3]
+    assert _decoded_roles(assignments) == ["HEAD", "HEAD", "HEAD"]
+    assert sorted(_decoded_statuses(tax_unit)) == ["SINGLE", "SINGLE", "SINGLE"]
+
+
+def test_construct_tax_units_prevents_mutual_adult_claim_cycles():
+    person = _person_fixture(
+        A_AGE=[39, 75, 42],
+        A_MARITL=[7, 5, 7],
+        A_EXPRRP=[1, 8, 13],
+        PEPAR1=[2, -1, -1],
+        PECOHAB=[3, -1, 1],
+        WSAL_VAL=[0, 0, 40_000],
+        INT_VAL=[13, 3, 3],
+    )
+
+    assignments, tax_unit = construct_tax_units(person, year=2024)
+
+    assert assignments["TAX_ID"].tolist() == [1, 2, 3]
+    assert _decoded_roles(assignments) == ["HEAD", "HEAD", "HEAD"]
+    assert sorted(_decoded_statuses(tax_unit)) == ["SINGLE", "SINGLE", "SINGLE"]
+
+
+def test_construct_tax_units_does_not_claim_adult_child_with_children():
+    person = _person_fixture(
+        A_AGE=[70, 42, 11],
+        A_EXPRRP=[1, 5, 7],
+        PEPAR1=[-1, 1, 2],
+        WSAL_VAL=[23_000, 0, 0],
+    )
+
+    assignments, tax_unit = construct_tax_units(person, year=2024)
+
+    assert assignments["TAX_ID"].tolist() == [1, 2, 2]
+    assert _decoded_roles(assignments) == ["HEAD", "HEAD", "DEPENDENT"]
+    assert sorted(_decoded_statuses(tax_unit)) == ["HEAD_OF_HOUSEHOLD", "SINGLE"]
+
+
+def test_construct_tax_units_keeps_older_grandchild_without_parent_pointer_separate():
+    person = _person_fixture(
+        A_AGE=[64, 58, 16],
+        A_MARITL=[1, 1, 7],
+        A_SPOUSE=[2, 1, 0],
+        A_EXPRRP=[1, 4, 7],
+        WSAL_VAL=[0, 9_000, 0],
+    )
+
+    assignments, tax_unit = construct_tax_units(person, year=2024)
+
+    assert assignments["TAX_ID"].tolist() == [1, 1, 2]
+    assert _decoded_roles(assignments) == ["HEAD", "SPOUSE", "HEAD"]
+    assert sorted(_decoded_statuses(tax_unit)) == ["JOINT", "SINGLE"]
+
+
+def test_construct_tax_units_claims_younger_grandchild_without_parent_pointer():
+    person = _person_fixture(
+        A_AGE=[64, 58, 12],
+        A_MARITL=[1, 1, 7],
+        A_SPOUSE=[2, 1, 0],
+        A_EXPRRP=[1, 4, 7],
+        WSAL_VAL=[0, 9_000, 0],
+    )
+
+    assignments, tax_unit = construct_tax_units(person, year=2024)
+
+    assert assignments["TAX_ID"].tolist() == [1, 1, 1]
+    assert _decoded_roles(assignments) == ["HEAD", "SPOUSE", "DEPENDENT"]
+    assert _decoded_statuses(tax_unit) == ["JOINT"]
+
+
+def test_construct_tax_units_claims_under15_nonrelative_without_parent_pointer():
+    person = _person_fixture(
+        A_AGE=[40, 12],
+        A_EXPRRP=[1, 14],
+        WSAL_VAL=[50_000, 0],
+    )
+
+    assignments, tax_unit = construct_tax_units(person, year=2024)
+
+    assert assignments["TAX_ID"].tolist() == [1, 1]
+    assert _decoded_roles(assignments) == ["HEAD", "DEPENDENT"]
+    assert _decoded_statuses(tax_unit) == ["SINGLE"]
+
+
+def test_census_documented_claims_under15_without_parent_pointer_to_main_unit():
+    person = _person_fixture(
+        A_AGE=[40, 12],
+        A_EXPRRP=[1, 14],
+        WSAL_VAL=[50_000, 0],
+        PTOTVAL=[50_000, 0],
+    )
+
+    assignments, tax_unit = construct_tax_units(
+        person,
+        year=2024,
+        mode="census_documented",
+    )
+
+    assert assignments["TAX_ID"].tolist() == [1, 1]
+    assert _decoded_roles(assignments) == ["HEAD", "DEPENDENT"]
+    assert _decoded_statuses(tax_unit) == ["HEAD_OF_HOUSEHOLD"]
+
+
+def test_census_documented_leaves_age15_without_parent_pointer_independent():
+    person = _person_fixture(
+        A_AGE=[40, 15],
+        A_EXPRRP=[1, 14],
+        WSAL_VAL=[50_000, 0],
+        PTOTVAL=[50_000, 0],
+    )
+
+    assignments, tax_unit = construct_tax_units(
+        person,
+        year=2024,
+        mode="census_documented",
+    )
+
+    assert assignments["TAX_ID"].tolist() == [1, 2]
+    assert _decoded_roles(assignments) == ["HEAD", "HEAD"]
+    assert sorted(_decoded_statuses(tax_unit)) == ["SINGLE", "SINGLE"]
+
+
+def test_census_documented_uses_total_money_income_for_split_parents():
+    person = _person_fixture(
+        A_AGE=[40, 38, 10],
+        A_MARITL=[7, 7, 7],
+        A_EXPRRP=[1, 13, 5],
+        PEPAR1=[-1, -1, 1],
+        PEPAR2=[-1, -1, 2],
+        WSAL_VAL=[0, 50_000, 0],
+        PTOTVAL=[30_000, 20_000, 0],
+    )
+
+    assignments, tax_unit = construct_tax_units(
+        person,
+        year=2024,
+        mode="census_documented",
+    )
+
+    assert assignments["TAX_ID"].tolist() == [1, 2, 1]
+    assert _decoded_roles(assignments) == ["HEAD", "HEAD", "DEPENDENT"]
+    assert sorted(_decoded_statuses(tax_unit)) == ["HEAD_OF_HOUSEHOLD", "SINGLE"]
+
+
+def test_construct_tax_units_rejects_unknown_mode():
+    person = _person_fixture(A_AGE=[40], A_EXPRRP=[1])
+
+    try:
+        construct_tax_units(person, year=2024, mode="unknown")
+    except ValueError as error:
+        assert "Unsupported tax-unit construction mode" in str(error)
+    else:
+        raise AssertionError("Expected construct_tax_units to reject unknown modes")

--- a/validation/cps_tax_unit_outcome_validation.py
+++ b/validation/cps_tax_unit_outcome_validation.py
@@ -1,0 +1,294 @@
+"""
+Compare PE-US tax outcomes under Census TAX_ID vs constructed CPS tax units.
+
+This harness keeps all non-tax-unit staged CPS arrays fixed and swaps only the
+tax-unit graph. It intentionally does not pass tax-unit role or filing-status
+inputs: those are PE-US tax rules, and the outcome benchmark shows constructed
+IDs perform best when PE-US infers those quantities from the new unit graph.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import zipfile
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pandas as pd
+from policyengine_core.data import Dataset
+
+from policyengine_us_data.datasets.cps.tax_unit_construction import construct_tax_units
+from policyengine_us_data.utils.soi import (
+    compare_soi_replication_to_soi,
+    get_soi,
+    pe_to_soi,
+)
+
+
+CONSTRUCTION_USECOLS = [
+    "PH_SEQ",
+    "P_SEQ",
+    "A_LINENO",
+    "A_AGE",
+    "A_MARITL",
+    "A_SPOUSE",
+    "PECOHAB",
+    "PEPAR1",
+    "PEPAR2",
+    "A_EXPRRP",
+    "A_ENRLW",
+    "A_FTPT",
+    "A_HSCOL",
+    "WSAL_VAL",
+    "SEMP_VAL",
+    "FRSE_VAL",
+    "INT_VAL",
+    "DIV_VAL",
+    "RNT_VAL",
+    "CAP_VAL",
+    "UC_VAL",
+    "OI_VAL",
+    "ANN_VAL",
+    "PNSN_VAL",
+    "PTOTVAL",
+    "SS_VAL",
+    "PEDISDRS",
+    "PEDISEAR",
+    "PEDISEYE",
+    "PEDISOUT",
+    "PEDISPHY",
+    "PEDISREM",
+    "TAX_ID",
+]
+
+
+def load_public_person_file(input_path: Path, csv_name: str | None) -> pd.DataFrame:
+    if input_path.suffix.lower() == ".zip":
+        with zipfile.ZipFile(input_path) as zf:
+            selected_name = csv_name
+            if selected_name is None:
+                matches = [
+                    name
+                    for name in zf.namelist()
+                    if name.lower().startswith("pppub")
+                    and name.lower().endswith(".csv")
+                ]
+                if not matches:
+                    raise FileNotFoundError(
+                        f"No pppub*.csv person file found in {input_path}."
+                    )
+                selected_name = sorted(matches)[0]
+            with zf.open(selected_name) as f:
+                return pd.read_csv(
+                    f,
+                    usecols=lambda col: col in CONSTRUCTION_USECOLS,
+                    low_memory=False,
+                )
+    return pd.read_csv(
+        input_path,
+        usecols=lambda col: col in CONSTRUCTION_USECOLS,
+        low_memory=False,
+    )
+
+
+def load_staged_arrays(path: Path) -> dict[str, np.ndarray]:
+    with h5py.File(path, "r") as f:
+        return {key: np.array(value) for key, value in f.items()}
+
+
+def make_constructed_id_dataset(
+    base: dict[str, np.ndarray],
+    public_person: pd.DataFrame,
+    year: int,
+) -> dict[str, np.ndarray]:
+    raw_person_id = (
+        public_person.PH_SEQ.astype(int) * 100 + public_person.P_SEQ.astype(int)
+    ).to_numpy()
+    if not np.array_equal(raw_person_id, base["person_id"]):
+        raise ValueError(
+            "Public CPS person file does not align with staged CPS person order."
+        )
+
+    assignments, tax_unit = construct_tax_units(public_person, year)
+    data = {
+        key: value
+        for key, value in base.items()
+        if key
+        not in {
+            "person_tax_unit_id",
+            "tax_unit_id",
+            "tax_unit_role_input",
+            "filing_status_input",
+            "is_related_to_head_or_spouse",
+        }
+    }
+    data["person_tax_unit_id"] = assignments["TAX_ID"].to_numpy(dtype=np.int64)
+    data["tax_unit_id"] = tax_unit["TAX_ID"].to_numpy(dtype=np.int64)
+    return data
+
+
+def dataset_class(
+    name: str,
+    data: dict[str, np.ndarray],
+    file_path: Path,
+    year: int,
+) -> type[Dataset]:
+    class InMemoryDataset(Dataset):
+        def load(self, key: str | None = None, mode: str = "r"):
+            del mode
+            if key is None:
+                return data
+            return data[key]
+
+        def load_dataset(self):
+            return data
+
+    InMemoryDataset.name = name
+    InMemoryDataset.label = name
+    InMemoryDataset.data_format = Dataset.ARRAYS
+    InMemoryDataset.time_period = year
+    InMemoryDataset.file_path = file_path
+    return InMemoryDataset
+
+
+def _metric_summary(frame: pd.DataFrame) -> dict:
+    relative_error = frame["Relative error"].to_numpy(dtype=float)
+    absolute_relative_error = np.abs(relative_error)
+    return {
+        "rows": int(len(frame)),
+        "mean_abs_relative_error": float(absolute_relative_error.mean()),
+        "median_abs_relative_error": float(np.median(absolute_relative_error)),
+        "rmse_relative_error": float(np.sqrt(np.mean(relative_error**2))),
+        "p90_abs_relative_error": float(np.quantile(absolute_relative_error, 0.9)),
+    }
+
+
+def summarize_soi_fit(
+    data: dict[str, np.ndarray],
+    name: str,
+    staged_path: Path,
+    year: int,
+) -> dict:
+    soi_df = pe_to_soi(dataset_class(name, data, staged_path, year), year)
+    comparison = compare_soi_replication_to_soi(soi_df, get_soi(year))
+
+    taxable = comparison[
+        comparison["Taxable only"]
+        & (comparison["AGI upper bound"] > 10_000)
+        & comparison["SOI Value"].ne(0)
+    ]
+    selected = comparison[
+        comparison["Variable"].isin(
+            [
+                "adjusted_gross_income",
+                "count",
+                "income_tax_before_credits",
+                "income_tax_after_credits",
+            ]
+        )
+        & (comparison["AGI upper bound"] > 10_000)
+        & comparison["SOI Value"].ne(0)
+    ]
+    aggregate = comparison[
+        comparison["Full population"] & comparison["SOI Value"].ne(0)
+    ]
+    filers = soi_df[soi_df["is_tax_filer"].astype(bool)]
+
+    return {
+        "tax_units": int(len(soi_df)),
+        "weighted_filers": float(filers["weight"].sum()),
+        "filing_status_counts": {
+            status: float(group["weight"].sum())
+            for status, group in filers.groupby("filing_status")
+        },
+        "taxable_soi_rows": _metric_summary(taxable),
+        "selected_tax_rows": _metric_summary(selected),
+        "aggregate_soi_rows": _metric_summary(aggregate),
+    }
+
+
+def compute_outcome_comparison(
+    staged_path: Path,
+    public_person_path: Path,
+    year: int,
+    csv_name: str | None = None,
+) -> dict:
+    base = load_staged_arrays(staged_path)
+    public_person = load_public_person_file(public_person_path, csv_name)
+    constructed = make_constructed_id_dataset(base, public_person, year)
+
+    census = summarize_soi_fit(base, "census_tax_units", staged_path, year)
+    policyengine = summarize_soi_fit(
+        constructed,
+        "policyengine_tax_units",
+        staged_path,
+        year,
+    )
+
+    return {
+        "year": year,
+        "staged_dataset": str(staged_path),
+        "public_person_file": str(public_person_path),
+        "census_tax_units": census,
+        "policyengine_tax_units": policyengine,
+        "deltas_policyengine_minus_census": {
+            "tax_units": policyengine["tax_units"] - census["tax_units"],
+            "weighted_filers": policyengine["weighted_filers"]
+            - census["weighted_filers"],
+            "taxable_soi_rows_mean_abs_relative_error": policyengine[
+                "taxable_soi_rows"
+            ]["mean_abs_relative_error"]
+            - census["taxable_soi_rows"]["mean_abs_relative_error"],
+            "taxable_soi_rows_rmse_relative_error": policyengine[
+                "taxable_soi_rows"
+            ]["rmse_relative_error"]
+            - census["taxable_soi_rows"]["rmse_relative_error"],
+            "selected_tax_rows_mean_abs_relative_error": policyengine[
+                "selected_tax_rows"
+            ]["mean_abs_relative_error"]
+            - census["selected_tax_rows"]["mean_abs_relative_error"],
+            "selected_tax_rows_rmse_relative_error": policyengine[
+                "selected_tax_rows"
+            ]["rmse_relative_error"]
+            - census["selected_tax_rows"]["rmse_relative_error"],
+            "aggregate_soi_rows_mean_abs_relative_error": policyengine[
+                "aggregate_soi_rows"
+            ]["mean_abs_relative_error"]
+            - census["aggregate_soi_rows"]["mean_abs_relative_error"],
+        },
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compare PE-US SOI tax outcome fit under Census TAX_ID versus "
+            "constructed CPS tax units."
+        )
+    )
+    parser.add_argument("staged_path", type=Path)
+    parser.add_argument("public_person_path", type=Path)
+    parser.add_argument("--csv-name", default=None)
+    parser.add_argument("--year", type=int, default=2024)
+    parser.add_argument("--output", type=Path, default=None)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    result = compute_outcome_comparison(
+        staged_path=args.staged_path,
+        public_person_path=args.public_person_path,
+        year=args.year,
+        csv_name=args.csv_name,
+    )
+    rendered = json.dumps(result, indent=2)
+    print(rendered)
+    if args.output is not None:
+        args.output.write_text(rendered)
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/cps_tax_unit_validation.py
+++ b/validation/cps_tax_unit_validation.py
@@ -1,0 +1,482 @@
+"""
+Compare constructed CPS tax units against Census TAX_ID partitions.
+
+The comparison is done within households using tax-unit member partitions rather
+than raw TAX_ID values, since constructed tax-unit identifiers are renumbered.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import zipfile
+from pathlib import Path
+
+import pandas as pd
+
+from policyengine_us_data.datasets.cps.tax_unit_construction import (
+    POLICYENGINE_MODE,
+    SUPPORTED_TAX_UNIT_CONSTRUCTION_MODES,
+    construct_tax_units,
+)
+from policyengine_us_data.datasets.cps.tax_unit_rule_helpers import (
+    CPSRelationshipCode,
+    qualifying_child_age_test,
+)
+
+
+DEFAULT_USECOLS = [
+    "PH_SEQ",
+    "A_LINENO",
+    "A_AGE",
+    "A_MARITL",
+    "A_SPOUSE",
+    "PECOHAB",
+    "PEPAR1",
+    "PEPAR2",
+    "A_EXPRRP",
+    "A_ENRLW",
+    "A_FTPT",
+    "A_HSCOL",
+    "WSAL_VAL",
+    "SEMP_VAL",
+    "FRSE_VAL",
+    "INT_VAL",
+    "DIV_VAL",
+    "RNT_VAL",
+    "CAP_VAL",
+    "UC_VAL",
+    "OI_VAL",
+    "ANN_VAL",
+    "PNSN_VAL",
+    "PTOTVAL",
+    "SS_VAL",
+    "PEDISDRS",
+    "PEDISEAR",
+    "PEDISEYE",
+    "PEDISOUT",
+    "PEDISPHY",
+    "PEDISREM",
+    "TAX_ID",
+]
+
+
+def load_person_file(
+    input_path: Path,
+    csv_name: str | None = None,
+    usecols: list[str] | None = None,
+) -> pd.DataFrame:
+    usecols = usecols or DEFAULT_USECOLS
+    if input_path.suffix.lower() == ".zip":
+        with zipfile.ZipFile(input_path) as zf:
+            selected_name = csv_name
+            if selected_name is None:
+                matches = [
+                    name
+                    for name in zf.namelist()
+                    if name.lower().startswith("pppub")
+                    and name.lower().endswith(".csv")
+                ]
+                if not matches:
+                    raise FileNotFoundError(
+                        f"No pppub*.csv person file found in {input_path}."
+                    )
+                selected_name = sorted(matches)[0]
+            with zf.open(selected_name) as f:
+                return pd.read_csv(f, usecols=usecols, low_memory=False)
+    return pd.read_csv(input_path, usecols=usecols, low_memory=False)
+
+
+def _has_tax_unit_student_evidence(row) -> bool:
+    return int(row.A_ENRLW) == 1 and (
+        int(row.A_FTPT) == 1 or int(row.A_HSCOL) in {1, 2}
+    )
+
+
+def compute_tax_unit_comparison(
+    person: pd.DataFrame,
+    year: int,
+    mode: str = POLICYENGINE_MODE,
+) -> dict:
+    person = person.copy()
+    person["CENSUS_TAX_ID"] = person["TAX_ID"].astype(int)
+    assignments, _ = construct_tax_units(person, year=year, mode=mode)
+    person = person.join(assignments.rename(columns={"TAX_ID": "CONSTRUCTED_TAX_ID"}))
+
+    rel_own_child = CPSRelationshipCode.OWN_CHILD.value
+    rel_grandchild = CPSRelationshipCode.GRANDCHILD.value
+    other_adult_rels = {
+        CPSRelationshipCode.PARENT.value,
+        CPSRelationshipCode.SIBLING.value,
+        CPSRelationshipCode.OTHER_RELATIVE.value,
+    }
+
+    exact_match = 0
+    same_unit_count = 0
+    constructed_lt = 0
+    constructed_gt = 0
+    person_same_unit = 0
+    persons_total = len(person)
+    mismatched_households = 0
+    mismatched_person_rows = 0
+    mismatch_buckets = {
+        "construct_fewer": 0,
+        "own_child_adult": 0,
+        "other_adult_relative": 0,
+        "grandchild_present": 0,
+        "no_parent_pointer_minor": 0,
+        "reciprocal_married_pair_split_by_census": 0,
+    }
+    reciprocal_spouse_split_households = 0
+    exact_match_excluding_census_spouse_split = 0
+    non_spouse_split_households = 0
+
+    reciprocal_spouse_people = 0
+    reciprocal_spouse_split_people_census = 0
+    reciprocal_spouse_split_people_constructed = 0
+    qual_child_pointer_people = 0
+    qual_child_pointer_split_census = 0
+    qual_child_pointer_split_constructed = 0
+    minor_people = 0
+    minor_singleton_census = 0
+    minor_singleton_constructed = 0
+    young_parent_pointer_people = 0
+    young_parent_pointer_split_census = 0
+    young_parent_pointer_split_constructed = 0
+
+    for household_id, household in person.groupby("PH_SEQ", sort=False):
+        household = household.copy()
+        household["line_no"] = household["A_LINENO"].astype(int)
+
+        census_groups = [
+            frozenset(group["line_no"].tolist())
+            for _, group in household.groupby("CENSUS_TAX_ID", sort=False)
+        ]
+        constructed_groups = [
+            frozenset(group["line_no"].tolist())
+            for _, group in household.groupby("CONSTRUCTED_TAX_ID", sort=False)
+        ]
+        census_partition = frozenset(census_groups)
+        constructed_partition = frozenset(constructed_groups)
+
+        census_unit_for_line = {
+            line_no: group for group in census_groups for line_no in group
+        }
+        constructed_unit_for_line = {
+            line_no: group for group in constructed_groups for line_no in group
+        }
+
+        household_exact = census_partition == constructed_partition
+        if household_exact:
+            exact_match += 1
+        else:
+            mismatched_households += 1
+            mismatched_person_rows += sum(
+                census_unit_for_line[line_no]
+                != constructed_unit_for_line[line_no]
+                for line_no in household["line_no"]
+            )
+
+        if len(census_groups) == len(constructed_groups):
+            same_unit_count += 1
+        elif len(constructed_groups) < len(census_groups):
+            constructed_lt += 1
+        else:
+            constructed_gt += 1
+
+        person_same_unit += sum(
+            census_unit_for_line[line_no] == constructed_unit_for_line[line_no]
+            for line_no in household["line_no"]
+        )
+
+        line_to_row = {
+            int(row.A_LINENO): row for row in household.itertuples(index=False)
+        }
+        line_to_census_tax = {
+            int(row.A_LINENO): int(row.CENSUS_TAX_ID)
+            for row in household.itertuples(index=False)
+        }
+        line_to_constructed_tax = {
+            int(row.A_LINENO): int(row.CONSTRUCTED_TAX_ID)
+            for row in household.itertuples(index=False)
+        }
+
+        household_has_census_spouse_split = False
+        for row in household.itertuples(index=False):
+            spouse_line = int(row.A_SPOUSE) if pd.notna(row.A_SPOUSE) else 0
+            line_no = int(row.A_LINENO)
+            if spouse_line <= 0:
+                continue
+            spouse = line_to_row.get(spouse_line)
+            if spouse is None:
+                continue
+            spouse_spouse_line = (
+                int(spouse.A_SPOUSE) if pd.notna(spouse.A_SPOUSE) else 0
+            )
+            if spouse_spouse_line != line_no:
+                continue
+            reciprocal_spouse_people += 1
+            if line_to_census_tax[line_no] != line_to_census_tax[spouse_line]:
+                reciprocal_spouse_split_people_census += 1
+                household_has_census_spouse_split = True
+            if (
+                line_to_constructed_tax[line_no]
+                != line_to_constructed_tax[spouse_line]
+            ):
+                reciprocal_spouse_split_people_constructed += 1
+
+        if household_has_census_spouse_split:
+            reciprocal_spouse_split_households += 1
+        else:
+            non_spouse_split_households += 1
+            if household_exact:
+                exact_match_excluding_census_spouse_split += 1
+
+        for row in household.itertuples(index=False):
+            line_no = int(row.A_LINENO)
+            age = int(row.A_AGE)
+            parent_lines = [
+                int(value)
+                for value in (row.PEPAR1, row.PEPAR2)
+                if pd.notna(value)
+                and int(value) > 0
+                and int(value) in line_to_row
+            ]
+            is_student = _has_tax_unit_student_evidence(row)
+            disability = any(
+                int(getattr(row, col)) == 1
+                for col in [
+                    "PEDISDRS",
+                    "PEDISEAR",
+                    "PEDISEYE",
+                    "PEDISOUT",
+                    "PEDISPHY",
+                    "PEDISREM",
+                ]
+            )
+
+            if age < 18:
+                minor_people += 1
+                if len(census_unit_for_line[line_no]) == 1:
+                    minor_singleton_census += 1
+                if len(constructed_unit_for_line[line_no]) == 1:
+                    minor_singleton_constructed += 1
+
+            if parent_lines and qualifying_child_age_test(
+                age, is_student, disability
+            ):
+                qual_child_pointer_people += 1
+                if not any(
+                    line_to_census_tax[line_no] == line_to_census_tax[parent_line]
+                    for parent_line in parent_lines
+                ):
+                    qual_child_pointer_split_census += 1
+                if not any(
+                    line_to_constructed_tax[line_no]
+                    == line_to_constructed_tax[parent_line]
+                    for parent_line in parent_lines
+                ):
+                    qual_child_pointer_split_constructed += 1
+
+            if parent_lines and 18 <= age <= 23:
+                young_parent_pointer_people += 1
+                if not any(
+                    line_to_census_tax[line_no] == line_to_census_tax[parent_line]
+                    for parent_line in parent_lines
+                ):
+                    young_parent_pointer_split_census += 1
+                if not any(
+                    line_to_constructed_tax[line_no]
+                    == line_to_constructed_tax[parent_line]
+                    for parent_line in parent_lines
+                ):
+                    young_parent_pointer_split_constructed += 1
+
+        if not household_exact:
+            if len(constructed_groups) < len(census_groups):
+                mismatch_buckets["construct_fewer"] += 1
+            if any(
+                int(row.A_EXPRRP) == rel_own_child and int(row.A_AGE) >= 18
+                for row in household.itertuples(index=False)
+            ):
+                mismatch_buckets["own_child_adult"] += 1
+            if any(
+                int(row.A_EXPRRP) in other_adult_rels and int(row.A_AGE) >= 18
+                for row in household.itertuples(index=False)
+            ):
+                mismatch_buckets["other_adult_relative"] += 1
+            if any(
+                int(row.A_EXPRRP) == rel_grandchild
+                for row in household.itertuples(index=False)
+            ):
+                mismatch_buckets["grandchild_present"] += 1
+            if any(
+                int(row.A_AGE) < 18
+                and all(
+                    (not pd.notna(value)) or int(value) <= 0
+                    for value in (row.PEPAR1, row.PEPAR2)
+                )
+                for row in household.itertuples(index=False)
+            ):
+                mismatch_buckets["no_parent_pointer_minor"] += 1
+            if household_has_census_spouse_split:
+                mismatch_buckets["reciprocal_married_pair_split_by_census"] += 1
+
+    households_total = int(person["PH_SEQ"].nunique())
+    return {
+        "mode": mode,
+        "summary": {
+            "households_total": households_total,
+            "persons_total": int(persons_total),
+            "household_exact_match_pct": round(
+                100 * exact_match / households_total, 2
+            ),
+            "household_exact_match_excluding_census_spouse_split_pct": round(
+                100
+                * exact_match_excluding_census_spouse_split
+                / non_spouse_split_households,
+                2,
+            )
+            if non_spouse_split_households
+            else None,
+            "census_spouse_split_households_pct": round(
+                100 * reciprocal_spouse_split_households / households_total, 2
+            ),
+            "person_same_unit_pct": round(100 * person_same_unit / persons_total, 2),
+            "households_same_unit_count_pct": round(
+                100 * same_unit_count / households_total, 2
+            ),
+            "constructed_lt_census_pct": round(
+                100 * constructed_lt / households_total, 2
+            ),
+            "constructed_gt_census_pct": round(
+                100 * constructed_gt / households_total, 2
+            ),
+            "census_tax_units": int(person["CENSUS_TAX_ID"].nunique()),
+            "constructed_tax_units": int(person["CONSTRUCTED_TAX_ID"].nunique()),
+            "mismatched_households": int(mismatched_households),
+            "mismatched_persons": int(mismatched_person_rows),
+        },
+        "mismatch_buckets_pct": {
+            key: (
+                round(100 * value / mismatched_households, 2)
+                if mismatched_households
+                else 0.0
+            )
+            for key, value in mismatch_buckets.items()
+        },
+        "legal_consistency": {
+            "reciprocal_spouse_people_split_pct": {
+                "census": round(
+                    100 * reciprocal_spouse_split_people_census / reciprocal_spouse_people,
+                    2,
+                )
+                if reciprocal_spouse_people
+                else None,
+                "constructed": round(
+                    100
+                    * reciprocal_spouse_split_people_constructed
+                    / reciprocal_spouse_people,
+                    2,
+                )
+                if reciprocal_spouse_people
+                else None,
+            },
+            "qualifying_child_with_parent_pointer_split_pct": {
+                "census": round(
+                    100 * qual_child_pointer_split_census / qual_child_pointer_people,
+                    2,
+                )
+                if qual_child_pointer_people
+                else None,
+                "constructed": round(
+                    100
+                    * qual_child_pointer_split_constructed
+                    / qual_child_pointer_people,
+                    2,
+                )
+                if qual_child_pointer_people
+                else None,
+            },
+            "minor_singleton_pct": {
+                "census": round(100 * minor_singleton_census / minor_people, 2)
+                if minor_people
+                else None,
+                "constructed": round(
+                    100 * minor_singleton_constructed / minor_people, 2
+                )
+                if minor_people
+                else None,
+            },
+            "young_adult_with_parent_pointer_split_pct": {
+                "census": round(
+                    100
+                    * young_parent_pointer_split_census
+                    / young_parent_pointer_people,
+                    2,
+                )
+                if young_parent_pointer_people
+                else None,
+                "constructed": round(
+                    100
+                    * young_parent_pointer_split_constructed
+                    / young_parent_pointer_people,
+                    2,
+                )
+                if young_parent_pointer_people
+                else None,
+            },
+        },
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare constructed CPS tax units against Census TAX_ID partitions."
+    )
+    parser.add_argument(
+        "input_path",
+        type=Path,
+        help="Path to the public-use CPS person CSV or zip archive containing it.",
+    )
+    parser.add_argument(
+        "--csv-name",
+        default=None,
+        help="CSV name inside the zip archive. Defaults to the first pppub*.csv.",
+    )
+    parser.add_argument(
+        "--year",
+        type=int,
+        default=2024,
+        help="Tax year for construction. Default: %(default)s",
+    )
+    parser.add_argument(
+        "--mode",
+        default=POLICYENGINE_MODE,
+        choices=sorted(SUPPORTED_TAX_UNIT_CONSTRUCTION_MODES),
+        help=(
+            "Tax-unit construction mode to benchmark. "
+            f"Default: {POLICYENGINE_MODE}"
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional JSON output path.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    person = load_person_file(args.input_path, csv_name=args.csv_name)
+    result = compute_tax_unit_comparison(person, year=args.year, mode=args.mode)
+    rendered = json.dumps(result, indent=2)
+    print(rendered)
+    if args.output is not None:
+        args.output.write_text(rendered)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Builds CPS tax units from ASEC household records instead of using Census `TAX_ID` as the production tax-unit graph.

Key points:

- Constructs tax units from reciprocal spouses, parent pointers, student/disability/age eligibility, gross-income limits, and relationship rules.
- Keeps only constructed `TAX_ID`s in the staged CPS data path; PE-US infers tax-unit roles and filing statuses from the resulting graph.
- Preserves `CENSUS_TAX_ID` for audit/comparison.
- Adds a `census_documented` comparison mode and two validation harnesses.
- Adds unit and integration coverage for assignment edge cases and CPS staging.

Closes #815.

## Validation

Structural comparison against the 2025 ASEC public person file for tax year 2024:

- Household exact match vs Census: `93.55%`
- Exact match excluding Census spouse-split households: `96.91%`
- Person same-unit match: `92.97%`
- Reciprocal spouse splits: Census `6.82%`, constructed `0.00%`
- Qualifying-child parent-pointer splits: Census `1.86%`, constructed `0.34%`
- Minor singleton rate: Census `1.35%`, constructed `1.28%`

Outcome comparison holding staged CPS arrays fixed and swapping only tax-unit IDs:

- Taxable SOI rows mean absolute relative error: `1.12884 -> 1.12773`
- Selected tax rows mean absolute relative error: `0.68472 -> 0.67852`
- Selected tax rows RMSE relative error: `2.45406 -> 2.40138`
- Aggregate SOI rows mean absolute relative error: `1.17441 -> 1.17380`

Commands run:

- `uv run ruff check policyengine_us_data/datasets/cps/census_cps.py policyengine_us_data/datasets/cps/cps.py policyengine_us_data/datasets/cps/tax_unit_construction.py policyengine_us_data/datasets/cps/tax_unit_rule_helpers.py tests/integration/test_census_cps.py tests/integration/test_cps.py tests/unit/datasets/test_cps_tax_unit_construction.py validation/cps_tax_unit_validation.py validation/cps_tax_unit_outcome_validation.py`
- `uv run pytest tests/unit/datasets/test_cps_tax_unit_construction.py -q`
- `uv run pytest tests/integration/test_census_cps.py -k 'resolve_person_usecols or fill_missing_optional_person_columns or create_tax_unit_table' -q`
- `uv run pytest tests/integration/test_cps.py -k 'add_personal_variables or add_id_variables or validate_raw_cps_schema' -q`
- `PYTHONPATH=/Users/maxghenis/PolicyEngine/policyengine-us uv run python validation/cps_tax_unit_outcome_validation.py policyengine_us_data/storage/cps_2024.h5 /tmp/asecpub25csv.zip --csv-name pppub25.csv --year 2024 --output /tmp/cps_tax_unit_outcome_validation_ids_only.json`
