### PR TITLE
Add WIC calibration targets

### DIFF
--- a/changelog.d/845.added.md
+++ b/changelog.d/845.added.md
@@ -1,1 +1,1 @@
-Add national WIC calibration targets for FY 2024 total program costs and average monthly participation.
+Add national WIC calibration targets for FY 2024 food costs and average monthly participation.

--- a/changelog.d/845.added.md
+++ b/changelog.d/845.added.md
@@ -1,0 +1,1 @@
+Add national WIC calibration targets for FY 2024 total program costs and average monthly participation.

--- a/policyengine_us_data/calibration/target_config.yaml
+++ b/policyengine_us_data/calibration/target_config.yaml
@@ -151,6 +151,8 @@ include:
     geo_level: national
   - variable: unemployment_compensation
     geo_level: national
+  - variable: wic
+    geo_level: national
 
   # === NATIONAL — retirement contribution targets ===
   - variable: traditional_ira_contributions
@@ -231,6 +233,11 @@ include:
   - variable: person_count
     geo_level: national
     domain_variable: ssn_card_type
+
+  # === NATIONAL — WIC participation count target ===
+  - variable: person_count
+    geo_level: national
+    domain_variable: wic
 
   # === NATIONAL — SOI deduction totals (non-reform) ===
   - variable: medical_expense_deduction

--- a/policyengine_us_data/db/etl_national_targets.py
+++ b/policyengine_us_data/db/etl_national_targets.py
@@ -23,6 +23,11 @@ from policyengine_us_data.utils.db import (
 )
 
 
+WIC_NATIONAL_ANNUAL_SUMMARY_SOURCE = (
+    "https://www.fns.usda.gov/sites/default/files/resource-files/wisummary-4.xlsx"
+)
+
+
 def extract_national_targets(year: int = DEFAULT_YEAR):
     """
     Extract national calibration targets from various sources.
@@ -197,6 +202,13 @@ def extract_national_targets(year: int = DEFAULT_YEAR):
             "year": 2024,
         },
         {
+            "variable": "wic",
+            "value": 7_332_200_000,
+            "source": WIC_NATIONAL_ANNUAL_SUMMARY_SOURCE,
+            "notes": "FY 2024 WIC total costs; National Level Annual Summary workbook, sheet 'Annual Participation and costs', FY 2024 row; food costs are $4.9115B",
+            "year": 2024,
+        },
+        {
             "variable": "real_estate_taxes",
             "value": 500e9,
             "source": "Census Bureau",
@@ -314,6 +326,13 @@ def extract_national_targets(year: int = DEFAULT_YEAR):
             "person_count": 19_743_689,
             "source": "CMS marketplace data",
             "notes": "ACA Premium Tax Credit recipients",
+            "year": 2024,
+        },
+        {
+            "constraint_variable": "wic",
+            "person_count": 6_704_000,
+            "source": WIC_NATIONAL_ANNUAL_SUMMARY_SOURCE,
+            "notes": "FY 2024 WIC average monthly participation; National Level Annual Summary workbook, sheet 'Annual Participation and costs', FY 2024 row",
             "year": 2024,
         },
         {
@@ -736,6 +755,10 @@ def load_national_targets(
                 constraint_value = "0"
             elif constraint_var == "aca_ptc":
                 stratum_notes = "National ACA Premium Tax Credit Recipients"
+                constraint_operation = ">"
+                constraint_value = "0"
+            elif constraint_var == "wic":
+                stratum_notes = "National WIC Recipients"
                 constraint_operation = ">"
                 constraint_value = "0"
             elif constraint_var == "spm_unit_energy_subsidy_reported":

--- a/policyengine_us_data/db/etl_national_targets.py
+++ b/policyengine_us_data/db/etl_national_targets.py
@@ -203,9 +203,9 @@ def extract_national_targets(year: int = DEFAULT_YEAR):
         },
         {
             "variable": "wic",
-            "value": 7_332_200_000,
+            "value": 4_911_500_000,
             "source": WIC_NATIONAL_ANNUAL_SUMMARY_SOURCE,
-            "notes": "FY 2024 WIC total costs; National Level Annual Summary workbook, sheet 'Annual Participation and costs', FY 2024 row; food costs are $4.9115B",
+            "notes": "FY 2024 WIC food costs, excluding nutrition services and administration; National Level Annual Summary workbook, sheet 'Annual Participation and costs', FY 2024 row",
             "year": 2024,
         },
         {

--- a/tests/unit/calibration/test_target_config.py
+++ b/tests/unit/calibration/test_target_config.py
@@ -245,6 +245,24 @@ class TestLoadTargetConfig:
             "domain_variable": "tanf",
         } in include_rules
 
+    def test_training_config_includes_wic_national_targets(self):
+        config = load_target_config(
+            str(
+                Path(__file__).resolve().parents[3]
+                / "policyengine_us_data"
+                / "calibration"
+                / "target_config.yaml"
+            )
+        )
+
+        include_rules = config["include"]
+        assert {"variable": "wic", "geo_level": "national"} in include_rules
+        assert {
+            "variable": "person_count",
+            "geo_level": "national",
+            "domain_variable": "wic",
+        } in include_rules
+
 
 class TestCalibrationPackageRoundTrip:
     def test_round_trip(self, sample_targets, tmp_path):

--- a/tests/unit/test_etl_national_targets.py
+++ b/tests/unit/test_etl_national_targets.py
@@ -220,9 +220,9 @@ def test_load_national_targets_supports_wic_targets(tmp_path, monkeypatch):
         [
             {
                 "variable": "wic",
-                "value": 7_332_200_000,
+                "value": 4_911_500_000,
                 "source": "https://www.fns.usda.gov/sites/default/files/resource-files/wisummary-4.xlsx",
-                "notes": "FY 2024 WIC total costs from FNS annual summary",
+                "notes": "FY 2024 WIC food costs from FNS annual summary",
                 "year": 2024,
             }
         ]
@@ -253,7 +253,7 @@ def test_load_national_targets_supports_wic_targets(tmp_path, monkeypatch):
             )
         ).first()
         assert wic_total_target is not None
-        assert wic_total_target.value == 7_332_200_000
+        assert wic_total_target.value == 4_911_500_000
 
         wic_stratum = session.exec(
             select(Stratum).where(Stratum.notes == "National WIC Recipients")

--- a/tests/unit/test_etl_national_targets.py
+++ b/tests/unit/test_etl_national_targets.py
@@ -199,3 +199,83 @@ def test_load_national_targets_supports_liheap_household_counts(tmp_path, monkey
         ).first()
         assert liheap_target is not None
         assert liheap_target.value == 5_876_646
+
+
+def test_load_national_targets_supports_wic_targets(tmp_path, monkeypatch):
+    calibration_dir = tmp_path / "calibration"
+    calibration_dir.mkdir()
+    db_uri = f"sqlite:///{calibration_dir / 'policy_data.db'}"
+    engine = create_database(db_uri)
+
+    with Session(engine) as session:
+        national = _make_stratum(session, notes="United States")
+        national_id = national.stratum_id
+
+    monkeypatch.setattr(
+        "policyengine_us_data.db.etl_national_targets.STORAGE_FOLDER",
+        tmp_path,
+    )
+
+    direct_targets_df = pd.DataFrame(
+        [
+            {
+                "variable": "wic",
+                "value": 7_332_200_000,
+                "source": "https://www.fns.usda.gov/sites/default/files/resource-files/wisummary-4.xlsx",
+                "notes": "FY 2024 WIC total costs from FNS annual summary",
+                "year": 2024,
+            }
+        ]
+    )
+    conditional_targets = [
+        {
+            "constraint_variable": "wic",
+            "person_count": 6_704_000,
+            "source": "https://www.fns.usda.gov/sites/default/files/resource-files/wisummary-4.xlsx",
+            "notes": "FY 2024 WIC average monthly participation",
+            "year": 2024,
+        }
+    ]
+
+    load_national_targets(
+        direct_targets_df=direct_targets_df,
+        tax_filer_df=pd.DataFrame(),
+        tax_expenditure_df=pd.DataFrame(),
+        conditional_targets=conditional_targets,
+    )
+
+    with Session(engine) as session:
+        wic_total_target = session.exec(
+            select(Target).where(
+                Target.stratum_id == national_id,
+                Target.variable == "wic",
+                Target.period == 2024,
+            )
+        ).first()
+        assert wic_total_target is not None
+        assert wic_total_target.value == 7_332_200_000
+
+        wic_stratum = session.exec(
+            select(Stratum).where(Stratum.notes == "National WIC Recipients")
+        ).first()
+        assert wic_stratum is not None
+
+        constraints = {
+            (
+                constraint.constraint_variable,
+                constraint.operation,
+                constraint.value,
+            )
+            for constraint in wic_stratum.constraints_rel
+        }
+        assert ("wic", ">", "0") in constraints
+
+        wic_count_target = session.exec(
+            select(Target).where(
+                Target.stratum_id == wic_stratum.stratum_id,
+                Target.variable == "person_count",
+                Target.period == 2024,
+            )
+        ).first()
+        assert wic_count_target is not None
+        assert wic_count_target.value == 6_704_000


### PR DESCRIPTION
## Summary
- Add FY 2024 national WIC total-cost and participation calibration targets from USDA FNS WIC Program Data.
- Include the national WIC dollar target and `person_count` for `wic > 0` in the training target config.
- Cover WIC target loading and target-config inclusion in unit tests.

## Source
USDA FNS exact workbook: [WIC Program Participation and Costs, National Level Annual Summary](https://www.fns.usda.gov/sites/default/files/resource-files/wisummary-4.xlsx), sheet `Annual Participation and costs`, FY 2024 row. The workbook is linked from the [FNS WIC Data Tables](https://www.fns.usda.gov/pd/wic-program) page under National Level Annual Summary and has data as of April 10, 2026.

FY 2024 values used:
- Total participation: 6.704 million average monthly participants
- Total costs: $7.3322B

Also shown in the same row but not used as the dollar target:
- Food costs: $4.9115B

## Validation
- `uv run ruff format --check policyengine_us_data/db/etl_national_targets.py tests/unit/test_etl_national_targets.py tests/unit/calibration/test_target_config.py`
- `uv run ruff check policyengine_us_data/db/etl_national_targets.py tests/unit/test_etl_national_targets.py tests/unit/calibration/test_target_config.py`
- `uv run pytest tests/unit/test_etl_national_targets.py tests/unit/calibration/test_target_config.py`
- `uv run python - <<'PY' ... extract_national_targets(year=2024) ... PY`
