### PR TITLE
Fix QBI simulation inputs

### DIFF
--- a/docs/appendix.md
+++ b/docs/appendix.md
@@ -47,7 +47,7 @@ for iteration in range(5000):
 
 ### Table A1: Complete List of Imputed Variables
 
-#### Variables Imputed from IRS Public Use File (67 variables)
+#### Variables Imputed from IRS Public Use File (70 variables)
 
 **Income Variables:**
 
@@ -113,6 +113,7 @@ for iteration in range(5000):
 - unadjusted_basis_qualified_property
 - business_is_sstb
 - sstb_self_employment_income
+- sstb_self_employment_income_would_be_qualified
 - sstb_w2_wages_from_qualified_business
 - sstb_unadjusted_basis_qualified_property
 - qualified_reit_and_ptp_income

--- a/paper/sections/methodology/puf_preprocessing.tex
+++ b/paper/sections/methodology/puf_preprocessing.tex
@@ -18,15 +18,19 @@ Total medical expenses are decomposed into specific categories using fixed ratio
 Key derived variables include:
 
 \paragraph{Qualified Business Income (QBI)}
-Calculated as the maximum of zero and the sum of:
+QBI-related inputs are simulated from source-level PUF income fields using the assumptions in \texttt{qbi\_assumptions.yaml}. The model first draws whether each source would be qualified business income, with source-specific probabilities for:
 \begin{itemize}
-    \item Schedule E income (E00900)
-    \item Partnership and S-corporation income (E26270)
-    \item Farm income (E02100)
-    \item Rental income (E27200)
+    \item Schedule C self-employment income
+    \item Partnership and S-corporation income
+    \item Farm operations income
+    \item Farm rent income
+    \item Rental income
+    \item Estate income
 \end{itemize}
 
-W2 wages from qualified business are then computed as 16\% of QBI.
+The persisted \texttt{*\_would\_be\_qualified} flags are then used consistently when constructing the QBI base for downstream imputation. W-2 wages from qualified business are simulated from positive qualified QBI by drawing profit margins, gross receipts, employee presence, and labor shares. UBIA is drawn for capital-intensive records using source-weighted capital-intensity probabilities and a lognormal amount scaled to positive QBI.
+
+Specified service trade or business (SSTB) status is drawn from positive mapped SSTB source amounts. When a record is classified as SSTB, Schedule C self-employment income and allocable W-2/UBIA inputs are split into SSTB-specific variables. Qualified REIT/PTP income and qualified BDC income are separately drawn from Bernoulli-lognormal distributions.
 
 \paragraph{Filing Status}
 Mapped from MARS codes:

--- a/policyengine_us_data/calibration/puf_impute.py
+++ b/policyengine_us_data/calibration/puf_impute.py
@@ -51,6 +51,7 @@ IMPUTED_VARIABLES = [
     "taxable_ira_distributions",
     "self_employment_income",
     "sstb_self_employment_income",
+    "sstb_self_employment_income_would_be_qualified",
     "w2_wages_from_qualified_business",
     "unadjusted_basis_qualified_property",
     "business_is_sstb",

--- a/policyengine_us_data/datasets/puf/puf.py
+++ b/policyengine_us_data/datasets/puf/puf.py
@@ -34,6 +34,23 @@ with open(yamlfilename, "r", encoding="utf-8") as yamlfile:
     QBI_PARAMS = yaml.safe_load(yamlfile)
 assert isinstance(QBI_PARAMS, dict)
 
+QBI_SOURCE_NAMES = tuple(QBI_PARAMS["qbi_qualification_probabilities"])
+QBI_QUALIFICATION_FLAG_BY_SOURCE = {
+    source: f"{source}_would_be_qualified" for source in QBI_SOURCE_NAMES
+}
+SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG = (
+    "sstb_self_employment_income_would_be_qualified"
+)
+QBI_QUALIFICATION_SEED = 41
+QBI_W2_UBIA_SEED = 42
+QBI_SSTB_SEED = 64
+QBI_SIMULATION_REQUIRED_VARIABLES = frozenset(
+    (
+        *QBI_QUALIFICATION_FLAG_BY_SOURCE.values(),
+        SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG,
+    )
+)
+
 
 # Helper functions ---
 def sample_bernoulli_lognormal(n, prob, log_mean, log_sigma, rng):
@@ -49,15 +66,81 @@ def sample_bernoulli_lognormal(n, prob, log_mean, log_sigma, rng):
 
 def conditionally_sample_lognormal(flag, target_mean, log_sigma, rng):
     """Generate a lognormal conditional on a binary flag."""
-    mu = np.log(target_mean) - (log_sigma**2 / 2)
+    flag = np.asarray(flag, dtype=bool)
+    target_mean = np.asarray(target_mean, dtype=float)
+    eligible = flag & (target_mean > 0)
+    safe_target_mean = np.where(target_mean > 0, target_mean, 1.0)
+    mu = np.log(safe_target_mean) - (log_sigma**2 / 2)
     return np.where(
-        flag,
+        eligible,
         rng.lognormal(
             mean=mu,
             sigma=log_sigma,
         ),
         0.0,
     )
+
+
+def draw_qbi_qualification_flags(n, *, seed=None):
+    """Draw source-level QBI qualification inputs."""
+    flag_rng = np.random.default_rng(seed)
+    return {
+        source: flag_rng.random(n) < prob
+        for source, prob in QBI_PARAMS["qbi_qualification_probabilities"].items()
+    }
+
+
+def add_qbi_qualification_flags_to_puf(puf, *, seed=None):
+    """Draw and persist source-level QBI qualification inputs."""
+    flags = draw_qbi_qualification_flags(len(puf), seed=seed)
+    for source, qualified in flags.items():
+        puf[QBI_QUALIFICATION_FLAG_BY_SOURCE[source]] = qualified
+    return puf
+
+
+def qualified_qbi_components(puf):
+    """Return source amounts after applying persisted QBI qualification flags."""
+    components = {}
+    for source, prob in QBI_PARAMS["qbi_qualification_probabilities"].items():
+        source_values = puf[source].fillna(0).to_numpy(dtype=float)
+        flag_name = QBI_QUALIFICATION_FLAG_BY_SOURCE[source]
+        if flag_name in puf:
+            qualified = puf[flag_name].fillna(False).astype(bool).to_numpy()
+            components[source] = source_values * qualified
+        else:
+            components[source] = source_values * prob
+    return pd.DataFrame(components, index=puf.index)
+
+
+def capital_intensity_probability(qbi_components):
+    """Estimate UBIA eligibility probability from positive qualified QBI sources."""
+    positive_components = qbi_components.clip(lower=0)
+    positive_total = positive_components.sum(axis=1).to_numpy()
+    source_probs = QBI_PARAMS["ubia_simulation"]["capital_intensity_probabilities"]
+    weighted_prob = np.zeros(len(qbi_components), dtype=float)
+    for source, prob in source_probs.items():
+        if source in positive_components:
+            weighted_prob += positive_components[source].to_numpy() * prob
+    return np.divide(
+        weighted_prob,
+        positive_total,
+        out=np.zeros_like(positive_total, dtype=float),
+        where=positive_total > 0,
+    ).clip(0, 1)
+
+
+def simulate_business_is_sstb(puf, *, rng, probability_map=None):
+    """Draw SSTB status only from positive mapped SSTB source amounts."""
+    sstb_probs = probability_map or QBI_PARAMS["sstb_prob_map_by_name"]
+    available_sources = [source for source in sstb_probs if source in puf]
+    if not available_sources:
+        return np.zeros(len(puf), dtype=bool)
+    sstb_sources = puf[available_sources].fillna(0).clip(lower=0)
+    has_sstb_source = sstb_sources.sum(axis=1).to_numpy() > 0
+    largest_sstb_source = sstb_sources.idxmax(axis=1)
+    pr_sstb = largest_sstb_source.map(sstb_probs).fillna(0.0).to_numpy()
+    pr_sstb = np.where(has_sstb_source, pr_sstb, 0.0)
+    return rng.binomial(n=1, p=pr_sstb).astype(bool)
 
 
 def simulate_w2_and_ubia_from_puf(puf, *, seed=None, diagnostics=True):
@@ -83,7 +166,6 @@ def simulate_w2_and_ubia_from_puf(puf, *, seed=None, diagnostics=True):
     rng = np.random.default_rng(seed)
 
     # Extract Qualified Business Income simulation parameters
-    qbi_probs = QBI_PARAMS["qbi_qualification_probabilities"]
     margin_params = QBI_PARAMS["profit_margin_distribution"]
     logit_params = QBI_PARAMS["has_employees_logit"]
 
@@ -99,16 +181,13 @@ def simulate_w2_and_ubia_from_puf(puf, *, seed=None, diagnostics=True):
     non_rental_beta_b = non_rental_labor["beta_b"]
     non_rental_scale = non_rental_labor["scale"]
 
-    depr_sigma = QBI_PARAMS["depreciation_proxy_sigma"]
-
     ubia_params = QBI_PARAMS["ubia_simulation"]
     ubia_multiple_of_qbi = ubia_params["multiple_of_qbi"]
     ubia_sigma = ubia_params["sigma"]
 
     # Estimate qualified business income
-    qbi = sum(
-        puf[income_type] * prob for income_type, prob in qbi_probs.items()
-    ).to_numpy()
+    qbi_components = qualified_qbi_components(puf)
+    qbi = qbi_components.sum(axis=1).to_numpy()
 
     # Simulate gross receipts by drawing a profit margin
     margins = (
@@ -135,16 +214,9 @@ def simulate_w2_and_ubia_from_puf(puf, *, seed=None, diagnostics=True):
 
     w2_wages = revenues * labor_ratios * has_employees
 
-    # A depreciation stand-in that scales with rents
-    depreciation_proxy = conditionally_sample_lognormal(
-        is_rental,
-        puf["rental_income"],
-        depr_sigma,
-        rng,
-    )
-
-    # UBIA simulation: lognormal, but only for capital-heavy records
-    is_capital_intensive = is_rental | (depreciation_proxy > 0)
+    # UBIA simulation: lognormal, but only for capital-heavy records.
+    pr_capital_intensive = capital_intensity_probability(qbi_components)
+    is_capital_intensive = rng.binomial(1, pr_capital_intensive).astype(bool)
 
     ubia = conditionally_sample_lognormal(
         is_capital_intensive,
@@ -424,28 +496,32 @@ def preprocess_puf(puf: pd.DataFrame) -> pd.DataFrame:
     puf["partnership_se_income"] = partnership_se
 
     # --- Qualified Business Income Deduction (QBID) simulation ---
-    w2, ubia = simulate_w2_and_ubia_from_puf(puf, seed=42)
+    puf = add_qbi_qualification_flags_to_puf(puf, seed=QBI_QUALIFICATION_SEED)
+    w2, ubia = simulate_w2_and_ubia_from_puf(puf, seed=QBI_W2_UBIA_SEED)
     puf["w2_wages_from_qualified_business"] = w2
     puf["unadjusted_basis_qualified_property"] = ubia
 
-    puf_qbi_sources_for_sstb = puf[QBI_PARAMS["sstb_prob_map_by_name"].keys()]
-    largest_qbi_source_name = puf_qbi_sources_for_sstb.idxmax(axis=1)
-
-    pr_sstb = largest_qbi_source_name.map(QBI_PARAMS["sstb_prob_map_by_name"]).fillna(
-        0.0
-    )
-    puf["business_is_sstb"] = rng.binomial(n=1, p=pr_sstb)
+    puf["business_is_sstb"] = simulate_business_is_sstb(puf, rng=rng)
     is_sstb = puf["business_is_sstb"].astype(bool)
 
     # The current PUF pipeline only imputes an all-or-nothing SSTB flag.
     # Use that to split Schedule C self-employment and allocable W-2/UBIA
     # inputs for policyengine-us without pretending to observe mixed cases.
     legacy_self_employment_income = puf["self_employment_income"].fillna(0)
+    self_employment_would_be_qualified = puf[
+        "self_employment_income_would_be_qualified"
+    ].astype(bool)
     puf["sstb_self_employment_income"] = np.where(
         is_sstb, legacy_self_employment_income, 0.0
     )
     puf["self_employment_income"] = np.where(
         is_sstb, 0.0, legacy_self_employment_income
+    )
+    puf[SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG] = np.where(
+        is_sstb, self_employment_would_be_qualified, False
+    )
+    puf["self_employment_income_would_be_qualified"] = np.where(
+        is_sstb, False, self_employment_would_be_qualified
     )
     puf["sstb_w2_wages_from_qualified_business"] = np.where(is_sstb, w2, 0.0)
     puf["sstb_unadjusted_basis_qualified_property"] = np.where(is_sstb, ubia, 0.0)
@@ -540,6 +616,13 @@ FINANCIAL_SUBSET = [
     "recapture_of_investment_credit",
     "unreported_payroll_tax",
     "pre_tax_contributions",
+    "estate_income_would_be_qualified",
+    "farm_operations_income_would_be_qualified",
+    "farm_rent_income_would_be_qualified",
+    "partnership_s_corp_income_would_be_qualified",
+    "rental_income_would_be_qualified",
+    "self_employment_income_would_be_qualified",
+    "sstb_self_employment_income_would_be_qualified",
     "w2_wages_from_qualified_business",
     "unadjusted_basis_qualified_property",
     "business_is_sstb",
@@ -563,6 +646,16 @@ class PUF(Dataset):
         if key in file_handle:
             del file_handle[key]
         file_handle.create_dataset(key, data=values)
+
+    @staticmethod
+    def _values_from_file_or_overrides(
+        file_handle, key: str, overrides: dict[str, np.ndarray], length: int
+    ) -> np.ndarray:
+        if key in overrides:
+            return np.asarray(overrides[key])
+        if key in file_handle:
+            return np.asarray(file_handle[key])
+        return np.zeros(length)
 
     def _sstb_split_overrides(self) -> dict[str, np.ndarray]:
         if not self.file_path.exists():
@@ -636,8 +729,121 @@ class PUF(Dataset):
 
         return overrides
 
+    def _qbi_simulation_overrides(
+        self, existing_overrides: dict[str, np.ndarray]
+    ) -> dict[str, np.ndarray]:
+        if not self.file_path.exists():
+            return {}
+
+        with h5py.File(self.file_path, "r") as file_handle:
+            keys = set(file_handle.keys())
+            if QBI_SIMULATION_REQUIRED_VARIABLES.issubset(keys):
+                return {}
+
+            length = None
+            for key in (
+                "household_id",
+                "self_employment_income",
+                "partnership_s_corp_income",
+            ):
+                if key in file_handle:
+                    length = len(file_handle[key])
+                    break
+            if length is None:
+                return {}
+
+            raw_qualification_flags = draw_qbi_qualification_flags(
+                length, seed=QBI_QUALIFICATION_SEED
+            )
+            is_sstb_existing = self._values_from_file_or_overrides(
+                file_handle, "business_is_sstb", existing_overrides, length
+            ).astype(bool)
+            self_employment_would_be_qualified = raw_qualification_flags[
+                "self_employment_income"
+            ]
+            flag_overrides = {
+                "self_employment_income_would_be_qualified": np.where(
+                    is_sstb_existing, False, self_employment_would_be_qualified
+                ),
+                SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG: np.where(
+                    is_sstb_existing, self_employment_would_be_qualified, False
+                ),
+            }
+            for source, qualified in raw_qualification_flags.items():
+                flag = QBI_QUALIFICATION_FLAG_BY_SOURCE[source]
+                if source != "self_employment_income":
+                    flag_overrides[flag] = qualified
+
+            has_all_qbi_sources = all(
+                source in file_handle or source in existing_overrides
+                for source in QBI_SOURCE_NAMES
+            )
+            if not has_all_qbi_sources:
+                return flag_overrides
+
+            source_arrays = {}
+            for source in QBI_SOURCE_NAMES:
+                source_arrays[source] = self._values_from_file_or_overrides(
+                    file_handle, source, existing_overrides, length
+                ).astype(float)
+
+            source_arrays["self_employment_income"] = (
+                self._values_from_file_or_overrides(
+                    file_handle,
+                    "self_employment_income",
+                    existing_overrides,
+                    length,
+                ).astype(float)
+                + self._values_from_file_or_overrides(
+                    file_handle,
+                    "sstb_self_employment_income",
+                    existing_overrides,
+                    length,
+                ).astype(float)
+            )
+
+            qbi_frame = pd.DataFrame(source_arrays)
+            for source, qualified in raw_qualification_flags.items():
+                qbi_frame[QBI_QUALIFICATION_FLAG_BY_SOURCE[source]] = qualified
+
+            w2, ubia = simulate_w2_and_ubia_from_puf(
+                qbi_frame, seed=QBI_W2_UBIA_SEED, diagnostics=False
+            )
+            is_sstb = simulate_business_is_sstb(
+                qbi_frame,
+                rng=np.random.default_rng(QBI_SSTB_SEED),
+                probability_map=QBI_PARAMS["sstb_prob_map_by_source_name"],
+            )
+            legacy_self_employment_income = source_arrays["self_employment_income"]
+
+            overrides = {
+                **flag_overrides,
+                "business_is_sstb": is_sstb,
+                "self_employment_income": np.where(
+                    is_sstb, 0.0, legacy_self_employment_income
+                ),
+                "sstb_self_employment_income": np.where(
+                    is_sstb, legacy_self_employment_income, 0.0
+                ),
+                "w2_wages_from_qualified_business": w2,
+                "unadjusted_basis_qualified_property": ubia,
+                "sstb_w2_wages_from_qualified_business": np.where(is_sstb, w2, 0.0),
+                "sstb_unadjusted_basis_qualified_property": np.where(
+                    is_sstb, ubia, 0.0
+                ),
+                "self_employment_income_would_be_qualified": np.where(
+                    is_sstb, False, self_employment_would_be_qualified
+                ),
+                SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG: np.where(
+                    is_sstb, self_employment_would_be_qualified, False
+                ),
+            }
+
+        return overrides
+
     def _ensure_sstb_split_inputs(self) -> dict[str, np.ndarray]:
         overrides = self._sstb_split_overrides()
+        overrides.update(self._qbi_simulation_overrides(overrides))
         if not overrides:
             return {}
 

--- a/policyengine_us_data/datasets/puf/qbi_assumptions.yaml
+++ b/policyengine_us_data/datasets/puf/qbi_assumptions.yaml
@@ -18,6 +18,11 @@ sstb_prob_map_by_name:
   E26390: 0.10
   E26400: 0.10
 
+sstb_prob_map_by_source_name:
+  self_employment_income: 0.20
+  partnership_s_corp_income: 0.15
+  estate_income: 0.10
+
 # Below, we assume that 7% of filers have nonzero REIT/PTP income,
 # and of those 7%, their REIT/PTP income is lognormal distributed with
 # mean of exp(8.04) = $3,103, and standard deviation 1.20 of the lognormal.
@@ -54,11 +59,19 @@ labor_ratio_distribution:
     beta_b: 2.0
     scale: 0.25
 
-depreciation_proxy_sigma: 0.8
-
 # lognormal(mean = 4 * QBI, sigma = 1)
 # produce a right-skewed spread whose mean is roughly 4 * QBI,
 # matching aggregate SOI ratios.
 ubia_simulation:
     multiple_of_qbi: 4.0
     sigma: 1.0
+    # Probability that positive QBI from each source is capital-intensive
+    # enough to hold qualified property. Row-level probabilities are weighted
+    # by positive qualified QBI source amounts.
+    capital_intensity_probabilities:
+      self_employment_income: 0.20
+      farm_operations_income: 0.45
+      farm_rent_income: 0.75
+      rental_income: 1.00
+      estate_income: 0.50
+      partnership_s_corp_income: 0.35

--- a/tests/unit/calibration/test_calibration_puf_impute.py
+++ b/tests/unit/calibration/test_calibration_puf_impute.py
@@ -159,6 +159,7 @@ class TestPufCloneDataset:
     def test_sstb_qbi_split_variables_imputed(self):
         expected = {
             "sstb_self_employment_income",
+            "sstb_self_employment_income_would_be_qualified",
             "sstb_w2_wages_from_qualified_business",
             "sstb_unadjusted_basis_qualified_property",
         }

--- a/tests/unit/datasets/test_puf_qbi.py
+++ b/tests/unit/datasets/test_puf_qbi.py
@@ -1,0 +1,144 @@
+import copy
+
+import h5py
+import numpy as np
+import pandas as pd
+
+from policyengine_us_data.datasets.puf import puf as puf_module
+from policyengine_us_data.datasets.puf.puf import PUF
+
+
+def _qbi_frame(n=1):
+    data = {source: np.zeros(n, dtype=float) for source in puf_module.QBI_SOURCE_NAMES}
+    data.update(
+        {
+            "E00900": np.zeros(n, dtype=float),
+            "E26270": np.zeros(n, dtype=float),
+            "E26390": np.zeros(n, dtype=float),
+            "E26400": np.zeros(n, dtype=float),
+        }
+    )
+    return pd.DataFrame(data)
+
+
+def _set_qbi_params(monkeypatch, mutate):
+    params = copy.deepcopy(puf_module.QBI_PARAMS)
+    mutate(params)
+    monkeypatch.setattr(puf_module, "QBI_PARAMS", params)
+    return params
+
+
+def test_add_qbi_qualification_flags_to_puf_persists_source_flags(monkeypatch):
+    def mutate(params):
+        for source in params["qbi_qualification_probabilities"]:
+            params["qbi_qualification_probabilities"][source] = 0.0
+        params["qbi_qualification_probabilities"]["self_employment_income"] = 1.0
+
+    _set_qbi_params(monkeypatch, mutate)
+    puf = puf_module.add_qbi_qualification_flags_to_puf(_qbi_frame(), seed=0)
+
+    assert bool(puf["self_employment_income_would_be_qualified"].iloc[0])
+    for source in puf_module.QBI_SOURCE_NAMES:
+        flag = puf_module.QBI_QUALIFICATION_FLAG_BY_SOURCE[source]
+        assert flag in puf
+    assert not bool(puf["rental_income_would_be_qualified"].iloc[0])
+
+
+def test_puf_financial_subset_exports_qbi_qualification_flags():
+    expected = {
+        *puf_module.QBI_QUALIFICATION_FLAG_BY_SOURCE.values(),
+        puf_module.SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG,
+    }
+
+    assert expected <= set(puf_module.FINANCIAL_SUBSET)
+
+
+def test_qualified_qbi_components_use_persisted_flags():
+    puf = _qbi_frame()
+    puf.loc[0, "self_employment_income"] = 100.0
+    puf.loc[0, "rental_income"] = 200.0
+    for source in puf_module.QBI_SOURCE_NAMES:
+        puf[puf_module.QBI_QUALIFICATION_FLAG_BY_SOURCE[source]] = False
+    puf["rental_income_would_be_qualified"] = True
+
+    components = puf_module.qualified_qbi_components(puf)
+
+    assert components.loc[0, "self_employment_income"] == 0.0
+    assert components.loc[0, "rental_income"] == 200.0
+
+
+def test_simulate_business_is_sstb_ignores_zero_and_unmapped_sources(monkeypatch):
+    def mutate(params):
+        for source in params["sstb_prob_map_by_name"]:
+            params["sstb_prob_map_by_name"][source] = 1.0
+
+    _set_qbi_params(monkeypatch, mutate)
+    puf = _qbi_frame(n=4)
+    puf.loc[0, "rental_income"] = 10_000.0
+    puf.loc[1, "E00900"] = 10_000.0
+    puf.loc[2, "E00900"] = -10_000.0
+    puf.loc[3, "E26270"] = 10_000.0
+
+    is_sstb = puf_module.simulate_business_is_sstb(puf, rng=np.random.default_rng(0))
+
+    np.testing.assert_array_equal(is_sstb, np.array([False, True, False, True]))
+
+
+def test_non_rental_capital_intensive_qbi_can_receive_ubia(monkeypatch):
+    def mutate(params):
+        for source in params["ubia_simulation"]["capital_intensity_probabilities"]:
+            params["ubia_simulation"]["capital_intensity_probabilities"][source] = 0.0
+        params["ubia_simulation"]["capital_intensity_probabilities"][
+            "self_employment_income"
+        ] = 1.0
+
+    _set_qbi_params(monkeypatch, mutate)
+    puf = _qbi_frame()
+    puf.loc[0, "self_employment_income"] = 10_000.0
+    for source in puf_module.QBI_SOURCE_NAMES:
+        puf[puf_module.QBI_QUALIFICATION_FLAG_BY_SOURCE[source]] = False
+    puf["self_employment_income_would_be_qualified"] = True
+
+    _, ubia = puf_module.simulate_w2_and_ubia_from_puf(puf, seed=0, diagnostics=False)
+
+    assert ubia[0] > 0
+
+
+def test_puf_load_dataset_backfills_qbi_simulation_inputs(tmp_path, monkeypatch):
+    class DummyPUF(PUF):
+        label = "Dummy PUF"
+        name = "dummy_puf"
+        time_period = 2024
+        file_path = tmp_path / "dummy_puf.h5"
+
+    def mutate(params):
+        for source in params["qbi_qualification_probabilities"]:
+            params["qbi_qualification_probabilities"][source] = 1.0
+        for source in params["ubia_simulation"]["capital_intensity_probabilities"]:
+            params["ubia_simulation"]["capital_intensity_probabilities"][source] = 1.0
+        for source in params["sstb_prob_map_by_source_name"]:
+            params["sstb_prob_map_by_source_name"][source] = 0.0
+
+    _set_qbi_params(monkeypatch, mutate)
+    with h5py.File(DummyPUF.file_path, "w") as file_handle:
+        file_handle.create_dataset("household_id", data=np.array([1, 2]))
+        file_handle.create_dataset(
+            "self_employment_income", data=np.array([10_000.0, 0.0])
+        )
+        file_handle.create_dataset(
+            "partnership_s_corp_income", data=np.array([0.0, 20_000.0])
+        )
+        for source in set(puf_module.QBI_SOURCE_NAMES) - {
+            "self_employment_income",
+            "partnership_s_corp_income",
+        }:
+            file_handle.create_dataset(source, data=np.zeros(2))
+
+    arrays = DummyPUF().load_dataset()
+
+    for flag in puf_module.QBI_SIMULATION_REQUIRED_VARIABLES:
+        assert flag in arrays
+    assert "w2_wages_from_qualified_business" in arrays
+    assert "unadjusted_basis_qualified_property" in arrays
+    np.testing.assert_array_equal(arrays["business_is_sstb"], np.array([False, False]))
+    assert np.all(arrays["unadjusted_basis_qualified_property"] > 0)


### PR DESCRIPTION
## Summary

- persist source-level QBI qualification flags in PUF data and carry the SSTB self-employment qualification flag through calibration imputation
- make W-2/UBIA simulation use persisted qualification flags, avoid false-positive SSTB draws for rows without positive mapped SSTB sources, and allow non-rental capital-intensive QBI records to receive UBIA
- add load-time QBI backfill for cached PUF H5s missing the new QBI schema
- update QBI assumptions, appendix counts, and paper methodology docs

## Issues

Closes #856
Closes #857
Closes #858
Closes #859

## Validation

- `uv run pytest tests/unit/datasets/test_puf_qbi.py tests/unit/calibration/test_calibration_puf_impute.py tests/unit/datasets/test_irs_puf.py -q` -> 28 passed, 1 skipped
- `uv run ruff format --check policyengine_us_data/datasets/puf/puf.py policyengine_us_data/calibration/puf_impute.py tests/unit/datasets/test_puf_qbi.py tests/unit/calibration/test_calibration_puf_impute.py`
- `uv run ruff check policyengine_us_data/datasets/puf/puf.py policyengine_us_data/calibration/puf_impute.py tests/unit/datasets/test_puf_qbi.py tests/unit/calibration/test_calibration_puf_impute.py`
- `uv run python scripts/run_quality_guards.py`
- `git diff --check`

## Notes

A second subagent review found no findings. Residual risk: this was not validated with a private full PUF regeneration; cached-H5 backfill necessarily approximates SSTB from processed source names when raw PUF columns are unavailable.
