### PR TITLE
Fix QBI simulation inputs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,13 @@ When adding, moving, or reviewing tests, read
 `docs/engineering/skills/testing.md`. Do not put pytest files under
 `policyengine_us_data/tests/`, do not import from `tests.conftest`, and do not
 import helpers across test lanes.
+
+## GitHub PRs
+
+Do not open `policyengine-us-data` PRs from forks. CI expects same-repository
+branches on `PolicyEngine/policyengine-us-data`, so push PR branches to the
+`upstream` remote (or another remote whose `gh repo view --json nameWithOwner`
+is `PolicyEngine/policyengine-us-data`). If you cannot push a branch to the
+upstream repository, stop and ask for access instead of creating a fork-based
+PR. Before sharing a PR, verify that the PR head repository is
+`PolicyEngine/policyengine-us-data`.

--- a/changelog.d/863.changed.md
+++ b/changelog.d/863.changed.md
@@ -1,0 +1,1 @@
+Replace QBI simulation assumptions with a documented source-based model for qualification, SSTB status, W-2 wages, UBIA, and REIT/PTP/BDC income.

--- a/docs/appendix.md
+++ b/docs/appendix.md
@@ -47,7 +47,7 @@ for iteration in range(5000):
 
 ### Table A1: Complete List of Imputed Variables
 
-#### Variables Imputed from IRS Public Use File (67 variables)
+#### Variables Imputed from IRS Public Use File (70 variables)
 
 **Income Variables:**
 
@@ -113,6 +113,7 @@ for iteration in range(5000):
 - unadjusted_basis_qualified_property
 - business_is_sstb
 - sstb_self_employment_income
+- sstb_self_employment_income_would_be_qualified
 - sstb_w2_wages_from_qualified_business
 - sstb_unadjusted_basis_qualified_property
 - qualified_reit_and_ptp_income

--- a/docs/myst.yml
+++ b/docs/myst.yml
@@ -24,6 +24,7 @@ project:
     - file: background.md
     - file: data.md
     - file: methodology.md
+    - file: qbi_simulation.md
     - file: long_term_projections.md
     - file: local_area_calibration_setup.ipynb
     - file: calibration.md

--- a/docs/qbi_simulation.md
+++ b/docs/qbi_simulation.md
@@ -31,7 +31,7 @@ services, brokerage, investing and investment management, trading, dealing, and
 businesses where reputation or skill is the principal asset. The current PUF
 does not identify these industries directly, so the model assigns probabilities
 by mapped source field and only draws SSTB status for records with a positive
-mapped SSTB source.
+qualified mapped SSTB source.
 
 ## Source Mapping
 

--- a/docs/qbi_simulation.md
+++ b/docs/qbi_simulation.md
@@ -1,0 +1,179 @@
+# Qualified Business Income Simulation
+
+This page documents the model behind
+`policyengine_us_data/datasets/puf/qbi_assumptions.yaml`. The YAML file stores
+parameters; this page stores the reasoning. Parameter changes should update both
+places and should cite reproducible public sources, not chat transcripts or
+one-off agent conversations.
+
+The IRS PUF does not directly report the Section 199A inputs used by
+PolicyEngine US: source-level QBI qualification flags, W-2 wages from qualified
+businesses, UBIA of qualified property, SSTB status, qualified REIT/PTP income,
+and qualified BDC income. The simulation is intentionally source-based: it
+starts from observed PUF income fields, draws source-level qualification and
+industry status, then uses source-weighted operating assumptions for receipts,
+payroll, and property.
+
+## Statutory Frame
+
+The model follows the structure in the IRS Form 8995 instructions. QBI can come
+from qualified items of income, gain, deduction, and loss from sole
+proprietorships, partnerships, S corporations, and certain estates and trusts.
+Wage income, reasonable compensation, guaranteed payments, capital gains,
+dividends, qualified REIT dividends, and qualified PTP income are not included
+in the trade or business QBI base. REIT dividends and PTP income enter the
+deduction separately.
+
+SSTBs are modeled separately because PolicyEngine US applies the taxable-income
+phaseout to the SSTB path. The IRS SSTB categories include health, law,
+accounting, actuarial science, performing arts, consulting, athletics, financial
+services, brokerage, investing and investment management, trading, dealing, and
+businesses where reputation or skill is the principal asset. The current PUF
+does not identify these industries directly, so the model assigns probabilities
+by mapped source field and only draws SSTB status for records with a positive
+mapped SSTB source.
+
+## Source Mapping
+
+| Model source | Main PUF construction | Reason for separate treatment |
+| --- | --- | --- |
+| `self_employment_income` | Schedule C net profit or loss, `E00900` | Usually a direct trade or business, with meaningful SSTB mix. |
+| `farm_operations_income` | Schedule F income, `E02100` | Active business income, higher capital intensity than typical services. |
+| `farm_rent_income` | Farm rental income, `E27200` | Rental or land-heavy income with higher property exposure. |
+| `rental_income` | Schedule E rents and royalties, `E25850 - E25860` | Must satisfy the Section 162 trade or business standard or rental safe harbor. |
+| `estate_income` | Estate and trust income, `E26390 - E26400` | QBI treatment depends on entity-level reporting and allocation. |
+| `partnership_s_corp_income` | Active partnership and S-corp income from Schedule E fields | Pass-through entities report Section 199A detail on K-1 attachments, which the PUF lacks. |
+
+## Qualification Probabilities
+
+The source-level `*_would_be_qualified` probabilities represent whether an
+observed income item is eligible to enter the non-SSTB or SSTB QBI path before
+taxable-income limitations. They are not meant to decide the final deduction.
+
+| Source | Probability | Rationale |
+| --- | ---: | --- |
+| `self_employment_income` | 0.95 | Schedule C net business income is generally in scope, with a small discount for items that fail the trade or business, domestic, or reporting tests. |
+| `farm_operations_income` | 0.98 | Schedule F active farming is treated as nearly always in scope. |
+| `farm_rent_income` | 0.80 | Farm rents are often business or self-rental income, but can include passive land-rent cases. |
+| `rental_income` | 0.70 | Schedule E rental income can qualify, but only if it satisfies the Section 162 standard or the rental real estate safe harbor. |
+| `estate_income` | 0.60 | Estate and trust amounts require entity-level allocation, which is only partially observed in the PUF. |
+| `partnership_s_corp_income` | 0.90 | Ordinary pass-through business income is usually in scope, but K-1 Section 199A detail can exclude some items. |
+
+## SSTB Probabilities
+
+The Schedule C SSTB probability is anchored to IRS 2022 sole proprietorship
+industry data. Using positive-net-income rows, selected SSTB-like industries
+sum to $165.1 billion of net income out of $543.9 billion for all nonfarm sole
+proprietorships, or 30.4 percent. The selected industries are legal services,
+accounting, consulting, financial investment and brokerage categories, health
+care, performing arts, spectator sports, and related industries. The YAML uses
+0.30 for `E00900`.
+
+Partnership and S-corp SSTB status is harder to identify from public aggregate
+tables because the industry categories are broader than Section 199A SSTB
+categories. For positive-income partnerships, broad IRS 2022 industry totals
+show large amounts in finance, professional services, management, health care,
+and arts. The model uses 0.25 for `partnership_s_corp_income`: higher than a
+pure professional-services-only share, lower than assigning all finance and
+management income to SSTBs. Estates and trusts use 0.15 because their PUF fields
+do not reveal the underlying trade or business industry.
+
+## W-2 Wages
+
+The wage model has three steps.
+
+1. For each positive qualified source, draw a source-specific profit margin from
+   a beta distribution. The record margin is the positive-QBI-weighted average
+   across sources, and gross receipts equal positive QBI divided by that margin.
+2. Draw whether the record has employees from a logit model:
+   `logit(p) = intercept + slope * receipts`. The slope is fixed in YAML and
+   the intercept is solved inside the current PUF so the mean employee
+   probability among positive-receipt QBI records equals
+   `target_share_among_positive_receipts`.
+3. Draw a source-weighted labor share of receipts from beta distributions and
+   set W-2 wages to `receipts * labor_share` for records with employees.
+
+The 0.18 employee-presence target is a record-level target, not an aggregate
+payroll target. It is anchored to the fact that most U.S. businesses have no
+paid employees, as measured by Census Nonemployer Statistics, while allowing
+larger receipt records to have much higher employee probabilities through the
+logit slope. Aggregate payroll levels should be checked against SOI tables after
+full PUF regeneration.
+
+| Source | Mean margin | Mean labor share of receipts |
+| --- | ---: | ---: |
+| `self_employment_income` | 0.300 | 0.125 |
+| `farm_operations_income` | 0.180 | 0.098 |
+| `farm_rent_income` | 0.230 | 0.013 |
+| `rental_income` | 0.277 | 0.013 |
+| `estate_income` | 0.230 | 0.089 |
+| `partnership_s_corp_income` | 0.214 | 0.110 |
+
+The Schedule C margin is close to the IRS 2022 sole proprietorship positive-net
+income margin for all nonfarm industries, 31.5 percent. The farm margin follows
+the agriculture, forestry, hunting, and fishing sole-proprietorship margin, 17.2
+percent. Real estate and rental sources use low labor shares because SOI
+payroll-to-receipts ratios are much lower for those industries than for health,
+food, and other labor-heavy industries.
+
+## UBIA
+
+UBIA is modeled as a source-weighted capital-intensity draw. The model first
+draws a Bernoulli capital-intensive flag using source-weighted probabilities,
+then draws a lognormal amount with mean equal to a source-weighted multiple of
+positive QBI and `sigma = 1.0`.
+
+| Source | Capital-intensive probability | UBIA mean multiple of QBI |
+| --- | ---: | ---: |
+| `self_employment_income` | 0.25 | 1.5 |
+| `farm_operations_income` | 0.70 | 4.0 |
+| `farm_rent_income` | 0.90 | 8.0 |
+| `rental_income` | 0.95 | 10.0 |
+| `estate_income` | 0.50 | 3.0 |
+| `partnership_s_corp_income` | 0.45 | 3.0 |
+
+These are property-stock assumptions, not depreciation deductions. Rental and
+farm-rent income receive the highest probabilities and multiples because real
+property and land-heavy businesses have the clearest qualified-property base.
+Schedule C receives a lower default because many service businesses have little
+qualified property even when they have positive QBI.
+
+## REIT, PTP, and BDC Income
+
+The model does not draw REIT/PTP or BDC income independently for all records.
+Instead it scales observed exposure bases:
+
+| Output | Exposure source | Probability | Mean share of exposure |
+| --- | --- | ---: | ---: |
+| `qualified_reit_and_ptp_income` | `non_qualified_dividend_income` | 0.35 | 0.100 |
+| `qualified_reit_and_ptp_income` | `partnership_s_corp_income` | 0.05 | 0.120 |
+| `qualified_bdc_income` | `non_qualified_dividend_income` | 0.05 | 0.030 |
+
+The dividend exposure uses non-qualified ordinary dividends because qualified
+REIT dividends are reported separately from qualified dividends. The partnership
+exposure is a proxy for PTP-related K-1 income. Amounts are clipped to be no
+larger than the observed exposure base.
+
+## Validation Targets
+
+The current parameters are source-grounded priors. They should be revisited
+when a full PUF regeneration is available. The most important validation checks
+are:
+
+- weighted totals for QBI, SSTB QBI, W-2 wages from qualified businesses, UBIA,
+  qualified REIT/PTP income, and qualified BDC income;
+- source-level shares of records with positive qualification flags;
+- payroll-to-receipts and depreciation-to-receipts ratios against SOI industry
+  tables;
+- distributional sensitivity for high-income taxpayers, where W-2, UBIA, and
+  SSTB phaseouts matter most.
+
+## Public Sources
+
+- IRS, [Instructions for Form 8995](https://www.irs.gov/instructions/i8995).
+- IRS, [Instructions for Schedule E](https://www.irs.gov/instructions/i1040se).
+- IRS SOI, [Individual income tax returns with small business income and losses](https://www.irs.gov/statistics/soi-tax-stats-individual-income-tax-returns-with-small-business-income-and-losses).
+- IRS SOI, [Partnership statistics by sector or industry](https://www.irs.gov/statistics/soi-tax-stats-partnership-statistics-by-sector-or-industry).
+- IRS SOI, [S corporation statistics](https://www.irs.gov/statistics/soi-tax-stats-s-corporation-statistics).
+- Census Bureau, [Nonemployer Statistics](https://www.census.gov/programs-surveys/nonemployer-statistics.html).
+- SBA Office of Advocacy, [Nonemployer demographic data project](https://advocacy.sba.gov/2019/09/19/advocacy-and-census-focus-on-the-smallest-small-businesses-with-a-new-nonemployer-demographic-data-project/).

--- a/paper/sections/methodology/puf_preprocessing.tex
+++ b/paper/sections/methodology/puf_preprocessing.tex
@@ -18,15 +18,19 @@ Total medical expenses are decomposed into specific categories using fixed ratio
 Key derived variables include:
 
 \paragraph{Qualified Business Income (QBI)}
-Calculated as the maximum of zero and the sum of:
+QBI-related inputs are simulated from source-level PUF income fields using the assumptions in \texttt{qbi\_assumptions.yaml}. The model first draws whether each source would be qualified business income, with source-specific probabilities for:
 \begin{itemize}
-    \item Schedule E income (E00900)
-    \item Partnership and S-corporation income (E26270)
-    \item Farm income (E02100)
-    \item Rental income (E27200)
+    \item Schedule C self-employment income
+    \item Partnership and S-corporation income
+    \item Farm operations income
+    \item Farm rent income
+    \item Rental income
+    \item Estate income
 \end{itemize}
 
-W2 wages from qualified business are then computed as 16\% of QBI.
+The persisted \texttt{*\_would\_be\_qualified} flags are then used consistently when constructing the QBI base for downstream imputation. W-2 wages from qualified business are simulated from positive qualified QBI by drawing profit margins, gross receipts, employee presence, and labor shares. UBIA is drawn for capital-intensive records using source-weighted capital-intensity probabilities and a lognormal amount scaled to positive QBI.
+
+Specified service trade or business (SSTB) status is drawn from positive mapped SSTB source amounts. When a record is classified as SSTB, Schedule C self-employment income and allocable W-2/UBIA inputs are split into SSTB-specific variables. Qualified REIT/PTP income and qualified BDC income are separately drawn from Bernoulli-lognormal distributions.
 
 \paragraph{Filing Status}
 Mapped from MARS codes:

--- a/paper/sections/methodology/puf_preprocessing.tex
+++ b/paper/sections/methodology/puf_preprocessing.tex
@@ -30,7 +30,7 @@ QBI-related inputs are simulated from source-level PUF income fields using the a
 
 The persisted \texttt{*\_would\_be\_qualified} flags are then used consistently when constructing the QBI base for downstream imputation. W-2 wages from qualified business are simulated from positive qualified QBI by drawing source-weighted profit margins, gross receipts, employee presence, and source-weighted labor shares. UBIA is drawn for capital-intensive records using source-weighted capital-intensity probabilities and a lognormal amount scaled to positive QBI.
 
-Specified service trade or business (SSTB) status is drawn from positive mapped SSTB source amounts. When a record is classified as SSTB, Schedule C self-employment income and allocable W-2/UBIA inputs are split into SSTB-specific variables. Qualified REIT/PTP income and qualified BDC income are simulated from observed dividend and pass-through exposure bases rather than assigned independently to all records.
+Specified service trade or business (SSTB) status is drawn from positive qualified mapped SSTB source amounts. When a record is classified as SSTB, Schedule C self-employment income and allocable W-2/UBIA inputs are split into SSTB-specific variables. Qualified REIT/PTP income and qualified BDC income are simulated from observed dividend and pass-through exposure bases rather than assigned independently to all records.
 
 \paragraph{Filing Status}
 Mapped from MARS codes:

--- a/paper/sections/methodology/puf_preprocessing.tex
+++ b/paper/sections/methodology/puf_preprocessing.tex
@@ -28,9 +28,9 @@ QBI-related inputs are simulated from source-level PUF income fields using the a
     \item Estate income
 \end{itemize}
 
-The persisted \texttt{*\_would\_be\_qualified} flags are then used consistently when constructing the QBI base for downstream imputation. W-2 wages from qualified business are simulated from positive qualified QBI by drawing profit margins, gross receipts, employee presence, and labor shares. UBIA is drawn for capital-intensive records using source-weighted capital-intensity probabilities and a lognormal amount scaled to positive QBI.
+The persisted \texttt{*\_would\_be\_qualified} flags are then used consistently when constructing the QBI base for downstream imputation. W-2 wages from qualified business are simulated from positive qualified QBI by drawing source-weighted profit margins, gross receipts, employee presence, and source-weighted labor shares. UBIA is drawn for capital-intensive records using source-weighted capital-intensity probabilities and a lognormal amount scaled to positive QBI.
 
-Specified service trade or business (SSTB) status is drawn from positive mapped SSTB source amounts. When a record is classified as SSTB, Schedule C self-employment income and allocable W-2/UBIA inputs are split into SSTB-specific variables. Qualified REIT/PTP income and qualified BDC income are separately drawn from Bernoulli-lognormal distributions.
+Specified service trade or business (SSTB) status is drawn from positive mapped SSTB source amounts. When a record is classified as SSTB, Schedule C self-employment income and allocable W-2/UBIA inputs are split into SSTB-specific variables. Qualified REIT/PTP income and qualified BDC income are simulated from observed dividend and pass-through exposure bases rather than assigned independently to all records.
 
 \paragraph{Filing Status}
 Mapped from MARS codes:

--- a/policyengine_us_data/calibration/puf_impute.py
+++ b/policyengine_us_data/calibration/puf_impute.py
@@ -51,6 +51,7 @@ IMPUTED_VARIABLES = [
     "taxable_ira_distributions",
     "self_employment_income",
     "sstb_self_employment_income",
+    "sstb_self_employment_income_would_be_qualified",
     "w2_wages_from_qualified_business",
     "unadjusted_basis_qualified_property",
     "business_is_sstb",

--- a/policyengine_us_data/calibration/target_config.yaml
+++ b/policyengine_us_data/calibration/target_config.yaml
@@ -298,6 +298,9 @@ include:
   - variable: qualified_business_income_deduction
     geo_level: national
     domain_variable: qualified_business_income_deduction
+  - variable: tax_unit_count
+    geo_level: national
+    domain_variable: qualified_business_income_deduction
 
   # === NATIONAL — JCT tax expenditure targets (reform_id=1..5) ===
   - variable: salt_deduction

--- a/policyengine_us_data/datasets/puf/puf.py
+++ b/policyengine_us_data/datasets/puf/puf.py
@@ -882,21 +882,33 @@ class PUF(Dataset):
             is_sstb_existing = self._values_from_file_or_overrides(
                 file_handle, "business_is_sstb", existing_overrides, length
             ).astype(bool)
-            self_employment_would_be_qualified = raw_qualification_flags[
-                "self_employment_income"
-            ]
-            flag_overrides = {
-                "self_employment_income_would_be_qualified": np.where(
-                    is_sstb_existing, False, self_employment_would_be_qualified
-                ),
-                SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG: np.where(
-                    is_sstb_existing, self_employment_would_be_qualified, False
-                ),
-            }
+
+            qualification_flags = {}
             for source, qualified in raw_qualification_flags.items():
                 flag = QBI_QUALIFICATION_FLAG_BY_SOURCE[source]
-                if source != "self_employment_income":
-                    flag_overrides[flag] = qualified
+                qualification_flags[source] = (
+                    self._values_from_file_or_overrides(
+                        file_handle, flag, existing_overrides, length
+                    ).astype(bool)
+                    if flag in file_handle or flag in existing_overrides
+                    else qualified
+                )
+            if (
+                SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG in file_handle
+                or SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG in existing_overrides
+            ):
+                sstb_self_employment_would_be_qualified = (
+                    self._values_from_file_or_overrides(
+                        file_handle,
+                        SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG,
+                        existing_overrides,
+                        length,
+                    ).astype(bool)
+                )
+                qualification_flags["self_employment_income"] = (
+                    qualification_flags["self_employment_income"]
+                    | sstb_self_employment_would_be_qualified
+                )
 
             source_arrays = {}
             for source in QBI_SOURCE_NAMES:
@@ -920,7 +932,7 @@ class PUF(Dataset):
             )
 
             qbi_frame = pd.DataFrame(source_arrays)
-            for source, qualified in raw_qualification_flags.items():
+            for source, qualified in qualification_flags.items():
                 qbi_frame[QBI_QUALIFICATION_FLAG_BY_SOURCE[source]] = qualified
             for source in (
                 "qualified_dividend_income",
@@ -976,6 +988,26 @@ class PUF(Dataset):
                 qbi_frame, rng=np.random.default_rng(QBI_INVESTMENT_SEED)
             )
             legacy_self_employment_income = source_arrays["self_employment_income"]
+            self_employment_would_be_qualified = qualification_flags[
+                "self_employment_income"
+            ]
+
+            flag_overrides = {}
+            for source, qualified in qualification_flags.items():
+                flag = QBI_QUALIFICATION_FLAG_BY_SOURCE[source]
+                if flag in file_handle or flag in existing_overrides:
+                    continue
+                if source == "self_employment_income":
+                    flag_overrides[flag] = np.where(is_sstb, False, qualified)
+                else:
+                    flag_overrides[flag] = qualified
+            if (
+                SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG not in file_handle
+                and SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG not in existing_overrides
+            ):
+                flag_overrides[SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG] = np.where(
+                    is_sstb, self_employment_would_be_qualified, False
+                )
 
             overrides = {
                 **flag_overrides,
@@ -992,12 +1024,6 @@ class PUF(Dataset):
                 "sstb_w2_wages_from_qualified_business": np.where(is_sstb, w2, 0.0),
                 "sstb_unadjusted_basis_qualified_property": np.where(
                     is_sstb, ubia, 0.0
-                ),
-                "self_employment_income_would_be_qualified": np.where(
-                    is_sstb, False, self_employment_would_be_qualified
-                ),
-                SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG: np.where(
-                    is_sstb, self_employment_would_be_qualified, False
                 ),
             }
 

--- a/policyengine_us_data/datasets/puf/puf.py
+++ b/policyengine_us_data/datasets/puf/puf.py
@@ -45,6 +45,8 @@ QBI_QUALIFICATION_SEED = 41
 QBI_W2_UBIA_SEED = 42
 QBI_INVESTMENT_SEED = 43
 QBI_SSTB_SEED = 64
+QBI_SIMULATION_VERSION = 1
+QBI_SIMULATION_VERSION_ATTR = "qbi_simulation_version"
 QBI_SIMULATION_REQUIRED_VARIABLES = frozenset(
     (
         *QBI_QUALIFICATION_FLAG_BY_SOURCE.values(),
@@ -857,7 +859,14 @@ class PUF(Dataset):
 
         with h5py.File(self.file_path, "r") as file_handle:
             keys = set(file_handle.keys())
-            if QBI_SIMULATION_REQUIRED_VARIABLES.issubset(keys):
+            is_current_qbi_simulation = (
+                file_handle.attrs.get(QBI_SIMULATION_VERSION_ATTR)
+                == QBI_SIMULATION_VERSION
+            )
+            if (
+                QBI_SIMULATION_REQUIRED_VARIABLES.issubset(keys)
+                and is_current_qbi_simulation
+            ):
                 return {}
 
             length = None
@@ -875,7 +884,7 @@ class PUF(Dataset):
             raw_qualification_flags = draw_qbi_qualification_flags(
                 length, seed=QBI_QUALIFICATION_SEED
             )
-            has_existing_sstb = (
+            has_existing_sstb = is_current_qbi_simulation and (
                 "business_is_sstb" in file_handle
                 or "business_is_sstb" in existing_overrides
             )
@@ -956,7 +965,8 @@ class PUF(Dataset):
                     existing_overrides,
                     length,
                 ).astype(float)
-                if (
+                if is_current_qbi_simulation
+                and (
                     "w2_wages_from_qualified_business" in file_handle
                     or "w2_wages_from_qualified_business" in existing_overrides
                 )
@@ -969,7 +979,8 @@ class PUF(Dataset):
                     existing_overrides,
                     length,
                 ).astype(float)
-                if (
+                if is_current_qbi_simulation
+                and (
                     "unadjusted_basis_qualified_property" in file_handle
                     or "unadjusted_basis_qualified_property" in existing_overrides
                 )
@@ -1030,8 +1041,9 @@ class PUF(Dataset):
         return overrides
 
     def _ensure_sstb_split_inputs(self) -> dict[str, np.ndarray]:
-        overrides = self._sstb_split_overrides()
-        overrides.update(self._qbi_simulation_overrides(overrides))
+        sstb_overrides = self._sstb_split_overrides()
+        qbi_overrides = self._qbi_simulation_overrides(sstb_overrides)
+        overrides = {**sstb_overrides, **qbi_overrides}
         if not overrides:
             return {}
 
@@ -1039,6 +1051,10 @@ class PUF(Dataset):
             with h5py.File(self.file_path, "r+") as file_handle:
                 for key, values in overrides.items():
                     self._replace_array(file_handle, key, values)
+                if qbi_overrides:
+                    file_handle.attrs[QBI_SIMULATION_VERSION_ATTR] = (
+                        QBI_SIMULATION_VERSION
+                    )
         except OSError:
             pass
 

--- a/policyengine_us_data/datasets/puf/puf.py
+++ b/policyengine_us_data/datasets/puf/puf.py
@@ -995,9 +995,20 @@ class PUF(Dataset):
                     probability_map=QBI_PARAMS["sstb_prob_map_by_source_name"],
                 )
             )
-            investment_qbi = simulate_investment_qbi_income_from_puf(
+            simulated_investment_qbi = simulate_investment_qbi_income_from_puf(
                 qbi_frame, rng=np.random.default_rng(QBI_INVESTMENT_SEED)
             )
+            investment_qbi = {
+                variable: (
+                    self._values_from_file_or_overrides(
+                        file_handle, variable, existing_overrides, length
+                    ).astype(float)
+                    if is_current_qbi_simulation
+                    and (variable in file_handle or variable in existing_overrides)
+                    else simulated_values
+                )
+                for variable, simulated_values in simulated_investment_qbi.items()
+            }
             legacy_self_employment_income = source_arrays["self_employment_income"]
             self_employment_would_be_qualified = qualification_flags[
                 "self_employment_income"

--- a/policyengine_us_data/datasets/puf/puf.py
+++ b/policyengine_us_data/datasets/puf/puf.py
@@ -256,12 +256,18 @@ def simulate_investment_qbi_income_from_puf(puf, *, rng):
 
 
 def simulate_business_is_sstb(puf, *, rng, probability_map=None):
-    """Draw SSTB status only from positive mapped SSTB source amounts."""
+    """Draw SSTB status only from positive qualified mapped SSTB sources."""
     sstb_probs = probability_map or QBI_PARAMS["sstb_prob_map_by_name"]
     available_sources = [source for source in sstb_probs if source in puf]
     if not available_sources:
         return np.zeros(len(puf), dtype=bool)
     sstb_sources = puf[available_sources].fillna(0).clip(lower=0)
+    for source in available_sources:
+        flag_name = QBI_QUALIFICATION_FLAG_BY_SOURCE.get(source)
+        if flag_name is None or flag_name not in puf:
+            continue
+        qualified = puf[flag_name].fillna(False).astype(bool).to_numpy()
+        sstb_sources[source] = sstb_sources[source].to_numpy(dtype=float) * qualified
     has_sstb_source = sstb_sources.sum(axis=1).to_numpy() > 0
     largest_sstb_source = sstb_sources.idxmax(axis=1)
     pr_sstb = largest_sstb_source.map(sstb_probs).fillna(0.0).to_numpy()
@@ -869,6 +875,10 @@ class PUF(Dataset):
             raw_qualification_flags = draw_qbi_qualification_flags(
                 length, seed=QBI_QUALIFICATION_SEED
             )
+            has_existing_sstb = (
+                "business_is_sstb" in file_handle
+                or "business_is_sstb" in existing_overrides
+            )
             is_sstb_existing = self._values_from_file_or_overrides(
                 file_handle, "business_is_sstb", existing_overrides, length
             ).astype(bool)
@@ -887,13 +897,6 @@ class PUF(Dataset):
                 flag = QBI_QUALIFICATION_FLAG_BY_SOURCE[source]
                 if source != "self_employment_income":
                     flag_overrides[flag] = qualified
-
-            has_all_qbi_sources = all(
-                source in file_handle or source in existing_overrides
-                for source in QBI_SOURCE_NAMES
-            )
-            if not has_all_qbi_sources:
-                return flag_overrides
 
             source_arrays = {}
             for source in QBI_SOURCE_NAMES:
@@ -931,13 +934,43 @@ class PUF(Dataset):
                         file_handle, source, existing_overrides, length
                     ).astype(float)
 
-            w2, ubia = simulate_w2_and_ubia_from_puf(
+            simulated_w2, simulated_ubia = simulate_w2_and_ubia_from_puf(
                 qbi_frame, seed=QBI_W2_UBIA_SEED, diagnostics=False
             )
-            is_sstb = simulate_business_is_sstb(
-                qbi_frame,
-                rng=np.random.default_rng(QBI_SSTB_SEED),
-                probability_map=QBI_PARAMS["sstb_prob_map_by_source_name"],
+            w2 = (
+                self._values_from_file_or_overrides(
+                    file_handle,
+                    "w2_wages_from_qualified_business",
+                    existing_overrides,
+                    length,
+                ).astype(float)
+                if (
+                    "w2_wages_from_qualified_business" in file_handle
+                    or "w2_wages_from_qualified_business" in existing_overrides
+                )
+                else simulated_w2
+            )
+            ubia = (
+                self._values_from_file_or_overrides(
+                    file_handle,
+                    "unadjusted_basis_qualified_property",
+                    existing_overrides,
+                    length,
+                ).astype(float)
+                if (
+                    "unadjusted_basis_qualified_property" in file_handle
+                    or "unadjusted_basis_qualified_property" in existing_overrides
+                )
+                else simulated_ubia
+            )
+            is_sstb = (
+                is_sstb_existing
+                if has_existing_sstb
+                else simulate_business_is_sstb(
+                    qbi_frame,
+                    rng=np.random.default_rng(QBI_SSTB_SEED),
+                    probability_map=QBI_PARAMS["sstb_prob_map_by_source_name"],
+                )
             )
             investment_qbi = simulate_investment_qbi_income_from_puf(
                 qbi_frame, rng=np.random.default_rng(QBI_INVESTMENT_SEED)

--- a/policyengine_us_data/datasets/puf/puf.py
+++ b/policyengine_us_data/datasets/puf/puf.py
@@ -914,13 +914,24 @@ class PUF(Dataset):
                 "business_is_sstb" in file_handle
                 or "business_is_sstb" in existing_overrides
             )
-            has_self_employment_split_overrides = (
-                "self_employment_income" in existing_overrides
-                or "sstb_self_employment_income" in existing_overrides
-            )
-            preserve_self_employment_split_flags = (
-                has_existing_sstb and not has_self_employment_split_overrides
-            )
+            self_employment_split_changed = np.zeros(length, dtype=bool)
+            for split_source in (
+                "self_employment_income",
+                "sstb_self_employment_income",
+            ):
+                if split_source in existing_overrides:
+                    original_values = (
+                        np.asarray(file_handle[split_source]).astype(float)
+                        if split_source in file_handle
+                        else np.zeros(length)
+                    )
+                    self_employment_split_changed = (
+                        self_employment_split_changed
+                        | ~np.isclose(
+                            np.asarray(existing_overrides[split_source]).astype(float),
+                            original_values,
+                        )
+                    )
             is_sstb_existing = self._values_from_file_or_overrides(
                 file_handle, "business_is_sstb", existing_overrides, length
             ).astype(bool)
@@ -948,14 +959,18 @@ class PUF(Dataset):
                                 length,
                             ).astype(bool)
                         )
-                    if len(split_flags) == 2 and preserve_self_employment_split_flags:
-                        qualification_flags[source] = split_flags[0] | split_flags[1]
+                    drawn_qualification = qualified
+                    for split_flag in split_flags:
+                        drawn_qualification = drawn_qualification | split_flag
+                    if len(split_flags) == 2 and has_existing_sstb:
+                        stored_qualification = split_flags[0] | split_flags[1]
+                        qualification_flags[source] = np.where(
+                            self_employment_split_changed,
+                            drawn_qualification,
+                            stored_qualification,
+                        )
                     else:
-                        qualification_flags[source] = qualified
-                        for split_flag in split_flags:
-                            qualification_flags[source] = (
-                                qualification_flags[source] | split_flag
-                            )
+                        qualification_flags[source] = drawn_qualification
                     continue
                 qualification_flags[source] = (
                     self._values_from_file_or_overrides(
@@ -1064,22 +1079,50 @@ class PUF(Dataset):
             for source, qualified in qualification_flags.items():
                 flag = QBI_QUALIFICATION_FLAG_BY_SOURCE[source]
                 if source == "self_employment_income":
-                    if preserve_self_employment_split_flags and (
+                    computed_flag = np.where(is_sstb, False, qualified)
+                    if has_existing_sstb and (
                         flag in file_handle or flag in existing_overrides
                     ):
+                        if self_employment_split_changed.any():
+                            existing_flag = self._values_from_file_or_overrides(
+                                file_handle, flag, existing_overrides, length
+                            ).astype(bool)
+                            flag_overrides[flag] = np.where(
+                                self_employment_split_changed,
+                                computed_flag,
+                                existing_flag,
+                            )
                         continue
+                    flag_overrides[flag] = computed_flag
+                    continue
                 elif flag in file_handle or flag in existing_overrides:
                     continue
-                if source == "self_employment_income":
-                    flag_overrides[flag] = np.where(is_sstb, False, qualified)
-                else:
-                    flag_overrides[flag] = qualified
-            if not preserve_self_employment_split_flags or (
-                SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG not in file_handle
-                and SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG not in existing_overrides
-            ):
-                flag_overrides[SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG] = np.where(
-                    is_sstb, self_employment_would_be_qualified, False
+                flag_overrides[flag] = qualified
+            computed_sstb_self_employment_flag = np.where(
+                is_sstb, self_employment_would_be_qualified, False
+            )
+            has_sstb_self_employment_flag = (
+                SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG in file_handle
+                or SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG in existing_overrides
+            )
+            if has_existing_sstb and has_sstb_self_employment_flag:
+                if self_employment_split_changed.any():
+                    existing_sstb_self_employment_flag = (
+                        self._values_from_file_or_overrides(
+                            file_handle,
+                            SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG,
+                            existing_overrides,
+                            length,
+                        ).astype(bool)
+                    )
+                    flag_overrides[SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG] = np.where(
+                        self_employment_split_changed,
+                        computed_sstb_self_employment_flag,
+                        existing_sstb_self_employment_flag,
+                    )
+            else:
+                flag_overrides[SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG] = (
+                    computed_sstb_self_employment_flag
                 )
 
             overrides = {

--- a/policyengine_us_data/datasets/puf/puf.py
+++ b/policyengine_us_data/datasets/puf/puf.py
@@ -798,6 +798,11 @@ class PUF(Dataset):
             if "business_is_sstb" not in file_handle:
                 return {}
             keys = set(file_handle.keys())
+            if (
+                file_handle.attrs.get(QBI_SIMULATION_VERSION_ATTR)
+                != QBI_SIMULATION_VERSION
+            ):
+                return {}
             is_sstb = np.asarray(file_handle["business_is_sstb"]).astype(bool)
             overrides = {}
             if "self_employment_income" in keys:

--- a/policyengine_us_data/datasets/puf/puf.py
+++ b/policyengine_us_data/datasets/puf/puf.py
@@ -940,7 +940,7 @@ class PUF(Dataset):
                                 length,
                             ).astype(bool)
                         )
-                    if len(split_flags) == 2:
+                    if len(split_flags) == 2 and has_existing_sstb:
                         qualification_flags[source] = split_flags[0] | split_flags[1]
                     else:
                         qualification_flags[source] = qualified

--- a/policyengine_us_data/datasets/puf/puf.py
+++ b/policyengine_us_data/datasets/puf/puf.py
@@ -882,6 +882,7 @@ class PUF(Dataset):
             if (
                 QBI_SIMULATION_REQUIRED_VARIABLES.issubset(keys)
                 and is_current_qbi_simulation
+                and not existing_overrides
             ):
                 return {}
 
@@ -913,6 +914,13 @@ class PUF(Dataset):
                 "business_is_sstb" in file_handle
                 or "business_is_sstb" in existing_overrides
             )
+            has_self_employment_split_overrides = (
+                "self_employment_income" in existing_overrides
+                or "sstb_self_employment_income" in existing_overrides
+            )
+            preserve_self_employment_split_flags = (
+                has_existing_sstb and not has_self_employment_split_overrides
+            )
             is_sstb_existing = self._values_from_file_or_overrides(
                 file_handle, "business_is_sstb", existing_overrides, length
             ).astype(bool)
@@ -940,7 +948,7 @@ class PUF(Dataset):
                                 length,
                             ).astype(bool)
                         )
-                    if len(split_flags) == 2 and has_existing_sstb:
+                    if len(split_flags) == 2 and preserve_self_employment_split_flags:
                         qualification_flags[source] = split_flags[0] | split_flags[1]
                     else:
                         qualification_flags[source] = qualified
@@ -1056,7 +1064,7 @@ class PUF(Dataset):
             for source, qualified in qualification_flags.items():
                 flag = QBI_QUALIFICATION_FLAG_BY_SOURCE[source]
                 if source == "self_employment_income":
-                    if has_existing_sstb and (
+                    if preserve_self_employment_split_flags and (
                         flag in file_handle or flag in existing_overrides
                     ):
                         continue
@@ -1066,7 +1074,7 @@ class PUF(Dataset):
                     flag_overrides[flag] = np.where(is_sstb, False, qualified)
                 else:
                     flag_overrides[flag] = qualified
-            if not has_existing_sstb or (
+            if not preserve_self_employment_split_flags or (
                 SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG not in file_handle
                 and SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG not in existing_overrides
             ):

--- a/policyengine_us_data/datasets/puf/puf.py
+++ b/policyengine_us_data/datasets/puf/puf.py
@@ -779,6 +779,17 @@ class PUF(Dataset):
             return np.asarray(file_handle[key])
         return np.zeros(length)
 
+    def _mark_current_qbi_simulation(self) -> None:
+        try:
+            with h5py.File(self.file_path, "r+") as file_handle:
+                file_handle.attrs[QBI_SIMULATION_VERSION_ATTR] = QBI_SIMULATION_VERSION
+        except OSError:
+            pass
+
+    def _save_current_qbi_dataset(self, arrays) -> None:
+        self.save_dataset(arrays)
+        self._mark_current_qbi_simulation()
+
     def _sstb_split_overrides(self) -> dict[str, np.ndarray]:
         if not self.file_path.exists():
             return {}
@@ -871,9 +882,18 @@ class PUF(Dataset):
 
             length = None
             for key in (
+                *QBI_SOURCE_NAMES,
+                "sstb_self_employment_income",
+                "business_is_sstb",
+                "w2_wages_from_qualified_business",
+                "unadjusted_basis_qualified_property",
+                "sstb_w2_wages_from_qualified_business",
+                "sstb_unadjusted_basis_qualified_property",
+                "qualified_reit_and_ptp_income",
+                "qualified_bdc_income",
+                "person_id",
+                "person_household_id",
                 "household_id",
-                "self_employment_income",
-                "partnership_s_corp_income",
             ):
                 if key in file_handle:
                     length = len(file_handle[key])
@@ -1163,7 +1183,7 @@ class PUF(Dataset):
                     ]
                     growth = current_index / start_index
                     arrays[variable] = arrays[variable] * growth
-            self.save_dataset(arrays)
+            self._save_current_qbi_dataset(arrays)
             return
 
         puf = disaggregate_aggregate_records(puf)  # 4 rows → ~120 weighted
@@ -1261,7 +1281,7 @@ class PUF(Dataset):
         self.holder = {
             variable: values[self.time_period] for variable, values in holder_tp.items()
         }
-        self.save_dataset(self.holder)
+        self._save_current_qbi_dataset(self.holder)
 
     def add_tax_unit(self, row, tax_unit_id):
         self.holder["tax_unit_id"].append(tax_unit_id)

--- a/policyengine_us_data/datasets/puf/puf.py
+++ b/policyengine_us_data/datasets/puf/puf.py
@@ -920,28 +920,41 @@ class PUF(Dataset):
             qualification_flags = {}
             for source, qualified in raw_qualification_flags.items():
                 flag = QBI_QUALIFICATION_FLAG_BY_SOURCE[source]
+                if source == "self_employment_income":
+                    split_flags = []
+                    if flag in file_handle or flag in existing_overrides:
+                        split_flags.append(
+                            self._values_from_file_or_overrides(
+                                file_handle, flag, existing_overrides, length
+                            ).astype(bool)
+                        )
+                    if (
+                        SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG in file_handle
+                        or SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG in existing_overrides
+                    ):
+                        split_flags.append(
+                            self._values_from_file_or_overrides(
+                                file_handle,
+                                SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG,
+                                existing_overrides,
+                                length,
+                            ).astype(bool)
+                        )
+                    if len(split_flags) == 2:
+                        qualification_flags[source] = split_flags[0] | split_flags[1]
+                    else:
+                        qualification_flags[source] = qualified
+                        for split_flag in split_flags:
+                            qualification_flags[source] = (
+                                qualification_flags[source] | split_flag
+                            )
+                    continue
                 qualification_flags[source] = (
                     self._values_from_file_or_overrides(
                         file_handle, flag, existing_overrides, length
                     ).astype(bool)
                     if flag in file_handle or flag in existing_overrides
                     else qualified
-                )
-            if (
-                SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG in file_handle
-                or SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG in existing_overrides
-            ):
-                sstb_self_employment_would_be_qualified = (
-                    self._values_from_file_or_overrides(
-                        file_handle,
-                        SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG,
-                        existing_overrides,
-                        length,
-                    ).astype(bool)
-                )
-                qualification_flags["self_employment_income"] = (
-                    qualification_flags["self_employment_income"]
-                    | sstb_self_employment_would_be_qualified
                 )
 
             source_arrays = {}

--- a/policyengine_us_data/datasets/puf/puf.py
+++ b/policyengine_us_data/datasets/puf/puf.py
@@ -34,6 +34,23 @@ with open(yamlfilename, "r", encoding="utf-8") as yamlfile:
     QBI_PARAMS = yaml.safe_load(yamlfile)
 assert isinstance(QBI_PARAMS, dict)
 
+QBI_SOURCE_NAMES = tuple(QBI_PARAMS["qbi_qualification_probabilities"])
+QBI_QUALIFICATION_FLAG_BY_SOURCE = {
+    source: f"{source}_would_be_qualified" for source in QBI_SOURCE_NAMES
+}
+SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG = (
+    "sstb_self_employment_income_would_be_qualified"
+)
+QBI_QUALIFICATION_SEED = 41
+QBI_W2_UBIA_SEED = 42
+QBI_SSTB_SEED = 64
+QBI_SIMULATION_REQUIRED_VARIABLES = frozenset(
+    (
+        *QBI_QUALIFICATION_FLAG_BY_SOURCE.values(),
+        SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG,
+    )
+)
+
 
 # Helper functions ---
 def sample_bernoulli_lognormal(n, prob, log_mean, log_sigma, rng):
@@ -49,15 +66,81 @@ def sample_bernoulli_lognormal(n, prob, log_mean, log_sigma, rng):
 
 def conditionally_sample_lognormal(flag, target_mean, log_sigma, rng):
     """Generate a lognormal conditional on a binary flag."""
-    mu = np.log(target_mean) - (log_sigma**2 / 2)
+    flag = np.asarray(flag, dtype=bool)
+    target_mean = np.asarray(target_mean, dtype=float)
+    eligible = flag & (target_mean > 0)
+    safe_target_mean = np.where(target_mean > 0, target_mean, 1.0)
+    mu = np.log(safe_target_mean) - (log_sigma**2 / 2)
     return np.where(
-        flag,
+        eligible,
         rng.lognormal(
             mean=mu,
             sigma=log_sigma,
         ),
         0.0,
     )
+
+
+def draw_qbi_qualification_flags(n, *, seed=None):
+    """Draw source-level QBI qualification inputs."""
+    flag_rng = np.random.default_rng(seed)
+    return {
+        source: flag_rng.random(n) < prob
+        for source, prob in QBI_PARAMS["qbi_qualification_probabilities"].items()
+    }
+
+
+def add_qbi_qualification_flags_to_puf(puf, *, seed=None):
+    """Draw and persist source-level QBI qualification inputs."""
+    flags = draw_qbi_qualification_flags(len(puf), seed=seed)
+    for source, qualified in flags.items():
+        puf[QBI_QUALIFICATION_FLAG_BY_SOURCE[source]] = qualified
+    return puf
+
+
+def qualified_qbi_components(puf):
+    """Return source amounts after applying persisted QBI qualification flags."""
+    components = {}
+    for source, prob in QBI_PARAMS["qbi_qualification_probabilities"].items():
+        source_values = puf[source].fillna(0).to_numpy(dtype=float)
+        flag_name = QBI_QUALIFICATION_FLAG_BY_SOURCE[source]
+        if flag_name in puf:
+            qualified = puf[flag_name].fillna(False).astype(bool).to_numpy()
+            components[source] = source_values * qualified
+        else:
+            components[source] = source_values * prob
+    return pd.DataFrame(components, index=puf.index)
+
+
+def capital_intensity_probability(qbi_components):
+    """Estimate UBIA eligibility probability from positive qualified QBI sources."""
+    positive_components = qbi_components.clip(lower=0)
+    positive_total = positive_components.sum(axis=1).to_numpy()
+    source_probs = QBI_PARAMS["ubia_simulation"]["capital_intensity_probabilities"]
+    weighted_prob = np.zeros(len(qbi_components), dtype=float)
+    for source, prob in source_probs.items():
+        if source in positive_components:
+            weighted_prob += positive_components[source].to_numpy() * prob
+    return np.divide(
+        weighted_prob,
+        positive_total,
+        out=np.zeros_like(positive_total, dtype=float),
+        where=positive_total > 0,
+    ).clip(0, 1)
+
+
+def simulate_business_is_sstb(puf, *, rng, probability_map=None):
+    """Draw SSTB status only from positive mapped SSTB source amounts."""
+    sstb_probs = probability_map or QBI_PARAMS["sstb_prob_map_by_name"]
+    available_sources = [source for source in sstb_probs if source in puf]
+    if not available_sources:
+        return np.zeros(len(puf), dtype=bool)
+    sstb_sources = puf[available_sources].fillna(0).clip(lower=0)
+    has_sstb_source = sstb_sources.sum(axis=1).to_numpy() > 0
+    largest_sstb_source = sstb_sources.idxmax(axis=1)
+    pr_sstb = largest_sstb_source.map(sstb_probs).fillna(0.0).to_numpy()
+    pr_sstb = np.where(has_sstb_source, pr_sstb, 0.0)
+    return rng.binomial(n=1, p=pr_sstb).astype(bool)
 
 
 def simulate_w2_and_ubia_from_puf(puf, *, seed=None, diagnostics=True):
@@ -83,7 +166,6 @@ def simulate_w2_and_ubia_from_puf(puf, *, seed=None, diagnostics=True):
     rng = np.random.default_rng(seed)
 
     # Extract Qualified Business Income simulation parameters
-    qbi_probs = QBI_PARAMS["qbi_qualification_probabilities"]
     margin_params = QBI_PARAMS["profit_margin_distribution"]
     logit_params = QBI_PARAMS["has_employees_logit"]
 
@@ -99,16 +181,13 @@ def simulate_w2_and_ubia_from_puf(puf, *, seed=None, diagnostics=True):
     non_rental_beta_b = non_rental_labor["beta_b"]
     non_rental_scale = non_rental_labor["scale"]
 
-    depr_sigma = QBI_PARAMS["depreciation_proxy_sigma"]
-
     ubia_params = QBI_PARAMS["ubia_simulation"]
     ubia_multiple_of_qbi = ubia_params["multiple_of_qbi"]
     ubia_sigma = ubia_params["sigma"]
 
     # Estimate qualified business income
-    qbi = sum(
-        puf[income_type] * prob for income_type, prob in qbi_probs.items()
-    ).to_numpy()
+    qbi_components = qualified_qbi_components(puf)
+    qbi = qbi_components.sum(axis=1).to_numpy()
 
     # Simulate gross receipts by drawing a profit margin
     margins = (
@@ -135,16 +214,9 @@ def simulate_w2_and_ubia_from_puf(puf, *, seed=None, diagnostics=True):
 
     w2_wages = revenues * labor_ratios * has_employees
 
-    # A depreciation stand-in that scales with rents
-    depreciation_proxy = conditionally_sample_lognormal(
-        is_rental,
-        puf["rental_income"],
-        depr_sigma,
-        rng,
-    )
-
-    # UBIA simulation: lognormal, but only for capital-heavy records
-    is_capital_intensive = is_rental | (depreciation_proxy > 0)
+    # UBIA simulation: lognormal, but only for capital-heavy records.
+    pr_capital_intensive = capital_intensity_probability(qbi_components)
+    is_capital_intensive = rng.binomial(1, pr_capital_intensive).astype(bool)
 
     ubia = conditionally_sample_lognormal(
         is_capital_intensive,
@@ -424,28 +496,32 @@ def preprocess_puf(puf: pd.DataFrame) -> pd.DataFrame:
     puf["partnership_se_income"] = partnership_se
 
     # --- Qualified Business Income Deduction (QBID) simulation ---
-    w2, ubia = simulate_w2_and_ubia_from_puf(puf, seed=42)
+    puf = add_qbi_qualification_flags_to_puf(puf, seed=QBI_QUALIFICATION_SEED)
+    w2, ubia = simulate_w2_and_ubia_from_puf(puf, seed=QBI_W2_UBIA_SEED)
     puf["w2_wages_from_qualified_business"] = w2
     puf["unadjusted_basis_qualified_property"] = ubia
 
-    puf_qbi_sources_for_sstb = puf[QBI_PARAMS["sstb_prob_map_by_name"].keys()]
-    largest_qbi_source_name = puf_qbi_sources_for_sstb.idxmax(axis=1)
-
-    pr_sstb = largest_qbi_source_name.map(QBI_PARAMS["sstb_prob_map_by_name"]).fillna(
-        0.0
-    )
-    puf["business_is_sstb"] = rng.binomial(n=1, p=pr_sstb)
+    puf["business_is_sstb"] = simulate_business_is_sstb(puf, rng=rng)
     is_sstb = puf["business_is_sstb"].astype(bool)
 
     # The current PUF pipeline only imputes an all-or-nothing SSTB flag.
     # Use that to split Schedule C self-employment and allocable W-2/UBIA
     # inputs for policyengine-us without pretending to observe mixed cases.
     legacy_self_employment_income = puf["self_employment_income"].fillna(0)
+    self_employment_would_be_qualified = puf[
+        "self_employment_income_would_be_qualified"
+    ].astype(bool)
     puf["sstb_self_employment_income"] = np.where(
         is_sstb, legacy_self_employment_income, 0.0
     )
     puf["self_employment_income"] = np.where(
         is_sstb, 0.0, legacy_self_employment_income
+    )
+    puf[SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG] = np.where(
+        is_sstb, self_employment_would_be_qualified, False
+    )
+    puf["self_employment_income_would_be_qualified"] = np.where(
+        is_sstb, False, self_employment_would_be_qualified
     )
     puf["sstb_w2_wages_from_qualified_business"] = np.where(is_sstb, w2, 0.0)
     puf["sstb_unadjusted_basis_qualified_property"] = np.where(is_sstb, ubia, 0.0)
@@ -540,6 +616,13 @@ FINANCIAL_SUBSET = [
     "recapture_of_investment_credit",
     "unreported_payroll_tax",
     "pre_tax_contributions",
+    "estate_income_would_be_qualified",
+    "farm_operations_income_would_be_qualified",
+    "farm_rent_income_would_be_qualified",
+    "partnership_s_corp_income_would_be_qualified",
+    "rental_income_would_be_qualified",
+    "self_employment_income_would_be_qualified",
+    "sstb_self_employment_income_would_be_qualified",
     "w2_wages_from_qualified_business",
     "unadjusted_basis_qualified_property",
     "business_is_sstb",
@@ -563,6 +646,16 @@ class PUF(Dataset):
         if key in file_handle:
             del file_handle[key]
         file_handle.create_dataset(key, data=values)
+
+    @staticmethod
+    def _values_from_file_or_overrides(
+        file_handle, key: str, overrides: dict[str, np.ndarray], length: int
+    ) -> np.ndarray:
+        if key in overrides:
+            return np.asarray(overrides[key])
+        if key in file_handle:
+            return np.asarray(file_handle[key])
+        return np.zeros(length)
 
     def _sstb_split_overrides(self) -> dict[str, np.ndarray]:
         if not self.file_path.exists():
@@ -636,8 +729,121 @@ class PUF(Dataset):
 
         return overrides
 
+    def _qbi_simulation_overrides(
+        self, existing_overrides: dict[str, np.ndarray]
+    ) -> dict[str, np.ndarray]:
+        if not self.file_path.exists():
+            return {}
+
+        with h5py.File(self.file_path, "r") as file_handle:
+            keys = set(file_handle.keys())
+            if QBI_SIMULATION_REQUIRED_VARIABLES.issubset(keys):
+                return {}
+
+            length = None
+            for key in (
+                "household_id",
+                "self_employment_income",
+                "partnership_s_corp_income",
+            ):
+                if key in file_handle:
+                    length = len(file_handle[key])
+                    break
+            if length is None:
+                return {}
+
+            raw_qualification_flags = draw_qbi_qualification_flags(
+                length, seed=QBI_QUALIFICATION_SEED
+            )
+            is_sstb_existing = self._values_from_file_or_overrides(
+                file_handle, "business_is_sstb", existing_overrides, length
+            ).astype(bool)
+            self_employment_would_be_qualified = raw_qualification_flags[
+                "self_employment_income"
+            ]
+            flag_overrides = {
+                "self_employment_income_would_be_qualified": np.where(
+                    is_sstb_existing, False, self_employment_would_be_qualified
+                ),
+                SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG: np.where(
+                    is_sstb_existing, self_employment_would_be_qualified, False
+                ),
+            }
+            for source, qualified in raw_qualification_flags.items():
+                flag = QBI_QUALIFICATION_FLAG_BY_SOURCE[source]
+                if source != "self_employment_income":
+                    flag_overrides[flag] = qualified
+
+            has_all_qbi_sources = all(
+                source in file_handle or source in existing_overrides
+                for source in QBI_SOURCE_NAMES
+            )
+            if not has_all_qbi_sources:
+                return flag_overrides
+
+            source_arrays = {}
+            for source in QBI_SOURCE_NAMES:
+                source_arrays[source] = self._values_from_file_or_overrides(
+                    file_handle, source, existing_overrides, length
+                ).astype(float)
+
+            source_arrays["self_employment_income"] = (
+                self._values_from_file_or_overrides(
+                    file_handle,
+                    "self_employment_income",
+                    existing_overrides,
+                    length,
+                ).astype(float)
+                + self._values_from_file_or_overrides(
+                    file_handle,
+                    "sstb_self_employment_income",
+                    existing_overrides,
+                    length,
+                ).astype(float)
+            )
+
+            qbi_frame = pd.DataFrame(source_arrays)
+            for source, qualified in raw_qualification_flags.items():
+                qbi_frame[QBI_QUALIFICATION_FLAG_BY_SOURCE[source]] = qualified
+
+            w2, ubia = simulate_w2_and_ubia_from_puf(
+                qbi_frame, seed=QBI_W2_UBIA_SEED, diagnostics=False
+            )
+            is_sstb = simulate_business_is_sstb(
+                qbi_frame,
+                rng=np.random.default_rng(QBI_SSTB_SEED),
+                probability_map=QBI_PARAMS["sstb_prob_map_by_source_name"],
+            )
+            legacy_self_employment_income = source_arrays["self_employment_income"]
+
+            overrides = {
+                **flag_overrides,
+                "business_is_sstb": is_sstb,
+                "self_employment_income": np.where(
+                    is_sstb, 0.0, legacy_self_employment_income
+                ),
+                "sstb_self_employment_income": np.where(
+                    is_sstb, legacy_self_employment_income, 0.0
+                ),
+                "w2_wages_from_qualified_business": w2,
+                "unadjusted_basis_qualified_property": ubia,
+                "sstb_w2_wages_from_qualified_business": np.where(is_sstb, w2, 0.0),
+                "sstb_unadjusted_basis_qualified_property": np.where(
+                    is_sstb, ubia, 0.0
+                ),
+                "self_employment_income_would_be_qualified": np.where(
+                    is_sstb, False, self_employment_would_be_qualified
+                ),
+                SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG: np.where(
+                    is_sstb, self_employment_would_be_qualified, False
+                ),
+            }
+
+        return overrides
+
     def _ensure_sstb_split_inputs(self) -> dict[str, np.ndarray]:
         overrides = self._sstb_split_overrides()
+        overrides.update(self._qbi_simulation_overrides(overrides))
         if not overrides:
             return {}
 

--- a/policyengine_us_data/datasets/puf/puf.py
+++ b/policyengine_us_data/datasets/puf/puf.py
@@ -1037,15 +1037,18 @@ class PUF(Dataset):
             flag_overrides = {}
             for source, qualified in qualification_flags.items():
                 flag = QBI_QUALIFICATION_FLAG_BY_SOURCE[source]
-                if (
-                    source != "self_employment_income" or is_current_qbi_simulation
-                ) and (flag in file_handle or flag in existing_overrides):
+                if source == "self_employment_income":
+                    if has_existing_sstb and (
+                        flag in file_handle or flag in existing_overrides
+                    ):
+                        continue
+                elif flag in file_handle or flag in existing_overrides:
                     continue
                 if source == "self_employment_income":
                     flag_overrides[flag] = np.where(is_sstb, False, qualified)
                 else:
                     flag_overrides[flag] = qualified
-            if not is_current_qbi_simulation or (
+            if not has_existing_sstb or (
                 SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG not in file_handle
                 and SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG not in existing_overrides
             ):

--- a/policyengine_us_data/datasets/puf/puf.py
+++ b/policyengine_us_data/datasets/puf/puf.py
@@ -43,27 +43,25 @@ SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG = (
 )
 QBI_QUALIFICATION_SEED = 41
 QBI_W2_UBIA_SEED = 42
+QBI_INVESTMENT_SEED = 43
 QBI_SSTB_SEED = 64
 QBI_SIMULATION_REQUIRED_VARIABLES = frozenset(
     (
         *QBI_QUALIFICATION_FLAG_BY_SOURCE.values(),
         SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG,
+        "business_is_sstb",
+        "sstb_self_employment_income",
+        "w2_wages_from_qualified_business",
+        "unadjusted_basis_qualified_property",
+        "sstb_w2_wages_from_qualified_business",
+        "sstb_unadjusted_basis_qualified_property",
+        "qualified_reit_and_ptp_income",
+        "qualified_bdc_income",
     )
 )
 
 
 # Helper functions ---
-def sample_bernoulli_lognormal(n, prob, log_mean, log_sigma, rng):
-    """Generate a Bernoulli-lognormal mixture."""
-    positive = rng.binomial(1, prob, size=n)
-    amounts = np.where(
-        positive,
-        rng.lognormal(mean=log_mean, sigma=log_sigma, size=n),
-        0.0,
-    )
-    return amounts
-
-
 def conditionally_sample_lognormal(flag, target_mean, log_sigma, rng):
     """Generate a lognormal conditional on a binary flag."""
     flag = np.asarray(flag, dtype=bool)
@@ -112,21 +110,149 @@ def qualified_qbi_components(puf):
     return pd.DataFrame(components, index=puf.index)
 
 
-def capital_intensity_probability(qbi_components):
-    """Estimate UBIA eligibility probability from positive qualified QBI sources."""
-    positive_components = qbi_components.clip(lower=0)
-    positive_total = positive_components.sum(axis=1).to_numpy()
-    source_probs = QBI_PARAMS["ubia_simulation"]["capital_intensity_probabilities"]
-    weighted_prob = np.zeros(len(qbi_components), dtype=float)
-    for source, prob in source_probs.items():
+def positive_qbi_source_amounts(qbi_components, params_by_source=None):
+    """Return positive QBI components limited to modeled sources."""
+    sources = (
+        [source for source in params_by_source if source in qbi_components]
+        if params_by_source is not None
+        else list(qbi_components.columns)
+    )
+    positive_components = qbi_components[sources].fillna(0).clip(lower=0)
+    positive_total = positive_components.sum(axis=1).to_numpy(dtype=float)
+    return positive_components, positive_total
+
+
+def source_weighted_parameter(qbi_components, params_by_source):
+    """Weight source-level scalar parameters by positive qualified QBI."""
+    positive_components, positive_total = positive_qbi_source_amounts(
+        qbi_components, params_by_source
+    )
+    weighted_value = np.zeros(len(qbi_components), dtype=float)
+    for source, value in params_by_source.items():
         if source in positive_components:
-            weighted_prob += positive_components[source].to_numpy() * prob
+            weighted_value += positive_components[source].to_numpy(dtype=float) * float(
+                value
+            )
     return np.divide(
-        weighted_prob,
+        weighted_value,
         positive_total,
         out=np.zeros_like(positive_total, dtype=float),
         where=positive_total > 0,
-    ).clip(0, 1)
+    )
+
+
+def draw_source_weighted_beta(qbi_components, params_by_source, rng):
+    """Draw source-level beta values and QBI-weight them within each record."""
+    positive_components, positive_total = positive_qbi_source_amounts(
+        qbi_components, params_by_source
+    )
+    weighted_draw = np.zeros(len(qbi_components), dtype=float)
+    for source, params in params_by_source.items():
+        if source not in positive_components:
+            continue
+        draw = rng.beta(
+            params["beta_a"], params["beta_b"], len(qbi_components)
+        ) * params.get("scale", 1.0) + params.get("shift", 0.0)
+        weighted_draw += positive_components[source].to_numpy(dtype=float) * draw
+    return np.divide(
+        weighted_draw,
+        positive_total,
+        out=np.zeros_like(positive_total, dtype=float),
+        where=positive_total > 0,
+    )
+
+
+def capital_intensity_probability(qbi_components):
+    """Estimate UBIA eligibility probability from positive qualified QBI sources."""
+    source_probs = QBI_PARAMS["ubia_simulation"]["capital_intensity_probabilities"]
+    return source_weighted_parameter(qbi_components, source_probs).clip(0, 1)
+
+
+def logistic(values):
+    """Numerically stable logistic transform."""
+    return 1.0 / (1.0 + np.exp(-np.clip(values, -700, 700)))
+
+
+def calibrate_logit_intercept(revenues, slope, target_share):
+    """Solve the employee-presence logit intercept for positive-receipt records."""
+    revenues = np.asarray(revenues, dtype=float)
+    positive = revenues > 0
+    if not np.any(positive):
+        return 0.0
+
+    target_share = np.clip(float(target_share), 1e-9, 1 - 1e-9)
+    slope_term = float(slope) * revenues[positive]
+    target_logit = np.log(target_share / (1 - target_share))
+    lower = target_logit - np.max(slope_term) - 80.0
+    upper = target_logit - np.min(slope_term) + 80.0
+    for _ in range(100):
+        midpoint = (lower + upper) / 2
+        mean_probability = logistic(midpoint + slope_term).mean()
+        if mean_probability < target_share:
+            lower = midpoint
+        else:
+            upper = midpoint
+    return (lower + upper) / 2
+
+
+def puf_column_values(puf, column):
+    """Return a PUF column as float values, or zeros when absent."""
+    if column not in puf:
+        return np.zeros(len(puf), dtype=float)
+    return puf[column].fillna(0).to_numpy(dtype=float)
+
+
+def non_qualified_dividend_income_from_puf(puf):
+    """Recover ordinary dividends that are not qualified dividends."""
+    if "non_qualified_dividend_income" in puf:
+        return puf_column_values(puf, "non_qualified_dividend_income")
+    if "E00600" in puf and "E00650" in puf:
+        return puf_column_values(puf, "E00600") - puf_column_values(puf, "E00650")
+    if "ordinary_dividend_income" in puf:
+        return puf_column_values(puf, "ordinary_dividend_income")
+    return np.zeros(len(puf), dtype=float)
+
+
+def sample_exposure_scaled_beta(base, params, rng):
+    """Sample a positive share of an observed exposure base."""
+    base = np.maximum(np.asarray(base, dtype=float), 0)
+    receives = (base > 0) & (
+        rng.random(len(base)) < float(params["probability_of_receiving"])
+    )
+    share = rng.beta(params["beta_a"], params["beta_b"], len(base)) * params.get(
+        "scale", 1.0
+    ) + params.get("shift", 0.0)
+    share = np.clip(share, 0, 1)
+    return np.where(receives, base * share, 0.0)
+
+
+def simulate_investment_qbi_income_from_puf(puf, *, rng):
+    """Simulate qualified REIT/PTP and BDC income from observed exposures."""
+    exposure_bases = {
+        "non_qualified_dividend_income": non_qualified_dividend_income_from_puf(puf),
+        "partnership_s_corp_income": puf_column_values(
+            puf, "partnership_s_corp_income"
+        ),
+    }
+
+    qualified_reit_and_ptp_income = np.zeros(len(puf), dtype=float)
+    for exposure_source, params in QBI_PARAMS["reit_ptp_income_distribution"].items():
+        base = exposure_bases.get(exposure_source)
+        if base is None:
+            continue
+        qualified_reit_and_ptp_income += sample_exposure_scaled_beta(base, params, rng)
+
+    qualified_bdc_income = np.zeros(len(puf), dtype=float)
+    for exposure_source, params in QBI_PARAMS["bdc_income_distribution"].items():
+        base = exposure_bases.get(exposure_source)
+        if base is None:
+            continue
+        qualified_bdc_income += sample_exposure_scaled_beta(base, params, rng)
+
+    return {
+        "qualified_reit_and_ptp_income": qualified_reit_and_ptp_income,
+        "qualified_bdc_income": qualified_bdc_income,
+    }
 
 
 def simulate_business_is_sstb(puf, *, rng, probability_map=None):
@@ -168,55 +294,45 @@ def simulate_w2_and_ubia_from_puf(puf, *, seed=None, diagnostics=True):
     # Extract Qualified Business Income simulation parameters
     margin_params = QBI_PARAMS["profit_margin_distribution"]
     logit_params = QBI_PARAMS["has_employees_logit"]
-
     labor_params = QBI_PARAMS["labor_ratio_distribution"]
-    rental_labor = labor_params["rental"]
-    non_rental_labor = labor_params["non_rental"]
-
-    rental_beta_a = rental_labor["beta_a"]
-    rental_beta_b = rental_labor["beta_b"]
-    rental_scale = rental_labor["scale"]
-
-    non_rental_beta_a = non_rental_labor["beta_a"]
-    non_rental_beta_b = non_rental_labor["beta_b"]
-    non_rental_scale = non_rental_labor["scale"]
 
     ubia_params = QBI_PARAMS["ubia_simulation"]
-    ubia_multiple_of_qbi = ubia_params["multiple_of_qbi"]
     ubia_sigma = ubia_params["sigma"]
 
     # Estimate qualified business income
     qbi_components = qualified_qbi_components(puf)
     qbi = qbi_components.sum(axis=1).to_numpy()
 
-    # Simulate gross receipts by drawing a profit margin
-    margins = (
-        rng.beta(margin_params["beta_a"], margin_params["beta_b"], qbi.size)
-        * margin_params["scale"]
-        + margin_params["shift"]
+    # Simulate gross receipts by drawing source-weighted profit margins.
+    margins = draw_source_weighted_beta(qbi_components, margin_params, rng)
+    revenues = np.divide(
+        np.maximum(qbi, 0),
+        margins,
+        out=np.zeros_like(qbi, dtype=float),
+        where=margins > 0,
     )
-    revenues = np.maximum(qbi, 0) / margins
 
-    logit = logit_params["intercept"] + logit_params["slope_per_dollar"] * revenues
+    intercept = calibrate_logit_intercept(
+        revenues,
+        logit_params["slope_per_dollar"],
+        logit_params["target_share_among_positive_receipts"],
+    )
+    logit = intercept + logit_params["slope_per_dollar"] * revenues
 
     # Set p = 0 when simulated receipts == 0 (no revenue means no payroll)
-    pr_has_employees = np.where(revenues == 0.0, 0.0, 1.0 / (1.0 + np.exp(-logit)))
+    pr_has_employees = np.where(revenues == 0.0, 0.0, logistic(logit))
     has_employees = rng.binomial(1, pr_has_employees)
 
-    # Labor share simulation
-    is_rental = puf["rental_income"].to_numpy() > 0
-
-    labor_ratios = np.where(
-        is_rental,
-        rng.beta(rental_beta_a, rental_beta_b, qbi.size) * rental_scale,
-        rng.beta(non_rental_beta_a, non_rental_beta_b, qbi.size) * non_rental_scale,
-    )
-
+    labor_ratios = draw_source_weighted_beta(qbi_components, labor_params, rng)
     w2_wages = revenues * labor_ratios * has_employees
 
     # UBIA simulation: lognormal, but only for capital-heavy records.
     pr_capital_intensive = capital_intensity_probability(qbi_components)
     is_capital_intensive = rng.binomial(1, pr_capital_intensive).astype(bool)
+    ubia_multiple_of_qbi = source_weighted_parameter(
+        qbi_components,
+        ubia_params["multiple_of_qbi"],
+    )
 
     ubia = conditionally_sample_lognormal(
         is_capital_intensive,
@@ -227,7 +343,13 @@ def simulate_w2_and_ubia_from_puf(puf, *, seed=None, diagnostics=True):
 
     if diagnostics:
         share_qbi_pos = np.mean(qbi > 0)
-        share_wages = np.mean((w2_wages > 0) & (qbi > 0))
+        qbi_positive = qbi > 0
+        qbi_positive_count = np.sum(qbi_positive)
+        share_wages = (
+            np.sum((w2_wages > 0) & qbi_positive) / qbi_positive_count
+            if qbi_positive_count
+            else 0.0
+        )
         print(f"Share with QBI > 0: {share_qbi_pos:6.2%}")
         print(f"Among those, share with W-2 wages: {share_wages:6.2%}")
         if np.any(w2_wages > 0):
@@ -501,7 +623,11 @@ def preprocess_puf(puf: pd.DataFrame) -> pd.DataFrame:
     puf["w2_wages_from_qualified_business"] = w2
     puf["unadjusted_basis_qualified_property"] = ubia
 
-    puf["business_is_sstb"] = simulate_business_is_sstb(puf, rng=rng)
+    puf["business_is_sstb"] = simulate_business_is_sstb(
+        puf,
+        rng=np.random.default_rng(QBI_SSTB_SEED),
+        probability_map=QBI_PARAMS["sstb_prob_map_by_source_name"],
+    )
     is_sstb = puf["business_is_sstb"].astype(bool)
 
     # The current PUF pipeline only imputes an all-or-nothing SSTB flag.
@@ -526,23 +652,11 @@ def preprocess_puf(puf: pd.DataFrame) -> pd.DataFrame:
     puf["sstb_w2_wages_from_qualified_business"] = np.where(is_sstb, w2, 0.0)
     puf["sstb_unadjusted_basis_qualified_property"] = np.where(is_sstb, ubia, 0.0)
 
-    reit_params = QBI_PARAMS["reit_ptp_income_distribution"]
-    p_reit_ptp = reit_params["probability_of_receiving"]
-    mu_reit_ptp = reit_params["log_normal_mu"]
-    sigma_reit_ptp = reit_params["log_normal_sigma"]
-
-    puf["qualified_reit_and_ptp_income"] = sample_bernoulli_lognormal(
-        len(puf), p_reit_ptp, mu_reit_ptp, sigma_reit_ptp, rng
+    investment_qbi = simulate_investment_qbi_income_from_puf(
+        puf, rng=np.random.default_rng(QBI_INVESTMENT_SEED)
     )
-
-    bdc_params = QBI_PARAMS["bdc_income_distribution"]
-    p_bdc = bdc_params["probability_of_receiving"]
-    mu_bdc = bdc_params["log_normal_mu"]
-    sigma_bdc = bdc_params["log_normal_sigma"]
-
-    puf["qualified_bdc_income"] = sample_bernoulli_lognormal(
-        len(puf), p_bdc, mu_bdc, sigma_bdc, rng
-    )
+    for variable, values in investment_qbi.items():
+        puf[variable] = values
     # -------- End of Qualified Business Income Deduction (QBID) -------
     puf["filing_status"] = puf.MARS.map(
         {
@@ -805,6 +919,17 @@ class PUF(Dataset):
             qbi_frame = pd.DataFrame(source_arrays)
             for source, qualified in raw_qualification_flags.items():
                 qbi_frame[QBI_QUALIFICATION_FLAG_BY_SOURCE[source]] = qualified
+            for source in (
+                "qualified_dividend_income",
+                "non_qualified_dividend_income",
+                "ordinary_dividend_income",
+                "E00600",
+                "E00650",
+            ):
+                if source in file_handle or source in existing_overrides:
+                    qbi_frame[source] = self._values_from_file_or_overrides(
+                        file_handle, source, existing_overrides, length
+                    ).astype(float)
 
             w2, ubia = simulate_w2_and_ubia_from_puf(
                 qbi_frame, seed=QBI_W2_UBIA_SEED, diagnostics=False
@@ -814,10 +939,14 @@ class PUF(Dataset):
                 rng=np.random.default_rng(QBI_SSTB_SEED),
                 probability_map=QBI_PARAMS["sstb_prob_map_by_source_name"],
             )
+            investment_qbi = simulate_investment_qbi_income_from_puf(
+                qbi_frame, rng=np.random.default_rng(QBI_INVESTMENT_SEED)
+            )
             legacy_self_employment_income = source_arrays["self_employment_income"]
 
             overrides = {
                 **flag_overrides,
+                **investment_qbi,
                 "business_is_sstb": is_sstb,
                 "self_employment_income": np.where(
                     is_sstb, 0.0, legacy_self_employment_income

--- a/policyengine_us_data/datasets/puf/puf.py
+++ b/policyengine_us_data/datasets/puf/puf.py
@@ -1006,13 +1006,15 @@ class PUF(Dataset):
             flag_overrides = {}
             for source, qualified in qualification_flags.items():
                 flag = QBI_QUALIFICATION_FLAG_BY_SOURCE[source]
-                if flag in file_handle or flag in existing_overrides:
+                if (
+                    source != "self_employment_income" or is_current_qbi_simulation
+                ) and (flag in file_handle or flag in existing_overrides):
                     continue
                 if source == "self_employment_income":
                     flag_overrides[flag] = np.where(is_sstb, False, qualified)
                 else:
                     flag_overrides[flag] = qualified
-            if (
+            if not is_current_qbi_simulation or (
                 SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG not in file_handle
                 and SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG not in existing_overrides
             ):

--- a/policyengine_us_data/datasets/puf/qbi_assumptions.yaml
+++ b/policyengine_us_data/datasets/puf/qbi_assumptions.yaml
@@ -18,6 +18,11 @@ sstb_prob_map_by_name:
   E26390: 0.10
   E26400: 0.10
 
+sstb_prob_map_by_source_name:
+  self_employment_income: 0.20
+  partnership_s_corp_income: 0.15
+  estate_income: 0.10
+
 # Below, we assume that 7% of filers have nonzero REIT/PTP income,
 # and of those 7%, their REIT/PTP income is lognormal distributed with
 # mean of exp(8.04) = $3,103, and standard deviation 1.20 of the lognormal.
@@ -54,11 +59,19 @@ labor_ratio_distribution:
     beta_b: 2.0
     scale: 0.25
 
-depreciation_proxy_sigma: 0.8
-
 # lognormal(mean = 4 * QBI, sigma = 1)
 # produce a right-skewed spread whose mean is roughly 4 * QBI,
 # matching aggregate SOI ratios.
 ubia_simulation:
     multiple_of_qbi: 4.0
     sigma: 1.0
+    # Probability that positive QBI from each source is capital-intensive
+    # enough to hold qualified property. Row-level probabilities are weighted
+    # by positive qualified QBI source amounts.
+    capital_intensity_probabilities:
+      self_employment_income: 0.20
+      farm_operations_income: 0.45
+      farm_rent_income: 0.75
+      rental_income: 1.00
+      estate_income: 0.50
+      partnership_s_corp_income: 0.35

--- a/policyengine_us_data/datasets/puf/qbi_assumptions.yaml
+++ b/policyengine_us_data/datasets/puf/qbi_assumptions.yaml
@@ -1,77 +1,119 @@
-# Probabilistic assumptions for Section 199A qualification and SSTB classification
-# QBI assumptions: https://chatgpt.com/share/6823cb37-7a28-8001-b2bb-0c0a7f47401c
-# UBIA assumptions: https://chatgpt.com/share/683b12a5-78dc-8006-81c9-479858312b30
-# REIT/PTP and BDC assumptions: https://chatgpt.com/c/6835f502-5b48-8006-833a-76170a0acd40
-
+# Probabilistic assumptions for Section 199A qualification and SSTB classification.
+# See docs/qbi_simulation.md for source definitions and rationale.
 
 qbi_qualification_probabilities:
-  self_employment_income: 0.8
-  farm_operations_income: 0.95
-  farm_rent_income: 0.5
-  rental_income: 0.4
-  estate_income: 0.5
-  partnership_s_corp_income: 0.85
+  self_employment_income: 0.95
+  farm_operations_income: 0.98
+  farm_rent_income: 0.80
+  rental_income: 0.70
+  estate_income: 0.60
+  partnership_s_corp_income: 0.90
 
 sstb_prob_map_by_name:
-  E00900: 0.20
-  E26270: 0.15
-  E26390: 0.10
-  E26400: 0.10
+  E00900: 0.30
+  E26270: 0.25
+  E26390: 0.15
+  E26400: 0.15
 
 sstb_prob_map_by_source_name:
-  self_employment_income: 0.20
-  partnership_s_corp_income: 0.15
-  estate_income: 0.10
+  self_employment_income: 0.30
+  partnership_s_corp_income: 0.25
+  estate_income: 0.15
 
-# Below, we assume that 7% of filers have nonzero REIT/PTP income,
-# and of those 7%, their REIT/PTP income is drawn from a lognormal
-# with median exp(8.04) = $3,103 and log-scale sigma 1.20.
 reit_ptp_income_distribution:
-  probability_of_receiving: 0.07
-  log_normal_mu: 8.04
-  log_normal_sigma: 1.20
+  non_qualified_dividend_income:
+    probability_of_receiving: 0.35
+    beta_a: 2.0
+    beta_b: 18.0
+    scale: 1.0
+  partnership_s_corp_income:
+    probability_of_receiving: 0.05
+    beta_a: 2.0
+    beta_b: 8.0
+    scale: 0.60
 
 bdc_income_distribution:
-  probability_of_receiving: 0.003
-  log_normal_mu: 8.71
-  log_normal_sigma: 1.00
+  non_qualified_dividend_income:
+    probability_of_receiving: 0.05
+    beta_a: 2.0
+    beta_b: 18.0
+    scale: 0.30
 
 profit_margin_distribution:
-  beta_a: 2.0
-  beta_b: 3.0
-  scale: 0.20
-  shift: 0.05
+  self_employment_income:
+    beta_a: 2.0
+    beta_b: 2.0
+    scale: 0.50
+    shift: 0.05
+  farm_operations_income:
+    beta_a: 2.0
+    beta_b: 4.0
+    scale: 0.45
+    shift: 0.03
+  farm_rent_income:
+    beta_a: 2.0
+    beta_b: 3.0
+    scale: 0.45
+    shift: 0.05
+  rental_income:
+    beta_a: 2.5
+    beta_b: 3.0
+    scale: 0.50
+    shift: 0.05
+  estate_income:
+    beta_a: 2.0
+    beta_b: 3.0
+    scale: 0.45
+    shift: 0.05
+  partnership_s_corp_income:
+    beta_a: 2.0
+    beta_b: 3.5
+    scale: 0.45
+    shift: 0.05
 
-# Logistic model:  p = 1 / (1 + exp(-(b0 + b1 * receipts)))
-# * b1 = 1.2e-6: odds roughly triple for each +$1 M of receipts
-# * b0 = -3.1: tuned so mean pr is roughly 14% in this PUF (matches SOI share)
 has_employees_logit:
-  intercept: -3.1
   slope_per_dollar: 1.2e-6
+  target_share_among_positive_receipts: 0.18
 
 labor_ratio_distribution:
-  rental:
-    beta_a: 1.5
-    beta_b: 8.0
-    scale: 0.08
-  non_rental:
+  self_employment_income:
     beta_a: 2.0
     beta_b: 2.0
     scale: 0.25
+  farm_operations_income:
+    beta_a: 2.0
+    beta_b: 2.5
+    scale: 0.22
+  farm_rent_income:
+    beta_a: 1.5
+    beta_b: 8.0
+    scale: 0.08
+  rental_income:
+    beta_a: 1.5
+    beta_b: 8.0
+    scale: 0.08
+  estate_income:
+    beta_a: 2.0
+    beta_b: 2.5
+    scale: 0.20
+  partnership_s_corp_income:
+    beta_a: 2.0
+    beta_b: 2.0
+    scale: 0.22
 
-# lognormal(mean = 4 * QBI, sigma = 1)
-# produce a right-skewed spread whose mean is roughly 4 * QBI,
-# matching aggregate SOI ratios.
 ubia_simulation:
-    multiple_of_qbi: 4.0
     sigma: 1.0
-    # Probability that positive QBI from each source is capital-intensive
-    # enough to hold qualified property. Row-level probabilities are weighted
-    # by positive qualified QBI source amounts.
+    multiple_of_qbi:
+      self_employment_income: 1.5
+      farm_operations_income: 4.0
+      farm_rent_income: 8.0
+      rental_income: 10.0
+      estate_income: 3.0
+      partnership_s_corp_income: 3.0
     capital_intensity_probabilities:
-      self_employment_income: 0.20
-      farm_operations_income: 0.45
-      farm_rent_income: 0.75
-      rental_income: 1.00
+      self_employment_income: 0.25
+      farm_operations_income: 0.70
+      farm_rent_income: 0.90
+      rental_income: 0.95
       estate_income: 0.50
-      partnership_s_corp_income: 0.35
+      partnership_s_corp_income: 0.45

--- a/policyengine_us_data/datasets/puf/qbi_assumptions.yaml
+++ b/policyengine_us_data/datasets/puf/qbi_assumptions.yaml
@@ -24,8 +24,8 @@ sstb_prob_map_by_source_name:
   estate_income: 0.10
 
 # Below, we assume that 7% of filers have nonzero REIT/PTP income,
-# and of those 7%, their REIT/PTP income is lognormal distributed with
-# mean of exp(8.04) = $3,103, and standard deviation 1.20 of the lognormal.
+# and of those 7%, their REIT/PTP income is drawn from a lognormal
+# with median exp(8.04) = $3,103 and log-scale sigma 1.20.
 reit_ptp_income_distribution:
   probability_of_receiving: 0.07
   log_normal_mu: 8.04
@@ -43,7 +43,7 @@ profit_margin_distribution:
   shift: 0.05
 
 # Logistic model:  p = 1 / (1 + exp(-(b0 + b1 * receipts)))
-# * b1 = 1.2e-6: odds roughly triple for each +$1 M; pr 50% near $1M
+# * b1 = 1.2e-6: odds roughly triple for each +$1 M of receipts
 # * b0 = -3.1: tuned so mean pr is roughly 14% in this PUF (matches SOI share)
 has_employees_logit:
   intercept: -3.1

--- a/policyengine_us_data/datasets/puf/qbi_assumptions.yaml
+++ b/policyengine_us_data/datasets/puf/qbi_assumptions.yaml
@@ -13,7 +13,6 @@ sstb_prob_map_by_name:
   E00900: 0.30
   E26270: 0.25
   E26390: 0.15
-  E26400: 0.15
 
 sstb_prob_map_by_source_name:
   self_employment_income: 0.30

--- a/policyengine_us_data/utils/loss.py
+++ b/policyengine_us_data/utils/loss.py
@@ -140,6 +140,42 @@ LOW_AGI_INVESTMENT_INCOME_SOI_VARIABLES = {
     "taxable_interest_income",
 }
 
+AGI_LEVEL_TARGETED_VARIABLES = (
+    "adjusted_gross_income",
+    "count",
+    "employment_income",
+    "business_net_profits",
+    "capital_gains_gross",
+    "ordinary_dividends",
+    "partnership_and_s_corp_income",
+    "qualified_dividends",
+    "taxable_interest_income",
+    "total_pension_income",
+    "total_social_security",
+)
+
+AGGREGATE_LEVEL_TARGETED_VARIABLES = (
+    "business_net_losses",
+    "capital_gains_distributions",
+    "capital_gains_losses",
+    "estate_income",
+    "estate_losses",
+    "exempt_interest",
+    "ira_distributions",
+    "partnership_and_s_corp_losses",
+    "rent_and_royalty_net_income",
+    "rent_and_royalty_net_losses",
+    # The current SOI source only exposes taxable-only aggregate targets for
+    # mortgage-interest deductions, not the AGI-bin detail used above.
+    "mortgage_interest_deductions",
+    # Keep the legacy loss matrix aligned with the national QBI amount and
+    # claimant-count controls used by the target-config calibration path.
+    "qualified_business_income_deduction",
+    "taxable_pension_income",
+    "taxable_social_security",
+    "unemployment_compensation",
+)
+
 
 def fmt(x):
     if x == -np.inf:
@@ -543,44 +579,13 @@ def build_loss_matrix(dataset: type, time_period):
     taxable = df["total_income_tax"].values > 0
     soi_subset = get_soi(time_period)
     targets_array = []
-    agi_level_targeted_variables = [
-        "adjusted_gross_income",
-        "count",
-        "employment_income",
-        "business_net_profits",
-        "capital_gains_gross",
-        "ordinary_dividends",
-        "partnership_and_s_corp_income",
-        "qualified_dividends",
-        "taxable_interest_income",
-        "total_pension_income",
-        "total_social_security",
-    ]
-    aggregate_level_targeted_variables = [
-        "business_net_losses",
-        "capital_gains_distributions",
-        "capital_gains_losses",
-        "estate_income",
-        "estate_losses",
-        "exempt_interest",
-        "ira_distributions",
-        "partnership_and_s_corp_losses",
-        "rent_and_royalty_net_income",
-        "rent_and_royalty_net_losses",
-        # The current SOI source only exposes taxable-only aggregate targets for
-        # mortgage-interest deductions, not the AGI-bin detail used above.
-        "mortgage_interest_deductions",
-        "taxable_pension_income",
-        "taxable_social_security",
-        "unemployment_compensation",
-    ]
     aggregate_level_targeted_variables = [
         variable
-        for variable in aggregate_level_targeted_variables
+        for variable in AGGREGATE_LEVEL_TARGETED_VARIABLES
         if variable in df.columns
     ]
     soi_subset = soi_subset[
-        soi_subset.Variable.isin(agi_level_targeted_variables)
+        soi_subset.Variable.isin(AGI_LEVEL_TARGETED_VARIABLES)
         | (
             soi_subset.Variable.isin(aggregate_level_targeted_variables)
             & (soi_subset["AGI lower bound"] == -np.inf)

--- a/tests/unit/calibration/test_calibration_puf_impute.py
+++ b/tests/unit/calibration/test_calibration_puf_impute.py
@@ -159,6 +159,7 @@ class TestPufCloneDataset:
     def test_sstb_qbi_split_variables_imputed(self):
         expected = {
             "sstb_self_employment_income",
+            "sstb_self_employment_income_would_be_qualified",
             "sstb_w2_wages_from_qualified_business",
             "sstb_unadjusted_basis_qualified_property",
         }

--- a/tests/unit/calibration/test_loss_targets.py
+++ b/tests/unit/calibration/test_loss_targets.py
@@ -3,6 +3,8 @@ import pandas as pd
 import pytest
 
 from policyengine_us_data.utils.loss import (
+    AGGREGATE_LEVEL_TARGETED_VARIABLES,
+    AGI_LEVEL_TARGETED_VARIABLES,
     _get_aca_national_targets,
     _add_ctc_targets,
     _get_medicaid_national_targets,
@@ -12,6 +14,11 @@ from policyengine_us_data.utils.loss import (
     _should_skip_soi_taxability_row,
     HARD_CODED_TOTALS,
 )
+
+
+def test_legacy_loss_targets_include_aggregate_qbi_deduction():
+    assert "qualified_business_income_deduction" in AGGREGATE_LEVEL_TARGETED_VARIABLES
+    assert "qualified_business_income_deduction" not in AGI_LEVEL_TARGETED_VARIABLES
 
 
 def test_aca_targets_roll_forward_to_2025():
@@ -154,6 +161,12 @@ def test_all_return_soi_skip_keeps_investment_income_targets():
     ordinary_taxable_row = pd.Series(
         {"Variable": "employment_income", "Taxable only": True}
     )
+    qbi_taxable_row = pd.Series(
+        {
+            "Variable": "qualified_business_income_deduction",
+            "Taxable only": True,
+        }
+    )
     capital_income_taxable_row = pd.Series(
         {"Variable": "capital_gains_gross", "Taxable only": True}
     )
@@ -161,6 +174,7 @@ def test_all_return_soi_skip_keeps_investment_income_targets():
     assert _should_skip_soi_taxability_row(ordinary_all_return_row)
     assert not _should_skip_soi_taxability_row(capital_income_all_return_row)
     assert not _should_skip_soi_taxability_row(ordinary_taxable_row)
+    assert not _should_skip_soi_taxability_row(qbi_taxable_row)
     assert _should_skip_soi_taxability_row(capital_income_taxable_row)
 
 

--- a/tests/unit/calibration/test_target_config.py
+++ b/tests/unit/calibration/test_target_config.py
@@ -236,6 +236,28 @@ class TestLoadTargetConfig:
                 "domain_variable": domain_variable,
             } in include_rules
 
+    def test_training_config_includes_national_qbi_deduction_targets(self):
+        config = load_target_config(
+            str(
+                Path(__file__).resolve().parents[3]
+                / "policyengine_us_data"
+                / "calibration"
+                / "target_config.yaml"
+            )
+        )
+
+        include_rules = config["include"]
+        assert {
+            "variable": "qualified_business_income_deduction",
+            "geo_level": "national",
+            "domain_variable": "qualified_business_income_deduction",
+        } in include_rules
+        assert {
+            "variable": "tax_unit_count",
+            "geo_level": "national",
+            "domain_variable": "qualified_business_income_deduction",
+        } in include_rules
+
     def test_training_config_includes_medicare_part_b_target(self):
         config = load_target_config(
             str(

--- a/tests/unit/datasets/test_irs_puf.py
+++ b/tests/unit/datasets/test_irs_puf.py
@@ -2,7 +2,15 @@ import h5py
 import numpy as np
 import pytest
 
-from policyengine_us_data.datasets.puf.puf import PUF
+from policyengine_us_data.datasets.puf.puf import (
+    PUF,
+    QBI_SIMULATION_VERSION,
+    QBI_SIMULATION_VERSION_ATTR,
+)
+
+
+def _mark_current_qbi_simulation(file_handle):
+    file_handle.attrs[QBI_SIMULATION_VERSION_ATTR] = QBI_SIMULATION_VERSION
 
 
 @pytest.mark.skip(reason="This test requires private data.")
@@ -35,6 +43,7 @@ def test_puf_load_dataset_backfills_sstb_split_inputs(tmp_path):
             "unadjusted_basis_qualified_property", data=np.array([5.0, 6.0])
         )
         file_handle.create_dataset("business_is_sstb", data=np.array([1, 0]))
+        _mark_current_qbi_simulation(file_handle)
 
     dataset = DummyPUF()
     arrays = dataset.load_dataset()
@@ -65,6 +74,7 @@ def test_puf_load_key_backfills_sstb_split_inputs(tmp_path):
             "self_employment_income", data=np.array([100.0, 200.0])
         )
         file_handle.create_dataset("business_is_sstb", data=np.array([1, 0]))
+        _mark_current_qbi_simulation(file_handle)
 
     dataset = DummyPUF()
 
@@ -91,6 +101,7 @@ def test_puf_load_key_repairs_partially_migrated_sstb_split_inputs(tmp_path):
             "sstb_self_employment_income", data=np.array([100.0, 0.0])
         )
         file_handle.create_dataset("business_is_sstb", data=np.array([1, 0]))
+        _mark_current_qbi_simulation(file_handle)
 
     dataset = DummyPUF()
 
@@ -130,6 +141,7 @@ def test_puf_load_read_only_backfilled_file_does_not_reopen_for_writes(tmp_path)
             data=np.array([5.0, 0.0]),
         )
         file_handle.create_dataset("business_is_sstb", data=np.array([1, 0]))
+        _mark_current_qbi_simulation(file_handle)
 
     DummyPUF.file_path.chmod(0o444)
     dataset = DummyPUF()
@@ -162,6 +174,7 @@ def test_puf_load_read_only_partially_migrated_file_uses_overrides(tmp_path):
             "sstb_self_employment_income", data=np.array([100.0, 0.0])
         )
         file_handle.create_dataset("business_is_sstb", data=np.array([1, 0]))
+        _mark_current_qbi_simulation(file_handle)
 
     DummyPUF.file_path.chmod(0o444)
     dataset = DummyPUF()

--- a/tests/unit/datasets/test_puf_qbi.py
+++ b/tests/unit/datasets/test_puf_qbi.py
@@ -529,56 +529,66 @@ def test_puf_load_dataset_moves_self_employment_flags_with_current_sstb_split(
     def mutate(params):
         for source in params["qbi_qualification_probabilities"]:
             params["qbi_qualification_probabilities"][source] = 0.0
+        params["qbi_qualification_probabilities"]["self_employment_income"] = 1.0
 
     _set_qbi_params(monkeypatch, mutate)
     with h5py.File(DummyPUF.file_path, "w") as file_handle:
-        file_handle.create_dataset("household_id", data=np.array([1]))
-        file_handle.create_dataset("self_employment_income", data=np.array([10_000.0]))
-        file_handle.create_dataset("sstb_self_employment_income", data=np.array([0.0]))
+        file_handle.create_dataset("household_id", data=np.array([1, 2]))
+        file_handle.create_dataset(
+            "self_employment_income", data=np.array([10_000.0, 20_000.0])
+        )
+        file_handle.create_dataset(
+            "sstb_self_employment_income", data=np.array([0.0, 0.0])
+        )
         for source in set(puf_module.QBI_SOURCE_NAMES) - {"self_employment_income"}:
-            file_handle.create_dataset(source, data=np.zeros(1))
+            file_handle.create_dataset(source, data=np.zeros(2))
         for flag in puf_module.QBI_QUALIFICATION_FLAG_BY_SOURCE.values():
             file_handle.create_dataset(
                 flag,
-                data=np.array([flag == "self_employment_income_would_be_qualified"]),
+                data=np.array(
+                    [flag == "self_employment_income_would_be_qualified", False]
+                ),
             )
         file_handle.create_dataset(
             puf_module.SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG,
-            data=np.array([False]),
+            data=np.array([False, False]),
         )
-        file_handle.create_dataset("business_is_sstb", data=np.array([True]))
+        file_handle.create_dataset("business_is_sstb", data=np.array([True, False]))
         file_handle.create_dataset(
-            "w2_wages_from_qualified_business", data=np.array([0.0])
-        )
-        file_handle.create_dataset(
-            "unadjusted_basis_qualified_property", data=np.array([0.0])
+            "w2_wages_from_qualified_business", data=np.array([0.0, 0.0])
         )
         file_handle.create_dataset(
-            "sstb_w2_wages_from_qualified_business", data=np.array([0.0])
+            "unadjusted_basis_qualified_property", data=np.array([0.0, 0.0])
         )
         file_handle.create_dataset(
-            "sstb_unadjusted_basis_qualified_property", data=np.array([0.0])
+            "sstb_w2_wages_from_qualified_business", data=np.array([0.0, 0.0])
         )
         file_handle.create_dataset(
-            "qualified_reit_and_ptp_income", data=np.array([0.0])
+            "sstb_unadjusted_basis_qualified_property", data=np.array([0.0, 0.0])
         )
-        file_handle.create_dataset("qualified_bdc_income", data=np.array([0.0]))
+        file_handle.create_dataset(
+            "qualified_reit_and_ptp_income", data=np.array([0.0, 0.0])
+        )
+        file_handle.create_dataset("qualified_bdc_income", data=np.array([0.0, 0.0]))
         file_handle.attrs[puf_module.QBI_SIMULATION_VERSION_ATTR] = (
             puf_module.QBI_SIMULATION_VERSION
         )
 
     arrays = DummyPUF().load_dataset()
 
-    np.testing.assert_allclose(arrays["self_employment_income"], np.array([0.0]))
     np.testing.assert_allclose(
-        arrays["sstb_self_employment_income"], np.array([10_000.0])
+        arrays["self_employment_income"], np.array([0.0, 20_000.0])
+    )
+    np.testing.assert_allclose(
+        arrays["sstb_self_employment_income"], np.array([10_000.0, 0.0])
     )
     np.testing.assert_array_equal(
-        arrays["self_employment_income_would_be_qualified"], np.array([False])
+        arrays["self_employment_income_would_be_qualified"],
+        np.array([False, False]),
     )
     np.testing.assert_array_equal(
         arrays[puf_module.SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG],
-        np.array([True]),
+        np.array([True, False]),
     )
 
 

--- a/tests/unit/datasets/test_puf_qbi.py
+++ b/tests/unit/datasets/test_puf_qbi.py
@@ -395,6 +395,57 @@ def test_puf_load_dataset_preserves_existing_qbi_qualification_flags(tmp_path):
         np.testing.assert_array_equal(arrays[flag], values)
 
 
+def test_puf_load_dataset_recomputes_unversioned_qbi_outputs(tmp_path, monkeypatch):
+    class DummyPUF(PUF):
+        label = "Dummy PUF"
+        name = "dummy_puf"
+        time_period = 2024
+        file_path = tmp_path / "dummy_puf.h5"
+
+    def mutate(params):
+        for source in params["qbi_qualification_probabilities"]:
+            params["qbi_qualification_probabilities"][source] = 0.0
+        params["qbi_qualification_probabilities"]["rental_income"] = 1.0
+        for source in params["sstb_prob_map_by_source_name"]:
+            params["sstb_prob_map_by_source_name"][source] = 1.0
+        for source in params["ubia_simulation"]["capital_intensity_probabilities"]:
+            params["ubia_simulation"]["capital_intensity_probabilities"][source] = 0.0
+        params["ubia_simulation"]["capital_intensity_probabilities"][
+            "rental_income"
+        ] = 1.0
+
+    _set_qbi_params(monkeypatch, mutate)
+    with h5py.File(DummyPUF.file_path, "w") as file_handle:
+        file_handle.create_dataset("household_id", data=np.array([1]))
+        file_handle.create_dataset("self_employment_income", data=np.array([10_000.0]))
+        file_handle.create_dataset("rental_income", data=np.array([20_000.0]))
+        for source in set(puf_module.QBI_SOURCE_NAMES) - {
+            "self_employment_income",
+            "rental_income",
+        }:
+            file_handle.create_dataset(source, data=np.zeros(1))
+        file_handle.create_dataset("business_is_sstb", data=np.array([True]))
+        file_handle.create_dataset(
+            "w2_wages_from_qualified_business", data=np.array([0.0])
+        )
+        file_handle.create_dataset(
+            "unadjusted_basis_qualified_property", data=np.array([0.0])
+        )
+        file_handle.create_dataset(
+            "qualified_reit_and_ptp_income", data=np.array([0.0])
+        )
+
+    arrays = DummyPUF().load_dataset()
+
+    np.testing.assert_array_equal(arrays["business_is_sstb"], np.array([False]))
+    assert arrays["unadjusted_basis_qualified_property"][0] > 0
+    with h5py.File(DummyPUF.file_path, "r") as file_handle:
+        assert (
+            file_handle.attrs[puf_module.QBI_SIMULATION_VERSION_ATTR]
+            == puf_module.QBI_SIMULATION_VERSION
+        )
+
+
 def test_puf_load_dataset_repairs_missing_qbi_source_with_full_outputs(
     tmp_path, monkeypatch
 ):

--- a/tests/unit/datasets/test_puf_qbi.py
+++ b/tests/unit/datasets/test_puf_qbi.py
@@ -517,6 +517,71 @@ def test_puf_load_dataset_backfills_missing_sstb_self_employment_flag(
     )
 
 
+def test_puf_load_dataset_moves_self_employment_flags_with_current_sstb_split(
+    tmp_path, monkeypatch
+):
+    class DummyPUF(PUF):
+        label = "Dummy PUF"
+        name = "dummy_puf"
+        time_period = 2024
+        file_path = tmp_path / "dummy_puf.h5"
+
+    def mutate(params):
+        for source in params["qbi_qualification_probabilities"]:
+            params["qbi_qualification_probabilities"][source] = 0.0
+
+    _set_qbi_params(monkeypatch, mutate)
+    with h5py.File(DummyPUF.file_path, "w") as file_handle:
+        file_handle.create_dataset("household_id", data=np.array([1]))
+        file_handle.create_dataset("self_employment_income", data=np.array([10_000.0]))
+        file_handle.create_dataset("sstb_self_employment_income", data=np.array([0.0]))
+        for source in set(puf_module.QBI_SOURCE_NAMES) - {"self_employment_income"}:
+            file_handle.create_dataset(source, data=np.zeros(1))
+        for flag in puf_module.QBI_QUALIFICATION_FLAG_BY_SOURCE.values():
+            file_handle.create_dataset(
+                flag,
+                data=np.array([flag == "self_employment_income_would_be_qualified"]),
+            )
+        file_handle.create_dataset(
+            puf_module.SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG,
+            data=np.array([False]),
+        )
+        file_handle.create_dataset("business_is_sstb", data=np.array([True]))
+        file_handle.create_dataset(
+            "w2_wages_from_qualified_business", data=np.array([0.0])
+        )
+        file_handle.create_dataset(
+            "unadjusted_basis_qualified_property", data=np.array([0.0])
+        )
+        file_handle.create_dataset(
+            "sstb_w2_wages_from_qualified_business", data=np.array([0.0])
+        )
+        file_handle.create_dataset(
+            "sstb_unadjusted_basis_qualified_property", data=np.array([0.0])
+        )
+        file_handle.create_dataset(
+            "qualified_reit_and_ptp_income", data=np.array([0.0])
+        )
+        file_handle.create_dataset("qualified_bdc_income", data=np.array([0.0]))
+        file_handle.attrs[puf_module.QBI_SIMULATION_VERSION_ATTR] = (
+            puf_module.QBI_SIMULATION_VERSION
+        )
+
+    arrays = DummyPUF().load_dataset()
+
+    np.testing.assert_allclose(arrays["self_employment_income"], np.array([0.0]))
+    np.testing.assert_allclose(
+        arrays["sstb_self_employment_income"], np.array([10_000.0])
+    )
+    np.testing.assert_array_equal(
+        arrays["self_employment_income_would_be_qualified"], np.array([False])
+    )
+    np.testing.assert_array_equal(
+        arrays[puf_module.SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG],
+        np.array([True]),
+    )
+
+
 def test_puf_load_dataset_recomputes_unversioned_qbi_outputs(tmp_path, monkeypatch):
     class DummyPUF(PUF):
         label = "Dummy PUF"

--- a/tests/unit/datasets/test_puf_qbi.py
+++ b/tests/unit/datasets/test_puf_qbi.py
@@ -67,6 +67,60 @@ def test_qualified_qbi_components_use_persisted_flags():
     assert components.loc[0, "rental_income"] == 200.0
 
 
+def test_draw_source_weighted_beta_uses_positive_qbi_weights():
+    qbi_components = pd.DataFrame(
+        {
+            "self_employment_income": [100.0],
+            "rental_income": [300.0],
+        }
+    )
+    params = {
+        "self_employment_income": {
+            "beta_a": 1.0,
+            "beta_b": 1.0,
+            "scale": 0.0,
+            "shift": 0.10,
+        },
+        "rental_income": {
+            "beta_a": 1.0,
+            "beta_b": 1.0,
+            "scale": 0.0,
+            "shift": 0.50,
+        },
+    }
+
+    draw = puf_module.draw_source_weighted_beta(
+        qbi_components, params, np.random.default_rng(0)
+    )
+
+    np.testing.assert_allclose(draw, np.array([0.40]))
+
+
+def test_calibrate_logit_intercept_matches_positive_receipt_target():
+    revenues = np.array([0.0, 10_000.0, 100_000.0, 1_000_000.0])
+    target_share = 0.25
+
+    intercept = puf_module.calibrate_logit_intercept(
+        revenues, slope=1e-6, target_share=target_share
+    )
+
+    probabilities = puf_module.logistic(intercept + 1e-6 * revenues[revenues > 0])
+    np.testing.assert_allclose(probabilities.mean(), target_share, atol=1e-12)
+
+
+def test_calibrate_logit_intercept_handles_large_receipts():
+    revenues = np.array([100_000_000.0, 200_000_000.0])
+    slope = 1.2e-6
+    target_share = 0.18
+
+    intercept = puf_module.calibrate_logit_intercept(
+        revenues, slope=slope, target_share=target_share
+    )
+
+    probabilities = puf_module.logistic(intercept + slope * revenues)
+    np.testing.assert_allclose(probabilities.mean(), target_share, atol=1e-12)
+
+
 def test_simulate_business_is_sstb_ignores_zero_and_unmapped_sources(monkeypatch):
     def mutate(params):
         for source in params["sstb_prob_map_by_name"]:
@@ -82,6 +136,28 @@ def test_simulate_business_is_sstb_ignores_zero_and_unmapped_sources(monkeypatch
     is_sstb = puf_module.simulate_business_is_sstb(puf, rng=np.random.default_rng(0))
 
     np.testing.assert_array_equal(is_sstb, np.array([False, True, False, True]))
+
+
+def test_simulate_business_is_sstb_source_map_ignores_estate_loss_column(
+    monkeypatch,
+):
+    def mutate(params):
+        for source in params["sstb_prob_map_by_source_name"]:
+            params["sstb_prob_map_by_source_name"][source] = 1.0
+
+    _set_qbi_params(monkeypatch, mutate)
+    puf = _qbi_frame(n=2)
+    puf.loc[0, "rental_income"] = 10_000.0
+    puf.loc[0, "E26400"] = 10_000.0
+    puf.loc[1, "estate_income"] = 10_000.0
+
+    is_sstb = puf_module.simulate_business_is_sstb(
+        puf,
+        rng=np.random.default_rng(0),
+        probability_map=puf_module.QBI_PARAMS["sstb_prob_map_by_source_name"],
+    )
+
+    np.testing.assert_array_equal(is_sstb, np.array([False, True]))
 
 
 def test_non_rental_capital_intensive_qbi_can_receive_ubia(monkeypatch):
@@ -102,6 +178,57 @@ def test_non_rental_capital_intensive_qbi_can_receive_ubia(monkeypatch):
     _, ubia = puf_module.simulate_w2_and_ubia_from_puf(puf, seed=0, diagnostics=False)
 
     assert ubia[0] > 0
+
+
+def test_investment_qbi_is_scaled_to_observed_exposures(monkeypatch):
+    def mutate(params):
+        params["reit_ptp_income_distribution"] = {
+            "non_qualified_dividend_income": {
+                "probability_of_receiving": 1.0,
+                "beta_a": 1.0,
+                "beta_b": 1.0,
+                "scale": 0.0,
+                "shift": 0.20,
+            },
+            "partnership_s_corp_income": {
+                "probability_of_receiving": 1.0,
+                "beta_a": 1.0,
+                "beta_b": 1.0,
+                "scale": 0.0,
+                "shift": 0.30,
+            },
+        }
+        params["bdc_income_distribution"] = {
+            "non_qualified_dividend_income": {
+                "probability_of_receiving": 1.0,
+                "beta_a": 1.0,
+                "beta_b": 1.0,
+                "scale": 0.0,
+                "shift": 0.05,
+            }
+        }
+
+    _set_qbi_params(monkeypatch, mutate)
+    puf = pd.DataFrame(
+        {
+            "qualified_dividend_income": [900.0, 0.0, 0.0],
+            "non_qualified_dividend_income": [100.0, 0.0, 0.0],
+            "partnership_s_corp_income": [0.0, 200.0, 0.0],
+        }
+    )
+
+    investment_qbi = puf_module.simulate_investment_qbi_income_from_puf(
+        puf, rng=np.random.default_rng(0)
+    )
+
+    np.testing.assert_allclose(
+        investment_qbi["qualified_reit_and_ptp_income"],
+        np.array([20.0, 60.0, 0.0]),
+    )
+    np.testing.assert_allclose(
+        investment_qbi["qualified_bdc_income"],
+        np.array([5.0, 0.0, 0.0]),
+    )
 
 
 def test_puf_load_dataset_backfills_qbi_simulation_inputs(tmp_path, monkeypatch):
@@ -140,5 +267,48 @@ def test_puf_load_dataset_backfills_qbi_simulation_inputs(tmp_path, monkeypatch)
         assert flag in arrays
     assert "w2_wages_from_qualified_business" in arrays
     assert "unadjusted_basis_qualified_property" in arrays
+    assert "qualified_reit_and_ptp_income" in arrays
+    assert "qualified_bdc_income" in arrays
     np.testing.assert_array_equal(arrays["business_is_sstb"], np.array([False, False]))
     assert np.all(arrays["unadjusted_basis_qualified_property"] > 0)
+
+
+def test_puf_load_dataset_repairs_partially_migrated_qbi_outputs(tmp_path, monkeypatch):
+    class DummyPUF(PUF):
+        label = "Dummy PUF"
+        name = "dummy_puf"
+        time_period = 2024
+        file_path = tmp_path / "dummy_puf.h5"
+
+    def mutate(params):
+        for source in params["qbi_qualification_probabilities"]:
+            params["qbi_qualification_probabilities"][source] = 1.0
+        for source in params["ubia_simulation"]["capital_intensity_probabilities"]:
+            params["ubia_simulation"]["capital_intensity_probabilities"][source] = 1.0
+        for source in params["sstb_prob_map_by_source_name"]:
+            params["sstb_prob_map_by_source_name"][source] = 0.0
+
+    _set_qbi_params(monkeypatch, mutate)
+    with h5py.File(DummyPUF.file_path, "w") as file_handle:
+        file_handle.create_dataset("household_id", data=np.array([1]))
+        file_handle.create_dataset("self_employment_income", data=np.array([10_000.0]))
+        for source in set(puf_module.QBI_SOURCE_NAMES) - {"self_employment_income"}:
+            file_handle.create_dataset(source, data=np.zeros(1))
+        for flag in puf_module.QBI_QUALIFICATION_FLAG_BY_SOURCE.values():
+            file_handle.create_dataset(flag, data=np.array([True]))
+        file_handle.create_dataset(
+            puf_module.SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG,
+            data=np.array([False]),
+        )
+        file_handle.create_dataset(
+            "qualified_reit_and_ptp_income", data=np.array([0.0])
+        )
+        file_handle.create_dataset("qualified_bdc_income", data=np.array([0.0]))
+
+    arrays = DummyPUF().load_dataset()
+
+    assert "w2_wages_from_qualified_business" in arrays
+    assert "unadjusted_basis_qualified_property" in arrays
+    assert "business_is_sstb" in arrays
+    assert "sstb_w2_wages_from_qualified_business" in arrays
+    assert "sstb_unadjusted_basis_qualified_property" in arrays

--- a/tests/unit/datasets/test_puf_qbi.py
+++ b/tests/unit/datasets/test_puf_qbi.py
@@ -299,6 +299,65 @@ def test_puf_load_dataset_backfills_qbi_simulation_inputs(tmp_path, monkeypatch)
     assert np.all(arrays["unadjusted_basis_qualified_property"] > 0)
 
 
+def test_puf_load_dataset_repairs_qbi_with_person_level_length(tmp_path, monkeypatch):
+    class DummyPUF(PUF):
+        label = "Dummy PUF"
+        name = "dummy_puf"
+        time_period = 2024
+        file_path = tmp_path / "dummy_puf.h5"
+
+    def mutate(params):
+        for source in params["qbi_qualification_probabilities"]:
+            params["qbi_qualification_probabilities"][source] = 1.0
+        for source in params["sstb_prob_map_by_source_name"]:
+            params["sstb_prob_map_by_source_name"][source] = 0.0
+
+    _set_qbi_params(monkeypatch, mutate)
+    with h5py.File(DummyPUF.file_path, "w") as file_handle:
+        file_handle.create_dataset("household_id", data=np.array([1]))
+        file_handle.create_dataset("person_id", data=np.array([101, 102]))
+        file_handle.create_dataset(
+            "self_employment_income", data=np.array([10_000.0, 0.0])
+        )
+        for source in set(puf_module.QBI_SOURCE_NAMES) - {"self_employment_income"}:
+            file_handle.create_dataset(source, data=np.zeros(2))
+
+    arrays = DummyPUF().load_dataset()
+
+    assert len(arrays["self_employment_income_would_be_qualified"]) == 2
+    assert len(arrays["business_is_sstb"]) == 2
+    np.testing.assert_array_equal(
+        arrays["self_employment_income_would_be_qualified"],
+        np.array([True, True]),
+    )
+
+
+def test_puf_save_current_qbi_dataset_marks_version(tmp_path):
+    class DummyPUF(PUF):
+        label = "Dummy PUF"
+        name = "dummy_puf"
+        time_period = 2024
+        file_path = tmp_path / "dummy_puf.h5"
+
+        def save_dataset(self, arrays):
+            with h5py.File(self.file_path, "w") as file_handle:
+                for key, values in arrays.items():
+                    file_handle.create_dataset(key, data=values)
+
+    DummyPUF()._save_current_qbi_dataset(
+        {
+            "person_id": np.array([101]),
+            "self_employment_income": np.array([10_000.0]),
+        }
+    )
+
+    with h5py.File(DummyPUF.file_path, "r") as file_handle:
+        assert (
+            file_handle.attrs[puf_module.QBI_SIMULATION_VERSION_ATTR]
+            == puf_module.QBI_SIMULATION_VERSION
+        )
+
+
 def test_puf_load_dataset_repairs_partially_migrated_qbi_outputs(tmp_path, monkeypatch):
     class DummyPUF(PUF):
         label = "Dummy PUF"

--- a/tests/unit/datasets/test_puf_qbi.py
+++ b/tests/unit/datasets/test_puf_qbi.py
@@ -340,6 +340,61 @@ def test_puf_load_dataset_repairs_partially_migrated_qbi_outputs(tmp_path, monke
     assert "sstb_unadjusted_basis_qualified_property" in arrays
 
 
+def test_puf_load_dataset_preserves_existing_qbi_qualification_flags(tmp_path):
+    class DummyPUF(PUF):
+        label = "Dummy PUF"
+        name = "dummy_puf"
+        time_period = 2024
+        file_path = tmp_path / "dummy_puf.h5"
+
+    stored_flags = {}
+    with h5py.File(DummyPUF.file_path, "w") as file_handle:
+        file_handle.create_dataset("household_id", data=np.array([1, 2]))
+        file_handle.create_dataset(
+            "self_employment_income", data=np.array([0.0, 20_000.0])
+        )
+        file_handle.create_dataset(
+            "sstb_self_employment_income", data=np.array([10_000.0, 0.0])
+        )
+        for source in set(puf_module.QBI_SOURCE_NAMES) - {"self_employment_income"}:
+            file_handle.create_dataset(source, data=np.zeros(2))
+        for index, flag in enumerate(
+            puf_module.QBI_QUALIFICATION_FLAG_BY_SOURCE.values()
+        ):
+            values = np.array([index % 2 == 0, index % 2 == 1])
+            stored_flags[flag] = values
+            file_handle.create_dataset(flag, data=values)
+        stored_flags[puf_module.SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG] = np.array(
+            [True, False]
+        )
+        file_handle.create_dataset(
+            puf_module.SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG,
+            data=stored_flags[puf_module.SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG],
+        )
+        file_handle.create_dataset("business_is_sstb", data=np.array([True, False]))
+        file_handle.create_dataset(
+            "w2_wages_from_qualified_business", data=np.array([10.0, 20.0])
+        )
+        file_handle.create_dataset(
+            "unadjusted_basis_qualified_property", data=np.array([5.0, 6.0])
+        )
+        file_handle.create_dataset(
+            "sstb_w2_wages_from_qualified_business", data=np.array([10.0, 0.0])
+        )
+        file_handle.create_dataset(
+            "sstb_unadjusted_basis_qualified_property", data=np.array([5.0, 0.0])
+        )
+        file_handle.create_dataset(
+            "qualified_reit_and_ptp_income", data=np.array([0.0, 0.0])
+        )
+
+    arrays = DummyPUF().load_dataset()
+
+    assert "qualified_bdc_income" in arrays
+    for flag, values in stored_flags.items():
+        np.testing.assert_array_equal(arrays[flag], values)
+
+
 def test_puf_load_dataset_repairs_missing_qbi_source_with_full_outputs(
     tmp_path, monkeypatch
 ):

--- a/tests/unit/datasets/test_puf_qbi.py
+++ b/tests/unit/datasets/test_puf_qbi.py
@@ -1,0 +1,144 @@
+import copy
+
+import h5py
+import numpy as np
+import pandas as pd
+
+from policyengine_us_data.datasets.puf import puf as puf_module
+from policyengine_us_data.datasets.puf.puf import PUF
+
+
+def _qbi_frame(n=1):
+    data = {source: np.zeros(n, dtype=float) for source in puf_module.QBI_SOURCE_NAMES}
+    data.update(
+        {
+            "E00900": np.zeros(n, dtype=float),
+            "E26270": np.zeros(n, dtype=float),
+            "E26390": np.zeros(n, dtype=float),
+            "E26400": np.zeros(n, dtype=float),
+        }
+    )
+    return pd.DataFrame(data)
+
+
+def _set_qbi_params(monkeypatch, mutate):
+    params = copy.deepcopy(puf_module.QBI_PARAMS)
+    mutate(params)
+    monkeypatch.setattr(puf_module, "QBI_PARAMS", params)
+    return params
+
+
+def test_add_qbi_qualification_flags_to_puf_persists_source_flags(monkeypatch):
+    def mutate(params):
+        for source in params["qbi_qualification_probabilities"]:
+            params["qbi_qualification_probabilities"][source] = 0.0
+        params["qbi_qualification_probabilities"]["self_employment_income"] = 1.0
+
+    _set_qbi_params(monkeypatch, mutate)
+    puf = puf_module.add_qbi_qualification_flags_to_puf(_qbi_frame(), seed=0)
+
+    assert bool(puf["self_employment_income_would_be_qualified"].iloc[0])
+    for source in puf_module.QBI_SOURCE_NAMES:
+        flag = puf_module.QBI_QUALIFICATION_FLAG_BY_SOURCE[source]
+        assert flag in puf
+    assert not bool(puf["rental_income_would_be_qualified"].iloc[0])
+
+
+def test_puf_financial_subset_exports_qbi_qualification_flags():
+    expected = {
+        *puf_module.QBI_QUALIFICATION_FLAG_BY_SOURCE.values(),
+        puf_module.SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG,
+    }
+
+    assert expected <= set(puf_module.FINANCIAL_SUBSET)
+
+
+def test_qualified_qbi_components_use_persisted_flags():
+    puf = _qbi_frame()
+    puf.loc[0, "self_employment_income"] = 100.0
+    puf.loc[0, "rental_income"] = 200.0
+    for source in puf_module.QBI_SOURCE_NAMES:
+        puf[puf_module.QBI_QUALIFICATION_FLAG_BY_SOURCE[source]] = False
+    puf["rental_income_would_be_qualified"] = True
+
+    components = puf_module.qualified_qbi_components(puf)
+
+    assert components.loc[0, "self_employment_income"] == 0.0
+    assert components.loc[0, "rental_income"] == 200.0
+
+
+def test_simulate_business_is_sstb_ignores_zero_and_unmapped_sources(monkeypatch):
+    def mutate(params):
+        for source in params["sstb_prob_map_by_name"]:
+            params["sstb_prob_map_by_name"][source] = 1.0
+
+    _set_qbi_params(monkeypatch, mutate)
+    puf = _qbi_frame(n=4)
+    puf.loc[0, "rental_income"] = 10_000.0
+    puf.loc[1, "E00900"] = 10_000.0
+    puf.loc[2, "E00900"] = -10_000.0
+    puf.loc[3, "E26270"] = 10_000.0
+
+    is_sstb = puf_module.simulate_business_is_sstb(puf, rng=np.random.default_rng(0))
+
+    np.testing.assert_array_equal(is_sstb, np.array([False, True, False, True]))
+
+
+def test_non_rental_capital_intensive_qbi_can_receive_ubia(monkeypatch):
+    def mutate(params):
+        for source in params["ubia_simulation"]["capital_intensity_probabilities"]:
+            params["ubia_simulation"]["capital_intensity_probabilities"][source] = 0.0
+        params["ubia_simulation"]["capital_intensity_probabilities"][
+            "self_employment_income"
+        ] = 1.0
+
+    _set_qbi_params(monkeypatch, mutate)
+    puf = _qbi_frame()
+    puf.loc[0, "self_employment_income"] = 10_000.0
+    for source in puf_module.QBI_SOURCE_NAMES:
+        puf[puf_module.QBI_QUALIFICATION_FLAG_BY_SOURCE[source]] = False
+    puf["self_employment_income_would_be_qualified"] = True
+
+    _, ubia = puf_module.simulate_w2_and_ubia_from_puf(puf, seed=0, diagnostics=False)
+
+    assert ubia[0] > 0
+
+
+def test_puf_load_dataset_backfills_qbi_simulation_inputs(tmp_path, monkeypatch):
+    class DummyPUF(PUF):
+        label = "Dummy PUF"
+        name = "dummy_puf"
+        time_period = 2024
+        file_path = tmp_path / "dummy_puf.h5"
+
+    def mutate(params):
+        for source in params["qbi_qualification_probabilities"]:
+            params["qbi_qualification_probabilities"][source] = 1.0
+        for source in params["ubia_simulation"]["capital_intensity_probabilities"]:
+            params["ubia_simulation"]["capital_intensity_probabilities"][source] = 1.0
+        for source in params["sstb_prob_map_by_source_name"]:
+            params["sstb_prob_map_by_source_name"][source] = 0.0
+
+    _set_qbi_params(monkeypatch, mutate)
+    with h5py.File(DummyPUF.file_path, "w") as file_handle:
+        file_handle.create_dataset("household_id", data=np.array([1, 2]))
+        file_handle.create_dataset(
+            "self_employment_income", data=np.array([10_000.0, 0.0])
+        )
+        file_handle.create_dataset(
+            "partnership_s_corp_income", data=np.array([0.0, 20_000.0])
+        )
+        for source in set(puf_module.QBI_SOURCE_NAMES) - {
+            "self_employment_income",
+            "partnership_s_corp_income",
+        }:
+            file_handle.create_dataset(source, data=np.zeros(2))
+
+    arrays = DummyPUF().load_dataset()
+
+    for flag in puf_module.QBI_SIMULATION_REQUIRED_VARIABLES:
+        assert flag in arrays
+    assert "w2_wages_from_qualified_business" in arrays
+    assert "unadjusted_basis_qualified_property" in arrays
+    np.testing.assert_array_equal(arrays["business_is_sstb"], np.array([False, False]))
+    assert np.all(arrays["unadjusted_basis_qualified_property"] > 0)

--- a/tests/unit/datasets/test_puf_qbi.py
+++ b/tests/unit/datasets/test_puf_qbi.py
@@ -385,7 +385,7 @@ def test_puf_load_dataset_preserves_existing_qbi_qualification_flags(tmp_path):
             "sstb_unadjusted_basis_qualified_property", data=np.array([5.0, 0.0])
         )
         file_handle.create_dataset(
-            "qualified_reit_and_ptp_income", data=np.array([0.0, 0.0])
+            "qualified_reit_and_ptp_income", data=np.array([123.0, 456.0])
         )
         file_handle.attrs[puf_module.QBI_SIMULATION_VERSION_ATTR] = (
             puf_module.QBI_SIMULATION_VERSION
@@ -394,6 +394,9 @@ def test_puf_load_dataset_preserves_existing_qbi_qualification_flags(tmp_path):
     arrays = DummyPUF().load_dataset()
 
     assert "qualified_bdc_income" in arrays
+    np.testing.assert_array_equal(
+        arrays["qualified_reit_and_ptp_income"], np.array([123.0, 456.0])
+    )
     for flag, values in stored_flags.items():
         np.testing.assert_array_equal(arrays[flag], values)
 

--- a/tests/unit/datasets/test_puf_qbi.py
+++ b/tests/unit/datasets/test_puf_qbi.py
@@ -387,6 +387,9 @@ def test_puf_load_dataset_preserves_existing_qbi_qualification_flags(tmp_path):
         file_handle.create_dataset(
             "qualified_reit_and_ptp_income", data=np.array([0.0, 0.0])
         )
+        file_handle.attrs[puf_module.QBI_SIMULATION_VERSION_ATTR] = (
+            puf_module.QBI_SIMULATION_VERSION
+        )
 
     arrays = DummyPUF().load_dataset()
 
@@ -439,6 +442,73 @@ def test_puf_load_dataset_recomputes_unversioned_qbi_outputs(tmp_path, monkeypat
 
     np.testing.assert_array_equal(arrays["business_is_sstb"], np.array([False]))
     assert arrays["unadjusted_basis_qualified_property"][0] > 0
+    with h5py.File(DummyPUF.file_path, "r") as file_handle:
+        assert (
+            file_handle.attrs[puf_module.QBI_SIMULATION_VERSION_ATTR]
+            == puf_module.QBI_SIMULATION_VERSION
+        )
+
+
+def test_puf_load_dataset_refreshes_unversioned_self_employment_qbi_flags(
+    tmp_path, monkeypatch
+):
+    class DummyPUF(PUF):
+        label = "Dummy PUF"
+        name = "dummy_puf"
+        time_period = 2024
+        file_path = tmp_path / "dummy_puf.h5"
+
+    def mutate(params):
+        for source in params["qbi_qualification_probabilities"]:
+            params["qbi_qualification_probabilities"][source] = 0.0
+        for source in params["sstb_prob_map_by_source_name"]:
+            params["sstb_prob_map_by_source_name"][source] = 0.0
+
+    _set_qbi_params(monkeypatch, mutate)
+    with h5py.File(DummyPUF.file_path, "w") as file_handle:
+        file_handle.create_dataset("household_id", data=np.array([1]))
+        file_handle.create_dataset("self_employment_income", data=np.array([0.0]))
+        file_handle.create_dataset(
+            "sstb_self_employment_income", data=np.array([10_000.0])
+        )
+        for source in set(puf_module.QBI_SOURCE_NAMES) - {"self_employment_income"}:
+            file_handle.create_dataset(source, data=np.zeros(1))
+        for flag in puf_module.QBI_QUALIFICATION_FLAG_BY_SOURCE.values():
+            file_handle.create_dataset(flag, data=np.array([False]))
+        file_handle.create_dataset(
+            puf_module.SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG,
+            data=np.array([True]),
+        )
+        file_handle.create_dataset("business_is_sstb", data=np.array([True]))
+        file_handle.create_dataset(
+            "w2_wages_from_qualified_business", data=np.array([0.0])
+        )
+        file_handle.create_dataset(
+            "unadjusted_basis_qualified_property", data=np.array([0.0])
+        )
+        file_handle.create_dataset(
+            "sstb_w2_wages_from_qualified_business", data=np.array([0.0])
+        )
+        file_handle.create_dataset(
+            "sstb_unadjusted_basis_qualified_property", data=np.array([0.0])
+        )
+        file_handle.create_dataset(
+            "qualified_reit_and_ptp_income", data=np.array([0.0])
+        )
+        file_handle.create_dataset("qualified_bdc_income", data=np.array([0.0]))
+
+    arrays = DummyPUF().load_dataset()
+
+    np.testing.assert_array_equal(arrays["business_is_sstb"], np.array([False]))
+    np.testing.assert_allclose(arrays["self_employment_income"], np.array([10_000.0]))
+    np.testing.assert_allclose(arrays["sstb_self_employment_income"], np.array([0.0]))
+    np.testing.assert_array_equal(
+        arrays["self_employment_income_would_be_qualified"], np.array([True])
+    )
+    np.testing.assert_array_equal(
+        arrays[puf_module.SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG],
+        np.array([False]),
+    )
     with h5py.File(DummyPUF.file_path, "r") as file_handle:
         assert (
             file_handle.attrs[puf_module.QBI_SIMULATION_VERSION_ATTR]

--- a/tests/unit/datasets/test_puf_qbi.py
+++ b/tests/unit/datasets/test_puf_qbi.py
@@ -578,6 +578,70 @@ def test_puf_load_dataset_refreshes_unversioned_self_employment_qbi_flags(
         )
 
 
+def test_puf_load_dataset_refreshes_self_employment_qbi_flags_when_sstb_missing(
+    tmp_path, monkeypatch
+):
+    class DummyPUF(PUF):
+        label = "Dummy PUF"
+        name = "dummy_puf"
+        time_period = 2024
+        file_path = tmp_path / "dummy_puf.h5"
+
+    def mutate(params):
+        for source in params["qbi_qualification_probabilities"]:
+            params["qbi_qualification_probabilities"][source] = 0.0
+        for source in params["sstb_prob_map_by_source_name"]:
+            params["sstb_prob_map_by_source_name"][source] = 0.0
+
+    _set_qbi_params(monkeypatch, mutate)
+    with h5py.File(DummyPUF.file_path, "w") as file_handle:
+        file_handle.create_dataset("household_id", data=np.array([1]))
+        file_handle.create_dataset("self_employment_income", data=np.array([0.0]))
+        file_handle.create_dataset(
+            "sstb_self_employment_income", data=np.array([10_000.0])
+        )
+        for source in set(puf_module.QBI_SOURCE_NAMES) - {"self_employment_income"}:
+            file_handle.create_dataset(source, data=np.zeros(1))
+        for flag in puf_module.QBI_QUALIFICATION_FLAG_BY_SOURCE.values():
+            file_handle.create_dataset(flag, data=np.array([False]))
+        file_handle.create_dataset(
+            puf_module.SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG,
+            data=np.array([True]),
+        )
+        file_handle.create_dataset(
+            "w2_wages_from_qualified_business", data=np.array([0.0])
+        )
+        file_handle.create_dataset(
+            "unadjusted_basis_qualified_property", data=np.array([0.0])
+        )
+        file_handle.create_dataset(
+            "sstb_w2_wages_from_qualified_business", data=np.array([0.0])
+        )
+        file_handle.create_dataset(
+            "sstb_unadjusted_basis_qualified_property", data=np.array([0.0])
+        )
+        file_handle.create_dataset(
+            "qualified_reit_and_ptp_income", data=np.array([0.0])
+        )
+        file_handle.create_dataset("qualified_bdc_income", data=np.array([0.0]))
+        file_handle.attrs[puf_module.QBI_SIMULATION_VERSION_ATTR] = (
+            puf_module.QBI_SIMULATION_VERSION
+        )
+
+    arrays = DummyPUF().load_dataset()
+
+    np.testing.assert_array_equal(arrays["business_is_sstb"], np.array([False]))
+    np.testing.assert_allclose(arrays["self_employment_income"], np.array([10_000.0]))
+    np.testing.assert_allclose(arrays["sstb_self_employment_income"], np.array([0.0]))
+    np.testing.assert_array_equal(
+        arrays["self_employment_income_would_be_qualified"], np.array([True])
+    )
+    np.testing.assert_array_equal(
+        arrays[puf_module.SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG],
+        np.array([False]),
+    )
+
+
 def test_puf_load_dataset_repairs_missing_qbi_source_with_full_outputs(
     tmp_path, monkeypatch
 ):

--- a/tests/unit/datasets/test_puf_qbi.py
+++ b/tests/unit/datasets/test_puf_qbi.py
@@ -568,6 +568,49 @@ def test_puf_load_dataset_recomputes_unversioned_qbi_outputs(tmp_path, monkeypat
         )
 
 
+def test_puf_load_dataset_refreshes_unversioned_stale_self_employment_flags(
+    tmp_path, monkeypatch
+):
+    class DummyPUF(PUF):
+        label = "Dummy PUF"
+        name = "dummy_puf"
+        time_period = 2024
+        file_path = tmp_path / "dummy_puf.h5"
+
+    def mutate(params):
+        for source in params["qbi_qualification_probabilities"]:
+            params["qbi_qualification_probabilities"][source] = 0.0
+        params["qbi_qualification_probabilities"]["self_employment_income"] = 1.0
+        for source in params["sstb_prob_map_by_source_name"]:
+            params["sstb_prob_map_by_source_name"][source] = 0.0
+
+    _set_qbi_params(monkeypatch, mutate)
+    with h5py.File(DummyPUF.file_path, "w") as file_handle:
+        file_handle.create_dataset("household_id", data=np.array([1]))
+        file_handle.create_dataset("self_employment_income", data=np.array([10_000.0]))
+        file_handle.create_dataset("sstb_self_employment_income", data=np.array([0.0]))
+        for source in set(puf_module.QBI_SOURCE_NAMES) - {"self_employment_income"}:
+            file_handle.create_dataset(source, data=np.zeros(1))
+        for flag in puf_module.QBI_QUALIFICATION_FLAG_BY_SOURCE.values():
+            file_handle.create_dataset(flag, data=np.array([False]))
+        file_handle.create_dataset(
+            puf_module.SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG,
+            data=np.array([False]),
+        )
+        file_handle.create_dataset("business_is_sstb", data=np.array([False]))
+
+    arrays = DummyPUF().load_dataset()
+
+    np.testing.assert_array_equal(arrays["business_is_sstb"], np.array([False]))
+    np.testing.assert_array_equal(
+        arrays["self_employment_income_would_be_qualified"], np.array([True])
+    )
+    np.testing.assert_array_equal(
+        arrays[puf_module.SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG],
+        np.array([False]),
+    )
+
+
 def test_puf_load_dataset_refreshes_unversioned_self_employment_qbi_flags(
     tmp_path, monkeypatch
 ):

--- a/tests/unit/datasets/test_puf_qbi.py
+++ b/tests/unit/datasets/test_puf_qbi.py
@@ -578,6 +578,43 @@ def test_puf_load_dataset_refreshes_unversioned_self_employment_qbi_flags(
         )
 
 
+def test_puf_load_dataset_preserves_unversioned_sstb_self_employment_income(
+    tmp_path, monkeypatch
+):
+    class DummyPUF(PUF):
+        label = "Dummy PUF"
+        name = "dummy_puf"
+        time_period = 2024
+        file_path = tmp_path / "dummy_puf.h5"
+
+    def mutate(params):
+        for source in params["qbi_qualification_probabilities"]:
+            params["qbi_qualification_probabilities"][source] = 0.0
+        params["qbi_qualification_probabilities"]["self_employment_income"] = 1.0
+        for source in params["sstb_prob_map_by_source_name"]:
+            params["sstb_prob_map_by_source_name"][source] = 0.0
+        params["sstb_prob_map_by_source_name"]["self_employment_income"] = 1.0
+
+    _set_qbi_params(monkeypatch, mutate)
+    with h5py.File(DummyPUF.file_path, "w") as file_handle:
+        file_handle.create_dataset("household_id", data=np.array([1]))
+        file_handle.create_dataset("self_employment_income", data=np.array([0.0]))
+        file_handle.create_dataset(
+            "sstb_self_employment_income", data=np.array([10_000.0])
+        )
+        for source in set(puf_module.QBI_SOURCE_NAMES) - {"self_employment_income"}:
+            file_handle.create_dataset(source, data=np.zeros(1))
+        file_handle.create_dataset("business_is_sstb", data=np.array([False]))
+
+    arrays = DummyPUF().load_dataset()
+
+    np.testing.assert_array_equal(arrays["business_is_sstb"], np.array([True]))
+    np.testing.assert_allclose(arrays["self_employment_income"], np.array([0.0]))
+    np.testing.assert_allclose(
+        arrays["sstb_self_employment_income"], np.array([10_000.0])
+    )
+
+
 def test_puf_load_dataset_refreshes_self_employment_qbi_flags_when_sstb_missing(
     tmp_path, monkeypatch
 ):

--- a/tests/unit/datasets/test_puf_qbi.py
+++ b/tests/unit/datasets/test_puf_qbi.py
@@ -127,6 +127,7 @@ def test_simulate_business_is_sstb_ignores_zero_and_unmapped_sources(monkeypatch
             params["sstb_prob_map_by_name"][source] = 1.0
 
     _set_qbi_params(monkeypatch, mutate)
+    assert "E26400" not in puf_module.QBI_PARAMS["sstb_prob_map_by_name"]
     puf = _qbi_frame(n=4)
     puf.loc[0, "rental_income"] = 10_000.0
     puf.loc[1, "E00900"] = 10_000.0
@@ -150,6 +151,31 @@ def test_simulate_business_is_sstb_source_map_ignores_estate_loss_column(
     puf.loc[0, "rental_income"] = 10_000.0
     puf.loc[0, "E26400"] = 10_000.0
     puf.loc[1, "estate_income"] = 10_000.0
+
+    is_sstb = puf_module.simulate_business_is_sstb(
+        puf,
+        rng=np.random.default_rng(0),
+        probability_map=puf_module.QBI_PARAMS["sstb_prob_map_by_source_name"],
+    )
+
+    np.testing.assert_array_equal(is_sstb, np.array([False, True]))
+
+
+def test_simulate_business_is_sstb_ignores_unqualified_sources(monkeypatch):
+    def mutate(params):
+        for source in params["sstb_prob_map_by_source_name"]:
+            params["sstb_prob_map_by_source_name"][source] = 1.0
+
+    _set_qbi_params(monkeypatch, mutate)
+    puf = _qbi_frame(n=2)
+    puf.loc[0, "self_employment_income"] = 10_000.0
+    puf.loc[0, "rental_income"] = 20_000.0
+    puf.loc[1, "self_employment_income"] = 10_000.0
+    puf.loc[1, "rental_income"] = 20_000.0
+    for source in puf_module.QBI_SOURCE_NAMES:
+        puf[puf_module.QBI_QUALIFICATION_FLAG_BY_SOURCE[source]] = False
+    puf.loc[:, "rental_income_would_be_qualified"] = True
+    puf.loc[1, "self_employment_income_would_be_qualified"] = True
 
     is_sstb = puf_module.simulate_business_is_sstb(
         puf,
@@ -312,3 +338,38 @@ def test_puf_load_dataset_repairs_partially_migrated_qbi_outputs(tmp_path, monke
     assert "business_is_sstb" in arrays
     assert "sstb_w2_wages_from_qualified_business" in arrays
     assert "sstb_unadjusted_basis_qualified_property" in arrays
+
+
+def test_puf_load_dataset_repairs_missing_qbi_source_with_full_outputs(
+    tmp_path, monkeypatch
+):
+    class DummyPUF(PUF):
+        label = "Dummy PUF"
+        name = "dummy_puf"
+        time_period = 2024
+        file_path = tmp_path / "dummy_puf.h5"
+
+    def mutate(params):
+        for source in params["qbi_qualification_probabilities"]:
+            params["qbi_qualification_probabilities"][source] = 1.0
+        for source in params["ubia_simulation"]["capital_intensity_probabilities"]:
+            params["ubia_simulation"]["capital_intensity_probabilities"][source] = 1.0
+        for source in params["sstb_prob_map_by_source_name"]:
+            params["sstb_prob_map_by_source_name"][source] = 0.0
+
+    _set_qbi_params(monkeypatch, mutate)
+    with h5py.File(DummyPUF.file_path, "w") as file_handle:
+        file_handle.create_dataset("household_id", data=np.array([1]))
+        file_handle.create_dataset("self_employment_income", data=np.array([10_000.0]))
+        for source in set(puf_module.QBI_SOURCE_NAMES) - {
+            "self_employment_income",
+            "estate_income",
+        }:
+            file_handle.create_dataset(source, data=np.zeros(1))
+
+    arrays = DummyPUF().load_dataset()
+
+    for variable in puf_module.QBI_SIMULATION_REQUIRED_VARIABLES:
+        assert variable in arrays
+    assert "estate_income" not in arrays
+    assert arrays["unadjusted_basis_qualified_property"][0] > 0

--- a/tests/unit/datasets/test_puf_qbi.py
+++ b/tests/unit/datasets/test_puf_qbi.py
@@ -460,6 +460,63 @@ def test_puf_load_dataset_preserves_existing_qbi_qualification_flags(tmp_path):
         np.testing.assert_array_equal(arrays[flag], values)
 
 
+def test_puf_load_dataset_backfills_missing_sstb_self_employment_flag(
+    tmp_path, monkeypatch
+):
+    class DummyPUF(PUF):
+        label = "Dummy PUF"
+        name = "dummy_puf"
+        time_period = 2024
+        file_path = tmp_path / "dummy_puf.h5"
+
+    def mutate(params):
+        for source in params["qbi_qualification_probabilities"]:
+            params["qbi_qualification_probabilities"][source] = 0.0
+        params["qbi_qualification_probabilities"]["self_employment_income"] = 1.0
+
+    _set_qbi_params(monkeypatch, mutate)
+    with h5py.File(DummyPUF.file_path, "w") as file_handle:
+        file_handle.create_dataset("household_id", data=np.array([1]))
+        file_handle.create_dataset("self_employment_income", data=np.array([0.0]))
+        file_handle.create_dataset(
+            "sstb_self_employment_income", data=np.array([10_000.0])
+        )
+        for source in set(puf_module.QBI_SOURCE_NAMES) - {"self_employment_income"}:
+            file_handle.create_dataset(source, data=np.zeros(1))
+        for flag in puf_module.QBI_QUALIFICATION_FLAG_BY_SOURCE.values():
+            file_handle.create_dataset(flag, data=np.array([False]))
+        file_handle.create_dataset("business_is_sstb", data=np.array([True]))
+        file_handle.create_dataset(
+            "w2_wages_from_qualified_business", data=np.array([0.0])
+        )
+        file_handle.create_dataset(
+            "unadjusted_basis_qualified_property", data=np.array([0.0])
+        )
+        file_handle.create_dataset(
+            "sstb_w2_wages_from_qualified_business", data=np.array([0.0])
+        )
+        file_handle.create_dataset(
+            "sstb_unadjusted_basis_qualified_property", data=np.array([0.0])
+        )
+        file_handle.create_dataset(
+            "qualified_reit_and_ptp_income", data=np.array([0.0])
+        )
+        file_handle.create_dataset("qualified_bdc_income", data=np.array([0.0]))
+        file_handle.attrs[puf_module.QBI_SIMULATION_VERSION_ATTR] = (
+            puf_module.QBI_SIMULATION_VERSION
+        )
+
+    arrays = DummyPUF().load_dataset()
+
+    np.testing.assert_array_equal(
+        arrays["self_employment_income_would_be_qualified"], np.array([False])
+    )
+    np.testing.assert_array_equal(
+        arrays[puf_module.SSTB_SELF_EMPLOYMENT_QUALIFICATION_FLAG],
+        np.array([True]),
+    )
+
+
 def test_puf_load_dataset_recomputes_unversioned_qbi_outputs(tmp_path, monkeypatch):
     class DummyPUF(PUF):
         label = "Dummy PUF"


### PR DESCRIPTION
## Summary

- replace the ChatGPT-linked QBI assumptions with a source-based model documented in `docs/qbi_simulation.md`
- make W-2, receipts, labor shares, UBIA, SSTB status, and REIT/PTP/BDC income depend on observed source composition and exposure bases
- keep source-level QBI qualification flags and repair cached PUF H5s that are missing any simulated QBI outputs
- update the paper methodology and docs table of contents for the permanent QBI simulation rationale
- add QBI deduction amount and claimant-count targets to both the new target config and the legacy `loss.py` calibration path

## Issues

Closes #856
Closes #857
Closes #858
Closes #859

## Validation

- `uv run pytest tests/unit/datasets/test_puf_qbi.py tests/unit/calibration/test_calibration_puf_impute.py tests/unit/datasets/test_irs_puf.py -q` -> 34 passed, 1 skipped
- `uv run ruff format --check policyengine_us_data/datasets/puf/puf.py tests/unit/datasets/test_puf_qbi.py`
- `uv run ruff check policyengine_us_data/datasets/puf/puf.py tests/unit/datasets/test_puf_qbi.py`
- `uv run python scripts/run_quality_guards.py`
- `git diff --check`
- GitHub PR checks are green, including `check-fork`
- Local legacy eCPS run after fetching `upstream/main`: rebuilt `puf_2024.h5`, `extended_cps_2024_half.h5`, `enhanced_cps_2024.h5`, `small_enhanced_cps_2024.h5`, and `sparse_enhanced_cps_2024.h5`
- Local legacy QBI target fit from the generated `enhanced_cps_2024.h5`: QBI deduction amount `$213.7B` vs `$217.2B` target (`-1.59%`); claimant count `21.96M` vs `24.39M` target (`-9.96%`)
- Compared with the cached local main `enhanced_cps_2024.h5`, the generated PR artifact lowers QBI deduction by `$30.8B` (`-12.6%`) and positive QBI deduction tax units by `2.1M` (`-8.7%`)

## Review

- Subagent review found two calibration/cache issues; both were fixed with regression tests.
- Follow-up subagent review found the fresh-generation SSTB source-map mismatch; fixed with a regression test.
- Final subagent review: no findings.

## Notes

The PR branch is in `PolicyEngine/policyengine-us-data`, not a fork. Residual model risk remains because the QBI parameters are documented, source-grounded priors rather than estimates fit to direct IRS QBI microdata.
