### PR TITLE
Add CRFB long-run TOB target contract

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -1,8 +1,8 @@
 name: Run Pipeline
 
 on:
-  push:
-    branches: [main]
+  # Full production pipeline runs are intentionally manual. They are too
+  # expensive to attach to every merged PR or automatic version-bump commit.
   workflow_dispatch:
     inputs:
       gpu:
@@ -41,9 +41,6 @@ concurrency:
 jobs:
   pipeline:
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.head_commit.message == 'Update package version'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -184,6 +184,7 @@ jobs:
     needs: check-fork
     outputs:
       run_integration: ${{ steps.check.outputs.run_integration }}
+      run_long_term_smoke: ${{ steps.check.outputs.run_long_term_smoke }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -197,3 +198,59 @@ jobs:
           else
             echo "run_integration=false" >> "$GITHUB_OUTPUT"
           fi
+          if echo "$CHANGED" | grep -qE '^(\.github/workflows/(pr|pipeline)\.yaml|policyengine_us_data/datasets/cps/long_term/|policyengine_us_data/storage/long_term_target_sources/|tests/unit/test_long_term_calibration_contract\.py)'; then
+            echo "run_long_term_smoke=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_long_term_smoke=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  long-term-projection-smoke:
+    name: Long-term 2100 smoke build
+    runs-on: ubuntu-latest
+    needs: [check-fork, lint, unit-tests, smoke-test, decide-test-scope]
+    if: needs.decide-test-scope.outputs.run_long_term_smoke == 'true'
+    timeout-minutes: 120
+    env:
+      HUGGING_FACE_TOKEN: ${{ secrets.HUGGING_FACE_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+      - uses: astral-sh/setup-uv@v8.1.0
+      - run: uv sync --dev
+      - name: Run 2100 long-term projection smoke build
+        run: |
+          OUTPUT_DIR="${RUNNER_TEMP}/long-term-projection-smoke"
+          mkdir -p "${OUTPUT_DIR}"
+          cd policyengine_us_data/datasets/cps/long_term
+          uv run python run_household_projection.py 2100 2100 \
+            --profile ss-payroll-tob \
+            --target-source oact_2025_08_05_provisional \
+            --support-augmentation-profile donor-backed-composite-v1 \
+            --support-augmentation-target-year 2100 \
+            --support-augmentation-blueprint-base-weight-scale 0.5 \
+            --allow-validation-failures \
+            --output-dir "${OUTPUT_DIR}" \
+            --save-h5
+      - name: Validate smoke build artifacts
+        run: |
+          OUTPUT_DIR="${RUNNER_TEMP}/long-term-projection-smoke"
+          test -f "${OUTPUT_DIR}/2100.h5"
+          test -f "${OUTPUT_DIR}/2100.h5.metadata.json"
+          test -f "${OUTPUT_DIR}/calibration_manifest.json"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          output_dir = Path(os.environ["RUNNER_TEMP"]) / "long-term-projection-smoke"
+          metadata = json.loads((output_dir / "2100.h5.metadata.json").read_text())
+          manifest = json.loads((output_dir / "calibration_manifest.json").read_text())
+
+          assert metadata["year"] == 2100
+          assert metadata["target_source"]["name"] == "oact_2025_08_05_provisional"
+          assert metadata["target_source"]["scenario_id"] == "crfb_post_obbba_tob_75y"
+          assert metadata["tax_assumption"]["name"] == "trustees-core-thresholds-v1"
+          assert manifest["years"] == [2100]
+          PY

--- a/changelog.d/crfb-tob-target.changed.md
+++ b/changelog.d/crfb-tob-target.changed.md
@@ -1,0 +1,1 @@
+Hardened long-run TOB target metadata with the CRFB Post-OBBBA scenario contract and hash validation, kept full production pipeline runs manual-only, and added a path-gated PR smoke check that builds a single 2100 long-term projection artifact when long-term pipeline code or targets change.

--- a/policyengine_us_data/datasets/cps/long_term/ssa_data.py
+++ b/policyengine_us_data/datasets/cps/long_term/ssa_data.py
@@ -1,5 +1,6 @@
 import json
 import os
+import hashlib
 from functools import lru_cache
 
 import numpy as np
@@ -14,6 +15,25 @@ _CURRENT_LONG_TERM_TARGET_SOURCE = os.environ.get(
     "POLICYENGINE_US_DATA_LONG_TERM_TARGET_SOURCE",
     DEFAULT_LONG_TERM_TARGET_SOURCE,
 )
+REQUIRED_LONG_TERM_TARGET_COLUMNS = {
+    "year",
+    "oasdi_cost_in_billion_2025_usd",
+    "cpi_w_intermediate",
+    "oasdi_cost_in_billion_nominal_usd",
+    "taxable_payroll_in_billion_nominal_usd",
+    "h6_income_rate_change",
+    "oasdi_tob_pct_of_taxable_payroll",
+    "oasdi_tob_billions_nominal_usd",
+    "hi_tob_billions_nominal_usd",
+}
+
+
+def file_sha256(path) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 @lru_cache(maxsize=1)
@@ -54,9 +74,52 @@ def describe_long_term_target_source(source_name: str | None = None) -> dict:
     return source
 
 
+def validate_long_term_target_source(source_name: str | None = None) -> dict:
+    source = describe_long_term_target_source(source_name)
+    csv_path = LONG_TERM_TARGET_SOURCES_DIR / source["file"]
+    actual_sha256 = file_sha256(csv_path)
+    expected_sha256 = source.get("sha256")
+    if expected_sha256 is not None and actual_sha256 != expected_sha256:
+        raise ValueError(
+            f"Hash mismatch for long-term target source {source['name']!r}: "
+            f"{actual_sha256} != {expected_sha256}"
+        )
+
+    df = pd.read_csv(csv_path)
+    missing_columns = REQUIRED_LONG_TERM_TARGET_COLUMNS - set(df.columns)
+    if missing_columns:
+        raise ValueError(
+            f"Long-term target source {source['name']!r} is missing columns: "
+            f"{sorted(missing_columns)}"
+        )
+
+    if df["year"].tolist() != list(range(2025, 2101)):
+        raise ValueError(
+            f"Long-term target source {source['name']!r} must contain one row "
+            "for each year 2025-2100."
+        )
+
+    contract = source.get("artifact_contract", {})
+    required_sha = contract.get("must_consume_baseline_sha256")
+    if required_sha is not None and required_sha != actual_sha256:
+        raise ValueError(
+            f"Long-term target source {source['name']!r} artifact contract "
+            "does not match the target CSV hash."
+        )
+
+    return {
+        "name": source["name"],
+        "file": source["file"],
+        "sha256": actual_sha256,
+        "rows": int(len(df)),
+        "years": [int(df["year"].min()), int(df["year"].max())],
+    }
+
+
 @lru_cache(maxsize=None)
 def _load_long_term_target_frame(source_name: str) -> pd.DataFrame:
     source = describe_long_term_target_source(source_name)
+    validate_long_term_target_source(source_name)
     csv_path = LONG_TERM_TARGET_SOURCES_DIR / source["file"]
     return pd.read_csv(csv_path)
 

--- a/policyengine_us_data/datasets/cps/long_term/tax_assumptions.py
+++ b/policyengine_us_data/datasets/cps/long_term/tax_assumptions.py
@@ -20,6 +20,90 @@ TRUSTEES_CORE_THRESHOLD_ASSUMPTION = {
         "capital_gains_thresholds",
         "amt_thresholds",
     ],
+    "not_default_current_law": True,
+}
+
+try:
+    from policyengine_us.reforms.ssa.trustees_core_thresholds import (
+        TRUSTEES_CORE_THRESHOLD_ASSUMPTION as _PE_TRUSTEES_CORE_THRESHOLD_ASSUMPTION,
+        create_trustees_core_thresholds_reform as _pe_create_trustees_core_thresholds_reform,
+    )
+except ImportError:
+    _pe_create_trustees_core_thresholds_reform = None
+else:
+    TRUSTEES_CORE_THRESHOLD_ASSUMPTION = dict(_PE_TRUSTEES_CORE_THRESHOLD_ASSUMPTION)
+
+
+# Fallback used until the PolicyEngine US dependency includes the native
+# trustees-core-thresholds-v1 reform.
+TRUSTEES_AVERAGE_WAGE_GROWTH_PCT = {
+    2034: 3.85,
+    2035: 3.72,
+    2036: 3.65,
+    2037: 3.66,
+    2038: 3.66,
+    2039: 3.68,
+    2040: 3.65,
+    2041: 3.63,
+    2042: 3.62,
+    2043: 3.60,
+    2044: 3.57,
+    2045: 3.55,
+    2046: 3.53,
+    2047: 3.53,
+    2048: 3.53,
+    2049: 3.52,
+    2050: 3.51,
+    2051: 3.51,
+    2052: 3.51,
+    2053: 3.50,
+    2054: 3.50,
+    2055: 3.49,
+    2056: 3.50,
+    2057: 3.51,
+    2058: 3.52,
+    2059: 3.52,
+    2060: 3.53,
+    2061: 3.53,
+    2062: 3.54,
+    2063: 3.55,
+    2064: 3.55,
+    2065: 3.55,
+    2066: 3.55,
+    2067: 3.56,
+    2068: 3.55,
+    2069: 3.55,
+    2070: 3.56,
+    2071: 3.55,
+    2072: 3.55,
+    2073: 3.55,
+    2074: 3.55,
+    2075: 3.56,
+    2076: 3.56,
+    2077: 3.56,
+    2078: 3.56,
+    2079: 3.56,
+    2080: 3.55,
+    2081: 3.56,
+    2082: 3.56,
+    2083: 3.56,
+    2084: 3.56,
+    2085: 3.56,
+    2086: 3.57,
+    2087: 3.56,
+    2088: 3.56,
+    2089: 3.56,
+    2090: 3.56,
+    2091: 3.56,
+    2092: 3.56,
+    2093: 3.55,
+    2094: 3.55,
+    2095: 3.55,
+    2096: 3.55,
+    2097: 3.55,
+    2098: 3.55,
+    2099: 3.55,
+    2100: 3.55,
 }
 
 
@@ -44,6 +128,24 @@ def _uprating_parameter_name(parameter) -> str | None:
     if isinstance(uprating, dict):
         return uprating.get("parameter")
     return uprating
+
+
+def _get_parameter_by_name(parameters, name: str):
+    current = parameters
+    for part in name.split("."):
+        current = getattr(current, part)
+    return current
+
+
+def _trustees_wage_growth_for_tax_year(year: int) -> float:
+    wage_year = year - 1
+    try:
+        return 1 + TRUSTEES_AVERAGE_WAGE_GROWTH_PCT[wage_year] / 100
+    except KeyError as error:
+        raise ValueError(
+            "No SSA Trustees average-wage growth rate for "
+            f"tax year {year} (calendar wage year {wage_year})."
+        ) from error
 
 
 def iter_updatable_parameters(
@@ -71,24 +173,46 @@ def iter_updatable_parameters(
 def apply_wage_growth_to_parameter(
     parameter,
     *,
-    nawi,
+    parameters,
     start_year: int,
     end_year: int,
+    projection_base_year: int = 2026,
 ) -> None:
     metadata = getattr(parameter, "metadata", {})
     uprating = metadata.get("uprating")
     rounding = uprating.get("rounding") if isinstance(uprating, dict) else None
+    uprating_name = _uprating_parameter_name(parameter)
+    if uprating_name is None:
+        return
+
+    # Validate that the referenced default uprating parameter exists.
+    _get_parameter_by_name(parameters, uprating_name)
+    values_by_year = {}
+
+    for year in range(projection_base_year + 1, start_year):
+        values_by_year[year] = float(parameter(f"{year}-01-01"))
 
     for year in range(start_year, end_year + 1):
-        previous_value = float(parameter(f"{year - 1}-01-01"))
-        wage_growth = float(nawi(f"{year - 1}-01-01")) / float(
-            nawi(f"{year - 2}-01-01")
-        )
+        if year - 1 in values_by_year:
+            previous_value = values_by_year[year - 1]
+        else:
+            previous_value = float(parameter(f"{year - 1}-01-01"))
+        wage_growth = _trustees_wage_growth_for_tax_year(year)
         updated_value = round_amount(previous_value * wage_growth, rounding)
+        values_by_year[year] = updated_value
+
+    for year, value in values_by_year.items():
         parameter.update(
             period=f"year:{year}-01-01:1",
-            value=updated_value,
+            value=value,
         )
+
+
+def _parameters_have_long_run_projection(parameters, end_year: int) -> bool:
+    parameter = parameters.gov.irs.income.bracket.thresholds.children["1"].SINGLE
+    return any(
+        value.instant_str == f"{end_year}-01-01" for value in parameter.values_list
+    )
 
 
 def create_wage_indexed_core_thresholds_reform(
@@ -96,10 +220,18 @@ def create_wage_indexed_core_thresholds_reform(
     start_year: int = 2035,
     end_year: int = 2100,
 ):
+    if _pe_create_trustees_core_thresholds_reform is not None:
+        return _pe_create_trustees_core_thresholds_reform(
+            start_year=start_year,
+            end_year=end_year,
+        )
+
     from policyengine_us.model_api import Reform
 
     def modify_parameters(parameters):
-        nawi = parameters.gov.ssa.nawi
+        if not _parameters_have_long_run_projection(parameters, end_year):
+            return parameters
+
         roots = [
             parameters.gov.irs.income.bracket.thresholds,
             parameters.gov.irs.deductions.standard.amount,
@@ -119,7 +251,7 @@ def create_wage_indexed_core_thresholds_reform(
                 seen.add(parameter.name)
                 apply_wage_growth_to_parameter(
                     parameter,
-                    nawi=nawi,
+                    parameters=parameters,
                     start_year=start_year,
                     end_year=end_year,
                 )
@@ -140,7 +272,9 @@ def create_wage_indexed_full_irs_uprating_reform(
     from policyengine_us.model_api import Reform
 
     def modify_parameters(parameters):
-        nawi = parameters.gov.ssa.nawi
+        if not _parameters_have_long_run_projection(parameters, end_year):
+            return parameters
+
         seen = set()
         for parameter in iter_updatable_parameters(
             parameters.gov.irs,
@@ -151,7 +285,7 @@ def create_wage_indexed_full_irs_uprating_reform(
             seen.add(parameter.name)
             apply_wage_growth_to_parameter(
                 parameter,
-                nawi=nawi,
+                parameters=parameters,
                 start_year=start_year,
                 end_year=end_year,
             )

--- a/policyengine_us_data/storage/long_term_target_sources/sources.json
+++ b/policyengine_us_data/storage/long_term_target_sources/sources.json
@@ -2,16 +2,27 @@
   "default_source": "trustees_2025_current_law",
   "sources": {
     "oact_2025_08_05_provisional": {
+      "artifact_contract": {
+        "must_consume_baseline_sha256": "75e9dbe6a30680670713089ceed3eb10d7ef597b88c4317d0b39571e25f381f3",
+        "must_expose_scenario_id": "crfb_post_obbba_tob_75y",
+        "reject_raw_current_law_substitution": true
+      },
+      "baseline_kind": "calibration_target",
+      "calibration_target_id": "post_obbba_calibrated_tob_75y",
       "derived_from": "trustees_2025_current_law",
       "description": "Post-OBBBA SSA OACT baseline overlay with provisional HI bridge for long-term calibration experiments.",
       "file": "oact_2025_08_05_provisional.csv",
       "hi_method": "match_oasdi_pct_change",
+      "law_mode": "trustees-core-thresholds-v1",
       "name": "oact_2025_08_05_provisional",
+      "not_law": true,
       "notes": [
         "OASDI TOB nominal deltas are taken from the August 5, 2025 OACT letter.",
         "2100 OASDI delta is carried forward from 2099 because the published delta table ends at 2099.",
         "HI TOB series is provisional: it applies the same percentage change as OASDI TOB to preserve the OASDI/HI share split until a published annual HI replacement series is available."
       ],
+      "scenario_id": "crfb_post_obbba_tob_75y",
+      "sha256": "75e9dbe6a30680670713089ceed3eb10d7ef597b88c4317d0b39571e25f381f3",
       "source_urls": [
         "https://www.ssa.gov/OACT/solvency/RWyden_20250805.pdf",
         "https://www.ssa.gov/oact/tr/2025/lrIndex.html"
@@ -19,12 +30,15 @@
       "type": "oact_override"
     },
     "trustees_2025_current_law": {
+      "baseline_kind": "current_law_comparator",
       "description": "2025 Trustees current-law baseline used by the legacy long-term calibration stack.",
       "file": "trustees_2025_current_law.csv",
       "name": "trustees_2025_current_law",
+      "not_law": false,
       "notes": [
         "Generated from social_security_aux.csv for explicit source selection."
       ],
+      "sha256": "e059aa9fba806b260a399b8a6a18b892a6363ba12ee00fe21ab109d09dff0ec4",
       "source_urls": [
         "https://www.ssa.gov/oact/tr/2025/lrIndex.html",
         "https://www.ssa.gov/oact/solvency/provisions/tables/table_run133.html"

--- a/tests/unit/test_long_term_calibration_contract.py
+++ b/tests/unit/test_long_term_calibration_contract.py
@@ -40,6 +40,7 @@ from policyengine_us_data.datasets.cps.long_term.ssa_data import (
     describe_long_term_target_source,
     load_oasdi_tob_projections,
     load_taxable_payroll_projections,
+    validate_long_term_target_source,
 )
 from policyengine_us_data.datasets.cps.long_term.support_augmentation import (
     AgeShiftCloneRule,
@@ -50,6 +51,10 @@ from policyengine_us_data.datasets.cps.long_term.support_augmentation import (
     augment_input_dataframe,
     household_support_summary,
     select_donor_households,
+)
+from policyengine_us_data.datasets.cps.long_term.tax_assumptions import (
+    TRUSTEES_CORE_THRESHOLD_ASSUMPTION,
+    create_wage_indexed_core_thresholds_reform,
 )
 from policyengine_us_data.datasets.cps.long_term.prototype_synthetic_2100_support import (
     SyntheticCandidate,
@@ -1002,6 +1007,47 @@ def test_long_term_target_sources_are_available_and_distinct():
         source_name="oact_2025_08_05_provisional",
     )
     assert oact_oasdi_2026 < trustees_oasdi_2026
+
+
+def test_post_obbba_target_source_carries_reproducibility_contract():
+    source = describe_long_term_target_source("oact_2025_08_05_provisional")
+    assert source["scenario_id"] == "crfb_post_obbba_tob_75y"
+    assert source["baseline_kind"] == "calibration_target"
+    assert source["not_law"] is True
+    assert source["law_mode"] == "trustees-core-thresholds-v1"
+    assert source["artifact_contract"] == {
+        "must_consume_baseline_sha256": source["sha256"],
+        "must_expose_scenario_id": "crfb_post_obbba_tob_75y",
+        "reject_raw_current_law_substitution": True,
+    }
+
+    validation = validate_long_term_target_source("oact_2025_08_05_provisional")
+    assert validation["sha256"] == source["sha256"]
+    assert validation["rows"] == 76
+    assert validation["years"] == [2025, 2100]
+
+
+def test_trustees_core_threshold_assumption_preserves_pre_2035_baseline():
+    from policyengine_us import CountryTaxBenefitSystem
+
+    baseline = CountryTaxBenefitSystem().parameters
+    reformed = CountryTaxBenefitSystem(
+        reform=(create_wage_indexed_core_thresholds_reform(),)
+    ).parameters
+
+    baseline_threshold = baseline.gov.irs.income.bracket.thresholds.children["1"].SINGLE
+    reformed_threshold = reformed.gov.irs.income.bracket.thresholds.children["1"].SINGLE
+    ss_threshold = (
+        baseline.gov.irs.social_security.taxability.threshold.base.main.SINGLE
+    )
+    reformed_ss_threshold = (
+        reformed.gov.irs.social_security.taxability.threshold.base.main.SINGLE
+    )
+
+    assert TRUSTEES_CORE_THRESHOLD_ASSUMPTION["not_default_current_law"] is True
+    assert reformed_threshold("2034-01-01") == baseline_threshold("2034-01-01")
+    assert reformed_threshold("2035-01-01") != baseline_threshold("2035-01-01")
+    assert reformed_ss_threshold("2100-01-01") == ss_threshold("2100-01-01")
 
 
 def test_normalize_metadata_backfills_validation_passed():


### PR DESCRIPTION
## Summary
- add reproducibility metadata and hash validation for the CRFB Post-OBBBA long-run TOB target source
- add the trustees-core-thresholds-v1 tax assumption path, with a fallback until policyengine-us ships the native reform
- keep the full production pipeline manual-only and add a path-gated PR smoke job that builds one 2100 artifact when long-term pipeline code or targets change

## Validation
- ruff check policyengine_us_data/datasets/cps/long_term/ssa_data.py policyengine_us_data/datasets/cps/long_term/tax_assumptions.py tests/unit/test_long_term_calibration_contract.py
- python scripts/run_quality_guards.py
- PYTHONPATH=. /Users/maxghenis/PolicyEngine/policyengine-us-data/.venv/bin/python -m pytest tests/unit/test_long_term_calibration_contract.py
- ruby YAML parse for .github/workflows/pr.yaml and .github/workflows/pipeline.yaml
- git diff --check

## Notes
- Full 2025-2100 production pipeline was intentionally not run; it remains manual-only.
- The new 2100 smoke build is path-gated and allows validation failures so it checks buildability and metadata contract, not final calibration quality.