### PR TITLE
Add CRFB long-run TOB target contract

### DIFF
--- a/changelog.d/crfb-tob-target.changed.md
+++ b/changelog.d/crfb-tob-target.changed.md
@@ -1,0 +1,1 @@
+Hardened long-run TOB target metadata with the CRFB Post-OBBBA scenario contract and hash validation, kept full production pipeline runs manual-only, and added unit-level coverage that the manual 2100 production command carries the expected long-run contract inputs.

--- a/policyengine_us_data/datasets/cps/long_term/build_long_term_target_sources.py
+++ b/policyengine_us_data/datasets/cps/long_term/build_long_term_target_sources.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 from pathlib import Path
 
@@ -14,6 +15,14 @@ OACT_DELTA_PATH = SOURCES_DIR / "oasdi_oact_20250805_nominal_delta.csv"
 TRUSTEES_OUTPUT_PATH = SOURCES_DIR / "trustees_2025_current_law.csv"
 OACT_OUTPUT_PATH = SOURCES_DIR / "oact_2025_08_05_provisional.csv"
 MANIFEST_PATH = SOURCES_DIR / "sources.json"
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def build_trustees_source() -> pd.DataFrame:
@@ -69,6 +78,8 @@ def build_oact_source(trustees: pd.DataFrame) -> pd.DataFrame:
 
 
 def write_manifest() -> None:
+    trustees_sha256 = file_sha256(TRUSTEES_OUTPUT_PATH)
+    oact_sha256 = file_sha256(OACT_OUTPUT_PATH)
     manifest = {
         "default_source": "trustees_2025_current_law",
         "sources": {
@@ -87,6 +98,9 @@ def write_manifest() -> None:
                 "notes": [
                     "Generated from social_security_aux.csv for explicit source selection.",
                 ],
+                "baseline_kind": "current_law_comparator",
+                "not_law": False,
+                "sha256": trustees_sha256,
             },
             "oact_2025_08_05_provisional": {
                 "name": "oact_2025_08_05_provisional",
@@ -107,6 +121,17 @@ def write_manifest() -> None:
                 ],
                 "derived_from": "trustees_2025_current_law",
                 "hi_method": "match_oasdi_pct_change",
+                "scenario_id": "crfb_post_obbba_tob_75y",
+                "baseline_kind": "calibration_target",
+                "calibration_target_id": "post_obbba_calibrated_tob_75y",
+                "law_mode": "trustees-2025-core-thresholds-v1",
+                "not_law": True,
+                "sha256": oact_sha256,
+                "artifact_contract": {
+                    "must_consume_baseline_sha256": oact_sha256,
+                    "must_expose_scenario_id": "crfb_post_obbba_tob_75y",
+                    "reject_raw_current_law_substitution": True,
+                },
             },
         },
     }

--- a/policyengine_us_data/datasets/cps/long_term/ssa_data.py
+++ b/policyengine_us_data/datasets/cps/long_term/ssa_data.py
@@ -1,5 +1,6 @@
 import json
 import os
+import hashlib
 from functools import lru_cache
 
 import numpy as np
@@ -14,6 +15,25 @@ _CURRENT_LONG_TERM_TARGET_SOURCE = os.environ.get(
     "POLICYENGINE_US_DATA_LONG_TERM_TARGET_SOURCE",
     DEFAULT_LONG_TERM_TARGET_SOURCE,
 )
+REQUIRED_LONG_TERM_TARGET_COLUMNS = {
+    "year",
+    "oasdi_cost_in_billion_2025_usd",
+    "cpi_w_intermediate",
+    "oasdi_cost_in_billion_nominal_usd",
+    "taxable_payroll_in_billion_nominal_usd",
+    "h6_income_rate_change",
+    "oasdi_tob_pct_of_taxable_payroll",
+    "oasdi_tob_billions_nominal_usd",
+    "hi_tob_billions_nominal_usd",
+}
+
+
+def file_sha256(path) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 @lru_cache(maxsize=1)
@@ -54,9 +74,52 @@ def describe_long_term_target_source(source_name: str | None = None) -> dict:
     return source
 
 
+def validate_long_term_target_source(source_name: str | None = None) -> dict:
+    source = describe_long_term_target_source(source_name)
+    csv_path = LONG_TERM_TARGET_SOURCES_DIR / source["file"]
+    actual_sha256 = file_sha256(csv_path)
+    expected_sha256 = source.get("sha256")
+    if expected_sha256 is not None and actual_sha256 != expected_sha256:
+        raise ValueError(
+            f"Hash mismatch for long-term target source {source['name']!r}: "
+            f"{actual_sha256} != {expected_sha256}"
+        )
+
+    df = pd.read_csv(csv_path)
+    missing_columns = REQUIRED_LONG_TERM_TARGET_COLUMNS - set(df.columns)
+    if missing_columns:
+        raise ValueError(
+            f"Long-term target source {source['name']!r} is missing columns: "
+            f"{sorted(missing_columns)}"
+        )
+
+    if df["year"].tolist() != list(range(2025, 2101)):
+        raise ValueError(
+            f"Long-term target source {source['name']!r} must contain one row "
+            "for each year 2025-2100."
+        )
+
+    contract = source.get("artifact_contract", {})
+    required_sha = contract.get("must_consume_baseline_sha256")
+    if required_sha is not None and required_sha != actual_sha256:
+        raise ValueError(
+            f"Long-term target source {source['name']!r} artifact contract "
+            "does not match the target CSV hash."
+        )
+
+    return {
+        "name": source["name"],
+        "file": source["file"],
+        "sha256": actual_sha256,
+        "rows": int(len(df)),
+        "years": [int(df["year"].min()), int(df["year"].max())],
+    }
+
+
 @lru_cache(maxsize=None)
 def _load_long_term_target_frame(source_name: str) -> pd.DataFrame:
     source = describe_long_term_target_source(source_name)
+    validate_long_term_target_source(source_name)
     csv_path = LONG_TERM_TARGET_SOURCES_DIR / source["file"]
     return pd.read_csv(csv_path)
 

--- a/policyengine_us_data/storage/long_term_target_sources/sources.json
+++ b/policyengine_us_data/storage/long_term_target_sources/sources.json
@@ -2,16 +2,27 @@
   "default_source": "trustees_2025_current_law",
   "sources": {
     "oact_2025_08_05_provisional": {
+      "artifact_contract": {
+        "must_consume_baseline_sha256": "75e9dbe6a30680670713089ceed3eb10d7ef597b88c4317d0b39571e25f381f3",
+        "must_expose_scenario_id": "crfb_post_obbba_tob_75y",
+        "reject_raw_current_law_substitution": true
+      },
+      "baseline_kind": "calibration_target",
+      "calibration_target_id": "post_obbba_calibrated_tob_75y",
       "derived_from": "trustees_2025_current_law",
       "description": "Post-OBBBA SSA OACT baseline overlay with provisional HI bridge for long-term calibration experiments.",
       "file": "oact_2025_08_05_provisional.csv",
       "hi_method": "match_oasdi_pct_change",
+      "law_mode": "trustees-2025-core-thresholds-v1",
       "name": "oact_2025_08_05_provisional",
+      "not_law": true,
       "notes": [
         "OASDI TOB nominal deltas are taken from the August 5, 2025 OACT letter.",
         "2100 OASDI delta is carried forward from 2099 because the published delta table ends at 2099.",
         "HI TOB series is provisional: it applies the same percentage change as OASDI TOB to preserve the OASDI/HI share split until a published annual HI replacement series is available."
       ],
+      "scenario_id": "crfb_post_obbba_tob_75y",
+      "sha256": "75e9dbe6a30680670713089ceed3eb10d7ef597b88c4317d0b39571e25f381f3",
       "source_urls": [
         "https://www.ssa.gov/OACT/solvency/RWyden_20250805.pdf",
         "https://www.ssa.gov/oact/tr/2025/lrIndex.html"
@@ -19,12 +30,15 @@
       "type": "oact_override"
     },
     "trustees_2025_current_law": {
+      "baseline_kind": "current_law_comparator",
       "description": "2025 Trustees current-law baseline used by the legacy long-term calibration stack.",
       "file": "trustees_2025_current_law.csv",
       "name": "trustees_2025_current_law",
+      "not_law": false,
       "notes": [
         "Generated from social_security_aux.csv for explicit source selection."
       ],
+      "sha256": "e059aa9fba806b260a399b8a6a18b892a6363ba12ee00fe21ab109d09dff0ec4",
       "source_urls": [
         "https://www.ssa.gov/oact/tr/2025/lrIndex.html",
         "https://www.ssa.gov/oact/solvency/provisions/tables/table_run133.html"

--- a/tests/unit/test_long_term_calibration_contract.py
+++ b/tests/unit/test_long_term_calibration_contract.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import hashlib
 import json
+from argparse import Namespace
+
 import numpy as np
 import pytest
 from policyengine_core.data.dataset import Dataset
 
 from policyengine_us_data.datasets.cps.long_term import (
+    build_long_term_target_sources as target_source_builder,
     calibration as calibration_module,
 )
 from policyengine_us_data.datasets.cps.long_term.calibration import (
@@ -40,6 +44,7 @@ from policyengine_us_data.datasets.cps.long_term.ssa_data import (
     describe_long_term_target_source,
     load_oasdi_tob_projections,
     load_taxable_payroll_projections,
+    validate_long_term_target_source,
 )
 from policyengine_us_data.datasets.cps.long_term.support_augmentation import (
     AgeShiftCloneRule,
@@ -54,6 +59,10 @@ from policyengine_us_data.datasets.cps.long_term.support_augmentation import (
     select_donor_households,
     valid_support_augmentation_profile_names,
 )
+from policyengine_us_data.datasets.cps.long_term.tax_assumptions import (
+    TRUSTEES_CORE_THRESHOLD_ASSUMPTION,
+    create_trustees_core_thresholds_reform,
+)
 from policyengine_us_data.datasets.cps.long_term.prototype_synthetic_2100_support import (
     SyntheticCandidate,
     _compose_role_donor_rows_to_target,
@@ -66,6 +75,9 @@ from policyengine_us_data.datasets.cps.long_term.run_household_projection_parall
     parse_years,
     validate_forwarded_args,
     year_output_dir,
+)
+from policyengine_us_data.datasets.cps.long_term.run_long_term_production import (
+    build_projection_command,
 )
 
 
@@ -1060,6 +1072,90 @@ def test_long_term_target_sources_are_available_and_distinct():
     assert oact_oasdi_2026 < trustees_oasdi_2026
 
 
+def test_post_obbba_target_source_carries_reproducibility_contract():
+    source = describe_long_term_target_source("oact_2025_08_05_provisional")
+    assert source["scenario_id"] == "crfb_post_obbba_tob_75y"
+    assert source["baseline_kind"] == "calibration_target"
+    assert source["not_law"] is True
+    assert source["law_mode"] == "trustees-2025-core-thresholds-v1"
+    assert source["artifact_contract"] == {
+        "must_consume_baseline_sha256": source["sha256"],
+        "must_expose_scenario_id": "crfb_post_obbba_tob_75y",
+        "reject_raw_current_law_substitution": True,
+    }
+
+    validation = validate_long_term_target_source("oact_2025_08_05_provisional")
+    assert validation["sha256"] == source["sha256"]
+    assert validation["rows"] == 76
+    assert validation["years"] == [2025, 2100]
+
+
+def test_long_term_target_source_rebuild_manifest_preserves_contract(
+    tmp_path, monkeypatch
+):
+    sources_dir = tmp_path / "long_term_target_sources"
+    sources_dir.mkdir()
+    trustees_path = sources_dir / "trustees_2025_current_law.csv"
+    oact_path = sources_dir / "oact_2025_08_05_provisional.csv"
+    manifest_path = sources_dir / "sources.json"
+    trustees_path.write_text("year,value\n2025,1\n", encoding="utf-8")
+    oact_path.write_text("year,value\n2025,2\n", encoding="utf-8")
+
+    monkeypatch.setattr(target_source_builder, "SOURCES_DIR", sources_dir)
+    monkeypatch.setattr(
+        target_source_builder,
+        "TRUSTEES_OUTPUT_PATH",
+        trustees_path,
+    )
+    monkeypatch.setattr(target_source_builder, "OACT_OUTPUT_PATH", oact_path)
+    monkeypatch.setattr(target_source_builder, "MANIFEST_PATH", manifest_path)
+
+    target_source_builder.write_manifest()
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    oact_sha256 = hashlib.sha256(oact_path.read_bytes()).hexdigest()
+    trustees_sha256 = hashlib.sha256(trustees_path.read_bytes()).hexdigest()
+    trustees = manifest["sources"]["trustees_2025_current_law"]
+    oact = manifest["sources"]["oact_2025_08_05_provisional"]
+    assert trustees["sha256"] == trustees_sha256
+    assert trustees["baseline_kind"] == "current_law_comparator"
+    assert trustees["not_law"] is False
+    assert oact["sha256"] == oact_sha256
+    assert oact["scenario_id"] == "crfb_post_obbba_tob_75y"
+    assert oact["baseline_kind"] == "calibration_target"
+    assert oact["calibration_target_id"] == "post_obbba_calibrated_tob_75y"
+    assert oact["law_mode"] == "trustees-2025-core-thresholds-v1"
+    assert oact["not_law"] is True
+    assert oact["artifact_contract"] == {
+        "must_consume_baseline_sha256": oact_sha256,
+        "must_expose_scenario_id": "crfb_post_obbba_tob_75y",
+        "reject_raw_current_law_substitution": True,
+    }
+
+
+def test_trustees_core_threshold_assumption_preserves_pre_2035_baseline():
+    from policyengine_us import CountryTaxBenefitSystem
+
+    baseline = CountryTaxBenefitSystem().parameters
+    reformed = CountryTaxBenefitSystem(
+        reform=(create_trustees_core_thresholds_reform(),)
+    ).parameters
+
+    baseline_threshold = baseline.gov.irs.income.bracket.thresholds.children["1"].SINGLE
+    reformed_threshold = reformed.gov.irs.income.bracket.thresholds.children["1"].SINGLE
+    ss_threshold = (
+        baseline.gov.irs.social_security.taxability.threshold.base.main.SINGLE
+    )
+    reformed_ss_threshold = (
+        reformed.gov.irs.social_security.taxability.threshold.base.main.SINGLE
+    )
+
+    assert TRUSTEES_CORE_THRESHOLD_ASSUMPTION["not_default_current_law"] is True
+    assert reformed_threshold("2034-01-01") == baseline_threshold("2034-01-01")
+    assert reformed_threshold("2035-01-01") != baseline_threshold("2035-01-01")
+    assert reformed_ss_threshold("2100-01-01") == ss_threshold("2100-01-01")
+
+
 def test_normalize_metadata_backfills_validation_passed():
     metadata = normalize_metadata(
         {
@@ -1309,6 +1405,49 @@ def test_write_support_augmentation_report_custom_filename(tmp_path):
 
 def test_parallel_projection_parse_years_supports_ranges_and_sorting():
     assert parse_years("2030,2028-2029,2030,2027") == [2027, 2028, 2029, 2030]
+
+
+def test_long_term_production_command_carries_2100_contract(tmp_path):
+    args = Namespace(
+        years="2100",
+        jobs=1,
+        profile="ss-payroll-tob",
+        target_source="oact_2025_08_05_provisional",
+        tax_assumption=TRUSTEES_CORE_THRESHOLD_ASSUMPTION["name"],
+        keep_temp=False,
+        base_dataset="",
+        support_augmentation_profile="donor-backed-composite-v1",
+        support_augmentation_target_year=2100,
+        support_augmentation_align_to_run_year=False,
+        support_augmentation_start_year=None,
+        support_augmentation_top_n_targets=None,
+        support_augmentation_donors_per_target=None,
+        support_augmentation_max_distance=None,
+        support_augmentation_clone_weight_scale=None,
+        support_augmentation_blueprint_base_weight_scale=0.5,
+        allow_validation_failures=True,
+    )
+
+    command = build_projection_command(args, tmp_path)
+
+    assert "run_household_projection_parallel.py" in command[1]
+    assert command[command.index("--years") + 1] == "2100"
+    assert command[command.index("--profile") + 1] == "ss-payroll-tob"
+    assert (
+        command[command.index("--target-source") + 1] == "oact_2025_08_05_provisional"
+    )
+    assert command[command.index("--tax-assumption") + 1] == (
+        "trustees-2025-core-thresholds-v1"
+    )
+    assert command[command.index("--support-augmentation-target-year") + 1] == "2100"
+    assert command[command.index("--support-augmentation-profile") + 1] == (
+        "donor-backed-composite-v1"
+    )
+    assert (
+        command[command.index("--support-augmentation-blueprint-base-weight-scale") + 1]
+        == "0.5"
+    )
+    assert "--allow-validation-failures" in command
 
 
 def test_parallel_projection_validate_forwarded_args_rejects_wrapper_flags():


### PR DESCRIPTION
## Summary
- add reproducibility metadata for the CRFB Post-OBBBA long-run TOB target source
- record source CSV SHA-256 hashes in the long-term target-source manifest
- validate long-term target-source hashes, required columns, exact 2025-2100 coverage, and artifact-contract hash alignment before loading target frames
- add focused contract tests for the CRFB overlay and 2100 production command metadata

## Validation
- `uv run pytest tests/unit/test_long_term_calibration_contract.py::test_post_obbba_target_source_carries_reproducibility_contract tests/unit/test_long_term_calibration_contract.py::test_long_term_production_command_carries_2100_contract -q`
- PR checks are expected to cover lint, unit, smoke, manifest contract, and integration tests.

## Notes
- The full 2025-2100 production pipeline was intentionally not run; this PR only hardens the metadata/validation contract for the long-term target-source files.