### PR TITLE
Add IRS SOI long-term capital gains target

### DIFF
--- a/changelog.d/add-irs-soi-capital-gains-targets.added.md
+++ b/changelog.d/add-irs-soi-capital-gains-targets.added.md
@@ -1,0 +1,1 @@
+Added IRS SOI aggregate and AGI-bin targets for long-term capital gains to the legacy enhanced CPS calibration loss matrix and target database.

--- a/policyengine_us_data/calibration/target_config.yaml
+++ b/policyengine_us_data/calibration/target_config.yaml
@@ -120,6 +120,8 @@ include:
     geo_level: national
   - variable: health_insurance_premiums_without_medicare_part_b
     geo_level: national
+  - variable: long_term_capital_gains
+    geo_level: national
   - variable: medicaid
     geo_level: national
   - variable: medicare_part_b_premium
@@ -194,6 +196,12 @@ include:
   - variable: tax_unit_count
     geo_level: national
     domain_variable: adjusted_gross_income,net_capital_gains
+  - variable: long_term_capital_gains
+    geo_level: national
+    domain_variable: adjusted_gross_income,long_term_capital_gains
+  - variable: tax_unit_count
+    geo_level: national
+    domain_variable: adjusted_gross_income,long_term_capital_gains
   # Re-include dividend / interest aggregates that were previously dropped
   # for "high error or tension". 30% rel-error on a soft target is still
   # vastly better than the 5-15x inflation we get with no constraint.

--- a/policyengine_us_data/db/etl_irs_soi.py
+++ b/policyengine_us_data/db/etl_irs_soi.py
@@ -123,6 +123,30 @@ NATIONAL_FINE_AGI_BRACKETS = {
     28: (10_000_000, np.inf),  # row 28
 }
 
+TABLE_1_4A_LTCG_AGI_BRACKETS = {
+    11: (-np.inf, 1),  # No adjusted gross income (includes deficits)
+    12: (1, 5_000),
+    13: (5_000, 10_000),
+    14: (10_000, 15_000),
+    15: (15_000, 20_000),
+    16: (20_000, 25_000),
+    17: (25_000, 30_000),
+    18: (30_000, 40_000),
+    19: (40_000, 50_000),
+    20: (50_000, 75_000),
+    21: (75_000, 100_000),
+    22: (100_000, 200_000),
+    23: (200_000, 500_000),
+    24: (500_000, 1_000_000),
+    25: (1_000_000, 1_500_000),
+    26: (1_500_000, 2_000_000),
+    27: (2_000_000, 5_000_000),
+    28: (5_000_000, 10_000_000),
+    29: (10_000_000, np.inf),
+}
+TABLE_1_4A_LTCG_COUNT_COLUMN = "BJ"
+TABLE_1_4A_LTCG_AMOUNT_COLUMN = "BK"
+
 
 def _skip_coarse_state_agi_person_count_target(geo_type: str, agi_stub: int) -> bool:
     """Skip the coarse state 500k+ count target when fine state bins are loaded.
@@ -893,6 +917,55 @@ def load_national_fine_agi_targets(
         )
 
 
+def load_national_ltcg_agi_targets(
+    session: Session, national_filer_stratum_id: int, target_year: int
+) -> None:
+    """Create national LTCG-by-AGI targets from Table 1.4A."""
+    workbook = _load_workbook("Table 1.4A", target_year)
+
+    for excel_row, (lower, upper) in TABLE_1_4A_LTCG_AGI_BRACKETS.items():
+        stratum = _get_or_create_national_agi_domain_stratum(
+            session,
+            national_filer_stratum_id,
+            "long_term_capital_gains",
+            lower,
+            upper,
+        )
+
+        count_value = _scaled_cell(
+            workbook,
+            excel_row,
+            TABLE_1_4A_LTCG_COUNT_COLUMN,
+            is_count=True,
+        )
+        amount_value = _scaled_cell(
+            workbook,
+            excel_row,
+            TABLE_1_4A_LTCG_AMOUNT_COLUMN,
+            is_count=False,
+        )
+        notes = f"Publication 1304 Table 1.4A row {excel_row} LTCG AGI bracket"
+
+        _upsert_target(
+            session,
+            stratum_id=stratum.stratum_id,
+            variable="tax_unit_count",
+            period=target_year,
+            value=count_value,
+            source="IRS SOI",
+            notes=notes,
+        )
+        _upsert_target(
+            session,
+            stratum_id=stratum.stratum_id,
+            variable="long_term_capital_gains",
+            period=target_year,
+            value=amount_value,
+            source="IRS SOI",
+            notes=notes,
+        )
+
+
 def transform_soi_data(raw_df):
     # National ---------------
     national_df = raw_df.copy().loc[(raw_df.STATE == "US")]
@@ -1100,6 +1173,7 @@ def load_soi_data(long_dfs, year, national_year: Optional[int] = None):
             national_year,
         )
         load_national_fine_agi_targets(session, filer_strata["national"], national_year)
+        load_national_ltcg_agi_targets(session, filer_strata["national"], national_year)
 
     load_state_fine_agi_targets(session, filer_strata, year)
     session.commit()

--- a/policyengine_us_data/db/etl_national_targets.py
+++ b/policyengine_us_data/db/etl_national_targets.py
@@ -41,6 +41,7 @@ def extract_national_targets(year: int = DEFAULT_YEAR):
         - tax_expenditure_targets: Variables targeted via repeal-based tax expenditures
         - conditional_count_targets: Enrollment counts requiring constraints
         - cbo_targets: List of CBO projection targets
+        - irs_soi_targets: List of IRS SOI aggregate targets
         - treasury_targets: List of Treasury/JCT targets
         - time_period: The target year
     """
@@ -413,6 +414,26 @@ def extract_national_targets(year: int = DEFAULT_YEAR):
                 f"{variable_name} (param: {param_name}): {e}"
             )
 
+    # IRS SOI aggregate targets - use time_period derived from dataset.
+    irs_soi_targets = []
+    try:
+        value = tax_benefit_system.parameters(
+            time_period
+        ).calibration.gov.irs.soi._children["long_term_capital_gains"]
+        irs_soi_targets.append(
+            {
+                "variable": "long_term_capital_gains",
+                "value": float(value),
+                "source": "IRS SOI",
+                "notes": (
+                    "IRS SOI total long-term capital gains, uprated by policyengine-us"
+                ),
+                "year": time_period,
+            }
+        )
+    except (KeyError, AttributeError) as e:
+        print(f"Warning: Could not extract IRS SOI LTCG parameter: {e}")
+
     # Treasury/JCT targets (EITC) - use time_period derived from dataset
     try:
         eitc_value = tax_benefit_system.parameters.calibration.gov.treasury.tax_expenditures.eitc(
@@ -437,6 +458,7 @@ def extract_national_targets(year: int = DEFAULT_YEAR):
         "tax_expenditure_targets": tax_expenditure_targets,
         "conditional_count_targets": conditional_count_targets,
         "cbo_targets": cbo_targets,
+        "irs_soi_targets": irs_soi_targets,
         "treasury_targets": treasury_targets,
         "time_period": time_period,
     }
@@ -471,7 +493,11 @@ def transform_national_targets(raw_targets):
         t for t in raw_targets["cbo_targets"] if t["variable"] == "income_tax_positive"
     ]
 
-    all_direct_targets = raw_targets["direct_sum_targets"] + cbo_non_tax
+    all_direct_targets = (
+        raw_targets["direct_sum_targets"]
+        + cbo_non_tax
+        + raw_targets.get("irs_soi_targets", [])
+    )
 
     # Tax-related targets that need filer constraint
     all_tax_filer_targets = (

--- a/policyengine_us_data/storage/calibration_targets/refresh_soi_table_targets.py
+++ b/policyengine_us_data/storage/calibration_targets/refresh_soi_table_targets.py
@@ -24,6 +24,7 @@ TABLE_FILE_SUFFIX = {
     "Table 1.1": "in11si.xls",
     "Table 1.2": "in12ms.xls",
     "Table 1.4": "in14ar.xls",
+    "Table 1.4A": "in14acg.xls",
     "Table 2.1": "in21id.xls",
     "Table 4.3": "in43ts.xls",
 }

--- a/policyengine_us_data/utils/loss.py
+++ b/policyengine_us_data/utils/loss.py
@@ -176,6 +176,12 @@ AGGREGATE_LEVEL_TARGETED_VARIABLES = (
     "unemployment_compensation",
 )
 
+IRS_SOI_AGGREGATE_TARGETS = [
+    # This complements the net capital gains target with the source-specific
+    # control used by downstream preferential-rate reforms.
+    ("long_term_capital_gains", ["long_term_capital_gains"], "long_term_capital_gains"),
+]
+
 
 def fmt(x):
     if x == -np.inf:
@@ -557,6 +563,26 @@ def _add_ctc_targets(loss_matrix, targets_list, sim, time_period):
     return targets_list, loss_matrix
 
 
+def _sum_household_variables(sim, variable_names):
+    return sum(
+        sim.calculate(variable_name, map_to="household").values
+        for variable_name in variable_names
+    )
+
+
+def _add_irs_soi_aggregate_targets(loss_matrix, targets_list, sim, time_period):
+    soi = sim.tax_benefit_system.parameters(time_period).calibration.gov.irs.soi
+
+    for label_suffix, pe_variables, soi_param_name in IRS_SOI_AGGREGATE_TARGETS:
+        label = f"nation/irs/soi/{label_suffix}"
+        loss_matrix[label] = _sum_household_variables(sim, pe_variables)
+        if any(pd.isna(loss_matrix[label])):
+            raise ValueError(f"Missing values for {label}")
+        targets_list.append(soi._children[soi_param_name])
+
+    return targets_list, loss_matrix
+
+
 def _should_skip_soi_agi_row(row) -> bool:
     """Skip fragile low-AGI SOI rows except for investment-income controls."""
     if row["AGI upper bound"] > 10_000:
@@ -744,6 +770,16 @@ def build_loss_matrix(dataset: type, time_period):
         values = sum(sim.calculate(v, map_to="household").values for v in pe_variables)
         loss_matrix[label] = values
         targets_array.append(income_by_source._children[cbo_param_name])
+
+    # IRS SOI aggregate capital-gains targets. This adds a long-term gains
+    # control on top of the CBO net capital gains aggregate, which is important
+    # for reforms that change preferential LTCG rates.
+    targets_array, loss_matrix = _add_irs_soi_aggregate_targets(
+        loss_matrix,
+        targets_array,
+        sim,
+        time_period,
+    )
 
     # 1. Medicaid Spending
     medicaid_spending_target, medicaid_enrollment_target, _ = (

--- a/tests/integration/test_database_build.py
+++ b/tests/integration/test_database_build.py
@@ -115,10 +115,35 @@ def test_national_targets_loaded(built_db):
     conn.close()
 
     variables = {r[0] for r in rows}
-    for expected in ["snap", "social_security", "ssi"]:
+    for expected in [
+        "long_term_capital_gains",
+        "snap",
+        "social_security",
+        "ssi",
+    ]:
         assert expected in variables, (
             f"National target '{expected}' missing. Found: {sorted(variables)}"
         )
+
+
+def test_national_ltcg_agi_targets_loaded(built_db):
+    """National Table 1.4A LTCG AGI-bin targets should be present."""
+    conn = sqlite3.connect(str(built_db))
+    rows = conn.execute("""
+        SELECT variable, COUNT(*)
+        FROM target_overview
+        WHERE geo_level = 'national'
+          AND domain_variable = 'adjusted_gross_income,long_term_capital_gains'
+          AND variable IN ('long_term_capital_gains', 'tax_unit_count')
+        GROUP BY variable
+        """).fetchall()
+    conn.close()
+
+    counts = dict(rows)
+    assert counts == {
+        "long_term_capital_gains": 19,
+        "tax_unit_count": 19,
+    }
 
 
 def test_jct_mortgage_tax_expenditure_uses_mortgage_specific_variable(built_db):

--- a/tests/unit/calibration/test_loss_targets.py
+++ b/tests/unit/calibration/test_loss_targets.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -5,8 +7,9 @@ import pytest
 from policyengine_us_data.utils.loss import (
     AGGREGATE_LEVEL_TARGETED_VARIABLES,
     AGI_LEVEL_TARGETED_VARIABLES,
-    _get_aca_national_targets,
+    _add_irs_soi_aggregate_targets,
     _add_ctc_targets,
+    _get_aca_national_targets,
     _get_medicaid_national_targets,
     _load_aca_spending_and_enrollment_targets,
     _load_medicaid_enrollment_targets,
@@ -99,6 +102,36 @@ class _FakeSimulation:
         return np.asarray(values, dtype=np.float32)
 
 
+class _FakeCapitalGainsSimulation:
+    def __init__(self):
+        self.calculate_calls = []
+        self.tax_benefit_system = SimpleNamespace(
+            parameters=lambda period: SimpleNamespace(
+                calibration=SimpleNamespace(
+                    gov=SimpleNamespace(
+                        irs=SimpleNamespace(
+                            soi=SimpleNamespace(
+                                _children={
+                                    "long_term_capital_gains": 1_650.0,
+                                }
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+    def calculate(self, variable, map_to=None, period=None):
+        self.calculate_calls.append((variable, map_to, period))
+        values = {
+            "long_term_capital_gains": [100.0, 0.0, 50.0],
+        }
+        if variable not in values:
+            raise AssertionError(f"Unexpected variable {variable!r}")
+        assert map_to == "household"
+        return _FakeArrayResult(values[variable])
+
+
 def test_add_ctc_targets(monkeypatch):
     monkeypatch.setattr(
         "policyengine_us_data.utils.loss.get_national_geography_soi_target",
@@ -133,6 +166,26 @@ def test_add_ctc_targets(monkeypatch):
         loss_matrix["nation/irs/non_refundable_ctc_count"],
         np.array([1.0, 1.0, 0.0], dtype=np.float32),
     )
+
+
+def test_add_irs_soi_capital_gains_targets():
+    sim = _FakeCapitalGainsSimulation()
+
+    targets, loss_matrix = _add_irs_soi_aggregate_targets(
+        pd.DataFrame(),
+        [],
+        sim,
+        2026,
+    )
+
+    assert targets == [1_650.0]
+    np.testing.assert_array_equal(
+        loss_matrix["nation/irs/soi/long_term_capital_gains"],
+        np.array([100.0, 0.0, 50.0], dtype=np.float32),
+    )
+    assert sim.calculate_calls == [
+        ("long_term_capital_gains", "household", None),
+    ]
 
 
 def test_low_agi_soi_skip_keeps_investment_income_targets():

--- a/tests/unit/calibration/test_target_config.py
+++ b/tests/unit/calibration/test_target_config.py
@@ -218,6 +218,7 @@ class TestLoadTargetConfig:
 
         include_rules = config["include"]
         variables = [
+            "long_term_capital_gains",
             "net_capital_gains",
             "dividend_income",
             "qualified_dividend_income",
@@ -270,6 +271,21 @@ class TestLoadTargetConfig:
 
         assert {
             "variable": "medicare_part_b_premium",
+            "geo_level": "national",
+        } in config["include"]
+
+    def test_training_config_includes_soi_ltcg_target(self):
+        config = load_target_config(
+            str(
+                Path(__file__).resolve().parents[3]
+                / "policyengine_us_data"
+                / "calibration"
+                / "target_config.yaml"
+            )
+        )
+
+        assert {
+            "variable": "long_term_capital_gains",
             "geo_level": "national",
         } in config["include"]
 

--- a/tests/unit/test_etl_irs_soi_overlay.py
+++ b/tests/unit/test_etl_irs_soi_overlay.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import numpy as np
 from sqlalchemy import text
 from sqlmodel import Session, select
 
@@ -22,6 +23,7 @@ from policyengine_us_data.db.etl_irs_soi import (
     _upsert_target,
     load_national_geography_ctc_agi_targets,
     load_national_geography_ctc_targets,
+    load_national_ltcg_agi_targets,
     load_national_workbook_soi_targets,
 )
 
@@ -490,3 +492,50 @@ def test_load_national_geography_ctc_agi_targets_creates_capital_income_domains(
     assert actual_pairs == expected_pairs
     assert set(rows["geo_level"]) == {"national"}
     assert set(rows["geographic_id"]) == {"US"}
+
+
+def test_load_national_ltcg_agi_targets_creates_table_14a_domain_targets(
+    monkeypatch, tmp_path
+):
+    db_uri, engine = _create_test_engine(tmp_path)
+    workbook = pd.DataFrame(np.zeros((12, 63)))
+    workbook.iat[10, 61] = 123.0
+    workbook.iat[10, 62] = 456.0
+
+    monkeypatch.setattr(
+        "policyengine_us_data.db.etl_irs_soi.TABLE_1_4A_LTCG_AGI_BRACKETS",
+        {11: (float("-inf"), 1.0)},
+    )
+    monkeypatch.setattr(
+        "policyengine_us_data.db.etl_irs_soi._load_workbook",
+        lambda table_name, year: workbook,
+    )
+
+    with Session(engine) as session:
+        national_filer_stratum = _create_national_filer_stratum(session)
+        load_national_ltcg_agi_targets(
+            session,
+            national_filer_stratum.stratum_id,
+            2023,
+        )
+        session.commit()
+
+    builder = UnifiedMatrixBuilder(db_uri=db_uri, time_period=2024)
+    rows = builder._query_targets(
+        {
+            "variables": ["tax_unit_count", "long_term_capital_gains"],
+            "domain_variables": ["adjusted_gross_income,long_term_capital_gains"],
+        }
+    )
+
+    assert set(rows["variable"]) == {
+        "tax_unit_count",
+        "long_term_capital_gains",
+    }
+    assert set(rows["domain_variable"]) == {
+        "adjusted_gross_income,long_term_capital_gains"
+    }
+    assert rows.set_index("variable").loc["tax_unit_count", "value"] == 123.0
+    assert (
+        rows.set_index("variable").loc["long_term_capital_gains", "value"] == 456_000.0
+    )


### PR DESCRIPTION
## Summary
- add the IRS SOI long-term capital gains aggregate target to the legacy enhanced CPS loss matrix
- load the same aggregate target into `policy_data.db` through `etl_national_targets.py`
- add IRS Publication 1304 Table 1.4A LTCG-by-AGI-bin targets to `policy_data.db`
- include the aggregate and AGI-bin LTCG targets in the default calibration `target_config.yaml`
- cover the loss-matrix helper, target-config inclusion, and DB-build presence with tests

## Notes
PR #868 already added AGI-bracket targets for net capital gains, dividends, and taxable interest. The additional source-backed targets here are:

- `calibration.gov.irs.soi.long_term_capital_gains`, which resolves to about $1.681T for 2026
- Publication 1304 Table 1.4A `Net long-term capital gain` by AGI bin, available through TY2023

I did not add `short_term_capital_gains`: the available parameter is PUF-derived "in the absence of a SOI target" and its 2026 value is negative, so it is not a comparable source-backed target.

Local comparison against the latest rebuilt `enhanced_cps_2024.h5`:

- aggregate positive LTCG: $1.755T vs $1.686T target, 1.04x
- aggregate net/default LTCG sum: $1.645T vs $1.681T uprated parameter, 0.98x
- several AGI bins still differ materially, so the Table 1.4A rows add distributional guardrails even though the aggregate is close

## Tests
- `uv run ruff check policyengine_us_data/db/etl_national_targets.py policyengine_us_data/db/etl_irs_soi.py policyengine_us_data/storage/calibration_targets/refresh_soi_table_targets.py policyengine_us_data/utils/loss.py tests/unit/calibration/test_loss_targets.py tests/unit/calibration/test_target_config.py tests/unit/test_etl_irs_soi_overlay.py tests/integration/test_database_build.py`
- `uv run pytest tests/unit/test_etl_national_targets.py tests/unit/calibration/test_loss_targets.py`
- `uv run pytest tests/unit/test_etl_irs_soi_overlay.py tests/unit/calibration/test_target_config.py`
- `uv run pytest tests/integration/test_database_build.py::test_national_ltcg_agi_targets_loaded`
- subagent review: no blocking issues
