### PR TITLE
Add tax-exempt interest calibration targets

### DIFF
--- a/changelog.d/add-tax-exempt-interest-targets.added.md
+++ b/changelog.d/add-tax-exempt-interest-targets.added.md
@@ -1,0 +1,1 @@
+Re-enabled SOI aggregate and AGI-bin targets for tax-exempt interest income in calibration.

--- a/policyengine_us_data/calibration/target_config.yaml
+++ b/policyengine_us_data/calibration/target_config.yaml
@@ -241,6 +241,18 @@ include:
   - variable: tax_unit_count
     geo_level: national
     domain_variable: adjusted_gross_income,taxable_interest_income
+  - variable: tax_exempt_interest_income
+    geo_level: national
+    domain_variable: tax_exempt_interest_income
+  - variable: tax_exempt_interest_income
+    geo_level: national
+    domain_variable: adjusted_gross_income,tax_exempt_interest_income
+  - variable: tax_unit_count
+    geo_level: national
+    domain_variable: tax_exempt_interest_income
+  - variable: tax_unit_count
+    geo_level: national
+    domain_variable: adjusted_gross_income,tax_exempt_interest_income
   - variable: refundable_ctc
     geo_level: national
     domain_variable: refundable_ctc
@@ -335,7 +347,7 @@ include:
   # NOT INCLUDED — high error or tension (from prior validation)
   # =====================================================================
   # rental_income (20%), income_tax_before_credits (21%),
-  # salt SOI (102%), tax_exempt_interest_income (61%),
+  # salt SOI (102%),
   # taxable_ira_distributions (68%), taxable_social_security (55%),
   # person_count by AGI bins (100%)
   #
@@ -344,3 +356,4 @@ include:
   #   dividend_income (was 26% rel-err)
   #   qualified_dividend_income (was 29%)
   #   taxable_interest_income (was 61%)
+  #   tax_exempt_interest_income (was 61%)

--- a/tests/unit/calibration/test_target_config.py
+++ b/tests/unit/calibration/test_target_config.py
@@ -222,6 +222,7 @@ class TestLoadTargetConfig:
             "net_capital_gains",
             "dividend_income",
             "qualified_dividend_income",
+            "tax_exempt_interest_income",
             "taxable_interest_income",
         ]
         for variable in variables:


### PR DESCRIPTION
## Summary
- re-enable national SOI tax-exempt interest aggregate targets
- add AGI-bin tax-exempt interest dollar and filer-count targets
- update target-config coverage test

## Context
The remaining outlier scan showed `tax_exempt_interest_income` still had a high top tail in the current Enhanced CPS. The locally available H5 sums to about `$82.6B` for 2024 with a max record around `$244M`; the stored 2023 SOI exempt-interest aggregate is `$66.1B`. This is much less severe than mortgage interest or the prior capital-gains issue, but it is targetable with the existing SOI Table 1.4 rows.

This follows the same logic as #868: a high-error soft target is preferable to leaving the aggregate unconstrained when the variable can affect downstream federal/state tax calculations.

## Validation
- `uv run pytest tests/unit/calibration/test_target_config.py -q`
- `uv run ruff format --check tests/unit/calibration/test_target_config.py`
- `uv run ruff check tests/unit/calibration/test_target_config.py`