### PR TITLE
Add tax-exempt interest and charitable deduction targets

### DIFF
--- a/changelog.d/add-tax-exempt-interest-targets.added.md
+++ b/changelog.d/add-tax-exempt-interest-targets.added.md
@@ -1,0 +1,1 @@
+Re-enabled SOI aggregate and AGI-bin targets for tax-exempt interest income and SOI aggregate targets for charitable deductions in calibration.

--- a/policyengine_us_data/calibration/target_config.yaml
+++ b/policyengine_us_data/calibration/target_config.yaml
@@ -241,6 +241,18 @@ include:
   - variable: tax_unit_count
     geo_level: national
     domain_variable: adjusted_gross_income,taxable_interest_income
+  - variable: tax_exempt_interest_income
+    geo_level: national
+    domain_variable: tax_exempt_interest_income
+  - variable: tax_exempt_interest_income
+    geo_level: national
+    domain_variable: adjusted_gross_income,tax_exempt_interest_income
+  - variable: tax_unit_count
+    geo_level: national
+    domain_variable: tax_exempt_interest_income
+  - variable: tax_unit_count
+    geo_level: national
+    domain_variable: adjusted_gross_income,tax_exempt_interest_income
   - variable: refundable_ctc
     geo_level: national
     domain_variable: refundable_ctc
@@ -300,6 +312,12 @@ include:
     domain_variable: ssn_card_type
 
   # === NATIONAL — SOI deduction totals (non-reform) ===
+  - variable: charitable_deduction
+    geo_level: national
+    domain_variable: charitable_deduction
+  - variable: tax_unit_count
+    geo_level: national
+    domain_variable: charitable_deduction
   - variable: medical_expense_deduction
     geo_level: national
     domain_variable: medical_expense_deduction,tax_unit_itemizes
@@ -335,7 +353,7 @@ include:
   # NOT INCLUDED — high error or tension (from prior validation)
   # =====================================================================
   # rental_income (20%), income_tax_before_credits (21%),
-  # salt SOI (102%), tax_exempt_interest_income (61%),
+  # salt SOI (102%),
   # taxable_ira_distributions (68%), taxable_social_security (55%),
   # person_count by AGI bins (100%)
   #
@@ -344,3 +362,4 @@ include:
   #   dividend_income (was 26% rel-err)
   #   qualified_dividend_income (was 29%)
   #   taxable_interest_income (was 61%)
+  #   tax_exempt_interest_income (was 61%)

--- a/policyengine_us_data/db/etl_irs_soi.py
+++ b/policyengine_us_data/db/etl_irs_soi.py
@@ -174,6 +174,7 @@ def _skip_coarse_state_agi_person_count_target(geo_type: str, agi_stub: int) -> 
 #     figure into a slot the district targets treat as net, creating a
 #     +40.7% / +26.1% / +3.1% definitional mismatch at 2023 values.
 WORKBOOK_NATIONAL_DOMAIN_TARGETS = {
+    "charitable_deduction": "charitable_contributions_deductions",
     "dividend_income": "ordinary_dividends",
     "income_tax_before_credits": "income_tax_before_credits",
     "qualified_dividend_income": "qualified_dividends",
@@ -192,6 +193,7 @@ NATIONAL_GEOGRAPHY_AGI_DOMAIN_TARGET_VARIABLES = (
     "net_capital_gains",
     "dividend_income",
     "qualified_dividend_income",
+    "tax_exempt_interest_income",
     "taxable_interest_income",
 )
 

--- a/tests/unit/calibration/test_target_config.py
+++ b/tests/unit/calibration/test_target_config.py
@@ -222,6 +222,7 @@ class TestLoadTargetConfig:
             "net_capital_gains",
             "dividend_income",
             "qualified_dividend_income",
+            "tax_exempt_interest_income",
             "taxable_interest_income",
         ]
         for variable in variables:
@@ -257,6 +258,30 @@ class TestLoadTargetConfig:
             "variable": "tax_unit_count",
             "geo_level": "national",
             "domain_variable": "qualified_business_income_deduction",
+        } in include_rules
+
+    def test_training_config_includes_national_charitable_deduction_targets(
+        self,
+    ):
+        config = load_target_config(
+            str(
+                Path(__file__).resolve().parents[3]
+                / "policyengine_us_data"
+                / "calibration"
+                / "target_config.yaml"
+            )
+        )
+
+        include_rules = config["include"]
+        assert {
+            "variable": "charitable_deduction",
+            "geo_level": "national",
+            "domain_variable": "charitable_deduction",
+        } in include_rules
+        assert {
+            "variable": "tax_unit_count",
+            "geo_level": "national",
+            "domain_variable": "charitable_deduction",
         } in include_rules
 
     def test_training_config_includes_medicare_part_b_target(self):

--- a/tests/unit/test_etl_irs_soi_overlay.py
+++ b/tests/unit/test_etl_irs_soi_overlay.py
@@ -14,6 +14,7 @@ from policyengine_us_data.db.create_database_tables import (
 )
 from policyengine_us_data.db.etl_irs_soi import (
     GEOGRAPHY_FILE_TARGET_SPECS,
+    WORKBOOK_NATIONAL_DOMAIN_TARGETS,
     get_geography_soi_year,
     get_national_geography_soi_agi_targets,
     get_national_geography_soi_target,
@@ -191,6 +192,13 @@ def test_workbook_overlay_wins_best_period_selection(monkeypatch, tmp_path):
     assert len(count_rows) == 1
     assert int(count_rows.iloc[0]["period"]) == 2023
     assert float(count_rows.iloc[0]["value"]) == 50.0
+
+
+def test_workbook_domain_targets_include_charitable_deduction():
+    assert (
+        WORKBOOK_NATIONAL_DOMAIN_TARGETS["charitable_deduction"]
+        == "charitable_contributions_deductions"
+    )
 
 
 def test_skip_coarse_state_agi_person_count_target_only_for_state_stub_9():
@@ -470,6 +478,7 @@ def test_load_national_geography_ctc_agi_targets_creates_capital_income_domains(
         "net_capital_gains",
         "dividend_income",
         "qualified_dividend_income",
+        "tax_exempt_interest_income",
         "taxable_interest_income",
     ]
     domains = [f"adjusted_gross_income,{variable}" for variable in variables]


### PR DESCRIPTION
## Summary
- re-enable national SOI tax-exempt interest aggregate targets
- add national AGI-bin tax-exempt interest dollar and filer-count targets to the ETL and target config
- add national SOI charitable deduction aggregate/count targets
- update target-config and ETL coverage tests

## Context
The remaining outlier scan showed a few non-mortgage, non-LTCG variables that were still targetable. The locally available H5 has `tax_exempt_interest_income` at about `$82.6B` for 2024 with a max record around `$244M`; the stored 2023 SOI exempt-interest aggregate is `$66.1B`. It also has `charitable_deduction` at about `$301.1B`; the stored 2023 SOI charitable-contribution deduction aggregate is `$212.0B`.

These are much less severe than mortgage interest or the prior capital-gains issue, but both are targetable with existing SOI rows. This follows the same logic as #868: a high-error soft target is preferable to leaving the aggregate unconstrained when the variable can affect downstream federal/state tax calculations.

## Validation
- `uv run pytest tests/unit/calibration/test_target_config.py -q`
- `uv run pytest tests/unit/calibration/test_target_config.py tests/unit/test_etl_irs_soi_overlay.py::test_load_national_geography_ctc_agi_targets_creates_capital_income_domains tests/unit/test_etl_irs_soi_overlay.py::test_workbook_domain_targets_include_charitable_deduction -q`
- `uv run ruff format --check policyengine_us_data/db/etl_irs_soi.py tests/unit/test_etl_irs_soi_overlay.py tests/unit/calibration/test_target_config.py`
- `uv run ruff check policyengine_us_data/db/etl_irs_soi.py tests/unit/test_etl_irs_soi_overlay.py tests/unit/calibration/test_target_config.py`