### PR TITLE
Harden CRFB long-run calibration

### DIFF
--- a/policyengine_us_data/datasets/cps/long_term/calibration.py
+++ b/policyengine_us_data/datasets/cps/long_term/calibration.py
@@ -35,7 +35,6 @@ def iterative_proportional_fitting(
         info: Dictionary with convergence info
     """
     w = w_initial.copy()
-    n_features = X.shape[1]
 
     for iter_num in range(max_iters):
         predictions = X.T @ w
@@ -103,6 +102,7 @@ def calibrate_greg(
     oasdi_tob_target=None,
     hi_tob_values=None,
     hi_tob_target=None,
+    extra_constraints=None,
     n_ages=86,
 ):
     """
@@ -140,6 +140,7 @@ def calibrate_greg(
         or (h6_income_values is not None and h6_revenue_target is not None)
         or (oasdi_tob_values is not None and oasdi_tob_target is not None)
         or (hi_tob_values is not None and hi_tob_target is not None)
+        or bool(extra_constraints)
     )
 
     if needs_aux_df:
@@ -166,6 +167,10 @@ def calibrate_greg(
         if hi_tob_values is not None and hi_tob_target is not None:
             aux_df["hi_tob"] = hi_tob_values
             controls["hi_tob"] = hi_tob_target
+
+        for name, (values, target) in (extra_constraints or {}).items():
+            aux_df[str(name)] = np.asarray(values, dtype=float)
+            controls[str(name)] = float(target)
 
         aux_vars = aux_df
     else:
@@ -194,6 +199,7 @@ def _build_constraint_dataframe_and_controls(
     oasdi_tob_target=None,
     hi_tob_values=None,
     hi_tob_target=None,
+    extra_constraints=None,
     n_ages=86,
 ):
     controls = {}
@@ -223,6 +229,10 @@ def _build_constraint_dataframe_and_controls(
         aux_df["hi_tob"] = np.asarray(hi_tob_values, dtype=float)
         controls["hi_tob"] = float(hi_tob_target)
 
+    for name, (values, target) in (extra_constraints or {}).items():
+        aux_df[str(name)] = np.asarray(values, dtype=float)
+        controls[str(name)] = float(target)
+
     return aux_df, controls
 
 
@@ -240,6 +250,7 @@ def calibrate_entropy(
     oasdi_tob_target=None,
     hi_tob_values=None,
     hi_tob_target=None,
+    extra_constraints=None,
     n_ages=86,
     max_iters=500,
     tol=1e-10,
@@ -264,6 +275,7 @@ def calibrate_entropy(
         oasdi_tob_target=oasdi_tob_target,
         hi_tob_values=hi_tob_values,
         hi_tob_target=hi_tob_target,
+        extra_constraints=extra_constraints,
         n_ages=n_ages,
     )
 
@@ -408,6 +420,7 @@ def calibrate_entropy_bounded(
     oasdi_tob_target=None,
     hi_tob_values=None,
     hi_tob_target=None,
+    extra_constraints=None,
     n_ages=86,
     max_constraint_error_pct=0.0,
     max_iters=500,
@@ -437,6 +450,7 @@ def calibrate_entropy_bounded(
         oasdi_tob_target=oasdi_tob_target,
         hi_tob_values=hi_tob_values,
         hi_tob_target=hi_tob_target,
+        extra_constraints=extra_constraints,
         n_ages=n_ages,
     )
 
@@ -627,6 +641,7 @@ def calibrate_lp_minimax(
     oasdi_tob_target=None,
     hi_tob_values=None,
     hi_tob_target=None,
+    extra_constraints=None,
     n_ages=86,
 ):
     """
@@ -650,6 +665,7 @@ def calibrate_lp_minimax(
         oasdi_tob_target=oasdi_tob_target,
         hi_tob_values=hi_tob_values,
         hi_tob_target=hi_tob_target,
+        extra_constraints=extra_constraints,
         n_ages=n_ages,
     )
 
@@ -740,6 +756,7 @@ def calibrate_weights(
     oasdi_tob_target=None,
     hi_tob_values=None,
     hi_tob_target=None,
+    extra_constraints=None,
     n_ages=86,
     max_iters=100,
     tol=1e-6,
@@ -767,6 +784,7 @@ def calibrate_weights(
         oasdi_tob_target: Optional OASDI TOB revenue target total
         hi_tob_values: Optional HI TOB revenue values per household
         hi_tob_target: Optional HI TOB revenue target total
+        extra_constraints: Optional dict of named (values, target) constraints
         n_ages: Number of age groups
         max_iters: Max iterations for IPF
         tol: Convergence tolerance for IPF
@@ -810,6 +828,7 @@ def calibrate_weights(
                 oasdi_tob_target,
                 hi_tob_values,
                 hi_tob_target,
+                extra_constraints,
                 n_ages,
             )
             return w_new, iterations, audit
@@ -843,10 +862,44 @@ def calibrate_weights(
                 oasdi_tob_target=oasdi_tob_target,
                 hi_tob_values=hi_tob_values,
                 hi_tob_target=hi_tob_target,
+                extra_constraints=extra_constraints,
                 n_ages=n_ages,
                 max_iters=max_iters * 5,
                 tol=max(tol, 1e-10),
             )
+            candidate_audit = build_calibration_audit(
+                X=X,
+                y_target=y_target,
+                weights=w_new,
+                baseline_weights=baseline_weights,
+                calibration_event=audit,
+                ss_values=ss_values,
+                ss_target=ss_target,
+                payroll_values=payroll_values,
+                payroll_target=payroll_target,
+                h6_income_values=h6_income_values,
+                h6_revenue_target=h6_revenue_target,
+                oasdi_tob_values=oasdi_tob_values,
+                oasdi_tob_target=oasdi_tob_target,
+                hi_tob_values=hi_tob_values,
+                hi_tob_target=hi_tob_target,
+                extra_constraints=extra_constraints,
+            )
+            allowed_error_pct = max(tol * 100, 1e-6)
+            if approximate_max_error_pct is not None:
+                allowed_error_pct = max(
+                    allowed_error_pct,
+                    float(approximate_max_error_pct),
+                )
+            candidate_error_pct = float(
+                candidate_audit.get("max_constraint_pct_error", 0.0)
+            )
+            if candidate_error_pct > allowed_error_pct + 1e-6:
+                raise RuntimeError(
+                    "Entropy calibration returned weights with max constraint "
+                    f"error {candidate_error_pct:.6f}%, above allowable "
+                    f"{allowed_error_pct:.6f}%."
+                )
             return w_new, iterations, audit
         except RuntimeError as error:
             audit["entropy_error"] = str(error)
@@ -864,10 +917,14 @@ def calibrate_weights(
                 oasdi_tob_target=oasdi_tob_target,
                 hi_tob_values=hi_tob_values,
                 hi_tob_target=hi_tob_target,
+                extra_constraints=extra_constraints,
                 n_ages=n_ages,
             )
             approximate_error_pct = float(feasibility["best_case_max_pct_error"])
-            if approximate_error_pct <= max(tol * 100, 1e-6):
+            exact_lp_available = approximate_error_pct <= max(tol * 100, 1e-6)
+            if exact_lp_available and (
+                not allow_approximate_entropy or approximate_max_error_pct is None
+            ):
                 audit["lp_fallback_used"] = True
                 audit["approximation_method"] = "lp_minimax_exact"
                 audit["approximate_solution_error_pct"] = approximate_error_pct
@@ -901,6 +958,7 @@ def calibrate_weights(
                     oasdi_tob_target=oasdi_tob_target,
                     hi_tob_values=hi_tob_values,
                     hi_tob_target=hi_tob_target,
+                    extra_constraints=extra_constraints,
                     n_ages=n_ages,
                 )
                 dense_lp_weights, dense_lp_info = densify_lp_solution(
@@ -937,6 +995,7 @@ def calibrate_weights(
                         oasdi_tob_target=oasdi_tob_target,
                         hi_tob_values=hi_tob_values,
                         hi_tob_target=hi_tob_target,
+                        extra_constraints=extra_constraints,
                         n_ages=n_ages,
                         max_constraint_error_pct=approximate_max_error_pct,
                         max_iters=max_iters * 10,
@@ -965,6 +1024,12 @@ def calibrate_weights(
                 audit["lp_blend_lambda"] = float(dense_lp_info["blend_lambda"])
                 return dense_lp_weights, iterations, audit
 
+            if exact_lp_available:
+                audit["lp_fallback_used"] = True
+                audit["approximation_method"] = "lp_minimax_exact"
+                audit["approximate_solution_error_pct"] = approximate_error_pct
+                return w_new, iterations, audit
+
             audit["lp_fallback_used"] = True
             audit["approximate_solution_used"] = True
             audit["approximation_method"] = "lp_minimax"
@@ -975,6 +1040,163 @@ def calibrate_weights(
             X, y_target, baseline_weights, max_iters, tol, verbose
         )
         return w_new, info["iterations"], audit
+
+
+def build_group_weight_concentration_audit(
+    *,
+    weights,
+    group_ids,
+    prefix: str,
+) -> dict[str, float | int]:
+    weights = np.asarray(weights, dtype=float)
+    group_ids = np.asarray(group_ids)
+    if weights.ndim != 1:
+        raise ValueError("weights must be one-dimensional")
+    if group_ids.shape[0] != weights.shape[0]:
+        raise ValueError("group_ids must have the same length as weights")
+
+    grouped = pd.Series(weights).groupby(pd.Series(group_ids), sort=False).sum()
+    group_weights = grouped.to_numpy(dtype=float)
+    positive_mask = group_weights > 0
+    weight_sum = float(group_weights.sum())
+    if weight_sum > 0:
+        sorted_weights = np.sort(group_weights)
+        top_10_share = float(sorted_weights[-10:].sum() / weight_sum * 100)
+        top_100_share = float(sorted_weights[-100:].sum() / weight_sum * 100)
+        max_share = float(sorted_weights[-1] / weight_sum * 100)
+    else:
+        top_10_share = 0.0
+        top_100_share = 0.0
+        max_share = 0.0
+
+    denominator = float(np.dot(group_weights, group_weights))
+    effective_sample_size = weight_sum**2 / denominator if denominator > 0 else 0.0
+
+    return {
+        f"{prefix}_count": int(group_weights.shape[0]),
+        f"positive_{prefix}_count": int(positive_mask.sum()),
+        f"{prefix}_effective_sample_size": float(effective_sample_size),
+        f"top_10_{prefix}_weight_share_pct": top_10_share,
+        f"top_100_{prefix}_weight_share_pct": top_100_share,
+        f"max_{prefix}_weight_share_pct": max_share,
+    }
+
+
+def build_target_contribution_support_audit(
+    *,
+    weights,
+    values,
+    prefix: str,
+) -> dict[str, float | int]:
+    weights = np.asarray(weights, dtype=float)
+    values = np.asarray(values, dtype=float)
+    if weights.ndim != 1 or values.ndim != 1:
+        raise ValueError("weights and values must be one-dimensional")
+    if values.shape[0] != weights.shape[0]:
+        raise ValueError("values must have the same length as weights")
+
+    contributions = np.abs(values * weights)
+    contributor_mask = contributions > 0
+    contributor_contributions = contributions[contributor_mask]
+    contribution_sum = float(contributor_contributions.sum())
+    if contribution_sum > 0:
+        sorted_contributions = np.sort(contributor_contributions)
+        top_10_share = float(sorted_contributions[-10:].sum() / contribution_sum * 100)
+        top_100_share = float(
+            sorted_contributions[-100:].sum() / contribution_sum * 100
+        )
+        max_share = float(sorted_contributions[-1] / contribution_sum * 100)
+    else:
+        top_10_share = 0.0
+        top_100_share = 0.0
+        max_share = 0.0
+
+    denominator = float(np.dot(contributor_contributions, contributor_contributions))
+    effective_sample_size = (
+        contribution_sum**2 / denominator if denominator > 0 else 0.0
+    )
+
+    return {
+        f"{prefix}_contributor_count": int(values.shape[0]),
+        f"{prefix}_positive_contributor_count": int(contributor_mask.sum()),
+        f"{prefix}_contributor_effective_sample_size": float(effective_sample_size),
+        f"top_10_{prefix}_contribution_share_pct": top_10_share,
+        f"top_100_{prefix}_contribution_share_pct": top_100_share,
+        f"max_{prefix}_contribution_share_pct": max_share,
+    }
+
+
+def build_clone_donor_family_weight_concentration_audit(
+    *,
+    weights,
+    household_ids,
+    clone_household_reports,
+    prefix: str = "clone_donor_family",
+) -> dict[str, float | int]:
+    household_ids = np.asarray(household_ids)
+    weights = np.asarray(weights, dtype=float)
+    if household_ids.shape[0] != weights.shape[0]:
+        raise ValueError("household_ids must have the same length as weights")
+
+    donor_lookup = {}
+    for clone_report in clone_household_reports or []:
+        clone_household_id = clone_report.get("clone_household_id")
+        if clone_household_id is None:
+            continue
+        older_donor = clone_report.get("older_donor_tax_unit_id")
+        worker_donor = clone_report.get("worker_donor_tax_unit_id")
+        donor_lookup[int(clone_household_id)] = (
+            f"donor_family:older={older_donor};worker={worker_donor}"
+        )
+
+    clone_mask = np.zeros(household_ids.shape[0], dtype=bool)
+    clone_group_ids = []
+    for idx, household_id in enumerate(household_ids):
+        donor_family_id = donor_lookup.get(int(household_id))
+        if donor_family_id is not None:
+            clone_mask[idx] = True
+            clone_group_ids.append(donor_family_id)
+
+    return build_group_weight_concentration_audit(
+        weights=weights[clone_mask],
+        group_ids=np.asarray(clone_group_ids, dtype=object),
+        prefix=prefix,
+    )
+
+
+def build_clone_donor_component_weight_concentration_audit(
+    *,
+    weights,
+    household_ids,
+    clone_household_reports,
+    donor_key: str,
+    prefix: str,
+) -> dict[str, float | int]:
+    household_ids = np.asarray(household_ids)
+    weights = np.asarray(weights, dtype=float)
+    if household_ids.shape[0] != weights.shape[0]:
+        raise ValueError("household_ids must have the same length as weights")
+
+    donor_lookup = {}
+    for clone_report in clone_household_reports or []:
+        clone_household_id = clone_report.get("clone_household_id")
+        if clone_household_id is None:
+            continue
+        donor_lookup[int(clone_household_id)] = clone_report.get(donor_key)
+
+    clone_mask = np.zeros(household_ids.shape[0], dtype=bool)
+    donor_group_ids = []
+    for idx, household_id in enumerate(household_ids):
+        donor_id = donor_lookup.get(int(household_id))
+        if donor_id is not None:
+            clone_mask[idx] = True
+            donor_group_ids.append(f"{donor_key}:{donor_id}")
+
+    return build_group_weight_concentration_audit(
+        weights=weights[clone_mask],
+        group_ids=np.asarray(donor_group_ids, dtype=object),
+        prefix=prefix,
+    )
 
 
 def build_calibration_audit(
@@ -994,6 +1216,7 @@ def build_calibration_audit(
     oasdi_tob_target=None,
     hi_tob_values=None,
     hi_tob_target=None,
+    extra_constraints=None,
 ):
     achieved_ages = X.T @ weights
     age_errors = (
@@ -1051,6 +1274,10 @@ def build_calibration_audit(
         ("oasdi_tob", oasdi_tob_values, oasdi_tob_target),
         ("hi_tob", hi_tob_values, hi_tob_target),
     ]
+    constraint_specs.extend(
+        (str(name), values, target)
+        for name, (values, target) in (extra_constraints or {}).items()
+    )
 
     for name, values, target in constraint_specs:
         if values is None or target is None:

--- a/policyengine_us_data/datasets/cps/long_term/prototype_synthetic_2100_support.py
+++ b/policyengine_us_data/datasets/cps/long_term/prototype_synthetic_2100_support.py
@@ -2217,7 +2217,6 @@ def build_donor_backed_augmented_input_dataframe(
     )
 
     clone_frames = []
-    clone_household_reports = []
     target_reports = []
     skipped_targets = []
 
@@ -2368,6 +2367,7 @@ def build_role_composite_augmented_input_dataframe(
     role_composite_weights, role_composite_solve_info = solve_synthetic_support(
         role_composite_candidates,
         year=target_year,
+        max_constraint_error_pct=0.5,
         baseline_weights=role_composite_prior,
     )
     role_composite_df = summarize_exact_candidates(

--- a/policyengine_us_data/datasets/cps/long_term/run_household_projection.py
+++ b/policyengine_us_data/datasets/cps/long_term/run_household_projection.py
@@ -3,7 +3,7 @@ Household-level projection pathway for income tax revenue 2025-2100.
 
 
 Usage:
-    python run_household_projection.py [START_YEAR] [END_YEAR] [--profile PROFILE] [--target-source SOURCE] [--tax-assumption ASSUMPTION] [--output-dir DIR] [--save-h5] [--allow-validation-failures]
+    python run_household_projection.py [START_YEAR] [END_YEAR] [--profile PROFILE] [--target-source SOURCE] [--tax-assumption ASSUMPTION] [--base-dataset PATH] [--output-dir DIR] [--save-h5] [--allow-validation-failures]
     python run_household_projection.py [START_YEAR] [END_YEAR] [--profile PROFILE] [--target-source SOURCE] [--support-augmentation-profile donor-backed-synthetic-v1] [--support-augmentation-target-year YEAR]
     python run_household_projection.py [START_YEAR] [END_YEAR] [--profile PROFILE] [--target-source SOURCE] [--support-augmentation-profile donor-backed-composite-v1] [--support-augmentation-target-year YEAR] [--support-augmentation-align-to-run-year] [--support-augmentation-blueprint-base-weight-scale SCALE]
     python run_household_projection.py [START_YEAR] [END_YEAR] [--greg] [--use-ss] [--use-payroll] [--use-h6-reform] [--use-tob] [--save-h5]
@@ -12,7 +12,8 @@ Usage:
     END_YEAR: Optional ending year (default: 2035)
     --profile: Named calibration contract (recommended)
     --target-source: Named long-term target source package
-    --tax-assumption: Long-run federal tax assumption (`trustees-core-thresholds-v1` by default)
+    --tax-assumption: Long-run federal tax assumption (`trustees-2025-core-thresholds-v1` by default)
+    --base-dataset: Base H5 dataset path or hf:// URL (default: enhanced_cps_2024 HF artifact)
     --output-dir: Output directory for generated H5 files and metadata
     --allow-validation-failures: Record validation issues in metadata and continue instead of aborting the run
     --support-augmentation-profile: Experimental late-year support expansion profile
@@ -52,7 +53,14 @@ from ssa_data import (
     load_taxable_payroll_projections,
     set_long_term_target_source,
 )
-from calibration import build_calibration_audit, calibrate_weights
+from calibration import (
+    build_calibration_audit,
+    build_clone_donor_component_weight_concentration_audit,
+    build_clone_donor_family_weight_concentration_audit,
+    build_group_weight_concentration_audit,
+    build_target_contribution_support_audit,
+    calibrate_weights,
+)
 from calibration_artifacts import (
     update_dataset_manifest,
     write_support_augmentation_report,
@@ -279,6 +287,104 @@ SUPPORTED_TAX_ASSUMPTIONS = {
     "current-law-literal",
     TRUSTEES_CORE_THRESHOLD_ASSUMPTION["name"],
 }
+INCOME_GUARD_GROUPS = {
+    "preferential_investment_income": (
+        "long_term_capital_gains_before_response",
+        "long_term_capital_gains_on_collectibles",
+        "qualified_dividend_income",
+    ),
+    "ordinary_nonpayroll_income": (
+        "short_term_capital_gains",
+        "non_sch_d_capital_gains",
+        "non_qualified_dividend_income",
+        "taxable_interest_income",
+        "tax_exempt_interest_income",
+        "partnership_s_corp_income",
+        "partnership_se_income",
+        "estate_income",
+        "rental_income",
+        "farm_income",
+        "farm_operations_income",
+        "farm_rent_income",
+        "miscellaneous_income",
+        "salt_refund_income",
+        "taxable_401k_distributions",
+        "taxable_403b_distributions",
+        "taxable_ira_distributions",
+        "taxable_private_pension_income",
+        "taxable_sep_distributions",
+        "tax_exempt_ira_distributions",
+        "tax_exempt_private_pension_income",
+        "qualified_bdc_income",
+        "qualified_reit_and_ptp_income",
+    ),
+}
+
+
+def _constraint_audit(constraints: dict[str, tuple[np.ndarray, float]], weights):
+    audit = {}
+    for name, (values, target) in constraints.items():
+        achieved = float(np.sum(np.asarray(values, dtype=float) * weights))
+        target = float(target)
+        error = achieved - target
+        audit[name] = {
+            "target": target,
+            "achieved": achieved,
+            "error": error,
+            "pct_error": 0.0 if target == 0 else error / target * 100,
+        }
+    return audit
+
+
+def _income_guard_provenance(
+    *,
+    hard_constraints: dict[str, tuple[np.ndarray, float]],
+    audit_only_constraints: dict[str, tuple[np.ndarray, float]],
+) -> dict[str, dict[str, str]]:
+    provenance: dict[str, dict[str, str]] = {}
+    for name in hard_constraints:
+        provenance[name] = {
+            "classification": "hard",
+            "source": "policyengine_formula_on_realized_rows",
+            "scoring_contract": "not directly consumed by reform scoring",
+        }
+    for name in audit_only_constraints:
+        provenance[name] = {
+            "classification": "audit_only",
+            "source": "policyengine_formula_on_realized_rows",
+            "scoring_contract": "not hard-calibrated in donor-composite blueprint mode",
+        }
+    return provenance
+
+
+def _donor_family_ids(
+    household_ids: np.ndarray,
+    augmentation_report: dict[str, object] | None,
+) -> np.ndarray:
+    family_ids = np.asarray(
+        [f"household:{int(value)}" for value in household_ids],
+        dtype=object,
+    )
+    if not augmentation_report:
+        return family_ids
+
+    clone_reports = augmentation_report.get("clone_household_reports", [])
+    donor_lookup = {}
+    for clone_report in clone_reports:
+        clone_household_id = clone_report.get("clone_household_id")
+        if clone_household_id is None:
+            continue
+        older_donor = clone_report.get("older_donor_tax_unit_id")
+        worker_donor = clone_report.get("worker_donor_tax_unit_id")
+        donor_lookup[int(clone_household_id)] = (
+            f"donor_family:older={older_donor};worker={worker_donor}"
+        )
+
+    for idx, household_id in enumerate(household_ids):
+        donor_family_id = donor_lookup.get(int(household_id))
+        if donor_family_id is not None:
+            family_ids[idx] = donor_family_id
+    return family_ids
 
 
 PROFILE_NAME = None
@@ -288,6 +394,13 @@ if "--profile" in sys.argv:
         raise ValueError("--profile requires a profile name")
     PROFILE_NAME = sys.argv[profile_index + 1]
     del sys.argv[profile_index : profile_index + 2]
+
+if "--base-dataset" in sys.argv:
+    base_dataset_index = sys.argv.index("--base-dataset")
+    if base_dataset_index + 1 >= len(sys.argv):
+        raise ValueError("--base-dataset requires a path or hf:// URL")
+    BASE_DATASET_PATH = sys.argv[base_dataset_index + 1]
+    del sys.argv[base_dataset_index : base_dataset_index + 2]
 
 TARGET_SOURCE = None
 if "--target-source" in sys.argv:
@@ -486,6 +599,8 @@ def _compose_reforms(*reforms):
     return reforms
 
 
+LONG_RUN_TAX_ASSUMPTION_END_YEAR = max(int(END_YEAR), 2100)
+
 if TAX_ASSUMPTION == "current-law-literal":
     ACTIVE_LONG_RUN_TAX_REFORM = None
     LONG_RUN_TAX_ASSUMPTION_METADATA = {
@@ -501,11 +616,11 @@ if TAX_ASSUMPTION == "current-law-literal":
 else:
     ACTIVE_LONG_RUN_TAX_REFORM = create_wage_indexed_core_thresholds_reform(
         start_year=TRUSTEES_CORE_THRESHOLD_ASSUMPTION["start_year"],
-        end_year=END_YEAR,
+        end_year=LONG_RUN_TAX_ASSUMPTION_END_YEAR,
     )
     LONG_RUN_TAX_ASSUMPTION_METADATA = get_long_run_tax_assumption_metadata(
         TAX_ASSUMPTION,
-        end_year=END_YEAR,
+        end_year=LONG_RUN_TAX_ASSUMPTION_END_YEAR,
     )
 
 BASE_DATASET = BASE_DATASET_PATH
@@ -542,10 +657,10 @@ else:
 print("=" * 70)
 print(f"HOUSEHOLD-LEVEL INCOME TAX PROJECTION: {START_YEAR}-{END_YEAR}")
 print("=" * 70)
-print(f"\nConfiguration:")
+print("\nConfiguration:")
 print(f"  Base year: {BASE_YEAR} (CPS microdata)")
 print(f"  Projection: {START_YEAR}-{END_YEAR}")
-print(f"  Calculation level: HOUSEHOLD ONLY (simplified)")
+print("  Calculation level: HOUSEHOLD ONLY (simplified)")
 print(f"  Calibration profile: {PROFILE.name}")
 print(f"  Profile description: {PROFILE.description}")
 print(f"  Target source: {TARGET_SOURCE}")
@@ -562,20 +677,20 @@ if SUPPORT_AUGMENTATION_PROFILE:
         f"{SUPPORT_AUGMENTATION_BLUEPRINT_BASE_WEIGHT_SCALE}"
     )
 if USE_SS:
-    print(f"  Including Social Security benefits constraint: Yes")
+    print("  Including Social Security benefits constraint: Yes")
 if USE_PAYROLL:
-    print(f"  Including taxable payroll constraint: Yes")
+    print("  Including taxable payroll constraint: Yes")
 if USE_H6_REFORM:
-    print(f"  Including H6 reform income impact constraint: Yes")
+    print("  Including H6 reform income impact constraint: Yes")
 if USE_TOB:
-    print(f"  Including TOB revenue constraint: Yes")
+    print("  Including TOB revenue constraint: Yes")
 elif BENCHMARK_TOB:
-    print(f"  Benchmarking TOB after calibration: Yes")
+    print("  Benchmarking TOB after calibration: Yes")
 if SAVE_H5:
     print(f"  Saving year-specific .h5 files: Yes (to {OUTPUT_DIR}/)")
     os.makedirs(OUTPUT_DIR, exist_ok=True)
 else:
-    print(f"  Saving year-specific .h5 files: No (use --save-h5 to enable)")
+    print("  Saving year-specific .h5 files: No (use --save-h5 to enable)")
 print(f"  Years to process: {END_YEAR - START_YEAR + 1}")
 est_time = (END_YEAR - START_YEAR + 1) * (3 if SAVE_H5 else 2)
 print(f"  Estimated time: ~{est_time:.0f} minutes")
@@ -705,7 +820,7 @@ n_years = target_matrix.shape[1]
 n_ages = target_matrix.shape[0]
 
 print(f"\nLoaded SSA projections: {n_ages} ages x {n_years} years")
-print(f"\nPopulation projections:")
+print("\nPopulation projections:")
 
 display_years = [
     y
@@ -866,6 +981,37 @@ for year_idx in range(n_years):
     baseline_weights = household_microseries.weights.values
     household_ids_hh = household_microseries.values
 
+    income_guard_constraints = {}
+    if year >= SUPPORT_AUGMENTATION_START_YEAR:
+        for group_name, components in INCOME_GUARD_GROUPS.items():
+            group_values = np.zeros(len(baseline_weights), dtype=float)
+            included_components = []
+            for component in components:
+                if component not in sim.tax_benefit_system.variables:
+                    continue
+                component_hh = sim.calculate(component, period=year, map_to="household")
+                group_values += np.asarray(component_hh.values, dtype=float)
+                included_components.append(component)
+            if not included_components:
+                continue
+            group_target = float(np.sum(group_values * baseline_weights))
+            if abs(group_target) <= 1e-6:
+                continue
+            income_guard_constraints[f"income_guard_{group_name}"] = (
+                group_values,
+                group_target,
+            )
+
+    if year in display_years and income_guard_constraints:
+        income_guard_total = sum(
+            target for _, target in income_guard_constraints.values()
+        )
+        print(
+            f"  [DEBUG {year}] Income guard baseline: "
+            f"${income_guard_total / 1e9:.1f}B across "
+            f"{len(income_guard_constraints)} groups"
+        )
+
     if not (
         SUPPORT_AUGMENTATION_ALIGN_TO_RUN_YEAR
         and current_support_augmentation_report is not None
@@ -1023,6 +1169,8 @@ for year_idx in range(n_years):
     payroll_values_calibration = (
         None if payroll_values_actual is None else payroll_values_actual.copy()
     )
+    income_guard_calibration_constraints = income_guard_constraints
+    income_guard_audit_only_constraints: dict[str, tuple[np.ndarray, float]] = {}
     blueprint_summary = None
     if (
         SUPPORT_AUGMENTATION_PROFILE == "donor-backed-composite-v1"
@@ -1041,14 +1189,6 @@ for year_idx in range(n_years):
             calibration_baseline_weights = calibration_blueprint["baseline_weights"]
             for idx, age_vector in calibration_blueprint["age_overrides"].items():
                 X_calibration[idx] = age_vector
-            if ss_values_calibration is not None:
-                for idx, target_value in calibration_blueprint["ss_overrides"].items():
-                    ss_values_calibration[idx] = target_value
-            if payroll_values_calibration is not None:
-                for idx, target_value in calibration_blueprint[
-                    "payroll_overrides"
-                ].items():
-                    payroll_values_calibration[idx] = target_value
             blueprint_summary = calibration_blueprint["summary"]
             if year in display_years:
                 print(
@@ -1073,6 +1213,7 @@ for year_idx in range(n_years):
         oasdi_tob_target=oasdi_tob_target if USE_TOB else None,
         hi_tob_values=hi_tob_values if USE_TOB else None,
         hi_tob_target=hi_tob_target if USE_TOB else None,
+        extra_constraints=income_guard_calibration_constraints,
         n_ages=X_current.shape[1],
         max_iters=100,
         tol=1e-6,
@@ -1102,7 +1243,97 @@ for year_idx in range(n_years):
         oasdi_tob_target=oasdi_tob_target if USE_TOB else None,
         hi_tob_values=hi_tob_values if USE_TOB else None,
         hi_tob_target=hi_tob_target if USE_TOB else None,
+        extra_constraints=income_guard_calibration_constraints,
     )
+    calibration_audit["constraint_provenance"] = {
+        "age_targets": {
+            "classification": "hard",
+            "source": TARGET_SOURCE,
+            "scoring_contract": "population calibration target",
+        },
+        "ss_total": {
+            "classification": "hard" if USE_SS else "unused",
+            "source": "policyengine_formula_on_scored_h5",
+            "scoring_contract": "same formula path used by production scoring",
+        },
+        "payroll_total": {
+            "classification": "hard" if USE_PAYROLL else "unused",
+            "source": "policyengine_formula_on_scored_h5",
+            "scoring_contract": "same formula path used by production scoring",
+        },
+        "oasdi_tob": {
+            "classification": "hard" if USE_TOB else "benchmark",
+            "source": "policyengine_formula_on_scored_h5",
+            "scoring_contract": "same formula path used by production scoring",
+        },
+        "hi_tob": {
+            "classification": "hard" if USE_TOB else "benchmark",
+            "source": "policyengine_formula_on_scored_h5",
+            "scoring_contract": "same formula path used by production scoring",
+        },
+        **_income_guard_provenance(
+            hard_constraints=income_guard_calibration_constraints,
+            audit_only_constraints=income_guard_audit_only_constraints,
+        ),
+    }
+    if income_guard_audit_only_constraints:
+        calibration_audit["audit_only_constraints"] = _constraint_audit(
+            income_guard_audit_only_constraints,
+            w_new,
+        )
+    target_support_specs = [
+        ("ss_total", ss_values_actual if USE_SS else None),
+        ("payroll_total", payroll_values_actual if USE_PAYROLL else None),
+        ("oasdi_tob", oasdi_tob_values if USE_TOB else None),
+        ("hi_tob", hi_tob_values if USE_TOB else None),
+    ]
+    for target_prefix, target_values in target_support_specs:
+        if target_values is None:
+            continue
+        calibration_audit.update(
+            build_target_contribution_support_audit(
+                weights=w_new,
+                values=target_values,
+                prefix=target_prefix,
+            )
+        )
+    if current_support_augmentation_report is not None:
+        clone_household_reports = current_support_augmentation_report.get(
+            "clone_household_reports", []
+        )
+        donor_family_audit = build_group_weight_concentration_audit(
+            weights=w_new,
+            group_ids=_donor_family_ids(
+                household_ids_hh,
+                current_support_augmentation_report,
+            ),
+            prefix="donor_family",
+        )
+        calibration_audit.update(donor_family_audit)
+        clone_donor_family_audit = build_clone_donor_family_weight_concentration_audit(
+            weights=w_new,
+            household_ids=household_ids_hh,
+            clone_household_reports=clone_household_reports,
+        )
+        calibration_audit.update(clone_donor_family_audit)
+        calibration_audit.update(
+            build_clone_donor_component_weight_concentration_audit(
+                weights=w_new,
+                household_ids=household_ids_hh,
+                clone_household_reports=clone_household_reports,
+                donor_key="older_donor_tax_unit_id",
+                prefix="clone_older_donor",
+            )
+        )
+        calibration_audit.update(
+            build_clone_donor_component_weight_concentration_audit(
+                weights=w_new,
+                household_ids=household_ids_hh,
+                clone_household_reports=clone_household_reports,
+                donor_key="worker_donor_tax_unit_id",
+                prefix="clone_worker_donor",
+            )
+        )
     if blueprint_summary is not None:
         calibration_audit["support_blueprint"] = blueprint_summary
     if BENCHMARK_TOB and oasdi_tob_values is not None and hi_tob_values is not None:

--- a/policyengine_us_data/datasets/cps/long_term/tax_assumptions.py
+++ b/policyengine_us_data/datasets/cps/long_term/tax_assumptions.py
@@ -22,6 +22,16 @@ TRUSTEES_CORE_THRESHOLD_ASSUMPTION = {
     ],
 }
 
+try:
+    from policyengine_us.reforms.ssa.trustees_core_thresholds import (
+        TRUSTEES_CORE_THRESHOLD_ASSUMPTION as _PE_TRUSTEES_CORE_THRESHOLD_ASSUMPTION,
+        create_trustees_core_thresholds_reform as _pe_create_trustees_core_thresholds_reform,
+    )
+except ImportError:
+    _pe_create_trustees_core_thresholds_reform = None
+else:
+    TRUSTEES_CORE_THRESHOLD_ASSUMPTION = dict(_PE_TRUSTEES_CORE_THRESHOLD_ASSUMPTION)
+
 
 def round_amount(amount: float, rounding: dict | None) -> float:
     if not rounding:
@@ -96,6 +106,12 @@ def create_wage_indexed_core_thresholds_reform(
     start_year: int = 2035,
     end_year: int = 2100,
 ):
+    if _pe_create_trustees_core_thresholds_reform is not None:
+        return _pe_create_trustees_core_thresholds_reform(
+            start_year=start_year,
+            end_year=end_year,
+        )
+
     from policyengine_us.model_api import Reform
 
     def modify_parameters(parameters):

--- a/tests/unit/test_long_term_calibration_contract.py
+++ b/tests/unit/test_long_term_calibration_contract.py
@@ -953,6 +953,41 @@ def test_entropy_calibration_uses_lp_exact_fallback_even_before_approximate_wind
     assert audit["approximation_method"] == "lp_minimax_exact"
 
 
+def test_entropy_calibration_rejects_large_constraint_error_without_exception(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        calibration_module,
+        "calibrate_entropy",
+        lambda *args, **kwargs: (np.array([1.0, 1.0]), 3),
+    )
+    monkeypatch.setattr(
+        calibration_module,
+        "calibrate_lp_minimax",
+        lambda *args, **kwargs: (
+            np.array([10.0, 2.0]),
+            1,
+            {"best_case_max_pct_error": 0.0},
+        ),
+    )
+
+    weights, _, audit = calibrate_weights(
+        X=np.array([[1.0], [0.0]]),
+        y_target=np.array([1.0]),
+        baseline_weights=np.array([1.0, 1.0]),
+        method="entropy",
+        payroll_values=np.array([1.0, 0.0]),
+        payroll_target=10.0,
+        n_ages=1,
+        allow_approximate_entropy=False,
+    )
+
+    np.testing.assert_allclose(weights, np.array([10.0, 2.0]))
+    assert audit["lp_fallback_used"] is True
+    assert audit["approximation_method"] == "lp_minimax_exact"
+    assert "above allowable" in audit["entropy_error"]
+
+
 def test_nonnegative_feasibility_diagnostic_distinguishes_feasible_and_infeasible():
     feasible_A = np.array(
         [


### PR DESCRIPTION
## Summary
- use the native PE-US Trustees core-threshold reform when available so the long-run tax assumption also carries NAWI/SOI income uprating metadata
- reject entropy calibration results that numerically return but miss hard constraints, falling back to the existing LP/bounded fallback path
- calibrate late-year donor-composite runs against realized SS/payroll rows, add income guard constraints/support concentration diagnostics, and keep role-composite support broad with a bounded support solve

## Validation
- uv run ruff check policyengine_us_data/datasets/cps/long_term/calibration.py policyengine_us_data/datasets/cps/long_term/prototype_synthetic_2100_support.py policyengine_us_data/datasets/cps/long_term/run_household_projection.py policyengine_us_data/datasets/cps/long_term/tax_assumptions.py tests/unit/test_long_term_calibration_contract.py
- uv run ruff format --check policyengine_us_data/datasets/cps/long_term/calibration.py policyengine_us_data/datasets/cps/long_term/prototype_synthetic_2100_support.py policyengine_us_data/datasets/cps/long_term/run_household_projection.py policyengine_us_data/datasets/cps/long_term/tax_assumptions.py tests/unit/test_long_term_calibration_contract.py
- uv run pytest tests/unit/test_long_term_calibration_contract.py -q
- Local 2075 rebuild produced exact calibration: max constraint error 0.00009%, 340 clone households, validation_passed=true

Depends on PolicyEngine/policyengine-us#8220 for the native Trustees income-uprating reform; the fallback path still works without it.