### PR TITLE
Port CPS tax-unit construction to ACS PUMS

### DIFF
--- a/changelog.d/888.added.md
+++ b/changelog.d/888.added.md
@@ -1,0 +1,1 @@
+Port CPS tax-unit construction to ACS PUMS so ACS datasets split unrelated household members into separate tax units.

--- a/policyengine_us_data/datasets/acs/acs.py
+++ b/policyengine_us_data/datasets/acs/acs.py
@@ -1,6 +1,9 @@
 from policyengine_core.data import Dataset
 import h5py
 from policyengine_us_data.datasets.acs.census_acs import CensusACS_2022
+from policyengine_us_data.datasets.acs.tax_unit_construction import (
+    construct_tax_units_acs,
+)
 from policyengine_us_data.storage import STORAGE_FOLDER
 from pandas import DataFrame
 import numpy as np
@@ -19,7 +22,7 @@ class ACS(Dataset):
         acs = h5py.File(self.file_path, mode="w")
         person, household = [raw_data[entity] for entity in ("person", "household")]
 
-        self.add_id_variables(acs, person, household)
+        self.add_id_variables(acs, person, household, self.time_period)
         self.add_person_variables(acs, person, household)
         self.add_household_variables(acs, household)
 
@@ -31,6 +34,7 @@ class ACS(Dataset):
         acs: h5py.File,
         person: DataFrame,
         household: DataFrame,
+        year: int,
     ) -> None:
         # Create numeric IDs based on SERIALNO
         h_id_to_number = pd.Series(
@@ -38,19 +42,23 @@ class ACS(Dataset):
         )
         household["household_id"] = h_id_to_number[household["SERIALNO"]].values
         person["household_id"] = h_id_to_number[person["SERIALNO"]].values
-        person["person_id"] = person.index + 1
+        person["person_id"] = np.arange(len(person)) + 1
+        person_tax_unit, tax_unit = construct_tax_units_acs(person, year)
 
         acs["person_id"] = person["person_id"]
         acs["household_id"] = household["household_id"]
         acs["spm_unit_id"] = acs["household_id"]
-        acs["tax_unit_id"] = acs["household_id"]
+        acs["tax_unit_id"] = tax_unit["TAX_ID"].values
         acs["family_id"] = acs["household_id"]
         acs["marital_unit_id"] = acs["household_id"]
         acs["person_household_id"] = person["household_id"]
         acs["person_spm_unit_id"] = person["household_id"]
-        acs["person_tax_unit_id"] = person["household_id"]
+        acs["person_tax_unit_id"] = person_tax_unit["TAX_ID"].values
         acs["person_family_id"] = person["household_id"]
         acs["person_marital_unit_id"] = person["household_id"]
+        acs["is_related_to_head_or_spouse"] = person_tax_unit[
+            "is_related_to_head_or_spouse"
+        ].values
         acs["household_weight"] = household.WGTP
 
     @staticmethod

--- a/policyengine_us_data/datasets/acs/acs_to_cps_columns.py
+++ b/policyengine_us_data/datasets/acs/acs_to_cps_columns.py
@@ -1,0 +1,485 @@
+"""
+Map ACS PUMS person records onto the CPS-like columns consumed by
+``policyengine_us_data.datasets.cps.tax_unit_construction``.
+
+Column contract:
+
+ACS ``household_id`` or dense ``SERIALNO`` -> CPS ``PH_SEQ``
+ACS ``SPORDER`` -> CPS ``A_LINENO``
+ACS ``AGEP`` -> CPS ``A_AGE``
+ACS ``MAR`` -> CPS ``A_MARITL`` using CPS-like codes:
+    1 married spouse present, 3 married spouse absent, 4 widowed,
+    5 divorced, 6 separated, 7 never married or under age 15
+ACS ``RELSHIPP`` (2019+) or ``RELP`` (pre-2019) -> CPS ``A_EXPRRP``
+ACS ``WAGP`` -> CPS ``WSAL_VAL``
+ACS ``SEMP`` -> CPS ``SEMP_VAL``
+ACS ``INTP`` -> CPS ``INT_VAL``
+ACS ``OIP`` plus ``PAP`` -> CPS ``OI_VAL``
+ACS ``RETP`` -> CPS ``PNSN_VAL``
+ACS ``SSP`` plus ``SSIP`` -> CPS ``SS_VAL``
+ACS ``PINCP`` -> CPS ``PTOTVAL``
+ACS ``DDRS``, ``DEAR``, ``DEYE``, ``DOUT``, ``DPHY``, ``DREM`` -> CPS
+    ``PEDISDRS``, ``PEDISEAR``, ``PEDISEYE``, ``PEDISOUT``,
+    ``PEDISPHY``, ``PEDISREM``
+ACS ``SCH`` and ``SCHG`` -> CPS ``A_ENRLW``, ``A_FTPT``, ``A_HSCOL``
+
+ACS does not provide universal spouse or parent pointers. This module links
+the reference person's spouse directly from RELSHIPP/RELP, pairs common
+non-reference in-law spouse patterns by age and marital status, and assigns
+parent pointers for own children, foster children, and grandchildren when the
+relationship-to-reference-person evidence supports it. The derived boolean
+``acs_spouse_link_imputed`` and ``acs_parent_link_imputed`` columns identify
+links that are heuristic rather than direct ACS relationship codes.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+ACS_REFERENCE_CODES = {20}
+ACS_SPOUSE_CODES = {21, 23}
+ACS_UNMARRIED_PARTNER_CODES = {22, 24}
+ACS_CHILD_OF_REFERENCE_CODES = {25, 26, 27}
+ACS_SIBLING_CODES = {28}
+ACS_PARENT_CODES = {29}
+ACS_GRANDCHILD_CODES = {30}
+ACS_PARENT_IN_LAW_CODES = {31}
+ACS_CHILD_IN_LAW_CODES = {32}
+ACS_OTHER_RELATIVE_CODES = {33}
+ACS_ROOMMATE_CODES = {34}
+ACS_FOSTER_CHILD_CODES = {35}
+ACS_OTHER_NONRELATIVE_CODES = {36, 37, 38}
+
+OLD_REFERENCE_CODES = {0}
+OLD_SPOUSE_CODES = {1}
+OLD_CHILD_OF_REFERENCE_CODES = {2, 3, 4}
+OLD_SIBLING_CODES = {5}
+OLD_PARENT_CODES = {6}
+OLD_GRANDCHILD_CODES = {7}
+OLD_PARENT_IN_LAW_CODES = {8}
+OLD_CHILD_IN_LAW_CODES = {9}
+OLD_OTHER_RELATIVE_CODES = {10}
+OLD_ROOMMATE_CODES = {11, 12}
+OLD_UNMARRIED_PARTNER_CODES = {13}
+OLD_FOSTER_CHILD_CODES = {14}
+OLD_OTHER_NONRELATIVE_CODES = {15, 16, 17}
+
+REQUIRED_ACS_TAX_UNIT_COLUMNS = {
+    "SPORDER",
+    "AGEP",
+    "MAR",
+    "SEX",
+    "WAGP",
+    "SEMP",
+    "INTP",
+    "RETP",
+    "OIP",
+    "PAP",
+    "SSP",
+    "SSIP",
+    "PINCP",
+    "SCH",
+    "SCHG",
+    "DDRS",
+    "DEAR",
+    "DEYE",
+    "DOUT",
+    "DPHY",
+    "DREM",
+}
+
+
+def acs_person_to_cps_tax_unit_columns(person: pd.DataFrame) -> pd.DataFrame:
+    _validate_required_columns(person)
+    original_index = person.index
+    person = person.reset_index(drop=True)
+    cps = pd.DataFrame(index=person.index)
+    rel, relationship_system = _relationship_codes(person)
+    household_id = _household_id(person)
+    line_no = _numeric(person, "SPORDER").astype(int)
+    age = _numeric(person, "AGEP").astype(int)
+
+    spouse_line, spouse_link_imputed = _infer_spouse_lines(
+        person=person,
+        rel=rel,
+        relationship_system=relationship_system,
+        household_id=household_id,
+        line_no=line_no,
+        age=age,
+    )
+    parent1, parent2, parent_link_imputed = _infer_parent_lines(
+        person=person,
+        rel=rel,
+        relationship_system=relationship_system,
+        household_id=household_id,
+        line_no=line_no,
+        age=age,
+        spouse_line=spouse_line,
+    )
+
+    cps["PH_SEQ"] = household_id.astype(int)
+    cps["A_LINENO"] = line_no.astype(int)
+    cps["A_AGE"] = age.astype(int)
+    cps["A_SPOUSE"] = spouse_line.astype(int)
+    cps["PEPAR1"] = parent1.astype(int)
+    cps["PEPAR2"] = parent2.astype(int)
+    cps["A_MARITL"] = _map_marital_status(person, spouse_line).astype(int)
+    cps["A_EXPRRP"] = _map_relationship_to_cps(rel, relationship_system, person)
+
+    cps["WSAL_VAL"] = _numeric(person, "WAGP")
+    cps["SEMP_VAL"] = _numeric(person, "SEMP")
+    cps["FRSE_VAL"] = 0.0
+    cps["INT_VAL"] = _numeric(person, "INTP")
+    cps["DIV_VAL"] = 0.0
+    cps["RNT_VAL"] = 0.0
+    cps["CAP_VAL"] = 0.0
+    cps["UC_VAL"] = 0.0
+    cps["OI_VAL"] = _numeric(person, "OIP") + _numeric(person, "PAP")
+    cps["ANN_VAL"] = 0.0
+    cps["PNSN_VAL"] = _numeric(person, "RETP")
+    cps["SS_VAL"] = _numeric(person, "SSP") + _numeric(person, "SSIP")
+    cps["PTOTVAL"] = _numeric(person, "PINCP")
+
+    disability_map = {
+        "DDRS": "PEDISDRS",
+        "DEAR": "PEDISEAR",
+        "DEYE": "PEDISEYE",
+        "DOUT": "PEDISOUT",
+        "DPHY": "PEDISPHY",
+        "DREM": "PEDISREM",
+    }
+    for acs_column, cps_column in disability_map.items():
+        cps[cps_column] = (_numeric(person, acs_column) == 1).astype(int)
+
+    school = _numeric(person, "SCH").astype(int)
+    grade = _numeric(person, "SCHG").astype(int)
+    enrolled = school.isin([2, 3])
+    cps["A_ENRLW"] = enrolled.astype(int)
+    cps["A_FTPT"] = enrolled.astype(int)
+    cps["A_HSCOL"] = np.select(
+        [grade.between(1, 14), grade.between(15, 16)],
+        [1, 2],
+        default=0,
+    ).astype(int)
+
+    cps["acs_spouse_link_imputed"] = spouse_link_imputed.astype(bool)
+    cps["acs_parent_link_imputed"] = parent_link_imputed.astype(bool)
+    cps.index = original_index
+    return cps
+
+
+def _validate_required_columns(person: pd.DataFrame) -> None:
+    missing = sorted(REQUIRED_ACS_TAX_UNIT_COLUMNS.difference(person.columns))
+    if "household_id" not in person.columns and "SERIALNO" not in person.columns:
+        missing.append("household_id or SERIALNO")
+    if "RELSHIPP" not in person.columns and "RELP" not in person.columns:
+        missing.append("RELSHIPP or RELP")
+    if missing:
+        raise KeyError(
+            "Missing required ACS columns for tax-unit construction: "
+            + ", ".join(missing)
+            + ". Regenerate the raw Census ACS dataset if this came from a "
+            "cached census_acs file."
+        )
+
+
+def _numeric(person: pd.DataFrame, column: str, default=0) -> pd.Series:
+    if column not in person.columns:
+        return pd.Series(default, index=person.index)
+    return pd.to_numeric(person[column], errors="coerce").fillna(default)
+
+
+def _household_id(person: pd.DataFrame) -> pd.Series:
+    if "household_id" in person.columns:
+        return _numeric(person, "household_id").astype(int)
+    codes, _ = pd.factorize(person["SERIALNO"], sort=False)
+    return pd.Series(codes + 1, index=person.index)
+
+
+def _relationship_codes(person: pd.DataFrame) -> tuple[pd.Series, str]:
+    if "RELSHIPP" in person.columns:
+        rel = _numeric(person, "RELSHIPP", default=-1).astype(int)
+        if (rel > 0).any():
+            return rel, "RELSHIPP"
+    if "RELP" in person.columns:
+        rel = _numeric(person, "RELP", default=-1).astype(int)
+        if (rel >= 0).any():
+            return rel, "RELP"
+
+    raise ValueError(
+        "ACS relationship columns contain no valid RELSHIPP or RELP codes."
+    )
+
+
+def _codes_for(system: str, relshipp_codes: set[int], relp_codes: set[int]) -> set[int]:
+    return relshipp_codes if system == "RELSHIPP" else relp_codes
+
+
+def _reference_codes(system: str) -> set[int]:
+    return _codes_for(system, ACS_REFERENCE_CODES, OLD_REFERENCE_CODES)
+
+
+def _spouse_codes(system: str) -> set[int]:
+    return _codes_for(system, ACS_SPOUSE_CODES, OLD_SPOUSE_CODES)
+
+
+def _child_codes(system: str) -> set[int]:
+    return _codes_for(
+        system, ACS_CHILD_OF_REFERENCE_CODES, OLD_CHILD_OF_REFERENCE_CODES
+    )
+
+
+def _foster_child_codes(system: str) -> set[int]:
+    return _codes_for(system, ACS_FOSTER_CHILD_CODES, OLD_FOSTER_CHILD_CODES)
+
+
+def _grandchild_codes(system: str) -> set[int]:
+    return _codes_for(system, ACS_GRANDCHILD_CODES, OLD_GRANDCHILD_CODES)
+
+
+def _child_in_law_codes(system: str) -> set[int]:
+    return _codes_for(system, ACS_CHILD_IN_LAW_CODES, OLD_CHILD_IN_LAW_CODES)
+
+
+def _parent_codes(system: str) -> set[int]:
+    return _codes_for(system, ACS_PARENT_CODES, OLD_PARENT_CODES)
+
+
+def _parent_in_law_codes(system: str) -> set[int]:
+    return _codes_for(system, ACS_PARENT_IN_LAW_CODES, OLD_PARENT_IN_LAW_CODES)
+
+
+def _map_marital_status(person: pd.DataFrame, spouse_line: pd.Series) -> pd.Series:
+    mar = _numeric(person, "MAR").astype(int)
+    result = pd.Series(7, index=person.index)
+    result[mar == 2] = 4
+    result[mar == 3] = 5
+    result[mar == 4] = 6
+    result[(mar == 1) & (spouse_line > 0)] = 1
+    result[(mar == 1) & (spouse_line <= 0)] = 3
+    return result
+
+
+def _map_relationship_to_cps(
+    rel: pd.Series,
+    system: str,
+    person: pd.DataFrame,
+) -> pd.Series:
+    result = pd.Series(14, index=rel.index, dtype=int)
+    household_size = rel.groupby(_household_id(person)).transform("size")
+    result[rel.isin(_reference_codes(system))] = np.where(
+        household_size[rel.isin(_reference_codes(system))] > 1,
+        1,
+        2,
+    )
+    spouse_mask = rel.isin(_spouse_codes(system))
+    sex = _numeric(person, "SEX").astype(int)
+    result[spouse_mask] = np.where(sex[spouse_mask] == 1, 3, 4)
+    result[rel.isin(_child_codes(system))] = 5
+    result[rel.isin(_foster_child_codes(system))] = 11
+    result[rel.isin(_grandchild_codes(system))] = 7
+    result[rel.isin(_codes_for(system, ACS_SIBLING_CODES, OLD_SIBLING_CODES))] = 9
+    result[rel.isin(_parent_codes(system))] = 8
+    result[
+        rel.isin(
+            _codes_for(
+                system,
+                ACS_PARENT_IN_LAW_CODES
+                | ACS_CHILD_IN_LAW_CODES
+                | ACS_OTHER_RELATIVE_CODES,
+                OLD_PARENT_IN_LAW_CODES
+                | OLD_CHILD_IN_LAW_CODES
+                | OLD_OTHER_RELATIVE_CODES,
+            )
+        )
+    ] = 10
+    result[
+        rel.isin(
+            _codes_for(
+                system,
+                ACS_UNMARRIED_PARTNER_CODES | ACS_ROOMMATE_CODES,
+                OLD_UNMARRIED_PARTNER_CODES | OLD_ROOMMATE_CODES,
+            )
+        )
+    ] = 13
+    result[
+        rel.isin(
+            _codes_for(
+                system,
+                ACS_OTHER_NONRELATIVE_CODES,
+                OLD_OTHER_NONRELATIVE_CODES,
+            )
+        )
+    ] = 14
+    return result
+
+
+def _infer_spouse_lines(
+    person: pd.DataFrame,
+    rel: pd.Series,
+    relationship_system: str,
+    household_id: pd.Series,
+    line_no: pd.Series,
+    age: pd.Series,
+) -> tuple[pd.Series, pd.Series]:
+    spouse_line = pd.Series(0, index=person.index, dtype=int)
+    imputed = pd.Series(False, index=person.index, dtype=bool)
+    mar = _numeric(person, "MAR").astype(int)
+
+    frame = pd.DataFrame(
+        {
+            "household_id": household_id,
+            "line_no": line_no,
+            "age": age,
+            "rel": rel,
+            "mar": mar,
+            "sex": _numeric(person, "SEX").astype(int),
+        },
+        index=person.index,
+    )
+
+    for _, household in frame.groupby("household_id", sort=False):
+        reference = household[
+            household["rel"].isin(_reference_codes(relationship_system))
+        ]
+        if reference.empty:
+            reference = household[household["line_no"] == household["line_no"].min()]
+        reference_index = reference.index[0]
+        reference_line = int(frame.loc[reference_index, "line_no"])
+
+        direct_spouses = household[
+            household["rel"].isin(_spouse_codes(relationship_system))
+            & (household["mar"] == 1)
+        ]
+        if not direct_spouses.empty and frame.loc[reference_index, "mar"] == 1:
+            spouse_index = direct_spouses.sort_values("line_no").index[0]
+            spouse_line.loc[reference_index] = int(frame.loc[spouse_index, "line_no"])
+            spouse_line.loc[spouse_index] = reference_line
+
+        unlinked = household[
+            (household["mar"] == 1)
+            & (household["age"] >= 18)
+            & (spouse_line.loc[household.index] <= 0)
+        ].copy()
+        remaining = set(unlinked.index)
+        for index in sorted(remaining, key=lambda item: frame.loc[item, "line_no"]):
+            if index not in remaining:
+                continue
+            candidate_indexes = [
+                candidate for candidate in remaining if candidate != index
+            ]
+            scored_candidates = []
+            for candidate in candidate_indexes:
+                score = _spouse_pair_score(
+                    frame.loc[index],
+                    frame.loc[candidate],
+                    relationship_system,
+                )
+                if score is not None:
+                    scored_candidates.append((score, candidate))
+            if not scored_candidates:
+                continue
+            _, spouse_index = max(scored_candidates)
+            spouse_line.loc[index] = int(frame.loc[spouse_index, "line_no"])
+            spouse_line.loc[spouse_index] = int(frame.loc[index, "line_no"])
+            imputed.loc[[index, spouse_index]] = True
+            remaining.discard(index)
+            remaining.discard(spouse_index)
+
+    return spouse_line, imputed
+
+
+def _spouse_pair_score(
+    person_a: pd.Series,
+    person_b: pd.Series,
+    relationship_system: str,
+) -> tuple[int, int, int] | None:
+    rel_a = int(person_a["rel"])
+    rel_b = int(person_b["rel"])
+    age_gap = abs(int(person_a["age"]) - int(person_b["age"]))
+    if age_gap > 20:
+        return None
+
+    child_codes = _child_codes(relationship_system)
+    child_in_law_codes = _child_in_law_codes(relationship_system)
+    parent_codes = _parent_codes(relationship_system)
+    parent_in_law_codes = _parent_in_law_codes(relationship_system)
+    pair = {rel_a, rel_b}
+    if pair & child_codes and pair & child_in_law_codes:
+        return (100, -age_gap, -min(int(person_a["line_no"]), int(person_b["line_no"])))
+    if pair & parent_codes and pair & parent_in_law_codes:
+        return (90, -age_gap, -min(int(person_a["line_no"]), int(person_b["line_no"])))
+    return None
+
+
+def _infer_parent_lines(
+    person: pd.DataFrame,
+    rel: pd.Series,
+    relationship_system: str,
+    household_id: pd.Series,
+    line_no: pd.Series,
+    age: pd.Series,
+    spouse_line: pd.Series,
+) -> tuple[pd.Series, pd.Series, pd.Series]:
+    parent1 = pd.Series(0, index=person.index, dtype=int)
+    parent2 = pd.Series(0, index=person.index, dtype=int)
+    imputed = pd.Series(False, index=person.index, dtype=bool)
+    frame = pd.DataFrame(
+        {
+            "household_id": household_id,
+            "line_no": line_no,
+            "age": age,
+            "rel": rel,
+            "spouse_line": spouse_line,
+        },
+        index=person.index,
+    )
+
+    for _, household in frame.groupby("household_id", sort=False):
+        reference = household[
+            household["rel"].isin(_reference_codes(relationship_system))
+        ]
+        if reference.empty:
+            reference = household[household["line_no"] == household["line_no"].min()]
+        reference_index = reference.index[0]
+        reference_line = int(frame.loc[reference_index, "line_no"])
+        reference_spouse_line = int(frame.loc[reference_index, "spouse_line"])
+
+        own_child_mask = household["rel"].isin(
+            _child_codes(relationship_system) | _foster_child_codes(relationship_system)
+        )
+        for index in household[own_child_mask].index:
+            parent1.loc[index] = reference_line
+            if reference_spouse_line > 0:
+                parent2.loc[index] = reference_spouse_line
+
+        grandchild_indexes = household[
+            household["rel"].isin(_grandchild_codes(relationship_system))
+        ].index
+        parent_candidates = household[
+            household["rel"].isin(
+                _child_codes(relationship_system)
+                | _child_in_law_codes(relationship_system)
+            )
+        ]
+        for index in grandchild_indexes:
+            possible = parent_candidates[
+                (parent_candidates["age"] - frame.loc[index, "age"]).between(15, 55)
+            ].copy()
+            if possible.empty:
+                continue
+            possible["score"] = -(possible["age"] - frame.loc[index, "age"] - 30).abs()
+            selected_index = possible.sort_values(
+                ["score", "age", "line_no"],
+                ascending=[False, False, True],
+            ).index[0]
+            selected_line = int(frame.loc[selected_index, "line_no"])
+            parent1.loc[index] = selected_line
+            selected_spouse_line = int(frame.loc[selected_index, "spouse_line"])
+            if selected_spouse_line > 0:
+                parent2.loc[index] = selected_spouse_line
+            imputed.loc[index] = True
+
+    return parent1, parent2, imputed

--- a/policyengine_us_data/datasets/acs/census_acs.py
+++ b/policyengine_us_data/datasets/acs/census_acs.py
@@ -17,11 +17,15 @@ PERSON_COLUMNS = [
     "AGEP",  # Age
     "CIT",  # Citizenship
     "MAR",  # Marital status
+    "RELSHIPP",  # Relationship to reference person
     "WAGP",  # Wage/salary
+    "INTP",  # Interest income
     "SSP",  # Social security income
     "SSIP",  # Supplemental security income
     "SEX",  # Sex
     "SEMP",  # Self-employment income
+    "SCH",  # School enrollment
+    "SCHG",  # Grade attending
     "SCHL",  # Educational attainment
     "RETP",  # Retirement income
     "PAP",  # Public assistance income
@@ -30,6 +34,12 @@ PERSON_COLUMNS = [
     "PINCP",  # Total income
     "POVPIP",  # Income-to-poverty line percentage
     "RAC1P",  # Race
+    "DDRS",  # Self-care difficulty
+    "DEAR",  # Hearing difficulty
+    "DEYE",  # Vision difficulty
+    "DOUT",  # Independent living difficulty
+    "DPHY",  # Ambulatory difficulty
+    "DREM",  # Cognitive difficulty
 ]
 
 HOUSEHOLD_COLUMNS = [
@@ -58,7 +68,6 @@ class CensusACS(Dataset):
     data_format = Dataset.TABLES
 
     def generate(self) -> None:
-        spm_url = f"https://www2.census.gov/programs-surveys/supplemental-poverty-measure/datasets/spm/spm_{self.time_period}_pu.dta"
         person_url = f"https://www2.census.gov/programs-surveys/acs/data/pums/{self.time_period}/1-Year/csv_pus.zip"
         household_url = f"https://www2.census.gov/programs-surveys/acs/data/pums/{self.time_period}/1-Year/csv_hus.zip"
 

--- a/policyengine_us_data/datasets/acs/tax_unit_construction.py
+++ b/policyengine_us_data/datasets/acs/tax_unit_construction.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from policyengine_us_data.datasets.acs.acs_to_cps_columns import (
+    acs_person_to_cps_tax_unit_columns,
+)
+from policyengine_us_data.datasets.cps.tax_unit_construction import (
+    POLICYENGINE_MODE,
+    construct_tax_units,
+)
+
+
+def construct_tax_units_acs(
+    person: pd.DataFrame,
+    year: int,
+    mode: str = POLICYENGINE_MODE,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    cps_like_person = acs_person_to_cps_tax_unit_columns(person)
+    assignments, tax_unit = construct_tax_units(
+        cps_like_person,
+        year=year,
+        mode=mode,
+    )
+    for column in ("acs_spouse_link_imputed", "acs_parent_link_imputed"):
+        assignments[column] = cps_like_person[column].values
+    return assignments, tax_unit

--- a/policyengine_us_data/datasets/cps/tax_unit_construction.py
+++ b/policyengine_us_data/datasets/cps/tax_unit_construction.py
@@ -787,13 +787,15 @@ def construct_tax_units(
             + ", ".join(sorted(SUPPORTED_TAX_UNIT_CONSTRUCTION_MODES))
         )
 
-    person_assignments = pd.DataFrame(index=person.index)
+    original_index = person.index
+    person = person.reset_index(drop=True)
+    person_assignments = pd.DataFrame(index=original_index)
     unit_key_records: list[tuple] = []
     unit_filing_records: list[str] = []
 
-    household_unit_keys: list[tuple] = []
-    household_roles: list[str] = []
-    household_related_flags: list[bool] = []
+    household_unit_key_by_row: dict[Any, tuple] = {}
+    household_role_by_row: dict[Any, str] = {}
+    household_related_flag_by_row: dict[Any, bool] = {}
 
     assignment_fn = (
         _determine_final_assignments_for_household_policyengine
@@ -812,25 +814,35 @@ def construct_tax_units(
 
         for row_index in household.index:
             unit_key = (int(household_id),) + tuple(unit_key_by_person[row_index])
-            household_unit_keys.append(unit_key)
-            household_roles.append(roles_by_person[row_index])
-            household_related_flags.append(related_to_head_or_spouse[row_index])
+            household_unit_key_by_row[row_index] = unit_key
+            household_role_by_row[row_index] = roles_by_person[row_index]
+            household_related_flag_by_row[row_index] = related_to_head_or_spouse[
+                row_index
+            ]
 
         for unit_key, filing_status in filing_status_by_unit.items():
             unit_key_records.append((int(household_id),) + tuple(unit_key))
             unit_filing_records.append(filing_status)
 
+    ordered_household_unit_keys = [
+        household_unit_key_by_row[row_index] for row_index in person.index
+    ]
     dense_unit_ids = {
         unit_key: unit_id
-        for unit_id, unit_key in enumerate(dict.fromkeys(household_unit_keys), start=1)
+        for unit_id, unit_key in enumerate(
+            dict.fromkeys(ordered_household_unit_keys),
+            start=1,
+        )
     }
     person_assignments["TAX_ID"] = np.array(
-        [dense_unit_ids[unit_key] for unit_key in household_unit_keys],
+        [dense_unit_ids[unit_key] for unit_key in ordered_household_unit_keys],
         dtype=np.int64,
     )
-    person_assignments["tax_unit_role_input"] = np.array(household_roles).astype("S")
+    person_assignments["tax_unit_role_input"] = np.array(
+        [household_role_by_row[row_index] for row_index in person.index]
+    ).astype("S")
     person_assignments["is_related_to_head_or_spouse"] = np.array(
-        household_related_flags,
+        [household_related_flag_by_row[row_index] for row_index in person.index],
         dtype=bool,
     )
 

--- a/tests/unit/datasets/test_acs_tax_unit_construction.py
+++ b/tests/unit/datasets/test_acs_tax_unit_construction.py
@@ -1,0 +1,237 @@
+import h5py
+import numpy as np
+import pandas as pd
+import pytest
+
+from policyengine_us_data.datasets.acs.acs import ACS
+from policyengine_us_data.datasets.acs.acs_to_cps_columns import (
+    acs_person_to_cps_tax_unit_columns,
+)
+from policyengine_us_data.datasets.acs.tax_unit_construction import (
+    construct_tax_units_acs,
+)
+
+
+def _acs_person_fixture(**overrides):
+    n = max((len(value) for value in overrides.values()), default=1)
+    defaults = {
+        "SERIALNO": np.repeat("1", n),
+        "SPORDER": np.arange(1, n + 1, dtype=int),
+        "household_id": np.ones(n, dtype=int),
+        "AGEP": np.zeros(n, dtype=int),
+        "MAR": np.full(n, 5, dtype=int),
+        "RELSHIPP": np.full(n, 36, dtype=int),
+        "SEX": np.ones(n, dtype=int),
+        "WAGP": np.zeros(n, dtype=float),
+        "SEMP": np.zeros(n, dtype=float),
+        "INTP": np.zeros(n, dtype=float),
+        "RETP": np.zeros(n, dtype=float),
+        "OIP": np.zeros(n, dtype=float),
+        "PAP": np.zeros(n, dtype=float),
+        "SSP": np.zeros(n, dtype=float),
+        "SSIP": np.zeros(n, dtype=float),
+        "PINCP": np.zeros(n, dtype=float),
+        "SCH": np.ones(n, dtype=int),
+        "SCHG": np.zeros(n, dtype=int),
+        "DDRS": np.full(n, 2, dtype=int),
+        "DEAR": np.full(n, 2, dtype=int),
+        "DEYE": np.full(n, 2, dtype=int),
+        "DOUT": np.full(n, 2, dtype=int),
+        "DPHY": np.full(n, 2, dtype=int),
+        "DREM": np.full(n, 2, dtype=int),
+    }
+    defaults.update(overrides)
+    return pd.DataFrame(defaults)
+
+
+def _decoded_roles(assignments: pd.DataFrame) -> list[str]:
+    return [value.decode() for value in assignments["tax_unit_role_input"].tolist()]
+
+
+def _decoded_statuses(tax_unit: pd.DataFrame) -> list[str]:
+    return [value.decode() for value in tax_unit["filing_status_input"].tolist()]
+
+
+def test_acs_mapper_links_reference_spouse_and_child():
+    person = _acs_person_fixture(
+        AGEP=[40, 38, 8],
+        MAR=[1, 1, 5],
+        RELSHIPP=[20, 21, 25],
+        SEX=[1, 2, 1],
+        WAGP=[60_000, 20_000, 0],
+    )
+
+    cps_like = acs_person_to_cps_tax_unit_columns(person)
+    assignments, tax_unit = construct_tax_units_acs(person, year=2022)
+
+    assert cps_like["A_SPOUSE"].tolist() == [2, 1, 0]
+    assert cps_like["PEPAR1"].tolist() == [0, 0, 1]
+    assert cps_like["PEPAR2"].tolist() == [0, 0, 2]
+    assert cps_like["A_MARITL"].tolist() == [1, 1, 7]
+    assert assignments["TAX_ID"].nunique() == 1
+    assert _decoded_roles(assignments) == ["HEAD", "SPOUSE", "DEPENDENT"]
+    assert _decoded_statuses(tax_unit) == ["JOINT"]
+
+
+def test_construct_tax_units_acs_splits_unrelated_adult_roommates():
+    person = _acs_person_fixture(
+        AGEP=[32, 29],
+        MAR=[5, 5],
+        RELSHIPP=[20, 34],
+        WAGP=[50_000, 45_000],
+    )
+
+    assignments, tax_unit = construct_tax_units_acs(person, year=2022)
+
+    assert assignments["TAX_ID"].tolist() == [1, 2]
+    assert _decoded_roles(assignments) == ["HEAD", "HEAD"]
+    assert sorted(_decoded_statuses(tax_unit)) == ["SINGLE", "SINGLE"]
+
+
+def test_construct_tax_units_acs_pairs_married_child_and_child_in_law():
+    person = _acs_person_fixture(
+        AGEP=[68, 35, 34, 5],
+        MAR=[2, 1, 1, 5],
+        RELSHIPP=[20, 25, 32, 30],
+        SEX=[2, 2, 1, 1],
+        WAGP=[20_000, 60_000, 55_000, 0],
+    )
+
+    cps_like = acs_person_to_cps_tax_unit_columns(person)
+    assignments, tax_unit = construct_tax_units_acs(person, year=2022)
+
+    assert cps_like["A_SPOUSE"].tolist() == [0, 3, 2, 0]
+    assert cps_like["acs_spouse_link_imputed"].tolist() == [
+        False,
+        True,
+        True,
+        False,
+    ]
+    assert cps_like["PEPAR1"].tolist() == [0, 1, 0, 2]
+    assert cps_like["PEPAR2"].tolist() == [0, 0, 0, 3]
+    assert cps_like["acs_parent_link_imputed"].tolist() == [
+        False,
+        False,
+        False,
+        True,
+    ]
+    assert assignments["TAX_ID"].tolist() == [1, 2, 2, 2]
+    assert _decoded_roles(assignments) == ["HEAD", "HEAD", "SPOUSE", "DEPENDENT"]
+    assert sorted(_decoded_statuses(tax_unit)) == ["JOINT", "SINGLE"]
+
+
+def test_construct_tax_units_acs_uses_three_generation_parent_inference():
+    person = _acs_person_fixture(
+        AGEP=[70, 30, 4],
+        MAR=[2, 5, 5],
+        RELSHIPP=[20, 25, 30],
+        SEX=[2, 2, 1],
+        WAGP=[35_000, 22_000, 0],
+    )
+
+    cps_like = acs_person_to_cps_tax_unit_columns(person)
+    assignments, tax_unit = construct_tax_units_acs(person, year=2022)
+
+    assert cps_like["PEPAR1"].tolist() == [0, 1, 2]
+    assert cps_like["PEPAR2"].tolist() == [0, 0, 0]
+    assert assignments["TAX_ID"].tolist() == [1, 2, 2]
+    assert _decoded_roles(assignments) == ["HEAD", "HEAD", "DEPENDENT"]
+    assert sorted(_decoded_statuses(tax_unit)) == ["HEAD_OF_HOUSEHOLD", "SINGLE"]
+
+
+def test_construct_tax_units_acs_splits_group_quarters_adults():
+    person = _acs_person_fixture(
+        AGEP=[22, 23],
+        MAR=[5, 5],
+        RELSHIPP=[37, 38],
+        WAGP=[15_000, 18_000],
+    )
+
+    assignments, tax_unit = construct_tax_units_acs(person, year=2022)
+
+    assert assignments["TAX_ID"].tolist() == [1, 2]
+    assert _decoded_roles(assignments) == ["HEAD", "HEAD"]
+    assert sorted(_decoded_statuses(tax_unit)) == ["SINGLE", "SINGLE"]
+
+
+def test_construct_tax_units_acs_handles_child_only_household():
+    person = _acs_person_fixture(
+        AGEP=[12, 10],
+        MAR=[5, 5],
+        RELSHIPP=[20, 28],
+        WAGP=[0, 0],
+    )
+
+    assignments, tax_unit = construct_tax_units_acs(person, year=2022)
+
+    assert assignments["TAX_ID"].tolist() == [1, 2]
+    assert _decoded_roles(assignments) == ["HEAD", "HEAD"]
+    assert sorted(_decoded_statuses(tax_unit)) == ["SINGLE", "SINGLE"]
+
+
+def test_acs_mapper_rejects_stale_raw_person_table_missing_tax_unit_columns():
+    person = _acs_person_fixture().drop(columns=["RELSHIPP", "INTP", "SCH", "SCHG"])
+
+    with pytest.raises(KeyError, match="Regenerate the raw Census ACS dataset"):
+        acs_person_to_cps_tax_unit_columns(person)
+
+
+def test_acs_add_id_variables_writes_tax_unit_ids():
+    person = _acs_person_fixture(
+        SERIALNO=["1", "1"],
+        household_id=[0, 0],
+        AGEP=[32, 29],
+        MAR=[5, 5],
+        RELSHIPP=[20, 34],
+        WAGP=[50_000, 45_000],
+    )
+    household = pd.DataFrame({"SERIALNO": ["1"], "WGTP": [100]})
+
+    with h5py.File("memory", mode="w", driver="core", backing_store=False) as acs:
+        ACS.add_id_variables(acs, person, household, year=2022)
+        person_tax_unit_id = acs["person_tax_unit_id"][:]
+        tax_unit_id = acs["tax_unit_id"][:]
+
+    assert person_tax_unit_id.tolist() == [1, 2]
+    assert tax_unit_id.tolist() == [1, 2]
+
+
+def test_acs_add_id_variables_handles_duplicate_person_index_labels():
+    person = _acs_person_fixture(
+        SERIALNO=["1", "2"],
+        AGEP=[32, 29],
+        MAR=[5, 5],
+        RELSHIPP=[20, 20],
+        WAGP=[50_000, 45_000],
+    )
+    person.index = [0, 0]
+    household = pd.DataFrame({"SERIALNO": ["1", "2"], "WGTP": [100, 90]})
+
+    with h5py.File("memory", mode="w", driver="core", backing_store=False) as acs:
+        ACS.add_id_variables(acs, person, household, year=2022)
+        person_id = acs["person_id"][:]
+        person_tax_unit_id = acs["person_tax_unit_id"][:]
+        tax_unit_id = acs["tax_unit_id"][:]
+
+    assert person_id.tolist() == [1, 2]
+    assert person_tax_unit_id.tolist() == [1, 2]
+    assert tax_unit_id.tolist() == [1, 2]
+
+
+def test_acs_add_id_variables_writes_related_to_head_or_spouse():
+    person = _acs_person_fixture(
+        SERIALNO=["1", "1"],
+        AGEP=[40, 12],
+        MAR=[5, 5],
+        RELSHIPP=[20, 36],
+        WAGP=[50_000, 0],
+    )
+    household = pd.DataFrame({"SERIALNO": ["1"], "WGTP": [100]})
+
+    with h5py.File("memory", mode="w", driver="core", backing_store=False) as acs:
+        ACS.add_id_variables(acs, person, household, year=2022)
+        person_tax_unit_id = acs["person_tax_unit_id"][:]
+        is_related_to_head_or_spouse = acs["is_related_to_head_or_spouse"][:]
+
+    assert person_tax_unit_id.tolist() == [1, 1]
+    assert is_related_to_head_or_spouse.tolist() == [True, False]

--- a/tests/unit/datasets/test_cps_tax_unit_construction.py
+++ b/tests/unit/datasets/test_cps_tax_unit_construction.py
@@ -206,6 +206,45 @@ def test_construct_tax_units_handles_nonconsecutive_person_index():
     assert _decoded_statuses(tax_unit) == ["HEAD_OF_HOUSEHOLD"]
 
 
+def test_construct_tax_units_handles_duplicate_person_index_labels():
+    person = _person_fixture(
+        PH_SEQ=[1, 2],
+        A_LINENO=[1, 1],
+        A_AGE=[40, 30],
+        A_EXPRRP=[1, 1],
+        WSAL_VAL=[50_000, 45_000],
+    )
+    person.index = [0, 0]
+
+    assignments, tax_unit = construct_tax_units(person, year=2024)
+
+    assert assignments.index.tolist() == [0, 0]
+    assert assignments["TAX_ID"].tolist() == [1, 2]
+    assert _decoded_roles(assignments) == ["HEAD", "HEAD"]
+    assert sorted(_decoded_statuses(tax_unit)) == ["SINGLE", "SINGLE"]
+
+
+def test_construct_tax_units_preserves_original_order_for_interleaved_households():
+    person = _person_fixture(
+        PH_SEQ=[1, 2, 1, 2],
+        A_LINENO=[1, 1, 2, 2],
+        A_AGE=[40, 32, 8, 29],
+        A_EXPRRP=[1, 1, 5, 13],
+        PEPAR1=[-1, -1, 1, -1],
+        WSAL_VAL=[50_000, 45_000, 0, 35_000],
+    )
+
+    assignments, tax_unit = construct_tax_units(person, year=2024)
+
+    assert assignments["TAX_ID"].tolist() == [1, 2, 1, 3]
+    assert _decoded_roles(assignments) == ["HEAD", "HEAD", "DEPENDENT", "HEAD"]
+    assert sorted(_decoded_statuses(tax_unit)) == [
+        "HEAD_OF_HOUSEHOLD",
+        "SINGLE",
+        "SINGLE",
+    ]
+
+
 def test_construct_tax_units_allows_missing_optional_evidence_columns():
     person = _person_fixture(
         A_AGE=[40, 10],


### PR DESCRIPTION
## Summary

- Ports the CPS tax-unit construction flow to ACS PUMS by mapping ACS person records onto the CPS constructor contract.
- Splits ACS tax units independently from households while preserving household-level SPM, family, and marital-unit placeholders.
- Adds ACS relationship, school, disability, and income source columns required for the mapper.
- Hardens the shared CPS constructor and ACS mapper against interleaved households and duplicate raw DataFrame index labels.

Fixes #888.

## Validation

- `uv run pytest tests/unit/datasets/test_acs_tax_unit_construction.py tests/unit/datasets/test_cps_tax_unit_construction.py`
- `uv run ruff check policyengine_us_data/datasets/acs/acs_to_cps_columns.py policyengine_us_data/datasets/acs/tax_unit_construction.py policyengine_us_data/datasets/acs/acs.py policyengine_us_data/datasets/acs/census_acs.py policyengine_us_data/datasets/cps/tax_unit_construction.py tests/unit/datasets/test_acs_tax_unit_construction.py tests/unit/datasets/test_cps_tax_unit_construction.py`
- `git diff --check`

## Review

- Ran sub-agent review loops until the final pass returned CLEAN.
