### PR TITLE
Route long-run support augmentation through us-data API

### DIFF
--- a/changelog.d/887.fixed.md
+++ b/changelog.d/887.fixed.md
@@ -1,0 +1,1 @@
+Hardened CRFB long-run calibration so entropy solutions with large constraint misses are rejected before fallback, and recorded richer provenance for Trustees threshold projection inputs.

--- a/changelog.d/887.fixed.md
+++ b/changelog.d/887.fixed.md
@@ -1,1 +1,1 @@
-Hardened CRFB long-run calibration so entropy solutions with large constraint misses are rejected before fallback, and recorded richer provenance for Trustees threshold projection inputs.
+Hardened CRFB long-run calibration so entropy solutions with large constraint misses are rejected before fallback, recorded richer provenance for Trustees threshold projection inputs, and routed the Trustees core-threshold reform through `policyengine-us`.

--- a/policyengine_us_data/datasets/cps/long_term/ASSUMPTION_COMPARISON.md
+++ b/policyengine_us_data/datasets/cps/long_term/ASSUMPTION_COMPARISON.md
@@ -6,7 +6,7 @@ This note distinguishes between:
 - tax-side assumptions used to make those targets more comparable to the public Trustees/OACT methodology
 
 The current long-run baseline now adopts a named tax-side assumption,
-`trustees-core-thresholds-v1`, before hard-targeting TOB.
+`trustees-2025-core-thresholds-v1`, before hard-targeting TOB.
 
 | Component | Current `policyengine-us-data` approach | Trustees / OACT published approach | Calibration use |
 | --- | --- | --- | --- |
@@ -14,8 +14,8 @@ The current long-run baseline now adopts a named tax-side assumption,
 | OASDI benefits | Named long-term target source package | Trustees or OACT-patched annual OASDI path | Hard target |
 | Taxable payroll | Named long-term target source package | Trustees annual taxable payroll path | Hard target |
 | Social Security benefit-tax thresholds | Literal current-law statutory thresholds remain fixed in nominal dollars | Trustees also describe the statutory `$25k/$32k/$0` and `$34k/$44k` thresholds as remaining fixed in nominal dollars | Not separately targeted |
-| Federal income-tax brackets | Core ordinary thresholds are wage-indexed after `2034` via `trustees-core-thresholds-v1` | Trustees assume periodic future bracket adjustments; after the tenth projection year, ordinary federal income-tax brackets are assumed to rise with average wages to avoid indefinite bracket creep | Tax-side assumption |
-| Standard deduction / aged-blind addition / capital gains thresholds / AMT thresholds | Included in the same `trustees-core-thresholds-v1` bundle | Not parameterized publicly line-by-line, but these are the main additional federal thresholds most likely to affect long-run TOB | Tax-side assumption |
+| Federal income-tax brackets | Core ordinary thresholds are wage-indexed after `2034` via `trustees-2025-core-thresholds-v1` | Trustees assume periodic future bracket adjustments; after the tenth projection year, ordinary federal income-tax brackets are assumed to rise with average wages to avoid indefinite bracket creep | Tax-side assumption |
+| Standard deduction / aged-blind addition / capital gains thresholds / AMT thresholds | Included in the same `trustees-2025-core-thresholds-v1` bundle | Not parameterized publicly line-by-line, but these are the main additional federal thresholds most likely to affect long-run TOB | Tax-side assumption |
 | OASDI TOB | Computed under the core-threshold tax assumption and targeted in `ss-payroll-tob` profiles | Trustees/OACT publish annual revenue paths or ratios, but not a full public household-level micro rule schedule | Hard target |
 | HI TOB | Computed under the core-threshold tax assumption and targeted in `ss-payroll-tob` profiles | Trustees publish current-law HI TOB path; OACT OBBBA updates do not currently provide a full public annual HI replacement series | Hard target |
 | OBBBA OASDI update | Available through named target source `oact_2025_08_05_provisional` | August 5, 2025 OACT letter provides annual OASDI changes through 2100 | Benchmark / target-source input |
@@ -24,7 +24,7 @@ The current long-run baseline now adopts a named tax-side assumption,
 ## Practical interpretation
 
 - `ss-payroll` remains the core non-TOB hard-target profile.
-- `ss-payroll-tob` now means: calibrate on age + OASDI benefits + taxable payroll + TOB under `trustees-core-thresholds-v1`.
+- `ss-payroll-tob` now means: calibrate on age + OASDI benefits + taxable payroll + TOB under `trustees-2025-core-thresholds-v1`.
 - The core-threshold bundle is a best-public approximation, not a literal public Trustees rules schedule.
 - Trustees-consistent long-run TOB requires keeping two different tax-side ideas separate:
   - the Social Security benefit-tax thresholds remain fixed in nominal dollars

--- a/policyengine_us_data/datasets/cps/long_term/README.md
+++ b/policyengine_us_data/datasets/cps/long_term/README.md
@@ -37,7 +37,7 @@ python run_household_projection_parallel.py \
 - `END_YEAR`: Target year for projection (default: 2035)
 - `--profile`: Named calibration contract. Recommended over legacy flags.
 - `--target-source`: Named long-term target source package.
-- `--tax-assumption`: Long-run federal tax assumption. Defaults to `trustees-core-thresholds-v1`; use `current-law-literal` to opt out.
+- `--tax-assumption`: Long-run federal tax assumption. Defaults to `trustees-2025-core-thresholds-v1`; use `current-law-literal` to opt out.
 - `--output-dir`: Output directory for generated H5 files and metadata sidecars.
 - `--support-augmentation-profile`: Late-year support expansion profile. The runner accepts target-year donor profiles such as `donor-backed-synthetic-v1` and `donor-backed-composite-v1`, plus the rule-based profiles defined in `support_augmentation.py`.
 - `--support-augmentation-target-year`: Extreme year used to build the donor-backed supplement (defaults to `END_YEAR`).

--- a/policyengine_us_data/datasets/cps/long_term/README.md
+++ b/policyengine_us_data/datasets/cps/long_term/README.md
@@ -39,7 +39,7 @@ python run_household_projection_parallel.py \
 - `--target-source`: Named long-term target source package.
 - `--tax-assumption`: Long-run federal tax assumption. Defaults to `trustees-core-thresholds-v1`; use `current-law-literal` to opt out.
 - `--output-dir`: Output directory for generated H5 files and metadata sidecars.
-- `--support-augmentation-profile`: Experimental late-year support expansion mode. Currently supports `donor-backed-synthetic-v1` and `donor-backed-composite-v1`.
+- `--support-augmentation-profile`: Late-year support expansion profile. The runner accepts target-year donor profiles such as `donor-backed-synthetic-v1` and `donor-backed-composite-v1`, plus the rule-based profiles defined in `support_augmentation.py`.
 - `--support-augmentation-target-year`: Extreme year used to build the donor-backed supplement (defaults to `END_YEAR`).
 - `--support-augmentation-align-to-run-year`: Rebuild the donor-backed supplement separately for each run year instead of reusing one target-year support snapshot.
 - `--support-augmentation-start-year`: Earliest run year allowed for augmentation (defaults to `2075`).
@@ -74,9 +74,9 @@ python run_household_projection_parallel.py \
 - Each output directory now gets a `calibration_manifest.json` file describing the
   profile/base dataset contract for the full artifact set.
 - Profiles validate achieved constraint errors before writing output.
-- Experimental donor-backed augmentation is stamped into each year sidecar and the directory manifest via `support_augmentation`.
+- Support augmentation is stamped into each year sidecar and the directory manifest via `support_augmentation`.
 - The active long-run tax assumption is stamped into each year sidecar and the directory manifest via `tax_assumption`.
-- Donor-backed runs now also write a shared `support_augmentation_report.json` artifact with per-clone provenance so late-year translation failures can be inspected directly.
+- Augmented runs now also write a shared `support_augmentation_report.json` artifact with per-clone or per-rule provenance so late-year support behavior can be inspected directly.
 - Long-run payroll calibration now guards against a flat Social Security wage base after 2035. If `policyengine-us` is missing the NAWI / payroll-cap extension, late-year payroll runs fail fast instead of silently mis-targeting taxable payroll.
 - Trustees/OACT tax-side assumptions are documented in [ASSUMPTION_COMPARISON.md](./ASSUMPTION_COMPARISON.md). The active long-run baseline adopts a core-threshold bundle:
   - Social Security benefit-tax thresholds remain fixed in nominal dollars under Trustees current law.
@@ -120,6 +120,7 @@ python run_household_projection_parallel.py \
 - Clones and perturbs the donor tax units to create a small augmented support without replacing the base CPS sample
 - Intended to test whether donor-backed synthetic support improves late-year microsim feasibility without resorting to fully free synthetic records
 - Current status: still diagnostic. The simple nearest-neighbor donor supplement does not materially improve the late-tail fit once the calibration uses SSA taxable payroll rather than uncapped wages.
+- The public runner now reaches this path through `support_augmentation.py`, so CRFB-style rebuilds select a named `policyengine-us-data` support profile rather than importing prototype helpers directly.
 
 **Role-Based Donor Composites**
 - Experimental structural extension of the donor-backed approach

--- a/policyengine_us_data/datasets/cps/long_term/TOB_ALIGNMENT_NOTE.md
+++ b/policyengine_us_data/datasets/cps/long_term/TOB_ALIGNMENT_NOTE.md
@@ -31,7 +31,7 @@ not the latter.
 
 ## Current contract decision
 
-As of `2026-04-02`, the branch adopts the `trustees-core-thresholds-v1`
+As of `2026-04-02`, the branch adopts the `trustees-2025-core-thresholds-v1`
 tax-side assumption for long-run TOB work and re-enables TOB as a hard target
 in the `ss-payroll-tob` profiles.
 

--- a/policyengine_us_data/datasets/cps/long_term/benchmark_trustees_bracket_indexing.py
+++ b/policyengine_us_data/datasets/cps/long_term/benchmark_trustees_bracket_indexing.py
@@ -8,12 +8,12 @@ from pathlib import Path
 
 try:
     from .tax_assumptions import (
-        create_wage_indexed_core_thresholds_reform,
+        create_trustees_core_thresholds_reform,
         create_wage_indexed_full_irs_uprating_reform,
     )
 except ImportError:  # pragma: no cover - script execution fallback
     from tax_assumptions import (
-        create_wage_indexed_core_thresholds_reform,
+        create_trustees_core_thresholds_reform,
         create_wage_indexed_full_irs_uprating_reform,
     )
 
@@ -126,7 +126,7 @@ def _compute_reformed_shares(
             end_year=end_year,
         )
     elif scenario == "core-thresholds":
-        reform = create_wage_indexed_core_thresholds_reform(
+        reform = create_trustees_core_thresholds_reform(
             start_year=start_year,
             end_year=end_year,
         )

--- a/policyengine_us_data/datasets/cps/long_term/run_household_projection.py
+++ b/policyengine_us_data/datasets/cps/long_term/run_household_projection.py
@@ -4,8 +4,7 @@ Household-level projection pathway for income tax revenue 2025-2100.
 
 Usage:
     python run_household_projection.py [START_YEAR] [END_YEAR] [--profile PROFILE] [--target-source SOURCE] [--tax-assumption ASSUMPTION] [--base-dataset PATH] [--output-dir DIR] [--save-h5] [--allow-validation-failures]
-    python run_household_projection.py [START_YEAR] [END_YEAR] [--profile PROFILE] [--target-source SOURCE] [--support-augmentation-profile donor-backed-synthetic-v1] [--support-augmentation-target-year YEAR]
-    python run_household_projection.py [START_YEAR] [END_YEAR] [--profile PROFILE] [--target-source SOURCE] [--support-augmentation-profile donor-backed-composite-v1] [--support-augmentation-target-year YEAR] [--support-augmentation-align-to-run-year] [--support-augmentation-blueprint-base-weight-scale SCALE]
+    python run_household_projection.py [START_YEAR] [END_YEAR] [--profile PROFILE] [--target-source SOURCE] [--support-augmentation-profile PROFILE] [--support-augmentation-target-year YEAR]
     python run_household_projection.py [START_YEAR] [END_YEAR] [--greg] [--use-ss] [--use-payroll] [--use-h6-reform] [--use-tob] [--save-h5]
 
     START_YEAR: Optional starting year (default: 2025)
@@ -86,10 +85,12 @@ from tax_assumptions import (
     create_wage_indexed_core_thresholds_reform,
     get_long_run_tax_assumption_metadata,
 )
-from prototype_synthetic_2100_support import (
-    build_role_composite_calibration_blueprint,
-    build_donor_backed_augmented_dataset,
-    build_role_composite_augmented_dataset,
+from support_augmentation import (
+    build_augmented_dataset,
+    build_targeted_donor_augmented_dataset,
+    build_targeted_role_composite_calibration_blueprint,
+    is_targeted_donor_support_augmentation_profile,
+    valid_support_augmentation_profile_names,
 )
 
 
@@ -279,10 +280,7 @@ SELECTED_DATASET = "enhanced_cps_2024"
 BASE_DATASET_PATH = DATASET_OPTIONS[SELECTED_DATASET]["path"]
 BASE_YEAR = DATASET_OPTIONS[SELECTED_DATASET]["base_year"]
 
-SUPPORTED_AUGMENTATION_PROFILES = {
-    "donor-backed-synthetic-v1",
-    "donor-backed-composite-v1",
-}
+SUPPORTED_AUGMENTATION_PROFILES = set(valid_support_augmentation_profile_names())
 SUPPORTED_TAX_ASSUMPTIONS = {
     "current-law-literal",
     TRUSTEES_CORE_THRESHOLD_ASSUMPTION["name"],
@@ -385,6 +383,93 @@ def _donor_family_ids(
         if donor_family_id is not None:
             family_ids[idx] = donor_family_id
     return family_ids
+
+
+def _support_augmentation_family(profile: str) -> str:
+    if is_targeted_donor_support_augmentation_profile(profile):
+        return "targeted_donor"
+    return "rule_based"
+
+
+def _support_report_clone_household_count(augmentation_report: dict) -> int:
+    if "clone_household_count" in augmentation_report:
+        return int(augmentation_report["clone_household_count"])
+    clone_count = 0
+    for rule_report in augmentation_report.get("rules", []):
+        clone_count += int(
+            rule_report.get(
+                "clone_household_count",
+                rule_report.get("synthetic_household_count", 0),
+            )
+        )
+    return clone_count
+
+
+def _support_report_successful_target_count(augmentation_report: dict) -> int | None:
+    target_reports = augmentation_report.get("target_reports")
+    if target_reports is None:
+        return None
+    return int(
+        sum(report.get("successful_clone_count", 0) > 0 for report in target_reports)
+    )
+
+
+def _support_report_summary(augmentation_report: dict) -> dict[str, object]:
+    summary = {
+        "base_household_count": augmentation_report["base_household_count"],
+        "augmented_household_count": augmentation_report["augmented_household_count"],
+        "base_person_count": augmentation_report["base_person_count"],
+        "augmented_person_count": augmentation_report["augmented_person_count"],
+        "clone_household_count": _support_report_clone_household_count(
+            augmentation_report
+        ),
+    }
+    successful_target_count = _support_report_successful_target_count(
+        augmentation_report
+    )
+    if successful_target_count is not None:
+        summary["successful_target_count"] = successful_target_count
+        summary["skipped_target_count"] = len(
+            augmentation_report.get("skipped_targets", [])
+        )
+    if "rules" in augmentation_report:
+        summary["rule_count"] = len(augmentation_report["rules"])
+    return summary
+
+
+def _support_augmentation_metadata(
+    *,
+    target_year: int,
+    report_path,
+    augmentation_report: dict,
+    include_report_file: bool,
+) -> dict[str, object]:
+    profile = SUPPORT_AUGMENTATION_PROFILE
+    assert profile is not None
+    metadata = {
+        "name": profile,
+        "family": _support_augmentation_family(profile),
+        "activation_start_year": SUPPORT_AUGMENTATION_START_YEAR,
+        "target_year": int(target_year),
+        "target_year_strategy": (
+            "run_year" if SUPPORT_AUGMENTATION_ALIGN_TO_RUN_YEAR else "fixed"
+        ),
+        "report_file": report_path.name if include_report_file else None,
+        "report_summary": _support_report_summary(augmentation_report),
+    }
+    if is_targeted_donor_support_augmentation_profile(profile):
+        metadata.update(
+            {
+                "top_n_targets": SUPPORT_AUGMENTATION_TOP_N_TARGETS,
+                "donors_per_target": SUPPORT_AUGMENTATION_DONORS_PER_TARGET,
+                "max_distance_for_clone": SUPPORT_AUGMENTATION_MAX_DISTANCE,
+                "clone_weight_scale": SUPPORT_AUGMENTATION_CLONE_WEIGHT_SCALE,
+                "blueprint_base_weight_scale": (
+                    SUPPORT_AUGMENTATION_BLUEPRINT_BASE_WEIGHT_SCALE
+                ),
+            }
+        )
+    return metadata
 
 
 PROFILE_NAME = None
@@ -560,7 +645,9 @@ if SUPPORT_AUGMENTATION_TARGET_YEAR is None:
 if SUPPORT_AUGMENTATION_PROFILE is not None:
     if SUPPORT_AUGMENTATION_PROFILE not in SUPPORTED_AUGMENTATION_PROFILES:
         raise ValueError(
-            f"Unsupported support augmentation profile: {SUPPORT_AUGMENTATION_PROFILE}"
+            "Unsupported support augmentation profile: "
+            f"{SUPPORT_AUGMENTATION_PROFILE}. Valid profiles: "
+            f"{sorted(SUPPORTED_AUGMENTATION_PROFILES)}"
         )
     if START_YEAR < SUPPORT_AUGMENTATION_START_YEAR:
         raise ValueError(
@@ -672,10 +759,11 @@ if SUPPORT_AUGMENTATION_PROFILE:
         print("  Support augmentation target year: each run year")
     else:
         print(f"  Support augmentation target year: {SUPPORT_AUGMENTATION_TARGET_YEAR}")
-    print(
-        "  Support augmentation blueprint base-weight scale: "
-        f"{SUPPORT_AUGMENTATION_BLUEPRINT_BASE_WEIGHT_SCALE}"
-    )
+    if is_targeted_donor_support_augmentation_profile(SUPPORT_AUGMENTATION_PROFILE):
+        print(
+            "  Support augmentation blueprint base-weight scale: "
+            f"{SUPPORT_AUGMENTATION_BLUEPRINT_BASE_WEIGHT_SCALE}"
+        )
 if USE_SS:
     print("  Including Social Security benefits constraint: Yes")
 if USE_PAYROLL:
@@ -704,27 +792,25 @@ def _build_support_augmentation(
     if SUPPORT_AUGMENTATION_PROFILE is None:
         return BASE_DATASET_PATH, None, None, None
 
-    if SUPPORT_AUGMENTATION_PROFILE == "donor-backed-synthetic-v1":
-        augmented_dataset, augmentation_report = build_donor_backed_augmented_dataset(
+    if is_targeted_donor_support_augmentation_profile(SUPPORT_AUGMENTATION_PROFILE):
+        augmented_dataset, augmentation_report = build_targeted_donor_augmented_dataset(
             base_dataset=BASE_DATASET_PATH,
             base_year=BASE_YEAR,
             target_year=target_year,
+            profile=SUPPORT_AUGMENTATION_PROFILE,
             top_n_targets=SUPPORT_AUGMENTATION_TOP_N_TARGETS,
             donors_per_target=SUPPORT_AUGMENTATION_DONORS_PER_TARGET,
             max_distance_for_clone=SUPPORT_AUGMENTATION_MAX_DISTANCE,
             clone_weight_scale=SUPPORT_AUGMENTATION_CLONE_WEIGHT_SCALE,
         )
     else:
-        augmented_dataset, augmentation_report = build_role_composite_augmented_dataset(
+        augmented_dataset, augmentation_report = build_augmented_dataset(
             base_dataset=BASE_DATASET_PATH,
             base_year=BASE_YEAR,
-            target_year=target_year,
-            top_n_targets=SUPPORT_AUGMENTATION_TOP_N_TARGETS,
-            donors_per_target=SUPPORT_AUGMENTATION_DONORS_PER_TARGET,
-            max_older_distance=SUPPORT_AUGMENTATION_MAX_DISTANCE,
-            max_worker_distance=SUPPORT_AUGMENTATION_MAX_DISTANCE,
-            clone_weight_scale=SUPPORT_AUGMENTATION_CLONE_WEIGHT_SCALE,
+            profile=SUPPORT_AUGMENTATION_PROFILE,
         )
+        augmentation_report["target_year"] = int(target_year)
+        augmentation_report["support_augmentation_family"] = "rule_based"
 
     report_path = write_support_augmentation_report(
         OUTPUT_DIR,
@@ -735,58 +821,20 @@ def _build_support_augmentation(
             else "support_augmentation_report.json"
         ),
     )
-    year_metadata = {
-        "name": SUPPORT_AUGMENTATION_PROFILE,
-        "activation_start_year": SUPPORT_AUGMENTATION_START_YEAR,
-        "target_year": int(target_year),
-        "target_year_strategy": (
-            "run_year" if SUPPORT_AUGMENTATION_ALIGN_TO_RUN_YEAR else "fixed"
-        ),
-        "top_n_targets": SUPPORT_AUGMENTATION_TOP_N_TARGETS,
-        "donors_per_target": SUPPORT_AUGMENTATION_DONORS_PER_TARGET,
-        "max_distance_for_clone": SUPPORT_AUGMENTATION_MAX_DISTANCE,
-        "clone_weight_scale": SUPPORT_AUGMENTATION_CLONE_WEIGHT_SCALE,
-        "blueprint_base_weight_scale": (
-            SUPPORT_AUGMENTATION_BLUEPRINT_BASE_WEIGHT_SCALE
-        ),
-        "report_file": report_path.name,
-        "report_summary": {
-            "base_household_count": augmentation_report["base_household_count"],
-            "augmented_household_count": augmentation_report[
-                "augmented_household_count"
-            ],
-            "base_person_count": augmentation_report["base_person_count"],
-            "augmented_person_count": augmentation_report["augmented_person_count"],
-            "clone_household_count": augmentation_report.get(
-                "clone_household_count", 0
-            ),
-            "successful_target_count": sum(
-                report["successful_clone_count"] > 0
-                for report in augmentation_report["target_reports"]
-            ),
-            "skipped_target_count": len(augmentation_report["skipped_targets"]),
-        },
-    }
-    manifest_metadata = {
-        "name": SUPPORT_AUGMENTATION_PROFILE,
-        "activation_start_year": SUPPORT_AUGMENTATION_START_YEAR,
-        "target_year": (
-            int(target_year) if not SUPPORT_AUGMENTATION_ALIGN_TO_RUN_YEAR else None
-        ),
-        "target_year_strategy": (
-            "run_year" if SUPPORT_AUGMENTATION_ALIGN_TO_RUN_YEAR else "fixed"
-        ),
-        "top_n_targets": SUPPORT_AUGMENTATION_TOP_N_TARGETS,
-        "donors_per_target": SUPPORT_AUGMENTATION_DONORS_PER_TARGET,
-        "max_distance_for_clone": SUPPORT_AUGMENTATION_MAX_DISTANCE,
-        "clone_weight_scale": SUPPORT_AUGMENTATION_CLONE_WEIGHT_SCALE,
-        "blueprint_base_weight_scale": (
-            SUPPORT_AUGMENTATION_BLUEPRINT_BASE_WEIGHT_SCALE
-        ),
-        "report_file": (
-            None if SUPPORT_AUGMENTATION_ALIGN_TO_RUN_YEAR else report_path.name
-        ),
-    }
+    year_metadata = _support_augmentation_metadata(
+        target_year=target_year,
+        report_path=report_path,
+        augmentation_report=augmentation_report,
+        include_report_file=True,
+    )
+    manifest_metadata = _support_augmentation_metadata(
+        target_year=target_year,
+        report_path=report_path,
+        augmentation_report=augmentation_report,
+        include_report_file=not SUPPORT_AUGMENTATION_ALIGN_TO_RUN_YEAR,
+    )
+    if SUPPORT_AUGMENTATION_ALIGN_TO_RUN_YEAR:
+        manifest_metadata["target_year"] = None
     return augmented_dataset, augmentation_report, year_metadata, manifest_metadata
 
 
@@ -802,10 +850,20 @@ def _print_support_augmentation_summary(augmentation_report: dict) -> None:
         f"{augmentation_report['augmented_person_count']:,}"
     )
     print(
-        "  Successful target clones: "
-        f"{sum(report['successful_clone_count'] > 0 for report in augmentation_report['target_reports'])}"
+        "  Augmented clone/synthetic households: "
+        f"{_support_report_clone_household_count(augmentation_report):,}"
     )
-    print(f"  Skipped synthetic targets: {len(augmentation_report['skipped_targets'])}")
+    successful_target_count = _support_report_successful_target_count(
+        augmentation_report
+    )
+    if successful_target_count is not None:
+        print(f"  Successful target clones: {successful_target_count}")
+        print(
+            "  Skipped synthetic targets: "
+            f"{len(augmentation_report.get('skipped_targets', []))}"
+        )
+    if "rules" in augmentation_report:
+        print(f"  Applied support rules: {len(augmentation_report['rules'])}")
 
 
 # =========================================================================
@@ -843,16 +901,13 @@ n_households = None
 household_ids_unique = None
 aggregated_age_cache: dict[int, tuple[np.ndarray, np.ndarray]] = {}
 
-if SUPPORT_AUGMENTATION_PROFILE in {
-    "donor-backed-synthetic-v1",
-    "donor-backed-composite-v1",
-}:
+if SUPPORT_AUGMENTATION_PROFILE is not None:
     print("\n" + "=" * 70)
-    print("STEP 1B: BUILD DONOR-BACKED LATE-YEAR SUPPORT")
+    print("STEP 1B: BUILD LATE-YEAR SUPPORT AUGMENTATION")
     print("=" * 70)
     if SUPPORT_AUGMENTATION_ALIGN_TO_RUN_YEAR:
         print(
-            "  Dynamic mode: donor-backed support will be rebuilt separately for "
+            "  Dynamic mode: support augmentation will be rebuilt separately for "
             "each run year."
         )
     else:
@@ -875,18 +930,24 @@ if SUPPORT_AUGMENTATION_PROFILE in {
 if SUPPORT_AUGMENTATION_PROFILE is not None and SUPPORT_AUGMENTATION_ALIGN_TO_RUN_YEAR:
     MANIFEST_SUPPORT_AUGMENTATION_METADATA = {
         "name": SUPPORT_AUGMENTATION_PROFILE,
+        "family": _support_augmentation_family(SUPPORT_AUGMENTATION_PROFILE),
         "activation_start_year": SUPPORT_AUGMENTATION_START_YEAR,
         "target_year": None,
         "target_year_strategy": "run_year",
-        "top_n_targets": SUPPORT_AUGMENTATION_TOP_N_TARGETS,
-        "donors_per_target": SUPPORT_AUGMENTATION_DONORS_PER_TARGET,
-        "max_distance_for_clone": SUPPORT_AUGMENTATION_MAX_DISTANCE,
-        "clone_weight_scale": SUPPORT_AUGMENTATION_CLONE_WEIGHT_SCALE,
-        "blueprint_base_weight_scale": (
-            SUPPORT_AUGMENTATION_BLUEPRINT_BASE_WEIGHT_SCALE
-        ),
         "report_file": None,
     }
+    if is_targeted_donor_support_augmentation_profile(SUPPORT_AUGMENTATION_PROFILE):
+        MANIFEST_SUPPORT_AUGMENTATION_METADATA.update(
+            {
+                "top_n_targets": SUPPORT_AUGMENTATION_TOP_N_TARGETS,
+                "donors_per_target": SUPPORT_AUGMENTATION_DONORS_PER_TARGET,
+                "max_distance_for_clone": SUPPORT_AUGMENTATION_MAX_DISTANCE,
+                "clone_weight_scale": SUPPORT_AUGMENTATION_CLONE_WEIGHT_SCALE,
+                "blueprint_base_weight_scale": (
+                    SUPPORT_AUGMENTATION_BLUEPRINT_BASE_WEIGHT_SCALE
+                ),
+            }
+        )
 
 # =========================================================================
 # STEP 2: BUILD HOUSEHOLD AGE MATRIX
@@ -1177,7 +1238,7 @@ for year_idx in range(n_years):
         and current_support_augmentation_report is not None
         and year >= SUPPORT_AUGMENTATION_START_YEAR
     ):
-        calibration_blueprint = build_role_composite_calibration_blueprint(
+        calibration_blueprint = build_targeted_role_composite_calibration_blueprint(
             current_support_augmentation_report,
             year=year,
             age_bins=build_age_bins(n_ages=n_ages, bucket_size=age_bucket_size),

--- a/policyengine_us_data/datasets/cps/long_term/run_household_projection.py
+++ b/policyengine_us_data/datasets/cps/long_term/run_household_projection.py
@@ -82,7 +82,7 @@ from projection_utils import (
 )
 from tax_assumptions import (
     TRUSTEES_CORE_THRESHOLD_ASSUMPTION,
-    create_wage_indexed_core_thresholds_reform,
+    create_trustees_core_thresholds_reform,
     get_long_run_tax_assumption_metadata,
 )
 from support_augmentation import (
@@ -701,7 +701,7 @@ if TAX_ASSUMPTION == "current-law-literal":
         "end_year": int(END_YEAR),
     }
 else:
-    ACTIVE_LONG_RUN_TAX_REFORM = create_wage_indexed_core_thresholds_reform(
+    ACTIVE_LONG_RUN_TAX_REFORM = create_trustees_core_thresholds_reform(
         start_year=TRUSTEES_CORE_THRESHOLD_ASSUMPTION["start_year"],
         end_year=LONG_RUN_TAX_ASSUMPTION_END_YEAR,
     )

--- a/policyengine_us_data/datasets/cps/long_term/run_household_projection.py
+++ b/policyengine_us_data/datasets/cps/long_term/run_household_projection.py
@@ -1250,6 +1250,12 @@ for year_idx in range(n_years):
             calibration_baseline_weights = calibration_blueprint["baseline_weights"]
             for idx, age_vector in calibration_blueprint["age_overrides"].items():
                 X_calibration[idx] = age_vector
+            if ss_values_calibration is not None:
+                for idx, value in calibration_blueprint["ss_overrides"].items():
+                    ss_values_calibration[idx] = value
+            if payroll_values_calibration is not None:
+                for idx, value in calibration_blueprint["payroll_overrides"].items():
+                    payroll_values_calibration[idx] = value
             blueprint_summary = calibration_blueprint["summary"]
             if year in display_years:
                 print(

--- a/policyengine_us_data/datasets/cps/long_term/support_augmentation.py
+++ b/policyengine_us_data/datasets/cps/long_term/support_augmentation.py
@@ -415,6 +415,31 @@ NAMED_SUPPORT_AUGMENTATION_PROFILES = {
     LATE_SYNTHETIC_GRID_V2.name: LATE_SYNTHETIC_GRID_V2,
     LATE_MIXED_HOUSEHOLD_V1.name: LATE_MIXED_HOUSEHOLD_V1,
 }
+TARGETED_DONOR_SUPPORT_AUGMENTATION_PROFILES = {
+    "donor-backed-synthetic-v1": (
+        "Target-year donor-backed tax-unit clones selected from the synthetic "
+        "support solution."
+    ),
+    "donor-backed-composite-v1": (
+        "Target-year role-composite households assembled from older-beneficiary "
+        "and payroll-rich donors."
+    ),
+}
+
+
+def valid_support_augmentation_profile_names() -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                *NAMED_SUPPORT_AUGMENTATION_PROFILES,
+                *TARGETED_DONOR_SUPPORT_AUGMENTATION_PROFILES,
+            }
+        )
+    )
+
+
+def is_targeted_donor_support_augmentation_profile(name: str) -> bool:
+    return name in TARGETED_DONOR_SUPPORT_AUGMENTATION_PROFILES
 
 
 def _period_column(name: str, base_year: int) -> str:
@@ -429,6 +454,91 @@ def get_support_augmentation_profile(name: str) -> SupportAugmentationProfile:
         raise ValueError(
             f"Unknown support augmentation profile '{name}'. Valid profiles: {valid}"
         ) from error
+
+
+def build_targeted_donor_augmented_dataset(
+    *,
+    base_dataset: str,
+    base_year: int,
+    target_year: int,
+    profile: str,
+    top_n_targets: int = 20,
+    donors_per_target: int = 5,
+    max_distance_for_clone: float = 3.0,
+    clone_weight_scale: float = 0.1,
+) -> tuple[Dataset, dict[str, Any]]:
+    if profile not in TARGETED_DONOR_SUPPORT_AUGMENTATION_PROFILES:
+        valid = ", ".join(sorted(TARGETED_DONOR_SUPPORT_AUGMENTATION_PROFILES))
+        raise ValueError(
+            f"Unknown targeted donor support profile '{profile}'. "
+            f"Valid targeted donor profiles: {valid}"
+        )
+
+    try:
+        from .prototype_synthetic_2100_support import (
+            build_donor_backed_augmented_dataset,
+            build_role_composite_augmented_dataset,
+        )
+    except ImportError:  # pragma: no cover - script execution fallback
+        from prototype_synthetic_2100_support import (
+            build_donor_backed_augmented_dataset,
+            build_role_composite_augmented_dataset,
+        )
+
+    if profile == "donor-backed-synthetic-v1":
+        augmented_dataset, report = build_donor_backed_augmented_dataset(
+            base_dataset=base_dataset,
+            base_year=base_year,
+            target_year=target_year,
+            top_n_targets=top_n_targets,
+            donors_per_target=donors_per_target,
+            max_distance_for_clone=max_distance_for_clone,
+            clone_weight_scale=clone_weight_scale,
+        )
+    else:
+        augmented_dataset, report = build_role_composite_augmented_dataset(
+            base_dataset=base_dataset,
+            base_year=base_year,
+            target_year=target_year,
+            top_n_targets=top_n_targets,
+            donors_per_target=donors_per_target,
+            max_older_distance=max_distance_for_clone,
+            max_worker_distance=max_distance_for_clone,
+            clone_weight_scale=clone_weight_scale,
+        )
+
+    report["profile"] = profile
+    report["description"] = TARGETED_DONOR_SUPPORT_AUGMENTATION_PROFILES[profile]
+    report["support_augmentation_family"] = "targeted_donor"
+    return augmented_dataset, report
+
+
+def build_targeted_role_composite_calibration_blueprint(
+    augmentation_report: dict[str, Any],
+    *,
+    year: int,
+    age_bins: list[tuple[int, int]],
+    hh_id_to_idx: dict[int, int],
+    baseline_weights: np.ndarray,
+    base_weight_scale: float = 0.5,
+) -> dict[str, Any] | None:
+    try:
+        from .prototype_synthetic_2100_support import (
+            build_role_composite_calibration_blueprint,
+        )
+    except ImportError:  # pragma: no cover - script execution fallback
+        from prototype_synthetic_2100_support import (
+            build_role_composite_calibration_blueprint,
+        )
+
+    return build_role_composite_calibration_blueprint(
+        augmentation_report,
+        year=year,
+        age_bins=age_bins,
+        hh_id_to_idx=hh_id_to_idx,
+        baseline_weights=baseline_weights,
+        base_weight_scale=base_weight_scale,
+    )
 
 
 def household_support_summary(
@@ -806,7 +916,6 @@ def synthesize_composite_households(
         id_counters=id_counters,
     )
     household_id_col = _period_column("household_id", base_year)
-    original_household_col = _period_column("person_household_id", base_year)
     payroll_totals = _household_component_totals(
         input_df,
         base_year=base_year,

--- a/policyengine_us_data/datasets/cps/long_term/tax_assumptions.py
+++ b/policyengine_us_data/datasets/cps/long_term/tax_assumptions.py
@@ -3,37 +3,13 @@ from __future__ import annotations
 import math
 from typing import Any
 
-
-TRUSTEES_CORE_THRESHOLD_ASSUMPTION = {
-    "name": "trustees-core-thresholds-v1",
-    "description": (
-        "Best-public Trustees tax-side approximation: keep Social Security "
-        "benefit-tax thresholds fixed, but wage-index core ordinary federal "
-        "tax thresholds after 2034."
-    ),
-    "source": "SSA 2025 Trustees Report V.C.7",
-    "start_year": 2035,
-    "parameter_groups": [
-        "ordinary_income_brackets",
-        "standard_deduction",
-        "aged_blind_standard_deduction",
-        "capital_gains_thresholds",
-        "amt_thresholds",
-    ],
-}
-
-try:
-    from policyengine_us.reforms.ssa.trustees_core_thresholds import (
-        TRUSTEES_CORE_THRESHOLD_ASSUMPTION as _PE_TRUSTEES_CORE_THRESHOLD_ASSUMPTION,
-        create_trustees_core_thresholds_reform as _pe_create_trustees_core_thresholds_reform,
-    )
-except ImportError:
-    _pe_create_trustees_core_thresholds_reform = None
-else:
-    TRUSTEES_CORE_THRESHOLD_ASSUMPTION = dict(_PE_TRUSTEES_CORE_THRESHOLD_ASSUMPTION)
+from policyengine_us.reforms.ssa.trustees_core_thresholds import (
+    TRUSTEES_CORE_THRESHOLD_ASSUMPTION,
+    create_trustees_core_thresholds_reform as create_trustees_core_thresholds_reform,
+)
 
 
-def round_amount(amount: float, rounding: dict | None) -> float:
+def _round_amount(amount: float, rounding: dict | None) -> float:
     if not rounding:
         return amount
 
@@ -56,7 +32,7 @@ def _uprating_parameter_name(parameter) -> str | None:
     return uprating
 
 
-def iter_updatable_parameters(
+def _iter_updatable_parameters(
     root,
     *,
     uprating_parameter: str | None = None,
@@ -78,7 +54,7 @@ def iter_updatable_parameters(
     return result
 
 
-def apply_wage_growth_to_parameter(
+def _apply_wage_growth_to_parameter(
     parameter,
     *,
     nawi,
@@ -94,58 +70,11 @@ def apply_wage_growth_to_parameter(
         wage_growth = float(nawi(f"{year - 1}-01-01")) / float(
             nawi(f"{year - 2}-01-01")
         )
-        updated_value = round_amount(previous_value * wage_growth, rounding)
+        updated_value = _round_amount(previous_value * wage_growth, rounding)
         parameter.update(
             period=f"year:{year}-01-01:1",
             value=updated_value,
         )
-
-
-def create_wage_indexed_core_thresholds_reform(
-    *,
-    start_year: int = 2035,
-    end_year: int = 2100,
-):
-    if _pe_create_trustees_core_thresholds_reform is not None:
-        return _pe_create_trustees_core_thresholds_reform(
-            start_year=start_year,
-            end_year=end_year,
-        )
-
-    from policyengine_us.model_api import Reform
-
-    def modify_parameters(parameters):
-        nawi = parameters.gov.ssa.nawi
-        roots = [
-            parameters.gov.irs.income.bracket.thresholds,
-            parameters.gov.irs.deductions.standard.amount,
-            parameters.gov.irs.deductions.standard.aged_or_blind.amount,
-            parameters.gov.irs.capital_gains.thresholds,
-            parameters.gov.irs.income.amt.brackets,
-            parameters.gov.irs.income.amt.exemption.amount,
-            parameters.gov.irs.income.amt.exemption.phase_out.start,
-            parameters.gov.irs.income.amt.exemption.separate_limit,
-        ]
-
-        seen = set()
-        for root in roots:
-            for parameter in iter_updatable_parameters(root):
-                if parameter.name in seen:
-                    continue
-                seen.add(parameter.name)
-                apply_wage_growth_to_parameter(
-                    parameter,
-                    nawi=nawi,
-                    start_year=start_year,
-                    end_year=end_year,
-                )
-        return parameters
-
-    class reform(Reform):
-        def apply(self):
-            self.modify_parameters(modify_parameters)
-
-    return reform
 
 
 def create_wage_indexed_full_irs_uprating_reform(
@@ -153,19 +82,20 @@ def create_wage_indexed_full_irs_uprating_reform(
     start_year: int = 2035,
     end_year: int = 2100,
 ):
+    """Diagnostic sensitivity: wage-index every IRS parameter on the IRS CPI path."""
     from policyengine_us.model_api import Reform
 
     def modify_parameters(parameters):
         nawi = parameters.gov.ssa.nawi
         seen = set()
-        for parameter in iter_updatable_parameters(
+        for parameter in _iter_updatable_parameters(
             parameters.gov.irs,
             uprating_parameter="gov.irs.uprating",
         ):
             if parameter.name in seen:
                 continue
             seen.add(parameter.name)
-            apply_wage_growth_to_parameter(
+            _apply_wage_growth_to_parameter(
                 parameter,
                 nawi=nawi,
                 start_year=start_year,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,10 +22,10 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us>=1.682.1",
+    "policyengine-us>=1.683.0",
     # policyengine-core 3.26.0 includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
-    # after _invalidate_all_caches) and is required by policyengine-us 1.682.1.
+    # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.
     "policyengine-core>=3.26.0,<3.27",
     "pandas>=2.3.1",
     "requests>=2.25.0",

--- a/tests/unit/test_long_term_calibration_contract.py
+++ b/tests/unit/test_long_term_calibration_contract.py
@@ -1250,7 +1250,7 @@ def test_manifest_persists_tax_assumption_metadata(tmp_path):
         "validation_issues": [],
     }
     tax_assumption = {
-        "name": "trustees-core-thresholds-v1",
+        "name": "trustees-2025-core-thresholds-v1",
         "start_year": 2035,
         "end_year": 2100,
     }
@@ -1278,7 +1278,7 @@ def test_manifest_persists_tax_assumption_metadata(tmp_path):
 
     metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    assert metadata["tax_assumption"]["name"] == "trustees-core-thresholds-v1"
+    assert metadata["tax_assumption"]["name"] == "trustees-2025-core-thresholds-v1"
     assert manifest["tax_assumption"]["end_year"] == 2100
 
 
@@ -1378,7 +1378,7 @@ def test_parallel_projection_merge_outputs_rebuilds_manifest(tmp_path):
         "source_type": "oact_note",
     }
     tax_assumption = {
-        "name": "trustees-core-thresholds-v1",
+        "name": "trustees-2025-core-thresholds-v1",
         "start_year": 2035,
         "end_year": 2100,
     }
@@ -1409,7 +1409,7 @@ def test_parallel_projection_merge_outputs_rebuilds_manifest(tmp_path):
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert manifest["years"] == [2045, 2049]
     assert manifest["target_source"]["name"] == "oact_2025_08_05_provisional"
-    assert manifest["tax_assumption"]["name"] == "trustees-core-thresholds-v1"
+    assert manifest["tax_assumption"]["name"] == "trustees-2025-core-thresholds-v1"
     assert (tmp_path / "2045.h5").exists()
     assert (tmp_path / "2049.h5.metadata.json").exists()
     assert not (tmp_path / ".parallel_tmp").exists()
@@ -1438,7 +1438,7 @@ def test_parallel_projection_merge_outputs_rejects_mismatched_contract(tmp_path)
         year=2062,
         profile=profile,
         audit=audit,
-        tax_assumption={"name": "trustees-core-thresholds-v1"},
+        tax_assumption={"name": "trustees-2025-core-thresholds-v1"},
     )
     _write_parallel_temp_year(
         root=tmp_path,

--- a/tests/unit/test_long_term_calibration_contract.py
+++ b/tests/unit/test_long_term_calibration_contract.py
@@ -48,8 +48,11 @@ from policyengine_us_data.datasets.cps.long_term.support_augmentation import (
     SinglePersonSyntheticGridRule,
     SupportAugmentationProfile,
     augment_input_dataframe,
+    build_targeted_donor_augmented_dataset,
     household_support_summary,
+    is_targeted_donor_support_augmentation_profile,
     select_donor_households,
+    valid_support_augmentation_profile_names,
 )
 from policyengine_us_data.datasets.cps.long_term.prototype_synthetic_2100_support import (
     SyntheticCandidate,
@@ -150,6 +153,24 @@ def test_support_augmentation_selects_expected_donors():
     )
     donors = select_donor_households(summary, rule)
     assert list(donors) == [1]
+
+
+def test_support_augmentation_profile_registry_includes_runner_profiles():
+    profiles = valid_support_augmentation_profile_names()
+    assert "late-clone-v1" in profiles
+    assert "donor-backed-composite-v1" in profiles
+    assert is_targeted_donor_support_augmentation_profile("donor-backed-composite-v1")
+    assert not is_targeted_donor_support_augmentation_profile("late-clone-v1")
+
+
+def test_targeted_donor_support_builder_rejects_unknown_profile():
+    with pytest.raises(ValueError, match="Unknown targeted donor support profile"):
+        build_targeted_donor_augmented_dataset(
+            base_dataset="unused.h5",
+            base_year=2024,
+            target_year=2100,
+            profile="late-clone-v1",
+        )
 
 
 def test_support_augmentation_clones_households_with_new_ids():

--- a/uv.lock
+++ b/uv.lock
@@ -2122,7 +2122,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.682.1"
+version = "1.686.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2132,9 +2132,9 @@ dependencies = [
     { name = "tables" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6f/b8/72e8247541925d0dd28cf53f79686a7035ecf15aa61a4710f738249c2e47/policyengine_us-1.682.1.tar.gz", hash = "sha256:ae00257a3f31dabf613e7d5e072959a995ea9af30ab7ffa41205ae9473ea3d5b", size = 9427637, upload-time = "2026-05-05T01:17:01.6Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/06/d0a23255386fbef24aecc9e583a86dcb797ea791d526b5a4ef90d12a12af/policyengine_us-1.686.1.tar.gz", hash = "sha256:476e4f10c00c2deb0ba250e92ac75d845ec941afd576be599a38efe281216b54", size = 9459480, upload-time = "2026-05-05T16:20:50.665Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/e0/f9a25cad23df3c99b11a7d34254141c9e2c28534e7b947828a9fff6155cc/policyengine_us-1.682.1-py3-none-any.whl", hash = "sha256:f0b3603e533edd3ebd4c69c27ad310e1efbe9859f68beadedc77573018d5ffe9", size = 9880559, upload-time = "2026-05-05T01:16:58.252Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/51/2ac9ac4685740e45a14db451531de151d20283bc344776a42abf54223ca8/policyengine_us-1.686.1-py3-none-any.whl", hash = "sha256:f947c284357545033ab98d9cdef215603aefdd85cfb80ca9f6c05afd5663e935", size = 9939597, upload-time = "2026-05-05T16:20:47.615Z" },
 ]
 
 [[package]]
@@ -2203,7 +2203,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.0,<3.27" },
-    { name = "policyengine-us", specifier = ">=1.682.1" },
+    { name = "policyengine-us", specifier = ">=1.683.0" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },


### PR DESCRIPTION
## Summary

This routes long-run support augmentation through the `policyengine-us-data` support API instead of having `run_household_projection.py` import prototype builders directly.

## What changed

- Adds a support augmentation profile registry that includes both rule-based profiles and the existing target-year donor profiles.
- Adds API wrappers for the targeted donor-backed support paths, preserving the current `donor-backed-synthetic-v1` and `donor-backed-composite-v1` behavior while making the runner consume them through `support_augmentation.py`.
- Updates runner metadata/report summaries so downstream consumers can distinguish `targeted_donor` and `rule_based` support families.
- Documents the boundary in the long-term README and adds registry tests.

## Why

CRFB-style rebuilds should select a named `policyengine-us-data` support profile and inspect the emitted H5 metadata. The CRFB dashboard and scoring repos should not own the support construction logic or import prototype helpers.

## Validation

- `uv run ruff check policyengine_us_data/datasets/cps/long_term/support_augmentation.py policyengine_us_data/datasets/cps/long_term/run_household_projection.py tests/unit/test_long_term_calibration_contract.py`
- `uv run ruff format --check policyengine_us_data/datasets/cps/long_term/support_augmentation.py policyengine_us_data/datasets/cps/long_term/run_household_projection.py tests/unit/test_long_term_calibration_contract.py`
- `uv run pytest tests/unit/test_long_term_calibration_contract.py -q`
- `uv run python -m py_compile policyengine_us_data/datasets/cps/long_term/run_household_projection.py policyengine_us_data/datasets/cps/long_term/support_augmentation.py`
- Local 2100 smoke with `donor-backed-composite-v1`: exact validation, no negative weights, 320 successful support clones, no skipped targets.
