### PR TITLE
Add bundle-compatible release manifests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -120,6 +120,27 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  bundle-release-manifest-contract:
+    name: Validate bundle release manifest contract
+    runs-on: ubuntu-latest
+    needs: [check-fork, lint]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+      - uses: astral-sh/setup-uv@v8.1.0
+      - run: uv sync --dev
+      - name: Install bundle contract validator
+        run: >
+          uv pip install
+          "policyengine-bundles @ git+https://github.com/PolicyEngine/policyengine-bundles@8ae9f56fefcf89f69b8a7e3bc49928509c6207be"
+      - name: Validate release manifest shape
+        run: >
+          uv run pytest
+          tests/unit/test_release_manifest.py::test_build_release_manifest_validates_against_bundle_contract
+          -v
+
   target-integration-tests:
     runs-on: ubuntu-latest
     needs: [check-fork, lint, unit-tests, smoke-test, decide-test-scope]

--- a/changelog.d/bundle-release-manifest.changed.md
+++ b/changelog.d/bundle-release-manifest.changed.md
@@ -1,0 +1,1 @@
+Extended US data release manifests with bundle-compatible model/core/build metadata and added contract validation against policyengine-bundles.

--- a/modal_app/local_area.py
+++ b/modal_app/local_area.py
@@ -104,7 +104,7 @@ from policyengine_us_data.utils.data_upload import (
     cleanup_staging_hf,
     upload_local_area_file,
     publish_release_manifest_to_hf,
-    should_finalize_local_area_release,
+    preflight_release_manifest_publish,
 )
 from policyengine_us_data.utils.version_manifest import (
     HFVersionInfo,
@@ -118,26 +118,29 @@ os.environ["US_DATA_RUN_ID"] = run_id
 rel_paths = json.loads('''{rel_paths_json}''')
 cleanup_staging = json.loads('''{cleanup_staging_json}''')
 run_dir = Path("{VOLUME_MOUNT}") / run_id
+national_h5 = run_dir / "national" / "US.h5"
+if not national_h5.exists():
+    raise RuntimeError(f"Expected national H5 at {{national_h5}}")
+
+print("Preflighting release manifest...")
+should_finalize, missing_prefixes = preflight_release_manifest_publish(
+    [(national_h5, "national/US.h5")],
+    version=version,
+    new_repo_paths=["national/US.h5"],
+    pipeline_run_id=run_id,
+)
 
 print(f"Promoting national H5 from staging to production (run_id={{run_id!r}})...")
 promoted = promote_staging_to_production_hf(rel_paths, version, run_id=run_id)
 print(f"Promoted {{promoted}} files to HuggingFace production")
 
-national_h5 = run_dir / "national" / "US.h5"
-if national_h5.exists():
-    print("Uploading national H5 to GCS...")
-    upload_local_area_file(
-        str(national_h5), "national", version=version, skip_hf=True
-    )
-    print("Uploaded national H5 to GCS")
-else:
-    raise RuntimeError(f"Expected national H5 at {{national_h5}}")
+print("Uploading national H5 to GCS...")
+upload_local_area_file(
+    str(national_h5), "national", version=version, skip_hf=True
+)
+print("Uploaded national H5 to GCS")
 
 print("Updating release manifest...")
-should_finalize, missing_prefixes = should_finalize_local_area_release(
-    version=version,
-    new_repo_paths=["national/US.h5"],
-)
 manifest = publish_release_manifest_to_hf(
     [(national_h5, "national/US.h5")],
     version=version,
@@ -193,7 +196,7 @@ from policyengine_us_data.utils.data_upload import (
     cleanup_staging_hf,
     upload_local_area_file,
     publish_release_manifest_to_hf,
-    should_finalize_local_area_release,
+    preflight_release_manifest_publish,
 )
 from policyengine_us_data.utils.version_manifest import (
     HFVersionInfo,
@@ -207,6 +210,21 @@ run_id = "{run_id}"
 os.environ["US_DATA_RUN_ID"] = run_id
 cleanup_staging = json.loads('''{cleanup_staging_json}''')
 run_dir = Path("{VOLUME_MOUNT}") / run_id
+manifest_files = [(run_dir / rel_path, rel_path) for rel_path in rel_paths]
+missing_local_paths = [str(path) for path, _ in manifest_files if not path.exists()]
+if missing_local_paths:
+    raise RuntimeError(
+        "Expected local-area artifacts before promotion: "
+        + ", ".join(missing_local_paths)
+    )
+
+print("Preflighting release manifest...")
+should_finalize, missing_prefixes = preflight_release_manifest_publish(
+    manifest_files,
+    version=version,
+    new_repo_paths=rel_paths,
+    pipeline_run_id=run_id,
+)
 
 print(f"Promoting {{len(rel_paths)}} files from staging/ to production (run_id={{run_id!r}})...")
 promoted = promote_staging_to_production_hf(rel_paths, version, run_id=run_id)
@@ -227,12 +245,8 @@ for rel_path in rel_paths:
 print(f"Uploaded {{gcs_count}} files to GCS")
 
 print("Updating release manifest...")
-should_finalize, missing_prefixes = should_finalize_local_area_release(
-    version=version,
-    new_repo_paths=rel_paths,
-)
 manifest = publish_release_manifest_to_hf(
-    [(run_dir / rel_path, rel_path) for rel_path in rel_paths],
+    manifest_files,
     version=version,
     create_tag=should_finalize,
     pipeline_run_id=run_id,

--- a/modal_app/local_area.py
+++ b/modal_app/local_area.py
@@ -142,6 +142,7 @@ manifest = publish_release_manifest_to_hf(
     [(national_h5, "national/US.h5")],
     version=version,
     create_tag=should_finalize,
+    pipeline_run_id=run_id,
 )
 if should_finalize:
     upload_manifest(
@@ -234,6 +235,7 @@ manifest = publish_release_manifest_to_hf(
     [(run_dir / rel_path, rel_path) for rel_path in rel_paths],
     version=version,
     create_tag=should_finalize,
+    pipeline_run_id=run_id,
 )
 if should_finalize:
     upload_manifest(

--- a/policyengine_us_data/calibration/promote_local_h5s.py
+++ b/policyengine_us_data/calibration/promote_local_h5s.py
@@ -137,6 +137,7 @@ def promote(files: list, rel_paths: list, version: str, run_id: str = ""):
         manifest_files,
         version=version,
         new_repo_paths=rel_paths,
+        pipeline_run_id=run_id,
     )
 
     logger.info(
@@ -152,6 +153,7 @@ def promote(files: list, rel_paths: list, version: str, run_id: str = ""):
         manifest_files,
         version=version,
         create_tag=should_finalize,
+        pipeline_run_id=run_id,
     )
     if should_finalize:
         upload_manifest(

--- a/policyengine_us_data/storage/upload_completed_datasets.py
+++ b/policyengine_us_data/storage/upload_completed_datasets.py
@@ -354,6 +354,7 @@ def promote_datasets(
         new_repo_paths=rel_paths,
         hf_repo_name=HF_REPO_NAME,
         hf_repo_type=HF_REPO_TYPE,
+        pipeline_run_id=run_id,
     )
 
     print(f"\nPromoting {len(rel_paths)} staged files to production...")
@@ -378,6 +379,7 @@ def promote_datasets(
         hf_repo_name=HF_REPO_NAME,
         hf_repo_type=HF_REPO_TYPE,
         create_tag=should_finalize,
+        pipeline_run_id=run_id,
     )
     if not should_finalize:
         print(

--- a/policyengine_us_data/utils/data_upload.py
+++ b/policyengine_us_data/utils/data_upload.py
@@ -8,7 +8,7 @@ from huggingface_hub import (
     CommitOperationDelete,
     hf_hub_download,
 )
-from huggingface_hub.errors import RevisionNotFoundError
+from huggingface_hub.errors import EntryNotFoundError, RevisionNotFoundError
 from google.cloud import storage
 from pathlib import Path
 from importlib import metadata
@@ -241,7 +241,7 @@ def load_release_manifest_from_hf(
             )
         except RevisionNotFoundError:
             return None
-        except Exception:
+        except EntryNotFoundError:
             continue
 
         with open(manifest_path) as f:

--- a/policyengine_us_data/utils/data_upload.py
+++ b/policyengine_us_data/utils/data_upload.py
@@ -1,5 +1,6 @@
 from io import BytesIO
-from typing import Dict, List, Optional, Sequence, Tuple
+from copy import deepcopy
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 from huggingface_hub import (
     HfApi,
     CommitOperationAdd,
@@ -16,6 +17,7 @@ import httpx
 import json
 import logging
 import os
+import subprocess
 
 from tenacity import (
     retry,
@@ -45,6 +47,7 @@ from policyengine_us_data.utils.trace_tro import (
     serialize_trace_tro,
 )
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_HF_TIMEOUT = 300
 MAX_RETRIES = 5
 RETRY_BASE_WAIT = 30
@@ -86,6 +89,19 @@ def _apply_run_context_for_release(
     return context.to_dict()
 
 
+def _pipeline_run_id_for_manifest(
+    pipeline_run_id: str = "",
+    run_context: Optional[Mapping[str, Any]] = None,
+) -> str | None:
+    if pipeline_run_id:
+        return pipeline_run_id
+    if run_context:
+        run_id = run_context.get("run_id")
+        if isinstance(run_id, str) and run_id:
+            return run_id
+    return None
+
+
 def _get_model_package_version(
     package_name: str = "policyengine-us",
 ) -> Optional[str]:
@@ -99,25 +115,90 @@ def _get_model_package_version(
         return None
 
 
+def _get_data_package_git_sha() -> Optional[str]:
+    github_sha = os.environ.get("GITHUB_SHA")
+    if github_sha:
+        return github_sha
+    try:
+        return subprocess.check_output(
+            ["git", "-C", str(REPO_ROOT), "rev-parse", "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def _get_core_package_runtime_metadata(
+    package_name: str = "policyengine-core",
+) -> Optional[Dict[str, Any]]:
+    module_name = package_name.replace("-", "_")
+    try:
+        runtime_metadata_module = __import__(
+            module_name,
+            fromlist=["get_runtime_metadata"],
+        )
+        get_runtime_metadata = getattr(
+            runtime_metadata_module,
+            "get_runtime_metadata",
+            None,
+        )
+        if callable(get_runtime_metadata):
+            runtime_metadata = get_runtime_metadata()
+            if isinstance(runtime_metadata, Mapping):
+                return dict(runtime_metadata)
+    except Exception:
+        logging.warning(
+            "Could not load runtime metadata from %s.",
+            package_name,
+            exc_info=True,
+        )
+
+    version = _get_model_package_version(package_name)
+    if version is None:
+        return None
+    return {
+        "name": package_name,
+        "version": version,
+    }
+
+
 def _get_model_package_build_metadata(
     package_name: str = "policyengine-us",
-) -> Dict[str, Optional[str]]:
-    metadata_payload: Dict[str, Optional[str]] = {
+) -> Dict[str, Any]:
+    metadata_payload: Dict[str, Any] = {
+        "name": package_name,
         "version": _get_model_package_version(package_name),
         "git_sha": None,
         "data_build_fingerprint": None,
+        "core": _get_core_package_runtime_metadata(),
     }
     module_name = package_name.replace("-", "_")
     try:
         build_metadata_module = __import__(
             f"{module_name}.build_metadata",
-            fromlist=["get_data_build_metadata"],
+            fromlist=["get_runtime_metadata", "get_data_build_metadata"],
+        )
+        get_runtime_metadata = getattr(
+            build_metadata_module,
+            "get_runtime_metadata",
+            None,
         )
         get_data_build_metadata = getattr(
             build_metadata_module, "get_data_build_metadata", None
         )
-        if callable(get_data_build_metadata):
-            package_metadata = get_data_build_metadata()
+        metadata_getter = (
+            get_runtime_metadata
+            if callable(get_runtime_metadata)
+            else get_data_build_metadata
+        )
+        if callable(metadata_getter):
+            package_metadata = metadata_getter()
+            if not isinstance(package_metadata, Mapping):
+                return metadata_payload
+            metadata_payload["name"] = package_metadata.get(
+                "name", metadata_payload["name"]
+            )
             metadata_payload["version"] = (
                 package_metadata.get("version") or metadata_payload["version"]
             )
@@ -125,6 +206,9 @@ def _get_model_package_build_metadata(
             metadata_payload["data_build_fingerprint"] = package_metadata.get(
                 "data_build_fingerprint"
             )
+            metadata_payload["core"] = package_metadata.get(
+                "core"
+            ) or metadata_payload.get("core")
     except Exception:
         logging.warning(
             "Could not load build metadata from %s while building release manifest.",
@@ -264,6 +348,8 @@ def preflight_release_manifest_publish(
     hf_repo_type: str = "model",
     model_package_name: str = "policyengine-us",
     model_package_version: Optional[str] = None,
+    pipeline_run_id: str = "",
+    run_context: Optional[Dict] = None,
 ) -> tuple[bool, list[str]]:
     should_finalize, missing_prefixes = should_finalize_local_area_release(
         version=version,
@@ -281,6 +367,7 @@ def preflight_release_manifest_publish(
         hf_repo_name=hf_repo_name,
         hf_repo_type=hf_repo_type,
     )
+    resolved_run_context = run_context or _run_context_for_release()
     model_build_metadata = _get_model_package_build_metadata(model_package_name)
     create_release_manifest_commit_operations(
         files_with_repo_paths=[
@@ -294,6 +381,12 @@ def preflight_release_manifest_publish(
         model_package_data_build_fingerprint=model_build_metadata[
             "data_build_fingerprint"
         ],
+        core_package_metadata=model_build_metadata.get("core"),
+        run_context=resolved_run_context,
+        pipeline_run_id=_pipeline_run_id_for_manifest(
+            pipeline_run_id, resolved_run_context
+        ),
+        data_package_git_sha=_get_data_package_git_sha(),
         existing_manifest=existing_manifest,
     )
     return should_finalize, missing_prefixes
@@ -308,6 +401,9 @@ def create_release_manifest_commit_operations(
     model_package_git_sha: Optional[str] = None,
     model_package_data_build_fingerprint: Optional[str] = None,
     run_context: Optional[Dict] = None,
+    core_package_metadata: Optional[Mapping[str, Any]] = None,
+    pipeline_run_id: Optional[str] = None,
+    data_package_git_sha: Optional[str] = None,
     existing_manifest: Optional[Dict] = None,
 ) -> Tuple[Dict, List[CommitOperationAdd]]:
     manifest = build_release_manifest(
@@ -319,6 +415,9 @@ def create_release_manifest_commit_operations(
         model_package_git_sha=model_package_git_sha,
         model_package_data_build_fingerprint=model_package_data_build_fingerprint,
         run_context=run_context,
+        core_package_metadata=core_package_metadata,
+        pipeline_run_id=pipeline_run_id,
+        data_package_git_sha=data_package_git_sha,
         existing_manifest=existing_manifest,
     )
     manifest_payload = serialize_release_manifest(manifest)
@@ -406,6 +505,8 @@ def get_matching_finalized_release_manifest(
     hf_repo_type: str,
     model_package_name: str,
     model_package_version: Optional[str] = None,
+    pipeline_run_id: str = "",
+    run_context: Optional[Dict] = None,
 ) -> Optional[Dict]:
     finalized_manifest = load_release_manifest_from_hf(
         version=version,
@@ -417,6 +518,24 @@ def get_matching_finalized_release_manifest(
         return None
 
     model_build_metadata = _get_model_package_build_metadata(model_package_name)
+    finalized_build = finalized_manifest.get("build")
+    finalized_build = finalized_build if isinstance(finalized_build, dict) else {}
+    finalized_build_metadata = finalized_build.get("metadata")
+    finalized_build_metadata = (
+        finalized_build_metadata if isinstance(finalized_build_metadata, dict) else {}
+    )
+    finalized_run_context = finalized_build_metadata.get(
+        "run_context"
+    ) or finalized_build.get("run")
+    finalized_run_context = (
+        finalized_run_context if isinstance(finalized_run_context, Mapping) else None
+    )
+    finalized_core_metadata = finalized_build.get("built_with_core_package")
+    finalized_core_metadata = (
+        finalized_core_metadata
+        if isinstance(finalized_core_metadata, Mapping)
+        else None
+    )
     candidate_manifest, _ = create_release_manifest_commit_operations(
         files_with_repo_paths=[
             (Path(path), repo_path) for path, repo_path in files_with_paths
@@ -429,17 +548,34 @@ def get_matching_finalized_release_manifest(
         model_package_data_build_fingerprint=model_build_metadata[
             "data_build_fingerprint"
         ],
+        core_package_metadata=finalized_core_metadata,
+        run_context=finalized_run_context,
+        pipeline_run_id=finalized_build_metadata.get("pipeline_run_id"),
+        data_package_git_sha=finalized_build_metadata.get("data_package_git_sha"),
         existing_manifest=finalized_manifest,
     )
-    if "created_at" in finalized_manifest:
-        candidate_manifest["created_at"] = finalized_manifest["created_at"]
-    finalized_build = finalized_manifest.get("build")
-    if isinstance(finalized_build, dict):
-        candidate_build = candidate_manifest.setdefault("build", {})
-        for field in ("build_id", "built_at"):
-            if field in finalized_build:
-                candidate_build[field] = finalized_build[field]
-    if candidate_manifest != finalized_manifest:
+    candidate_build = candidate_manifest.setdefault("build", {})
+    for field in ("build_id", "built_at"):
+        if field in finalized_build:
+            candidate_build[field] = finalized_build[field]
+
+    comparable_finalized_manifest = deepcopy(finalized_manifest)
+    legacy_created_at = comparable_finalized_manifest.pop("created_at", None)
+    if legacy_created_at is not None and "built_at" not in finalized_build:
+        candidate_build["built_at"] = legacy_created_at
+    if legacy_created_at is not None:
+        comparable_finalized_manifest.setdefault("build", {}).setdefault(
+            "built_at", legacy_created_at
+        )
+    comparable_build = comparable_finalized_manifest.get("build")
+    if isinstance(comparable_build, dict):
+        legacy_run = comparable_build.pop("run", None)
+        if legacy_run:
+            comparable_build.setdefault("metadata", {}).setdefault(
+                "run_context", legacy_run
+            )
+    comparable_finalized_manifest.setdefault("compatible_core_packages", [])
+    if candidate_manifest != comparable_finalized_manifest:
         raise RuntimeError(
             f"Release {version} is already finalized on {hf_repo_name}. "
             "Refusing to mutate the tagged release manifest."
@@ -514,6 +650,7 @@ def upload_files_to_hf(
         hf_repo_type=hf_repo_type,
     )
     model_build_metadata = _get_model_package_build_metadata()
+    run_context = _run_context_for_release()
     _, manifest_operations = create_release_manifest_commit_operations(
         files_with_repo_paths=files_with_repo_paths,
         version=version,
@@ -523,7 +660,10 @@ def upload_files_to_hf(
         model_package_data_build_fingerprint=model_build_metadata[
             "data_build_fingerprint"
         ],
-        run_context=_run_context_for_release(),
+        run_context=run_context,
+        core_package_metadata=model_build_metadata.get("core"),
+        pipeline_run_id=_pipeline_run_id_for_manifest(run_context=run_context),
+        data_package_git_sha=_get_data_package_git_sha(),
         existing_manifest=existing_manifest,
     )
     hf_operations.extend(manifest_operations)
@@ -689,9 +829,12 @@ def publish_release_manifest_to_hf(
     model_package_name: str = "policyengine-us",
     model_package_version: Optional[str] = None,
     create_tag: bool = False,
+    pipeline_run_id: str = "",
+    run_context: Optional[Dict] = None,
 ) -> Dict:
     token = os.environ.get("HUGGING_FACE_TOKEN")
     api = HfApi()
+    resolved_run_context = run_context or _run_context_for_release()
     finalized_manifest = get_matching_finalized_release_manifest(
         files_with_paths=files_with_paths,
         version=version,
@@ -699,6 +842,8 @@ def publish_release_manifest_to_hf(
         hf_repo_type=hf_repo_type,
         model_package_name=model_package_name,
         model_package_version=model_package_version,
+        pipeline_run_id=pipeline_run_id,
+        run_context=resolved_run_context,
     )
     if finalized_manifest is not None:
         return finalized_manifest
@@ -726,7 +871,12 @@ def publish_release_manifest_to_hf(
         model_package_data_build_fingerprint=model_build_metadata[
             "data_build_fingerprint"
         ],
-        run_context=_run_context_for_release(),
+        run_context=resolved_run_context,
+        core_package_metadata=model_build_metadata.get("core"),
+        pipeline_run_id=_pipeline_run_id_for_manifest(
+            pipeline_run_id, resolved_run_context
+        ),
+        data_package_git_sha=_get_data_package_git_sha(),
         existing_manifest=existing_manifest,
     )
     parent_commit = get_repo_head_revision(

--- a/policyengine_us_data/utils/release_manifest.py
+++ b/policyengine_us_data/utils/release_manifest.py
@@ -84,7 +84,78 @@ def _core_version(core_package_metadata: Mapping[str, Any] | None) -> str | None
     return version if isinstance(version, str) and version else None
 
 
-def _base_manifest(
+def _model_package_compatibility(
+    *,
+    model_package_name: str,
+    model_package_version: str | None,
+    additional_compatible_specifiers: Sequence[str] | None = None,
+) -> list[Dict[str, str]]:
+    compatible_packages = []
+    if model_package_version:
+        compatible_packages.append(
+            {
+                "name": model_package_name,
+                "specifier": f"=={model_package_version}",
+            }
+        )
+    for specifier in additional_compatible_specifiers or ():
+        compatible_packages.append({"name": model_package_name, "specifier": specifier})
+    return compatible_packages
+
+
+def _core_package_compatibility(
+    core_package_metadata: Mapping[str, Any] | None,
+) -> list[Dict[str, str]]:
+    core_version = _core_version(core_package_metadata)
+    if not core_version:
+        return []
+    return [
+        {
+            "name": core_package_metadata.get("name", "policyengine-core"),
+            "specifier": f"=={core_version}",
+        }
+    ]
+
+
+def _build_section(
+    *,
+    model_package_name: str,
+    model_package_version: str | None,
+    model_package_git_sha: str | None,
+    model_package_data_build_fingerprint: str | None,
+    core_package_metadata: Mapping[str, Any] | None,
+    run_context: Mapping[str, Any] | None,
+    build_id: str,
+    created_at: str,
+    pipeline_run_id: str | None,
+    data_package_git_sha: str | None,
+) -> Dict:
+    build = {
+        "build_id": build_id,
+        "built_at": created_at,
+    }
+    build_metadata = _build_metadata(
+        pipeline_run_id=pipeline_run_id,
+        data_package_git_sha=data_package_git_sha,
+        run_context=run_context,
+    )
+    if build_metadata:
+        build["metadata"] = build_metadata
+    model_package_metadata = _runtime_component_metadata(
+        name=model_package_name,
+        version=model_package_version,
+        git_sha=model_package_git_sha,
+        data_build_fingerprint=model_package_data_build_fingerprint,
+        core_package_metadata=core_package_metadata,
+    )
+    if model_package_metadata is not None:
+        build["built_with_model_package"] = model_package_metadata
+    if core_package_metadata is not None:
+        build["built_with_core_package"] = dict(core_package_metadata)
+    return build
+
+
+def _new_manifest(
     *,
     version: str,
     data_package_name: str,
@@ -100,28 +171,61 @@ def _base_manifest(
     pipeline_run_id: str | None,
     data_package_git_sha: str | None,
 ) -> Dict:
-    build_metadata = _build_metadata(
-        pipeline_run_id=pipeline_run_id,
-        data_package_git_sha=data_package_git_sha,
-        run_context=run_context,
-    )
-    manifest = {
+    return {
         "schema_version": RELEASE_MANIFEST_SCHEMA_VERSION,
         "data_package": {
             "name": data_package_name,
             "version": version,
         },
-        "compatible_model_packages": [],
-        "compatible_core_packages": [],
+        "compatible_model_packages": _model_package_compatibility(
+            model_package_name=model_package_name,
+            model_package_version=model_package_version,
+            additional_compatible_specifiers=additional_compatible_specifiers,
+        ),
+        "compatible_core_packages": _core_package_compatibility(core_package_metadata),
         "default_datasets": {},
-        "build": {
-            "build_id": build_id,
-            "built_at": created_at,
-        },
+        "build": _build_section(
+            model_package_name=model_package_name,
+            model_package_version=model_package_version,
+            model_package_git_sha=model_package_git_sha,
+            model_package_data_build_fingerprint=model_package_data_build_fingerprint,
+            core_package_metadata=core_package_metadata,
+            run_context=run_context,
+            build_id=build_id,
+            created_at=created_at,
+            pipeline_run_id=pipeline_run_id,
+            data_package_git_sha=data_package_git_sha,
+        ),
         "artifacts": {},
     }
+
+
+def _update_existing_build_section(
+    manifest: Dict,
+    *,
+    model_package_name: str,
+    model_package_version: str | None,
+    model_package_git_sha: str | None,
+    model_package_data_build_fingerprint: str | None,
+    core_package_metadata: Mapping[str, Any] | None,
+    run_context: Mapping[str, Any] | None,
+    build_id: str,
+    created_at: str,
+    pipeline_run_id: str | None,
+    data_package_git_sha: str | None,
+) -> None:
+    build = manifest.setdefault("build", {})
+    build.setdefault("build_id", build_id)
+    build.setdefault("built_at", created_at)
+
+    build_metadata = _build_metadata(
+        pipeline_run_id=pipeline_run_id,
+        data_package_git_sha=data_package_git_sha,
+        run_context=run_context,
+    )
     if build_metadata:
-        manifest["build"]["metadata"] = build_metadata
+        build.setdefault("metadata", {}).update(build_metadata)
+
     model_package_metadata = _runtime_component_metadata(
         name=model_package_name,
         version=model_package_version,
@@ -130,29 +234,53 @@ def _base_manifest(
         core_package_metadata=core_package_metadata,
     )
     if model_package_metadata is not None:
-        manifest["build"]["built_with_model_package"] = model_package_metadata
+        build["built_with_model_package"] = model_package_metadata
     if core_package_metadata is not None:
-        manifest["build"]["built_with_core_package"] = dict(core_package_metadata)
-    if model_package_version:
-        manifest["compatible_model_packages"].append(
-            {
-                "name": model_package_name,
-                "specifier": f"=={model_package_version}",
-            }
-        )
-    for specifier in additional_compatible_specifiers or ():
-        manifest["compatible_model_packages"].append(
-            {"name": model_package_name, "specifier": specifier}
-        )
-    core_version = _core_version(core_package_metadata)
-    if core_version:
-        manifest["compatible_core_packages"].append(
-            {
-                "name": core_package_metadata.get("name", "policyengine-core"),
-                "specifier": f"=={core_version}",
-            }
-        )
-    return manifest
+        build["built_with_core_package"] = dict(core_package_metadata)
+
+
+def _update_existing_manifest_metadata(
+    manifest: Dict,
+    *,
+    model_package_name: str,
+    model_package_version: str | None,
+    model_package_git_sha: str | None,
+    model_package_data_build_fingerprint: str | None,
+    core_package_metadata: Mapping[str, Any] | None,
+    run_context: Mapping[str, Any] | None,
+    build_id: str,
+    created_at: str,
+    additional_compatible_specifiers: Sequence[str] | None = None,
+    pipeline_run_id: str | None,
+    data_package_git_sha: str | None,
+) -> None:
+    manifest["schema_version"] = RELEASE_MANIFEST_SCHEMA_VERSION
+    manifest.setdefault("compatible_core_packages", [])
+    _update_existing_build_section(
+        manifest,
+        model_package_name=model_package_name,
+        model_package_version=model_package_version,
+        model_package_git_sha=model_package_git_sha,
+        model_package_data_build_fingerprint=model_package_data_build_fingerprint,
+        core_package_metadata=core_package_metadata,
+        run_context=run_context,
+        build_id=build_id,
+        created_at=created_at,
+        pipeline_run_id=pipeline_run_id,
+        data_package_git_sha=data_package_git_sha,
+    )
+
+    compatible_model_packages = _model_package_compatibility(
+        model_package_name=model_package_name,
+        model_package_version=model_package_version,
+        additional_compatible_specifiers=additional_compatible_specifiers,
+    )
+    if compatible_model_packages:
+        manifest["compatible_model_packages"] = compatible_model_packages
+
+    compatible_core_packages = _core_package_compatibility(core_package_metadata)
+    if compatible_core_packages:
+        manifest["compatible_core_packages"] = compatible_core_packages
 
 
 def _normalize_existing_manifest(
@@ -174,6 +302,52 @@ def _normalize_existing_manifest(
         if legacy_run:
             build.setdefault("metadata", {}).setdefault("run_context", legacy_run)
     return manifest
+
+
+def _artifact_entry(
+    *,
+    local_path: Path,
+    path_in_repo: str,
+    repo_id: str,
+    version: str,
+) -> Dict[str, Any]:
+    return {
+        "kind": _artifact_kind(path_in_repo),
+        "path": path_in_repo,
+        "repo_id": repo_id,
+        "revision": version,
+        "sha256": compute_file_checksum(local_path),
+        "size_bytes": local_path.stat().st_size,
+    }
+
+
+def _update_artifacts(
+    manifest: Dict,
+    *,
+    files_with_repo_paths: Sequence[Tuple[Path | str, str]],
+    repo_id: str,
+    version: str,
+) -> None:
+    artifacts = manifest.setdefault("artifacts", {})
+    for local_path, path_in_repo in files_with_repo_paths:
+        local_path = Path(local_path)
+        artifacts[_artifact_key(path_in_repo)] = _artifact_entry(
+            local_path=local_path,
+            path_in_repo=path_in_repo,
+            repo_id=repo_id,
+            version=version,
+        )
+
+
+def _update_default_datasets(
+    manifest: Dict,
+    default_datasets: Optional[Mapping[str, str]] = None,
+) -> None:
+    defaults = manifest.setdefault("default_datasets", {})
+    if default_datasets:
+        defaults.update(default_datasets)
+    if "national" not in defaults and "enhanced_cps_2024" in manifest["artifacts"]:
+        defaults["national"] = "enhanced_cps_2024"
 
 
 def build_release_manifest(
@@ -205,7 +379,7 @@ def build_release_manifest(
     resolved_build_id = build_id or f"{data_package_name}-{version}"
 
     if manifest is None:
-        manifest = _base_manifest(
+        manifest = _new_manifest(
             version=version,
             data_package_name=data_package_name,
             model_package_name=model_package_name,
@@ -221,69 +395,28 @@ def build_release_manifest(
             data_package_git_sha=data_package_git_sha,
         )
     else:
-        manifest["schema_version"] = RELEASE_MANIFEST_SCHEMA_VERSION
-        manifest.setdefault("compatible_core_packages", [])
-        manifest.setdefault("build", {})
-        manifest["build"].setdefault("build_id", resolved_build_id)
-        manifest["build"].setdefault("built_at", manifest_timestamp)
-        build_metadata = _build_metadata(
+        _update_existing_manifest_metadata(
+            manifest,
+            model_package_name=model_package_name,
+            model_package_version=model_package_version,
+            model_package_git_sha=model_package_git_sha,
+            model_package_data_build_fingerprint=model_package_data_build_fingerprint,
+            core_package_metadata=core_package_metadata,
+            run_context=run_context,
+            build_id=resolved_build_id,
+            created_at=manifest_timestamp,
+            additional_compatible_specifiers=additional_compatible_specifiers,
             pipeline_run_id=pipeline_run_id,
             data_package_git_sha=data_package_git_sha,
-            run_context=run_context,
         )
-        if build_metadata:
-            manifest["build"].setdefault("metadata", {}).update(build_metadata)
-        model_package_metadata = _runtime_component_metadata(
-            name=model_package_name,
-            version=model_package_version,
-            git_sha=model_package_git_sha,
-            data_build_fingerprint=model_package_data_build_fingerprint,
-            core_package_metadata=core_package_metadata,
-        )
-        if model_package_metadata is not None:
-            manifest["build"]["built_with_model_package"] = model_package_metadata
-        if core_package_metadata is not None:
-            manifest["build"]["built_with_core_package"] = dict(core_package_metadata)
-        compat = []
-        if model_package_version:
-            compat.append(
-                {
-                    "name": model_package_name,
-                    "specifier": f"=={model_package_version}",
-                }
-            )
-        for specifier in additional_compatible_specifiers or ():
-            compat.append({"name": model_package_name, "specifier": specifier})
-        if compat:
-            manifest["compatible_model_packages"] = compat
-        core_version = _core_version(core_package_metadata)
-        if core_version:
-            manifest["compatible_core_packages"] = [
-                {
-                    "name": core_package_metadata.get("name", "policyengine-core"),
-                    "specifier": f"=={core_version}",
-                }
-            ]
 
-    if default_datasets:
-        manifest.setdefault("default_datasets", {}).update(default_datasets)
-
-    for local_path, path_in_repo in files_with_repo_paths:
-        local_path = Path(local_path)
-        manifest["artifacts"][_artifact_key(path_in_repo)] = {
-            "kind": _artifact_kind(path_in_repo),
-            "path": path_in_repo,
-            "repo_id": repo_id,
-            "revision": version,
-            "sha256": compute_file_checksum(local_path),
-            "size_bytes": local_path.stat().st_size,
-        }
-
-    if (
-        "national" not in manifest["default_datasets"]
-        and "enhanced_cps_2024" in manifest["artifacts"]
-    ):
-        manifest["default_datasets"]["national"] = "enhanced_cps_2024"
+    _update_artifacts(
+        manifest,
+        files_with_repo_paths=files_with_repo_paths,
+        repo_id=repo_id,
+        version=version,
+    )
+    _update_default_datasets(manifest, default_datasets)
 
     return manifest
 

--- a/policyengine_us_data/utils/release_manifest.py
+++ b/policyengine_us_data/utils/release_manifest.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from datetime import datetime, timezone
 import json
 from pathlib import Path, PurePosixPath
-from typing import Dict, Mapping, Optional, Sequence, Tuple
+from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
 
 from policyengine_us_data.utils.manifest import compute_file_checksum
 
@@ -32,6 +32,58 @@ def _artifact_kind(path_in_repo: str) -> str:
     return "auxiliary"
 
 
+def _without_none_values(payload: Mapping[str, Any]) -> Dict[str, Any]:
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def _runtime_component_metadata(
+    *,
+    name: str,
+    version: str | None,
+    git_sha: str | None = None,
+    data_build_fingerprint: str | None = None,
+    core_package_metadata: Mapping[str, Any] | None = None,
+) -> Dict[str, Any] | None:
+    if version is None:
+        return None
+
+    metadata = _without_none_values(
+        {
+            "name": name,
+            "version": version,
+            "git_sha": git_sha,
+            "data_build_fingerprint": data_build_fingerprint,
+        }
+    )
+    if core_package_metadata is not None:
+        metadata["core"] = dict(core_package_metadata)
+    return metadata
+
+
+def _build_metadata(
+    *,
+    pipeline_run_id: str | None,
+    data_package_git_sha: str | None,
+    run_context: Mapping[str, Any] | None,
+) -> Dict[str, Any]:
+    metadata = _without_none_values(
+        {
+            "pipeline_run_id": pipeline_run_id,
+            "data_package_git_sha": data_package_git_sha,
+        }
+    )
+    if run_context:
+        metadata["run_context"] = dict(run_context)
+    return metadata
+
+
+def _core_version(core_package_metadata: Mapping[str, Any] | None) -> str | None:
+    if core_package_metadata is None:
+        return None
+    version = core_package_metadata.get("version")
+    return version if isinstance(version, str) and version else None
+
+
 def _base_manifest(
     *,
     version: str,
@@ -40,11 +92,19 @@ def _base_manifest(
     model_package_version: str | None,
     model_package_git_sha: str | None,
     model_package_data_build_fingerprint: str | None,
-    run_context: Mapping[str, str] | None,
+    core_package_metadata: Mapping[str, Any] | None,
+    run_context: Mapping[str, Any] | None,
     build_id: str,
     created_at: str,
     additional_compatible_specifiers: Sequence[str] | None = None,
+    pipeline_run_id: str | None,
+    data_package_git_sha: str | None,
 ) -> Dict:
+    build_metadata = _build_metadata(
+        pipeline_run_id=pipeline_run_id,
+        data_package_git_sha=data_package_git_sha,
+        run_context=run_context,
+    )
     manifest = {
         "schema_version": RELEASE_MANIFEST_SCHEMA_VERSION,
         "data_package": {
@@ -52,27 +112,27 @@ def _base_manifest(
             "version": version,
         },
         "compatible_model_packages": [],
+        "compatible_core_packages": [],
         "default_datasets": {},
-        "created_at": created_at,
         "build": {
             "build_id": build_id,
             "built_at": created_at,
         },
         "artifacts": {},
     }
-    if (
-        model_package_version
-        or model_package_git_sha
-        or model_package_data_build_fingerprint
-    ):
-        manifest["build"]["built_with_model_package"] = {
-            "name": model_package_name,
-            "version": model_package_version,
-            "git_sha": model_package_git_sha,
-            "data_build_fingerprint": model_package_data_build_fingerprint,
-        }
-    if run_context:
-        manifest["build"]["run"] = dict(run_context)
+    if build_metadata:
+        manifest["build"]["metadata"] = build_metadata
+    model_package_metadata = _runtime_component_metadata(
+        name=model_package_name,
+        version=model_package_version,
+        git_sha=model_package_git_sha,
+        data_build_fingerprint=model_package_data_build_fingerprint,
+        core_package_metadata=core_package_metadata,
+    )
+    if model_package_metadata is not None:
+        manifest["build"]["built_with_model_package"] = model_package_metadata
+    if core_package_metadata is not None:
+        manifest["build"]["built_with_core_package"] = dict(core_package_metadata)
     if model_package_version:
         manifest["compatible_model_packages"].append(
             {
@@ -83,6 +143,14 @@ def _base_manifest(
     for specifier in additional_compatible_specifiers or ():
         manifest["compatible_model_packages"].append(
             {"name": model_package_name, "specifier": specifier}
+        )
+    core_version = _core_version(core_package_metadata)
+    if core_version:
+        manifest["compatible_core_packages"].append(
+            {
+                "name": core_package_metadata.get("name", "policyengine-core"),
+                "specifier": f"=={core_version}",
+            }
         )
     return manifest
 
@@ -98,7 +166,14 @@ def _normalize_existing_manifest(
     package = existing_manifest.get("data_package", {})
     if package.get("name") != data_package_name or package.get("version") != version:
         return None
-    return deepcopy(dict(existing_manifest))
+    manifest = deepcopy(dict(existing_manifest))
+    manifest.pop("created_at", None)
+    build = manifest.get("build")
+    if isinstance(build, dict):
+        legacy_run = build.pop("run", None)
+        if legacy_run:
+            build.setdefault("metadata", {}).setdefault("run_context", legacy_run)
+    return manifest
 
 
 def build_release_manifest(
@@ -111,8 +186,11 @@ def build_release_manifest(
     model_package_version: str | None = None,
     model_package_git_sha: str | None = None,
     model_package_data_build_fingerprint: str | None = None,
-    run_context: Mapping[str, str] | None = None,
+    core_package_metadata: Optional[Mapping[str, Any]] = None,
+    run_context: Mapping[str, Any] | None = None,
     build_id: str | None = None,
+    pipeline_run_id: str | None = None,
+    data_package_git_sha: str | None = None,
     existing_manifest: Mapping | None = None,
     default_datasets: Optional[Mapping[str, str]] = None,
     created_at: str | None = None,
@@ -134,31 +212,39 @@ def build_release_manifest(
             model_package_version=model_package_version,
             model_package_git_sha=model_package_git_sha,
             model_package_data_build_fingerprint=model_package_data_build_fingerprint,
+            core_package_metadata=core_package_metadata,
             run_context=run_context,
             build_id=resolved_build_id,
             created_at=manifest_timestamp,
             additional_compatible_specifiers=additional_compatible_specifiers,
+            pipeline_run_id=pipeline_run_id,
+            data_package_git_sha=data_package_git_sha,
         )
     else:
         manifest["schema_version"] = RELEASE_MANIFEST_SCHEMA_VERSION
-        manifest["created_at"] = manifest_timestamp
+        manifest.setdefault("compatible_core_packages", [])
         manifest.setdefault("build", {})
         manifest["build"].setdefault("build_id", resolved_build_id)
         manifest["build"].setdefault("built_at", manifest_timestamp)
-        if (
-            model_package_version
-            or model_package_git_sha
-            or model_package_data_build_fingerprint
-        ):
-            manifest["build"]["built_with_model_package"] = {
-                "name": model_package_name,
-                "version": model_package_version,
-                "git_sha": model_package_git_sha,
-                "data_build_fingerprint": model_package_data_build_fingerprint,
-            }
+        build_metadata = _build_metadata(
+            pipeline_run_id=pipeline_run_id,
+            data_package_git_sha=data_package_git_sha,
+            run_context=run_context,
+        )
+        if build_metadata:
+            manifest["build"].setdefault("metadata", {}).update(build_metadata)
+        model_package_metadata = _runtime_component_metadata(
+            name=model_package_name,
+            version=model_package_version,
+            git_sha=model_package_git_sha,
+            data_build_fingerprint=model_package_data_build_fingerprint,
+            core_package_metadata=core_package_metadata,
+        )
+        if model_package_metadata is not None:
+            manifest["build"]["built_with_model_package"] = model_package_metadata
+        if core_package_metadata is not None:
+            manifest["build"]["built_with_core_package"] = dict(core_package_metadata)
         compat = []
-        if run_context:
-            manifest["build"]["run"] = dict(run_context)
         if model_package_version:
             compat.append(
                 {
@@ -170,6 +256,14 @@ def build_release_manifest(
             compat.append({"name": model_package_name, "specifier": specifier})
         if compat:
             manifest["compatible_model_packages"] = compat
+        core_version = _core_version(core_package_metadata)
+        if core_version:
+            manifest["compatible_core_packages"] = [
+                {
+                    "name": core_package_metadata.get("name", "policyengine-core"),
+                    "specifier": f"=={core_version}",
+                }
+            ]
 
     if default_datasets:
         manifest.setdefault("default_datasets", {}).update(default_datasets)

--- a/tests/support/modal_local_area.py
+++ b/tests/support/modal_local_area.py
@@ -74,6 +74,8 @@ def load_local_area_module(*, stub_policyengine: bool = True):
         fake_local_h5 = ModuleType("policyengine_us_data.calibration.local_h5")
         fake_utils = ModuleType("policyengine_us_data.utils")
         fake_run_context = ModuleType("policyengine_us_data.utils.run_context")
+        fake_pipeline_metadata = ModuleType("policyengine_us_data.pipeline_metadata")
+        fake_pipeline_schema = ModuleType("policyengine_us_data.pipeline_schema")
         fake_partitioning = ModuleType(
             "policyengine_us_data.calibration.local_h5.partitioning"
         )
@@ -85,6 +87,8 @@ def load_local_area_module(*, stub_policyengine: bool = True):
         fake_local_h5.__path__ = []
         fake_utils.__path__ = []
         fake_run_context.resolve_run_id = lambda explicit="", **kwargs: explicit
+        fake_pipeline_metadata.pipeline_node = lambda *args, **kwargs: lambda func: func
+        fake_pipeline_schema.PipelineNode = SimpleNamespace
         fake_partitioning.partition_weighted_work_items = lambda *args, **kwargs: []
         fake_fingerprinting.PublishingInputBundle = object
 
@@ -109,6 +113,8 @@ def load_local_area_module(*, stub_policyengine: bool = True):
                 "policyengine_us_data.calibration.local_h5.partitioning": (
                     fake_partitioning
                 ),
+                "policyengine_us_data.pipeline_metadata": fake_pipeline_metadata,
+                "policyengine_us_data.pipeline_schema": fake_pipeline_schema,
             }
         )
 

--- a/tests/unit/test_modal_local_area.py
+++ b/tests/unit/test_modal_local_area.py
@@ -17,6 +17,11 @@ def test_build_promote_national_publish_script_imports_version_manifest_helpers(
     assert "HFVersionInfo" in script
     assert "build_manifest" in script
     assert "upload_manifest" in script
+    assert "preflight_release_manifest_publish" in script
+    assert "should_finalize_local_area_release" not in script
+    assert script.index(
+        "should_finalize, missing_prefixes = preflight_release_manifest_publish("
+    ) < script.index("promoted = promote_staging_to_production_hf(")
     assert 'os.environ["US_DATA_RUN_ID"] = run_id' in script
     assert 'os.environ["RUN_ID"]' not in script
 
@@ -30,7 +35,11 @@ def test_build_promote_publish_script_finalizes_complete_release():
         rel_paths=["states/AL.h5", "districts/AL-01.h5", "cities/NYC.h5"],
     )
 
-    assert "should_finalize_local_area_release" in script
+    assert "preflight_release_manifest_publish" in script
+    assert "should_finalize_local_area_release" not in script
+    assert script.index(
+        "should_finalize, missing_prefixes = preflight_release_manifest_publish("
+    ) < script.index("promoted = promote_staging_to_production_hf(")
     assert "create_tag=should_finalize" in script
     assert "upload_manifest(" in script
     assert 'os.environ["US_DATA_RUN_ID"] = run_id' in script

--- a/tests/unit/test_release_manifest.py
+++ b/tests/unit/test_release_manifest.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from huggingface_hub import CommitOperationAdd
+import pytest
 
 from policyengine_us_data.utils.data_upload import (
     load_release_manifest_from_hf,
@@ -30,6 +31,10 @@ def _sha256(content: bytes) -> str:
 
 EXPECTED_COMPATIBLE_MODEL_PACKAGES = [
     {"name": "policyengine-us", "specifier": "==1.634.4"}
+]
+EXPECTED_CORE_PACKAGE = {"name": "policyengine-core", "version": "3.25.4"}
+EXPECTED_COMPATIBLE_CORE_PACKAGES = [
+    {"name": "policyengine-core", "specifier": "==3.25.4"}
 ]
 
 
@@ -68,6 +73,9 @@ def test_build_release_manifest_tracks_uploaded_artifacts(tmp_path):
         model_package_version="1.634.4",
         model_package_git_sha="deadbeef",
         model_package_data_build_fingerprint="sha256:fingerprint",
+        core_package_metadata=EXPECTED_CORE_PACKAGE,
+        pipeline_run_id="run-123",
+        data_package_git_sha="cafebabe",
         created_at="2026-04-10T12:00:00Z",
     )
 
@@ -77,15 +85,22 @@ def test_build_release_manifest_tracks_uploaded_artifacts(tmp_path):
     }
     assert manifest["schema_version"] == RELEASE_MANIFEST_SCHEMA_VERSION
     assert manifest["compatible_model_packages"] == EXPECTED_COMPATIBLE_MODEL_PACKAGES
+    assert manifest["compatible_core_packages"] == EXPECTED_COMPATIBLE_CORE_PACKAGES
     assert manifest["build"] == {
         "build_id": "policyengine-us-data-1.73.0",
         "built_at": "2026-04-10T12:00:00Z",
+        "metadata": {
+            "pipeline_run_id": "run-123",
+            "data_package_git_sha": "cafebabe",
+        },
         "built_with_model_package": {
             "name": "policyengine-us",
             "version": "1.634.4",
             "git_sha": "deadbeef",
             "data_build_fingerprint": "sha256:fingerprint",
+            "core": EXPECTED_CORE_PACKAGE,
         },
+        "built_with_core_package": EXPECTED_CORE_PACKAGE,
     }
     assert manifest["default_datasets"] == {"national": "enhanced_cps_2024"}
 
@@ -166,7 +181,7 @@ def test_build_release_manifest_merges_existing_release_same_version(tmp_path):
 
     assert set(manifest["artifacts"]) == {"enhanced_cps_2024", "districts/NC-01"}
     assert manifest["default_datasets"] == {"national": "enhanced_cps_2024"}
-    assert manifest["created_at"] == "2026-04-10T12:00:00Z"
+    assert "created_at" not in manifest
     assert manifest["build"] == {
         "build_id": "policyengine-us-data-1.73.0",
         "built_at": "2026-04-10T12:00:00Z",
@@ -198,11 +213,39 @@ def test_build_release_manifest_records_run_context(tmp_path):
         created_at="2026-04-10T12:00:00Z",
     )
 
-    assert manifest["build"]["run"] == {
+    assert manifest["build"]["metadata"]["run_context"] == {
         "run_id": "usdata-gha123-a1-abcdef12",
         "modal_app_name": "policyengine-us-data-pub-usdata-gha123-a1-abcdef12",
         "hf_staging_prefix": "staging/usdata-gha123-a1-abcdef12",
     }
+
+
+def test_build_release_manifest_validates_against_bundle_contract(tmp_path):
+    policyengine_bundles = pytest.importorskip("policyengine_bundles")
+    dataset_path = _write_file(
+        tmp_path / "enhanced_cps_2024.h5",
+        b"national-dataset",
+    )
+
+    manifest = build_release_manifest(
+        files_with_repo_paths=[(dataset_path, "enhanced_cps_2024.h5")],
+        version="1.73.0",
+        repo_id="policyengine/policyengine-us-data",
+        run_context={
+            "run_id": "usdata-gha123-a1-abcdef12",
+            "modal_app_name": "policyengine-us-data-pub-usdata-gha123-a1-abcdef12",
+            "hf_staging_prefix": "staging/usdata-gha123-a1-abcdef12",
+        },
+        model_package_version="1.634.4",
+        model_package_git_sha="deadbeef",
+        model_package_data_build_fingerprint="sha256:fingerprint",
+        core_package_metadata=EXPECTED_CORE_PACKAGE,
+        pipeline_run_id="run-123",
+        data_package_git_sha="cafebabe",
+        created_at="2026-04-10T12:00:00Z",
+    )
+
+    policyengine_bundles.DataReleaseManifest.model_validate(manifest)
 
 
 def test_load_release_manifest_from_hf_uses_explicit_revision_when_requested(tmp_path):
@@ -246,6 +289,10 @@ def test_upload_files_to_hf_adds_release_manifest_operations(tmp_path):
                 "git_sha": "deadbeef",
                 "data_build_fingerprint": "sha256:fingerprint",
             },
+        ),
+        patch(
+            "policyengine_us_data.utils.data_upload._get_data_package_git_sha",
+            return_value=None,
         ),
         patch.dict(
             "policyengine_us_data.utils.data_upload.os.environ",
@@ -298,6 +345,10 @@ def test_upload_files_to_hf_does_not_tag_until_finalize(tmp_path):
                 "git_sha": "deadbeef",
                 "data_build_fingerprint": "sha256:fingerprint",
             },
+        ),
+        patch(
+            "policyengine_us_data.utils.data_upload._get_data_package_git_sha",
+            return_value=None,
         ),
         patch.dict(
             "policyengine_us_data.utils.data_upload.os.environ",
@@ -369,6 +420,10 @@ def test_publish_release_manifest_to_hf_can_finalize_and_tag(tmp_path):
                 "data_build_fingerprint": "sha256:fingerprint",
             },
         ),
+        patch(
+            "policyengine_us_data.utils.data_upload._get_data_package_git_sha",
+            return_value=None,
+        ),
         patch.dict(
             "policyengine_us_data.utils.data_upload.os.environ",
             {"HUGGING_FACE_TOKEN": "token"},
@@ -392,6 +447,57 @@ def test_publish_release_manifest_to_hf_can_finalize_and_tag(tmp_path):
             "data_build_fingerprint": "sha256:fingerprint",
         },
     }
+
+
+def test_publish_release_manifest_records_bundle_build_metadata(tmp_path):
+    dataset_path = _write_file(
+        tmp_path / "enhanced_cps_2024.h5",
+        b"national-dataset",
+    )
+
+    mock_api = MagicMock()
+    mock_api.create_commit.return_value = MagicMock(oid="commit-sha")
+
+    with (
+        patch("policyengine_us_data.utils.data_upload.HfApi", return_value=mock_api),
+        patch(
+            "policyengine_us_data.utils.data_upload.load_release_manifest_from_hf",
+            return_value=None,
+        ),
+        patch(
+            "policyengine_us_data.utils.data_upload._get_model_package_build_metadata",
+            return_value={
+                "version": "1.634.4",
+                "git_sha": "deadbeef",
+                "data_build_fingerprint": "sha256:fingerprint",
+                "core": EXPECTED_CORE_PACKAGE,
+            },
+        ),
+        patch(
+            "policyengine_us_data.utils.data_upload._get_data_package_git_sha",
+            return_value="cafebabe",
+        ),
+        patch.dict(
+            "policyengine_us_data.utils.data_upload.os.environ",
+            {"HUGGING_FACE_TOKEN": "token"},
+            clear=False,
+        ),
+    ):
+        manifest = publish_release_manifest_to_hf(
+            [(dataset_path, "enhanced_cps_2024.h5")],
+            version="1.73.0",
+            pipeline_run_id="run-123",
+        )
+
+    assert manifest["compatible_core_packages"] == EXPECTED_COMPATIBLE_CORE_PACKAGES
+    assert manifest["build"]["metadata"] == {
+        "pipeline_run_id": "run-123",
+        "data_package_git_sha": "cafebabe",
+    }
+    assert manifest["build"]["built_with_core_package"] == EXPECTED_CORE_PACKAGE
+    assert (
+        manifest["build"]["built_with_model_package"]["core"] == EXPECTED_CORE_PACKAGE
+    )
 
 
 def test_missing_release_prefixes_requires_full_local_area_bundle():

--- a/tests/unit/test_release_manifest.py
+++ b/tests/unit/test_release_manifest.py
@@ -29,12 +29,17 @@ def _sha256(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
 
 
+EXPECTED_MODEL_PACKAGE_VERSION = "9.8.6"
 EXPECTED_COMPATIBLE_MODEL_PACKAGES = [
-    {"name": "policyengine-us", "specifier": "==1.634.4"}
+    {"name": "policyengine-us", "specifier": f"=={EXPECTED_MODEL_PACKAGE_VERSION}"}
 ]
-EXPECTED_CORE_PACKAGE = {"name": "policyengine-core", "version": "3.25.4"}
+EXPECTED_CORE_PACKAGE_VERSION = "9.8.7"
+EXPECTED_CORE_PACKAGE = {
+    "name": "policyengine-core",
+    "version": EXPECTED_CORE_PACKAGE_VERSION,
+}
 EXPECTED_COMPATIBLE_CORE_PACKAGES = [
-    {"name": "policyengine-core", "specifier": "==3.25.4"}
+    {"name": "policyengine-core", "specifier": f"=={EXPECTED_CORE_PACKAGE_VERSION}"}
 ]
 
 
@@ -70,7 +75,7 @@ def test_build_release_manifest_tracks_uploaded_artifacts(tmp_path):
         ],
         version="1.73.0",
         repo_id="policyengine/policyengine-us-data",
-        model_package_version="1.634.4",
+        model_package_version=EXPECTED_MODEL_PACKAGE_VERSION,
         model_package_git_sha="deadbeef",
         model_package_data_build_fingerprint="sha256:fingerprint",
         core_package_metadata=EXPECTED_CORE_PACKAGE,
@@ -95,7 +100,7 @@ def test_build_release_manifest_tracks_uploaded_artifacts(tmp_path):
         },
         "built_with_model_package": {
             "name": "policyengine-us",
-            "version": "1.634.4",
+            "version": EXPECTED_MODEL_PACKAGE_VERSION,
             "git_sha": "deadbeef",
             "data_build_fingerprint": "sha256:fingerprint",
             "core": EXPECTED_CORE_PACKAGE,
@@ -172,7 +177,7 @@ def test_build_release_manifest_merges_existing_release_same_version(tmp_path):
         files_with_repo_paths=[(district_path, "districts/NC-01.h5")],
         version="1.73.0",
         repo_id="policyengine/policyengine-us-data",
-        model_package_version="1.634.4",
+        model_package_version=EXPECTED_MODEL_PACKAGE_VERSION,
         model_package_git_sha="deadbeef",
         model_package_data_build_fingerprint="sha256:fingerprint",
         existing_manifest=existing_manifest,
@@ -187,7 +192,7 @@ def test_build_release_manifest_merges_existing_release_same_version(tmp_path):
         "built_at": "2026-04-10T12:00:00Z",
         "built_with_model_package": {
             "name": "policyengine-us",
-            "version": "1.634.4",
+            "version": EXPECTED_MODEL_PACKAGE_VERSION,
             "git_sha": "deadbeef",
             "data_build_fingerprint": "sha256:fingerprint",
         },
@@ -236,7 +241,7 @@ def test_build_release_manifest_validates_against_bundle_contract(tmp_path):
             "modal_app_name": "policyengine-us-data-pub-usdata-gha123-a1-abcdef12",
             "hf_staging_prefix": "staging/usdata-gha123-a1-abcdef12",
         },
-        model_package_version="1.634.4",
+        model_package_version=EXPECTED_MODEL_PACKAGE_VERSION,
         model_package_git_sha="deadbeef",
         model_package_data_build_fingerprint="sha256:fingerprint",
         core_package_metadata=EXPECTED_CORE_PACKAGE,
@@ -267,6 +272,15 @@ def test_load_release_manifest_from_hf_uses_explicit_revision_when_requested(tmp
     assert mock_download.call_args.kwargs["revision"] == "1.73.0"
 
 
+def test_load_release_manifest_from_hf_raises_non_missing_download_errors():
+    with patch(
+        "policyengine_us_data.utils.data_upload.hf_hub_download",
+        side_effect=RuntimeError("temporary Hugging Face failure"),
+    ):
+        with pytest.raises(RuntimeError, match="temporary Hugging Face failure"):
+            load_release_manifest_from_hf(version="1.73.0", revision="1.73.0")
+
+
 def test_upload_files_to_hf_adds_release_manifest_operations(tmp_path):
     dataset_path = _write_file(
         tmp_path / "enhanced_cps_2024.h5",
@@ -285,7 +299,7 @@ def test_upload_files_to_hf_adds_release_manifest_operations(tmp_path):
         patch(
             "policyengine_us_data.utils.data_upload._get_model_package_build_metadata",
             return_value={
-                "version": "1.634.4",
+                "version": EXPECTED_MODEL_PACKAGE_VERSION,
                 "git_sha": "deadbeef",
                 "data_build_fingerprint": "sha256:fingerprint",
             },
@@ -341,7 +355,7 @@ def test_upload_files_to_hf_does_not_tag_until_finalize(tmp_path):
         patch(
             "policyengine_us_data.utils.data_upload._get_model_package_build_metadata",
             return_value={
-                "version": "1.634.4",
+                "version": EXPECTED_MODEL_PACKAGE_VERSION,
                 "git_sha": "deadbeef",
                 "data_build_fingerprint": "sha256:fingerprint",
             },
@@ -387,7 +401,7 @@ def test_publish_release_manifest_to_hf_can_finalize_and_tag(tmp_path):
             "built_at": "2026-04-10T12:00:00Z",
             "built_with_model_package": {
                 "name": "policyengine-us",
-                "version": "1.634.4",
+                "version": EXPECTED_MODEL_PACKAGE_VERSION,
                 "git_sha": "deadbeef",
                 "data_build_fingerprint": "sha256:fingerprint",
             },
@@ -415,7 +429,7 @@ def test_publish_release_manifest_to_hf_can_finalize_and_tag(tmp_path):
         patch(
             "policyengine_us_data.utils.data_upload._get_model_package_build_metadata",
             return_value={
-                "version": "1.634.4",
+                "version": EXPECTED_MODEL_PACKAGE_VERSION,
                 "git_sha": "deadbeef",
                 "data_build_fingerprint": "sha256:fingerprint",
             },
@@ -442,7 +456,7 @@ def test_publish_release_manifest_to_hf_can_finalize_and_tag(tmp_path):
         "built_at": "2026-04-10T12:00:00Z",
         "built_with_model_package": {
             "name": "policyengine-us",
-            "version": "1.634.4",
+            "version": EXPECTED_MODEL_PACKAGE_VERSION,
             "git_sha": "deadbeef",
             "data_build_fingerprint": "sha256:fingerprint",
         },
@@ -467,7 +481,7 @@ def test_publish_release_manifest_records_bundle_build_metadata(tmp_path):
         patch(
             "policyengine_us_data.utils.data_upload._get_model_package_build_metadata",
             return_value={
-                "version": "1.634.4",
+                "version": EXPECTED_MODEL_PACKAGE_VERSION,
                 "git_sha": "deadbeef",
                 "data_build_fingerprint": "sha256:fingerprint",
                 "core": EXPECTED_CORE_PACKAGE,
@@ -589,7 +603,7 @@ def test_publish_release_manifest_to_hf_rejects_finalized_release(tmp_path):
             "built_at": "2026-04-10T12:00:00Z",
             "built_with_model_package": {
                 "name": "policyengine-us",
-                "version": "1.634.4",
+                "version": EXPECTED_MODEL_PACKAGE_VERSION,
                 "git_sha": "deadbeef",
                 "data_build_fingerprint": "sha256:fingerprint",
             },
@@ -615,12 +629,12 @@ def test_publish_release_manifest_to_hf_rejects_finalized_release(tmp_path):
         ),
         patch(
             "policyengine_us_data.utils.data_upload._get_model_package_version",
-            return_value="1.634.4",
+            return_value=EXPECTED_MODEL_PACKAGE_VERSION,
         ),
         patch(
             "policyengine_us_data.utils.data_upload._get_model_package_build_metadata",
             return_value={
-                "version": "1.634.4",
+                "version": EXPECTED_MODEL_PACKAGE_VERSION,
                 "git_sha": "deadbeef",
                 "data_build_fingerprint": "sha256:fingerprint",
             },
@@ -654,7 +668,7 @@ def test_publish_release_manifest_to_hf_rejects_mutating_finalized_release(tmp_p
             "built_at": "2026-04-10T12:00:00Z",
             "built_with_model_package": {
                 "name": "policyengine-us",
-                "version": "1.634.4",
+                "version": EXPECTED_MODEL_PACKAGE_VERSION,
                 "git_sha": "deadbeef",
                 "data_build_fingerprint": "sha256:fingerprint",
             },
@@ -680,12 +694,12 @@ def test_publish_release_manifest_to_hf_rejects_mutating_finalized_release(tmp_p
         ),
         patch(
             "policyengine_us_data.utils.data_upload._get_model_package_version",
-            return_value="1.634.4",
+            return_value=EXPECTED_MODEL_PACKAGE_VERSION,
         ),
         patch(
             "policyengine_us_data.utils.data_upload._get_model_package_build_metadata",
             return_value={
-                "version": "1.634.4",
+                "version": EXPECTED_MODEL_PACKAGE_VERSION,
                 "git_sha": "deadbeef",
                 "data_build_fingerprint": "sha256:fingerprint",
             },

--- a/tests/unit/test_upload_completed_datasets.py
+++ b/tests/unit/test_upload_completed_datasets.py
@@ -442,6 +442,7 @@ def test_upload_datasets_promote_only_uses_staged_artifacts(tmp_path, monkeypatc
                 "hf_repo_name": upload_module.HF_REPO_NAME,
                 "hf_repo_type": upload_module.HF_REPO_TYPE,
                 "create_tag": False,
+                "pipeline_run_id": "run-123",
             },
         )
     ]


### PR DESCRIPTION
Fixes #893

## Summary

This draft PR wires US data release manifests into the experimental bundle/reproducibility contract.

- Adds bundle-compatible core/package/build metadata to generated release manifests.
- Carries pipeline run IDs, data package git SHAs, and run context metadata through upload and promotion paths.
- Normalizes legacy manifests for comparison so older finalized metadata does not block promotion checks.
- Adds a PR workflow job that installs `policyengine-bundles` and validates the release manifest schema contract.

## Validation

- `ruff check modal_app/local_area.py policyengine_us_data/calibration/promote_local_h5s.py policyengine_us_data/storage/upload_completed_datasets.py policyengine_us_data/utils/data_upload.py policyengine_us_data/utils/release_manifest.py tests/unit/test_release_manifest.py`
- `ruff format modal_app/local_area.py policyengine_us_data/calibration/promote_local_h5s.py policyengine_us_data/storage/upload_completed_datasets.py policyengine_us_data/utils/data_upload.py policyengine_us_data/utils/release_manifest.py tests/unit/test_release_manifest.py`
- `PYTHONPATH=/Users/administrator/Documents/PolicyEngine/policyengine-bundles/src:$PYTHONPATH python -m pytest tests/unit/test_release_manifest.py -v`
- `python -m pytest tests/unit/utils/test_data_upload.py -v`
- `python -m pytest tests/unit/test_trace_tro.py -v`
- `python -m pytest tests/unit/test_promote_local_h5s.py -v`
- `git diff --check`

## Notes

This is intentionally draft because it demonstrates the bundle contract integration before the release orchestration and bundle schema are finalized.