### PR TITLE
Add local H5 clone weight contract

### DIFF
--- a/changelog.d/h5-clone-weight-contract.added.md
+++ b/changelog.d/h5-clone-weight-contract.added.md
@@ -1,0 +1,1 @@
+Added the local H5 clone weight matrix contract for upcoming migration slices.

--- a/policyengine_us_data/calibration/local_h5/__init__.py
+++ b/policyengine_us_data/calibration/local_h5/__init__.py
@@ -3,5 +3,5 @@
 Modules in this package should land only when they become active runtime
 seams rather than speculative placeholders. The current early slices
 introduce ``partitioning.py``, ``requests.py``, ``area_catalog.py``,
-``fingerprinting.py``, and ``geography_loader.py``.
+``fingerprinting.py``, ``geography_loader.py``, and ``weights.py``.
 """

--- a/policyengine_us_data/calibration/local_h5/weights.py
+++ b/policyengine_us_data/calibration/local_h5/weights.py
@@ -1,0 +1,170 @@
+"""Clone-weight shape contracts for local H5 publication.
+
+This module defines the narrow structural boundary around the flat
+clone-level calibration weight vector used by current H5 publication paths.
+It is intentionally pure and does not perform file IO.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+from policyengine_us_data.pipeline_metadata import pipeline_node
+
+__all__ = ["CloneWeightMatrix"]
+
+
+@pipeline_node(
+    id="clone_weight_matrix",
+    label="CloneWeightMatrix",
+    node_type="library",
+    description=("Explicit shape contract for flat clone-level calibration weights."),
+    source_file="policyengine_us_data/calibration/local_h5/weights.py",
+    status="current",
+    stability="moving",
+    pathways=["local_h5"],
+    artifacts_in=[
+        "calibration_weights.npy",
+        "national_calibration_weights.npy",
+    ],
+    validation_commands=[
+        "uv run pytest tests/unit/calibration/test_local_h5_weights.py"
+    ],
+)
+@dataclass(frozen=True)
+class CloneWeightMatrix:
+    """Structured view of clone-level household weights.
+
+    The canonical in-memory representation remains the flat vector of length
+    ``n_records * n_clones``. Matrix views are derived on demand as
+    ``(n_clones, n_records)`` arrays.
+
+    Attributes:
+        values: Flat clone-level weight vector.
+        n_records: Number of base records represented by each clone.
+        n_clones: Number of clone copies represented in the flat vector.
+    """
+
+    values: np.ndarray
+    n_records: int
+    n_clones: int
+
+    def __post_init__(self) -> None:
+        vector = self._normalize_vector(self.values)
+        n_records = self._normalize_positive_count("n_records", self.n_records)
+        n_clones = self._normalize_positive_count("n_clones", self.n_clones)
+        expected_length = n_records * n_clones
+
+        if vector.size != expected_length:
+            raise ValueError(
+                f"Weight vector length {vector.size} does not equal "
+                f"n_records * n_clones={expected_length}"
+            )
+
+        normalized = np.array(vector, copy=True)
+        normalized.setflags(write=False)
+        object.__setattr__(self, "values", normalized)
+        object.__setattr__(self, "n_records", n_records)
+        object.__setattr__(self, "n_clones", n_clones)
+
+    @classmethod
+    def from_vector(
+        cls,
+        values: ArrayLike,
+        n_records: int,
+    ) -> "CloneWeightMatrix":
+        """Build a structured weight contract when record count is known.
+
+        Args:
+            values: Flat clone-level weight vector.
+            n_records: Number of base records per clone.
+
+        Returns:
+            A validated `CloneWeightMatrix`.
+        """
+
+        vector = cls._normalize_vector(values)
+        normalized_records = cls._normalize_positive_count("n_records", n_records)
+        if vector.size % normalized_records != 0:
+            raise ValueError(
+                f"Weight vector length {vector.size} is not divisible by "
+                f"n_records={normalized_records}"
+            )
+        return cls(
+            values=vector,
+            n_records=normalized_records,
+            n_clones=vector.size // normalized_records,
+        )
+
+    @classmethod
+    def from_vector_with_clone_count(
+        cls,
+        values: ArrayLike,
+        n_clones: int,
+    ) -> "CloneWeightMatrix":
+        """Build a structured weight contract when clone count is known.
+
+        Args:
+            values: Flat clone-level weight vector.
+            n_clones: Number of clone copies represented in the vector.
+
+        Returns:
+            A validated `CloneWeightMatrix`.
+        """
+
+        vector = cls._normalize_vector(values)
+        normalized_clones = cls._normalize_positive_count("n_clones", n_clones)
+        if vector.size % normalized_clones != 0:
+            raise ValueError(
+                f"Weight vector length {vector.size} is not divisible by "
+                f"n_clones={normalized_clones}"
+            )
+        return cls(
+            values=vector,
+            n_records=vector.size // normalized_clones,
+            n_clones=normalized_clones,
+        )
+
+    def as_vector(self) -> np.ndarray:
+        """Return the flat vector representation.
+
+        Returns:
+            A read-only view of the flat clone-level weight vector.
+        """
+
+        return self.values
+
+    def as_matrix(self) -> np.ndarray:
+        """Return the clone-by-record matrix representation.
+
+        Returns:
+            A read-only ``(n_clones, n_records)`` view of the weights.
+        """
+
+        matrix = self.values.reshape(self.n_clones, self.n_records)
+        matrix.setflags(write=False)
+        return matrix
+
+    @staticmethod
+    def _normalize_vector(values: ArrayLike) -> np.ndarray:
+        vector = np.asarray(values)
+        if vector.ndim != 1:
+            raise ValueError("Weight vector must be one-dimensional")
+        if vector.size == 0:
+            raise ValueError("Weight vector must be non-empty")
+        if not np.issubdtype(vector.dtype, np.number):
+            raise TypeError("Weight vector must have a numeric dtype")
+        return vector
+
+    @staticmethod
+    def _normalize_positive_count(name: str, value: int) -> int:
+        if isinstance(value, bool) or not isinstance(value, int | np.integer):
+            raise TypeError(f"{name} must be an integer")
+
+        normalized = int(value)
+        if normalized <= 0:
+            raise ValueError(f"{name} must be positive")
+        return normalized

--- a/policyengine_us_data/calibration/local_h5/weights.py
+++ b/policyengine_us_data/calibration/local_h5/weights.py
@@ -157,6 +157,8 @@ class CloneWeightMatrix:
             raise ValueError("Weight vector must be non-empty")
         if not np.issubdtype(vector.dtype, np.number):
             raise TypeError("Weight vector must have a numeric dtype")
+        if np.issubdtype(vector.dtype, np.complexfloating):
+            raise TypeError("Weight vector must have a real numeric dtype")
         return vector
 
     @staticmethod

--- a/tests/unit/calibration/fixtures/test_local_h5_weights.py
+++ b/tests/unit/calibration/fixtures/test_local_h5_weights.py
@@ -1,0 +1,70 @@
+"""Fixture helpers for ``test_local_h5_weights.py``."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import numpy as np
+
+__test__ = False
+
+
+def _ensure_package(name: str, path: Path) -> None:
+    """Register a synthetic package so local imports resolve from disk."""
+
+    package = sys.modules.get(name)
+    if package is None:
+        package = ModuleType(name)
+        package.__path__ = [str(path)]
+        sys.modules[name] = package
+        return
+    package.__path__ = [str(path)]
+
+
+def _load_module(name: str, path: Path):
+    """Load one module from disk under a specific fully-qualified name."""
+
+    sys.modules.pop(name, None)
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_weights_exports():
+    """Load the local H5 weights module under a synthetic package name."""
+
+    local_h5_root = (
+        Path(__file__).resolve().parents[4]
+        / "policyengine_us_data"
+        / "calibration"
+        / "local_h5"
+    )
+    package_name = "local_h5_weights_fixture"
+
+    for name in list(sys.modules):
+        if name == package_name or name.startswith(f"{package_name}."):
+            sys.modules.pop(name, None)
+
+    _ensure_package(package_name, local_h5_root)
+    weights_module = _load_module(
+        f"{package_name}.weights",
+        local_h5_root / "weights.py",
+    )
+    return {
+        "module": weights_module,
+        "CloneWeightMatrix": weights_module.CloneWeightMatrix,
+        "make_weight_vector": make_weight_vector,
+    }
+
+
+def make_weight_vector(length: int) -> np.ndarray:
+    """Create a small deterministic numeric vector for shape tests."""
+
+    return np.arange(length, dtype=float) + 1.0

--- a/tests/unit/calibration/test_local_h5_weights.py
+++ b/tests/unit/calibration/test_local_h5_weights.py
@@ -103,6 +103,13 @@ def test_normalization_rejects_non_numeric_vectors():
         CloneWeightMatrix.from_vector(vector, n_records=1)
 
 
+def test_normalization_rejects_complex_vectors():
+    vector = np.array([1.0 + 2.0j, 3.0 + 4.0j])
+
+    with pytest.raises(TypeError, match="real numeric dtype"):
+        CloneWeightMatrix.from_vector(vector, n_records=1)
+
+
 def test_normalization_rejects_non_one_dimensional_vectors():
     vector = np.arange(6, dtype=float).reshape(2, 3)
 

--- a/tests/unit/calibration/test_local_h5_weights.py
+++ b/tests/unit/calibration/test_local_h5_weights.py
@@ -1,0 +1,129 @@
+import numpy as np
+import pytest
+
+from tests.unit.calibration.fixtures.test_local_h5_weights import (
+    load_weights_exports,
+)
+
+
+exports = load_weights_exports()
+CloneWeightMatrix = exports["CloneWeightMatrix"]
+make_weight_vector = exports["make_weight_vector"]
+
+
+def test_from_vector_derives_clone_count_from_record_count():
+    vector = make_weight_vector(6)
+
+    weights = CloneWeightMatrix.from_vector(vector, n_records=3)
+
+    assert weights.n_records == 3
+    assert weights.n_clones == 2
+    assert np.array_equal(weights.as_vector(), vector)
+
+
+def test_from_vector_with_clone_count_derives_record_count():
+    vector = make_weight_vector(6)
+
+    weights = CloneWeightMatrix.from_vector_with_clone_count(vector, n_clones=2)
+
+    assert weights.n_records == 3
+    assert weights.n_clones == 2
+    assert np.array_equal(weights.as_vector(), vector)
+
+
+def test_as_matrix_returns_clone_by_record_shape():
+    vector = make_weight_vector(6)
+    weights = CloneWeightMatrix.from_vector(vector, n_records=3)
+
+    matrix = weights.as_matrix()
+
+    assert matrix.shape == (2, 3)
+    assert np.array_equal(matrix[0], np.array([1.0, 2.0, 3.0]))
+    assert np.array_equal(matrix[1], np.array([4.0, 5.0, 6.0]))
+
+
+def test_from_vector_accepts_array_like_values():
+    weights = CloneWeightMatrix.from_vector([1.0, 2.0, 3.0, 4.0], n_records=2)
+
+    assert weights.n_records == 2
+    assert weights.n_clones == 2
+    assert np.array_equal(weights.as_matrix(), np.array([[1.0, 2.0], [3.0, 4.0]]))
+
+
+def test_direct_construction_rejects_inconsistent_shape():
+    vector = make_weight_vector(5)
+
+    with pytest.raises(ValueError, match="does not equal n_records \\* n_clones"):
+        CloneWeightMatrix(values=vector, n_records=2, n_clones=3)
+
+
+def test_from_vector_rejects_non_divisible_record_shape():
+    vector = make_weight_vector(5)
+
+    with pytest.raises(ValueError, match="not divisible by n_records=2"):
+        CloneWeightMatrix.from_vector(vector, n_records=2)
+
+
+def test_from_vector_with_clone_count_rejects_non_divisible_clone_shape():
+    vector = make_weight_vector(5)
+
+    with pytest.raises(ValueError, match="not divisible by n_clones=2"):
+        CloneWeightMatrix.from_vector_with_clone_count(vector, n_clones=2)
+
+
+def test_from_vector_rejects_non_positive_dimensions():
+    vector = make_weight_vector(4)
+
+    with pytest.raises(ValueError, match="n_records must be positive"):
+        CloneWeightMatrix.from_vector(vector, n_records=0)
+
+    with pytest.raises(ValueError, match="n_clones must be positive"):
+        CloneWeightMatrix.from_vector_with_clone_count(vector, n_clones=0)
+
+
+def test_from_vector_rejects_non_integer_dimensions():
+    vector = make_weight_vector(4)
+
+    with pytest.raises(TypeError, match="n_records must be an integer"):
+        CloneWeightMatrix.from_vector(vector, n_records=2.0)
+
+    with pytest.raises(TypeError, match="n_clones must be an integer"):
+        CloneWeightMatrix.from_vector_with_clone_count(vector, n_clones=True)
+
+
+def test_normalization_rejects_empty_vectors():
+    with pytest.raises(ValueError, match="must be non-empty"):
+        CloneWeightMatrix.from_vector(np.array([], dtype=float), n_records=1)
+
+
+def test_normalization_rejects_non_numeric_vectors():
+    vector = np.array(["a", "b"], dtype=object)
+
+    with pytest.raises(TypeError, match="numeric dtype"):
+        CloneWeightMatrix.from_vector(vector, n_records=1)
+
+
+def test_normalization_rejects_non_one_dimensional_vectors():
+    vector = np.arange(6, dtype=float).reshape(2, 3)
+
+    with pytest.raises(ValueError, match="one-dimensional"):
+        CloneWeightMatrix.from_vector(vector, n_records=3)
+
+
+def test_internal_storage_is_decoupled_from_source_vector():
+    vector = make_weight_vector(4)
+    weights = CloneWeightMatrix.from_vector(vector, n_records=2)
+
+    vector[0] = 99.0
+
+    assert weights.as_vector()[0] == 1.0
+
+
+def test_weight_views_are_read_only():
+    weights = CloneWeightMatrix.from_vector(make_weight_vector(4), n_records=2)
+
+    with pytest.raises(ValueError, match="read-only"):
+        weights.as_vector()[0] = 99.0
+
+    with pytest.raises(ValueError, match="read-only"):
+        weights.as_matrix()[0, 0] = 99.0


### PR DESCRIPTION
Fixes #896

## Summary
- add `CloneWeightMatrix` as the PR4a local H5 clone-weight contract
- validate one-dimensional, non-empty, real numeric flat weight vectors and clone/record shape invariants
- add focused unit coverage for valid shapes, invalid dimensions, invalid dtypes, direct construction mismatch, read-only views, and source-vector decoupling

## Scope boundary
This intentionally does not rewire Modal workers or active H5 runtime paths. Existing publication code continues to pass raw numpy arrays until later migration slices consume this contract.

## Verification
- `python -m pytest tests/unit/calibration/test_local_h5_weights.py -q`
- `ruff check policyengine_us_data/calibration/local_h5/weights.py tests/unit/calibration/test_local_h5_weights.py`
- `ruff format --check policyengine_us_data/calibration/local_h5/weights.py tests/unit/calibration/test_local_h5_weights.py`
- `python scripts/run_quality_guards.py`

Note: `uv run ...` remains blocked locally on macOS x86_64 because `torch==2.9.1` has no compatible wheel for this platform.