### PR TITLE
Add manual long-run projection workflow

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -63,9 +63,10 @@ The PR is valid only if the head repository is `PolicyEngine/policyengine-us-dat
 
 ## CI workflows
 
-Five workflow files in `.github/workflows/`:
+Six workflow files in `.github/workflows/`:
 
 - `pr.yaml` — fork check, lint, uv.lock freshness, towncrier fragment check, unit tests, smoke test, independent docs build, and quality guards. Integration tests trigger when files in `policyengine_us_data/`, `modal_app/`, or `tests/integration/` change. ~2–3 min for the unit path.
 - `push.yaml` — on push to main: either version-bump + PyPI publish (on `Update package version` commits), or a full Modal data build with integration tests (on everything else).
 - `pipeline.yaml` — dispatch only, spawns the H5 generation pipeline on Modal with configurable GPU/epochs/workers.
+- `long_run_projection.yaml` — dispatch only, builds long-run CPS projection H5 files for explicit sampled years and can optionally upload them to a run-scoped Hugging Face staging prefix.
 - `local_area_publish.yaml` / `local_area_promote.yaml` — manual dispatch to build/stage local-area H5 files and promote a run-scoped US data release.

--- a/.github/workflows/long_run_projection.yaml
+++ b/.github/workflows/long_run_projection.yaml
@@ -1,0 +1,246 @@
+name: Build Long-Run Projection Dataset
+
+on:
+  workflow_dispatch:
+    inputs:
+      years:
+        description: "Projection years/ranges to build"
+        required: true
+        default: "2026-2035,2040,2045,2050,2055,2060,2065,2070,2075,2080,2085,2090,2095,2100"
+        type: string
+      jobs:
+        description: "Parallel year subprocesses"
+        required: true
+        default: "4"
+        type: string
+      profile:
+        description: "Long-run calibration profile"
+        required: true
+        default: "ss-payroll-tob"
+        type: string
+      target_source:
+        description: "Named long-term target source"
+        required: true
+        default: "trustees_2025_current_law"
+        type: string
+      tax_assumption:
+        description: "Long-run federal tax assumption"
+        required: true
+        default: "trustees-2025-core-thresholds-v1"
+        type: string
+      base_dataset:
+        description: "Optional base H5 path or hf:// URL; blank uses runner default"
+        required: false
+        default: ""
+        type: string
+      support_augmentation_profile:
+        description: "Optional late-year support augmentation profile"
+        required: false
+        default: ""
+        type: string
+      support_augmentation_target_year:
+        description: "Optional fixed support augmentation target year"
+        required: false
+        default: ""
+        type: string
+      support_augmentation_align_to_run_year:
+        description: "Rebuild support augmentation separately for each run year"
+        required: false
+        default: false
+        type: boolean
+      support_augmentation_start_year:
+        description: "Optional earliest support augmentation year"
+        required: false
+        default: ""
+        type: string
+      support_augmentation_top_n_targets:
+        description: "Optional number of synthetic target types to map to donors"
+        required: false
+        default: ""
+        type: string
+      support_augmentation_donors_per_target:
+        description: "Optional number of real donor tax units per target"
+        required: false
+        default: ""
+        type: string
+      support_augmentation_max_distance:
+        description: "Optional maximum donor-match distance"
+        required: false
+        default: ""
+        type: string
+      support_augmentation_clone_weight_scale:
+        description: "Optional baseline donor-clone weight multiplier"
+        required: false
+        default: ""
+        type: string
+      support_augmentation_blueprint_base_weight_scale:
+        description: "Optional donor-composite blueprint base-weight scale"
+        required: false
+        default: ""
+        type: string
+      allow_validation_failures:
+        description: "Allow invalid artifacts to be written for diagnostics"
+        required: false
+        default: false
+        type: boolean
+      upload_to_hf_staging:
+        description: "Upload generated H5s and metadata to run-scoped HF staging"
+        required: false
+        default: false
+        type: boolean
+      run_id:
+        description: "Optional run ID; blank derives one from the GitHub run"
+        required: false
+        default: ""
+        type: string
+      source_sha:
+        description: "Exact policyengine-us-data commit SHA or ref to checkout"
+        required: false
+        default: ""
+        type: string
+
+concurrency:
+  group: long-run-projection-${{ github.run_id }}-${{ github.run_attempt }}
+  cancel-in-progress: false
+
+jobs:
+  build-long-run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      contents: read
+    env:
+      US_DATA_RUN_ID: ${{ inputs.run_id || '' }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.source_sha || github.sha }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - uses: astral-sh/setup-uv@v8.1.0
+
+      - name: Resolve run context
+        id: run-context
+        run: |
+          checked_out_sha="$(git rev-parse HEAD)"
+          echo "CHECKED_OUT_SHA=${checked_out_sha}" >> "$GITHUB_ENV"
+          GITHUB_SHA="${checked_out_sha}" python .github/scripts/resolve_run_context.py
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Build long-run projection artifacts
+        env:
+          ALLOW_VALIDATION_FAILURES: ${{ inputs.allow_validation_failures }}
+          BASE_DATASET: ${{ inputs.base_dataset }}
+          HUGGING_FACE_TOKEN: ${{ inputs.upload_to_hf_staging && secrets.HUGGING_FACE_TOKEN || '' }}
+          JOBS: ${{ inputs.jobs }}
+          OUTPUT_DIR: projected_long_term/${{ steps.run-context.outputs.run_id }}
+          PROFILE: ${{ inputs.profile }}
+          SUPPORT_AUGMENTATION_ALIGN_TO_RUN_YEAR: ${{ inputs.support_augmentation_align_to_run_year }}
+          SUPPORT_AUGMENTATION_BLUEPRINT_BASE_WEIGHT_SCALE: ${{ inputs.support_augmentation_blueprint_base_weight_scale }}
+          SUPPORT_AUGMENTATION_CLONE_WEIGHT_SCALE: ${{ inputs.support_augmentation_clone_weight_scale }}
+          SUPPORT_AUGMENTATION_DONORS_PER_TARGET: ${{ inputs.support_augmentation_donors_per_target }}
+          SUPPORT_AUGMENTATION_MAX_DISTANCE: ${{ inputs.support_augmentation_max_distance }}
+          SUPPORT_AUGMENTATION_PROFILE: ${{ inputs.support_augmentation_profile }}
+          SUPPORT_AUGMENTATION_START_YEAR: ${{ inputs.support_augmentation_start_year }}
+          SUPPORT_AUGMENTATION_TARGET_YEAR: ${{ inputs.support_augmentation_target_year }}
+          SUPPORT_AUGMENTATION_TOP_N_TARGETS: ${{ inputs.support_augmentation_top_n_targets }}
+          TARGET_SOURCE: ${{ inputs.target_source }}
+          TAX_ASSUMPTION: ${{ inputs.tax_assumption }}
+          UPLOAD_TO_HF_STAGING: ${{ inputs.upload_to_hf_staging }}
+          YEARS: ${{ inputs.years }}
+        run: |
+          set -euo pipefail
+          SOURCE_SHA="${CHECKED_OUT_SHA}"
+
+          cmd=(
+            uv run python policyengine_us_data/datasets/cps/long_term/run_long_term_production.py
+            --years "${YEARS}"
+            --jobs "${JOBS}"
+            --output-dir "${OUTPUT_DIR}"
+            --profile "${PROFILE}"
+            --target-source "${TARGET_SOURCE}"
+            --tax-assumption "${TAX_ASSUMPTION}"
+            --run-id "${{ steps.run-context.outputs.run_id }}"
+            --source-sha "${SOURCE_SHA}"
+          )
+
+          if [ -n "${BASE_DATASET}" ]; then
+            cmd+=(--base-dataset "${BASE_DATASET}")
+          fi
+          if [ -n "${SUPPORT_AUGMENTATION_PROFILE}" ]; then
+            cmd+=(--support-augmentation-profile "${SUPPORT_AUGMENTATION_PROFILE}")
+          fi
+          if [ -n "${SUPPORT_AUGMENTATION_TARGET_YEAR}" ]; then
+            cmd+=(--support-augmentation-target-year "${SUPPORT_AUGMENTATION_TARGET_YEAR}")
+          fi
+          if [ "${SUPPORT_AUGMENTATION_ALIGN_TO_RUN_YEAR}" = "true" ]; then
+            cmd+=(--support-augmentation-align-to-run-year)
+          fi
+          if [ -n "${SUPPORT_AUGMENTATION_START_YEAR}" ]; then
+            cmd+=(--support-augmentation-start-year "${SUPPORT_AUGMENTATION_START_YEAR}")
+          fi
+          if [ -n "${SUPPORT_AUGMENTATION_TOP_N_TARGETS}" ]; then
+            cmd+=(--support-augmentation-top-n-targets "${SUPPORT_AUGMENTATION_TOP_N_TARGETS}")
+          fi
+          if [ -n "${SUPPORT_AUGMENTATION_DONORS_PER_TARGET}" ]; then
+            cmd+=(--support-augmentation-donors-per-target "${SUPPORT_AUGMENTATION_DONORS_PER_TARGET}")
+          fi
+          if [ -n "${SUPPORT_AUGMENTATION_MAX_DISTANCE}" ]; then
+            cmd+=(--support-augmentation-max-distance "${SUPPORT_AUGMENTATION_MAX_DISTANCE}")
+          fi
+          if [ -n "${SUPPORT_AUGMENTATION_CLONE_WEIGHT_SCALE}" ]; then
+            cmd+=(--support-augmentation-clone-weight-scale "${SUPPORT_AUGMENTATION_CLONE_WEIGHT_SCALE}")
+          fi
+          if [ -n "${SUPPORT_AUGMENTATION_BLUEPRINT_BASE_WEIGHT_SCALE}" ]; then
+            cmd+=(--support-augmentation-blueprint-base-weight-scale "${SUPPORT_AUGMENTATION_BLUEPRINT_BASE_WEIGHT_SCALE}")
+          fi
+          if [ "${ALLOW_VALIDATION_FAILURES}" = "true" ]; then
+            cmd+=(--allow-validation-failures)
+          fi
+          if [ "${UPLOAD_TO_HF_STAGING}" = "true" ]; then
+            cmd+=(--upload-to-hf-staging)
+          fi
+
+          "${cmd[@]}"
+
+      - name: Upload manifests and logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: long-run-projection-manifests-${{ steps.run-context.outputs.run_id }}
+          if-no-files-found: warn
+          path: |
+            projected_long_term/${{ steps.run-context.outputs.run_id }}/long_run_production_manifest.json
+            projected_long_term/${{ steps.run-context.outputs.run_id }}/calibration_manifest.json
+            projected_long_term/${{ steps.run-context.outputs.run_id }}/*.h5.metadata.json
+            projected_long_term/${{ steps.run-context.outputs.run_id }}/support_augmentation_report*.json
+            projected_long_term/${{ steps.run-context.outputs.run_id }}/.parallel_logs/*.log
+
+      - name: Summarize run
+        if: always()
+        env:
+          PROFILE: ${{ inputs.profile }}
+          RUN_ID: ${{ steps.run-context.outputs.run_id }}
+          TARGET_SOURCE: ${{ inputs.target_source }}
+          TAX_ASSUMPTION: ${{ inputs.tax_assumption }}
+          UPLOAD_TO_HF_STAGING: ${{ inputs.upload_to_hf_staging }}
+          YEARS: ${{ inputs.years }}
+        run: |
+          {
+            echo "## Long-run projection build"
+            echo ""
+            echo "- Run ID: \`${RUN_ID}\`"
+            echo "- Years: \`${YEARS}\`"
+            echo "- Profile: \`${PROFILE}\`"
+            echo "- Target source: \`${TARGET_SOURCE}\`"
+            echo "- Tax assumption: \`${TAX_ASSUMPTION}\`"
+            echo "- HF staging upload: \`${UPLOAD_TO_HF_STAGING}\`"
+            if [ "${UPLOAD_TO_HF_STAGING}" = "true" ]; then
+              echo "- HF staging prefix: \`staging/${RUN_ID}/long_term/\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/changelog.d/895.added.md
+++ b/changelog.d/895.added.md
@@ -1,0 +1,1 @@
+Added a manual long-run projection workflow with sampled-year controls, run manifests, and opt-in Hugging Face staging upload.

--- a/policyengine_us_data/datasets/cps/long_term/README.md
+++ b/policyengine_us_data/datasets/cps/long_term/README.md
@@ -31,6 +31,14 @@ python run_household_projection_parallel.py \
   --output-dir ./projected_datasets_parallel \
   --profile ss-payroll-tob \
   --target-source oact_2025_08_05_provisional
+
+# Production wrapper with a sampled-year specification and run manifest
+python run_long_term_production.py \
+  --years 2026-2035,2040,2045,2050,2055,2060,2065,2070,2075,2080,2085,2090,2095,2100 \
+  --jobs 4 \
+  --output-dir ./projected_datasets_production \
+  --profile ss-payroll-tob \
+  --target-source trustees_2025_current_law
 ```
 
 **Arguments:**
@@ -58,6 +66,13 @@ python run_household_projection_parallel.py \
 - `run_household_projection_parallel.py` runs one `run_household_projection.py YEAR YEAR ...` subprocess per year and merges the resulting H5 artifacts into one output directory.
 - The wrapper forces `--save-h5` and controls `--output-dir` itself, so those flags should not be forwarded to the inner runner.
 - Per-year stdout/stderr logs are written under `OUTPUT_DIR/.parallel_logs/`.
+
+**Manual production workflow:**
+- `.github/workflows/long_run_projection.yaml` is `workflow_dispatch` only. It does not run on pull requests, normal merges, or the standard `push.yaml` publication path.
+- The workflow calls `run_long_term_production.py`, which wraps the parallel runner, writes `long_run_production_manifest.json`, and preserves per-year logs with the run metadata.
+- The default year set builds the 10-year budget window plus 5-year sampled points through `2100`; override `years` for full annual builds or narrower diagnostics.
+- Hugging Face upload is disabled by default. Set `upload_to_hf_staging=true` only for a candidate run that should publish generated H5s and metadata under `staging/{run_id}/long_term/`.
+- Late-year support augmentation remains an explicit input. The workflow exposes the donor-backed controls, but it does not silently enable experimental support profiles.
 
 **Named profiles:**
 - `age-only`: IPF age-only calibration
@@ -205,6 +220,7 @@ python run_household_projection_parallel.py \
 ### Files in this Directory
 
 - **`run_household_projection.py`** - Main projection script (see Quick Start)
+- **`run_long_term_production.py`** - Manual production wrapper for sampled-year long-run H5 builds, run manifests, logs, and optional HF staging upload
 - **`calibration.py`** - IPF and GREG weight calibration implementations
 - **`ssa_data.py`** - Load SSA population and named long-term target source projections
 - **`build_long_term_target_sources.py`** - Rebuild named long-term target source packages

--- a/policyengine_us_data/datasets/cps/long_term/run_long_term_production.py
+++ b/policyengine_us_data/datasets/cps/long_term/run_long_term_production.py
@@ -1,0 +1,351 @@
+"""Manual production wrapper for long-run CPS projection artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import UTC, datetime
+from importlib import metadata
+from pathlib import Path
+
+from policyengine_us_data.datasets.cps.long_term.run_household_projection_parallel import (
+    parse_years,
+)
+from policyengine_us_data.utils.data_upload import upload_to_staging_hf
+from policyengine_us_data.utils.run_context import resolve_run_id
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+PARALLEL_RUNNER = SCRIPT_DIR / "run_household_projection_parallel.py"
+DEFAULT_HF_REPO = "policyengine/policyengine-us-data"
+DEFAULT_ARTIFACT_PREFIX = "long_term"
+DEFAULT_TAX_ASSUMPTION = "trustees-2025-core-thresholds-v1"
+
+
+def _git_sha() -> str:
+    try:
+        completed = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=Path(__file__).resolve().parents[4],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return ""
+    return completed.stdout.strip()
+
+
+def _package_version(package_name: str) -> str | None:
+    try:
+        return metadata.version(package_name)
+    except metadata.PackageNotFoundError:
+        return None
+
+
+def _add_optional_value(
+    command: list[str],
+    flag: str,
+    value: str | int | float | None,
+) -> None:
+    if value is None or value == "":
+        return
+    command.extend([flag, str(value)])
+
+
+def build_projection_command(args: argparse.Namespace, output_dir: Path) -> list[str]:
+    command = [
+        sys.executable,
+        str(PARALLEL_RUNNER),
+        "--years",
+        args.years,
+        "--jobs",
+        str(args.jobs),
+        "--output-dir",
+        str(output_dir),
+        "--profile",
+        args.profile,
+        "--target-source",
+        args.target_source,
+        "--tax-assumption",
+        args.tax_assumption,
+    ]
+    if args.keep_temp:
+        command.append("--keep-temp")
+
+    _add_optional_value(command, "--base-dataset", args.base_dataset)
+    _add_optional_value(
+        command,
+        "--support-augmentation-profile",
+        args.support_augmentation_profile,
+    )
+    _add_optional_value(
+        command,
+        "--support-augmentation-target-year",
+        args.support_augmentation_target_year,
+    )
+    if args.support_augmentation_align_to_run_year:
+        command.append("--support-augmentation-align-to-run-year")
+    _add_optional_value(
+        command,
+        "--support-augmentation-start-year",
+        args.support_augmentation_start_year,
+    )
+    _add_optional_value(
+        command,
+        "--support-augmentation-top-n-targets",
+        args.support_augmentation_top_n_targets,
+    )
+    _add_optional_value(
+        command,
+        "--support-augmentation-donors-per-target",
+        args.support_augmentation_donors_per_target,
+    )
+    _add_optional_value(
+        command,
+        "--support-augmentation-max-distance",
+        args.support_augmentation_max_distance,
+    )
+    _add_optional_value(
+        command,
+        "--support-augmentation-clone-weight-scale",
+        args.support_augmentation_clone_weight_scale,
+    )
+    _add_optional_value(
+        command,
+        "--support-augmentation-blueprint-base-weight-scale",
+        args.support_augmentation_blueprint_base_weight_scale,
+    )
+    if args.allow_validation_failures:
+        command.append("--allow-validation-failures")
+    return command
+
+
+def _artifact_record(path: Path, output_dir: Path, artifact_prefix: str) -> dict:
+    rel_path = relative_artifact_path(path, output_dir, artifact_prefix)
+    return {
+        "local_path": str(path),
+        "staging_relative_path": rel_path,
+        "size_bytes": path.stat().st_size,
+    }
+
+
+def collect_artifacts(output_dir: Path, artifact_prefix: str) -> list[Path]:
+    top_level_patterns = (
+        "*.h5",
+        "*.h5.metadata.json",
+        "calibration_manifest.json",
+        "support_augmentation_report*.json",
+        "long_run_production_manifest.json",
+    )
+    artifacts: list[Path] = []
+    for pattern in top_level_patterns:
+        artifacts.extend(
+            path for path in sorted(output_dir.glob(pattern)) if path.is_file()
+        )
+    log_dir = output_dir / ".parallel_logs"
+    if log_dir.exists():
+        artifacts.extend(
+            path for path in sorted(log_dir.glob("*.log")) if path.is_file()
+        )
+    return sorted(
+        set(artifacts),
+        key=lambda path: relative_artifact_path(path, output_dir, artifact_prefix),
+    )
+
+
+def relative_artifact_path(path: Path, output_dir: Path, artifact_prefix: str) -> str:
+    artifact_prefix = artifact_prefix.strip("/")
+    if path.parent == output_dir / ".parallel_logs":
+        return f"{artifact_prefix}/logs/{path.name}"
+    return f"{artifact_prefix}/{path.name}"
+
+
+def write_manifest(
+    *,
+    args: argparse.Namespace,
+    output_dir: Path,
+    command: list[str],
+    years: list[int],
+    run_id: str,
+    source_sha: str,
+    artifacts: list[Path],
+) -> Path:
+    manifest_path = output_dir / "long_run_production_manifest.json"
+    recorded_artifacts = [path for path in artifacts if path != manifest_path]
+    payload = {
+        "created_at": datetime.now(UTC).isoformat(),
+        "run_id": run_id,
+        "source_sha": source_sha,
+        "git_sha": _git_sha(),
+        "github": {
+            "repository": os.environ.get("GITHUB_REPOSITORY", ""),
+            "workflow": os.environ.get("GITHUB_WORKFLOW", ""),
+            "run_id": os.environ.get("GITHUB_RUN_ID", ""),
+            "run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT", ""),
+            "run_url": os.environ.get("US_DATA_GITHUB_RUN_URL", ""),
+        },
+        "package_versions": {
+            "policyengine-us-data": _package_version("policyengine_us_data"),
+            "policyengine-us": _package_version("policyengine-us"),
+            "policyengine-core": _package_version("policyengine-core"),
+        },
+        "projection": {
+            "years_spec": args.years,
+            "years": years,
+            "jobs": args.jobs,
+            "profile": args.profile,
+            "target_source": args.target_source,
+            "tax_assumption": args.tax_assumption,
+            "base_dataset": args.base_dataset or None,
+            "allow_validation_failures": args.allow_validation_failures,
+            "support_augmentation": {
+                "profile": args.support_augmentation_profile or None,
+                "target_year": args.support_augmentation_target_year,
+                "align_to_run_year": args.support_augmentation_align_to_run_year,
+                "start_year": args.support_augmentation_start_year,
+                "top_n_targets": args.support_augmentation_top_n_targets,
+                "donors_per_target": args.support_augmentation_donors_per_target,
+                "max_distance": args.support_augmentation_max_distance,
+                "clone_weight_scale": args.support_augmentation_clone_weight_scale,
+                "blueprint_base_weight_scale": (
+                    args.support_augmentation_blueprint_base_weight_scale
+                ),
+            },
+        },
+        "command": command,
+        "hf_staging": {
+            "enabled": args.upload_to_hf_staging,
+            "repo": args.hf_repo if args.upload_to_hf_staging else None,
+            "artifact_prefix": args.artifact_prefix,
+            "run_id": run_id if args.upload_to_hf_staging else None,
+        },
+        "artifacts": [
+            _artifact_record(path, output_dir, args.artifact_prefix)
+            for path in recorded_artifacts
+        ],
+    }
+    manifest_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    return manifest_path
+
+
+def upload_artifacts(
+    *,
+    artifacts: list[Path],
+    output_dir: Path,
+    args: argparse.Namespace,
+    run_id: str,
+    source_sha: str,
+) -> int:
+    if not os.environ.get("HUGGING_FACE_TOKEN"):
+        raise ValueError(
+            "HUGGING_FACE_TOKEN is required when --upload-to-hf-staging is set."
+        )
+    if not run_id:
+        raise ValueError(
+            "--run-id or US_DATA_RUN_ID is required for HF staging upload."
+        )
+
+    files_with_paths = [
+        (path, relative_artifact_path(path, output_dir, args.artifact_prefix))
+        for path in artifacts
+    ]
+    return upload_to_staging_hf(
+        files_with_paths,
+        version=source_sha or "unknown-source",
+        hf_repo_name=args.hf_repo,
+        batch_size=args.hf_batch_size,
+        run_id=run_id,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build long-run CPS projection H5 artifacts and optionally upload "
+            "them to a run-scoped Hugging Face staging prefix."
+        )
+    )
+    parser.add_argument("--years", required=True)
+    parser.add_argument("--jobs", type=int, default=4)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--profile", default="ss-payroll-tob")
+    parser.add_argument("--target-source", default="trustees_2025_current_law")
+    parser.add_argument("--tax-assumption", default=DEFAULT_TAX_ASSUMPTION)
+    parser.add_argument("--base-dataset", default="")
+    parser.add_argument("--allow-validation-failures", action="store_true")
+    parser.add_argument("--keep-temp", action="store_true")
+    parser.add_argument("--support-augmentation-profile", default="")
+    parser.add_argument("--support-augmentation-target-year", type=int)
+    parser.add_argument(
+        "--support-augmentation-align-to-run-year",
+        action="store_true",
+    )
+    parser.add_argument("--support-augmentation-start-year", type=int)
+    parser.add_argument("--support-augmentation-top-n-targets", type=int)
+    parser.add_argument("--support-augmentation-donors-per-target", type=int)
+    parser.add_argument("--support-augmentation-max-distance", type=float)
+    parser.add_argument("--support-augmentation-clone-weight-scale", type=float)
+    parser.add_argument(
+        "--support-augmentation-blueprint-base-weight-scale",
+        type=float,
+    )
+    parser.add_argument("--run-id", default="")
+    parser.add_argument("--source-sha", default="")
+    parser.add_argument("--upload-to-hf-staging", action="store_true")
+    parser.add_argument("--hf-repo", default=DEFAULT_HF_REPO)
+    parser.add_argument("--hf-batch-size", type=int, default=50)
+    parser.add_argument("--artifact-prefix", default=DEFAULT_ARTIFACT_PREFIX)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    years = parse_years(args.years)
+    output_dir = Path(args.output_dir).expanduser().resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    run_id = resolve_run_id(args.run_id)
+    source_sha = args.source_sha or os.environ.get("GITHUB_SHA", "") or _git_sha()
+
+    command = build_projection_command(args, output_dir)
+    print("Running long-run projection command:")
+    print(" ".join(command))
+    subprocess.run(command, check=True)
+
+    artifacts = collect_artifacts(output_dir, args.artifact_prefix)
+    manifest_path = write_manifest(
+        args=args,
+        output_dir=output_dir,
+        command=command,
+        years=years,
+        run_id=run_id,
+        source_sha=source_sha,
+        artifacts=artifacts,
+    )
+    artifacts = collect_artifacts(output_dir, args.artifact_prefix)
+    print(f"Wrote production manifest: {manifest_path}")
+    print(f"Collected {len(artifacts)} long-run artifacts.")
+
+    if args.upload_to_hf_staging:
+        uploaded_count = upload_artifacts(
+            artifacts=artifacts,
+            output_dir=output_dir,
+            args=args,
+            run_id=run_id,
+            source_sha=source_sha,
+        )
+        print(
+            f"Uploaded {uploaded_count} files to staging/{run_id}/"
+            f"{args.artifact_prefix.strip('/')} in {args.hf_repo}."
+        )
+    else:
+        print("HF staging upload skipped. Pass --upload-to-hf-staging to publish.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a `workflow_dispatch` long-run projection workflow for explicit sampled-year builds.
- Add `run_long_term_production.py` to wrap the parallel long-run runner, write a production manifest, collect per-year logs, and optionally upload H5s/metadata to run-scoped HF staging.
- Document that long-run production is manual-only and not triggered by normal PR, merge, or `push.yaml` CI.

This is stacked on #895 so the PR is based on `codex/crfb-long-run-calibration-hardening`; after #895 merges, retarget this PR to `main`.

## Validation
- `uv run --no-sync --with pyyaml python scripts/run_quality_guards.py`
- `uv run ruff format --check .`
- `uv run ruff check policyengine_us_data/datasets/cps/long_term/run_long_term_production.py`
- `uv run --no-sync --with pyyaml python - <<PY ... yaml.safe_load(...)`
- Wrapper smoke test for command construction, production manifest, log paths, and staging-relative artifact paths
- `git diff --check`