### PR TITLE
Fix calibration target domains

### DIFF
--- a/changelog.d/fix-eitc-and-state-agi-target-domains.fixed.md
+++ b/changelog.d/fix-eitc-and-state-agi-target-domains.fixed.md
@@ -1,0 +1,1 @@
+Fix EITC, state AGI, ACA enrollment, and Medicaid enrollment calibration target domains to exclude out-of-domain records.

--- a/policyengine_us_data/db/etl_aca_agi_state_targets.py
+++ b/policyengine_us_data/db/etl_aca_agi_state_targets.py
@@ -219,41 +219,26 @@ def _load_agi_state_targets(session: Session, year: int, geo_strata: dict) -> No
 
         constraints = [
             StratumConstraint(
+                constraint_variable="tax_unit_is_filer",
+                operation="==",
+                value="1",
+            ),
+            StratumConstraint(
                 constraint_variable="state_fips",
                 operation="==",
                 value=str(state_fips),
             ),
             StratumConstraint(
                 constraint_variable="adjusted_gross_income",
-                operation="<=",
+                operation="<",
                 value=str(upper),
             ),
+            StratumConstraint(
+                constraint_variable="adjusted_gross_income",
+                operation=">=",
+                value=str(lower),
+            ),
         ]
-        if is_count:
-            if lower > 0:
-                constraints.append(
-                    StratumConstraint(
-                        constraint_variable="adjusted_gross_income",
-                        operation=">=",
-                        value=str(lower),
-                    )
-                )
-            else:
-                constraints.append(
-                    StratumConstraint(
-                        constraint_variable="adjusted_gross_income",
-                        operation=">",
-                        value="0",
-                    )
-                )
-        else:
-            constraints.append(
-                StratumConstraint(
-                    constraint_variable="adjusted_gross_income",
-                    operation=">=",
-                    value=str(lower),
-                )
-            )
         stratum = _get_or_create_stratum(
             session,
             parent_stratum_id,

--- a/policyengine_us_data/db/etl_irs_soi.py
+++ b/policyengine_us_data/db/etl_irs_soi.py
@@ -850,6 +850,40 @@ def load_state_fine_agi_targets(
         )
 
 
+def _get_eitc_recipient_constraints(geo_info: dict) -> list[StratumConstraint]:
+    constraints = [
+        StratumConstraint(
+            constraint_variable="tax_unit_is_filer",
+            operation="==",
+            value="1",
+        ),
+        StratumConstraint(
+            constraint_variable="eitc",
+            operation=">",
+            value="0",
+        ),
+    ]
+
+    if geo_info["type"] == "state":
+        constraints.append(
+            StratumConstraint(
+                constraint_variable="state_fips",
+                operation="==",
+                value=str(geo_info["state_fips"]),
+            )
+        )
+    elif geo_info["type"] == "district":
+        constraints.append(
+            StratumConstraint(
+                constraint_variable="congressional_district_geoid",
+                operation="==",
+                value=str(geo_info["congressional_district_geoid"]),
+            )
+        )
+
+    return constraints
+
+
 def load_national_fine_agi_targets(
     session: Session, national_filer_stratum_id: int, target_year: int
 ) -> None:
@@ -1199,46 +1233,17 @@ def load_soi_data(long_dfs, year, national_year: Optional[int] = None):
             # Determine parent stratum based on geographic level - use filer strata not geo strata
             if geo_info["type"] == "national":
                 parent_stratum_id = filer_strata["national"]
-                note = f"National EITC received with {n_children} children (filers)"
-                constraints = [
-                    StratumConstraint(
-                        constraint_variable="tax_unit_is_filer",
-                        operation="==",
-                        value="1",
-                    )
-                ]
+                note = f"National EITC received with {n_children} children (recipients)"
             elif geo_info["type"] == "state":
                 parent_stratum_id = filer_strata["state"][geo_info["state_fips"]]
-                note = f"State FIPS {geo_info['state_fips']} EITC received with {n_children} children (filers)"
-                constraints = [
-                    StratumConstraint(
-                        constraint_variable="tax_unit_is_filer",
-                        operation="==",
-                        value="1",
-                    ),
-                    StratumConstraint(
-                        constraint_variable="state_fips",
-                        operation="==",
-                        value=str(geo_info["state_fips"]),
-                    ),
-                ]
+                note = f"State FIPS {geo_info['state_fips']} EITC received with {n_children} children (recipients)"
             elif geo_info["type"] == "district":
                 parent_stratum_id = filer_strata["district"][
                     geo_info["congressional_district_geoid"]
                 ]
-                note = f"Congressional District {geo_info['congressional_district_geoid']} EITC received with {n_children} children (filers)"
-                constraints = [
-                    StratumConstraint(
-                        constraint_variable="tax_unit_is_filer",
-                        operation="==",
-                        value="1",
-                    ),
-                    StratumConstraint(
-                        constraint_variable="congressional_district_geoid",
-                        operation="==",
-                        value=str(geo_info["congressional_district_geoid"]),
-                    ),
-                ]
+                note = f"Congressional District {geo_info['congressional_district_geoid']} EITC received with {n_children} children (recipients)"
+
+            constraints = _get_eitc_recipient_constraints(geo_info)
 
             # Check if stratum already exists
             existing_stratum = session.exec(

--- a/policyengine_us_data/db/etl_national_targets.py
+++ b/policyengine_us_data/db/etl_national_targets.py
@@ -314,7 +314,7 @@ def extract_national_targets(year: int = DEFAULT_YEAR):
     # Store with actual source year
     conditional_count_targets = [
         {
-            "constraint_variable": "medicaid",
+            "constraint_variable": "medicaid_enrolled",
             "person_count": 72_429_055,
             "source": "CMS/HHS administrative data",
             "notes": "Medicaid enrollment count",
@@ -539,6 +539,90 @@ def transform_national_targets(raw_targets):
     conditional_targets = raw_targets["conditional_count_targets"]
 
     return direct_df, tax_filer_df, tax_expenditure_df, conditional_targets
+
+
+def _conditional_count_stratum_details(
+    cond_target: dict,
+) -> tuple[str, list[StratumConstraint]]:
+    constraint_var = cond_target["constraint_variable"]
+
+    if constraint_var == "medicaid_enrolled":
+        return (
+            "National Medicaid Enrollment",
+            [
+                StratumConstraint(
+                    constraint_variable="medicaid_enrolled",
+                    operation="==",
+                    value="True",
+                ),
+                StratumConstraint(
+                    constraint_variable="is_medicaid_eligible",
+                    operation="==",
+                    value="True",
+                ),
+            ],
+        )
+
+    if constraint_var == "aca_ptc":
+        return (
+            "National ACA Premium Tax Credit Recipients",
+            [
+                StratumConstraint(
+                    constraint_variable="aca_ptc",
+                    operation=">",
+                    value="0",
+                ),
+                StratumConstraint(
+                    constraint_variable="is_aca_ptc_eligible",
+                    operation="==",
+                    value="True",
+                ),
+            ],
+        )
+
+    if constraint_var == "spm_unit_energy_subsidy_reported":
+        return (
+            "National LIHEAP Recipient Households",
+            [
+                StratumConstraint(
+                    constraint_variable="spm_unit_energy_subsidy_reported",
+                    operation=">",
+                    value="0",
+                )
+            ],
+        )
+
+    if constraint_var == "ssn_card_type":
+        return (
+            "National Undocumented Population",
+            [
+                StratumConstraint(
+                    constraint_variable="ssn_card_type",
+                    operation="==",
+                    value=cond_target.get("constraint_value", "NONE"),
+                )
+            ],
+        )
+
+    return (
+        f"National {constraint_var} Recipients",
+        [
+            StratumConstraint(
+                constraint_variable=constraint_var,
+                operation=">",
+                value="0",
+            )
+        ],
+    )
+
+
+def _constraint_tuples(
+    constraints: list[StratumConstraint],
+) -> set[tuple[str, str, str]]:
+    return {
+        (constraint.constraint_variable, constraint.operation, constraint.value)
+        for constraint in constraints
+    }
 
 
 def load_national_targets(
@@ -767,32 +851,10 @@ def load_national_targets(
 
         # Process conditional count targets (enrollment counts)
         for cond_target in conditional_targets:
-            constraint_var = cond_target["constraint_variable"]
             target_year = cond_target["year"]
             target_variable = cond_target.get("target_variable", "person_count")
             target_value = cond_target.get(target_variable)
-
-            # Determine constraint details
-            if constraint_var == "medicaid":
-                stratum_notes = "National Medicaid Enrollment"
-                constraint_operation = ">"
-                constraint_value = "0"
-            elif constraint_var == "aca_ptc":
-                stratum_notes = "National ACA Premium Tax Credit Recipients"
-                constraint_operation = ">"
-                constraint_value = "0"
-            elif constraint_var == "spm_unit_energy_subsidy_reported":
-                stratum_notes = "National LIHEAP Recipient Households"
-                constraint_operation = ">"
-                constraint_value = "0"
-            elif constraint_var == "ssn_card_type":
-                stratum_notes = "National Undocumented Population"
-                constraint_operation = "=="
-                constraint_value = cond_target.get("constraint_value", "NONE")
-            else:
-                stratum_notes = f"National {constraint_var} Recipients"
-                constraint_operation = ">"
-                constraint_value = "0"
+            stratum_notes, constraints = _conditional_count_stratum_details(cond_target)
 
             # Check if this stratum already exists
             existing_stratum = session.exec(
@@ -803,6 +865,13 @@ def load_national_targets(
             ).first()
 
             if existing_stratum:
+                if _constraint_tuples(existing_stratum.constraints_rel) != (
+                    _constraint_tuples(constraints)
+                ):
+                    existing_stratum.constraints_rel = constraints
+                    session.add(existing_stratum)
+                    session.flush()
+
                 # Update the existing target in this stratum
                 existing_target = session.exec(
                     select(Target).where(
@@ -815,7 +884,10 @@ def load_national_targets(
                 if existing_target:
                     existing_target.value = target_value
                     existing_target.source = "PolicyEngine"
-                    print(f"Updated enrollment target for {constraint_var}")
+                    print(
+                        "Updated enrollment target for "
+                        f"{cond_target['constraint_variable']}"
+                    )
                 else:
                     # Add new target to existing stratum
                     new_target = Target(
@@ -828,7 +900,10 @@ def load_national_targets(
                         notes=f"{cond_target['notes']} | Source: {cond_target['source']}",
                     )
                     session.add(new_target)
-                    print(f"Added enrollment target for {constraint_var}")
+                    print(
+                        "Added enrollment target for "
+                        f"{cond_target['constraint_variable']}"
+                    )
             else:
                 # Create new stratum with constraint
                 new_stratum = Stratum(
@@ -837,13 +912,7 @@ def load_national_targets(
                 )
 
                 # Add constraint
-                new_stratum.constraints_rel = [
-                    StratumConstraint(
-                        constraint_variable=constraint_var,
-                        operation=constraint_operation,
-                        value=constraint_value,
-                    )
-                ]
+                new_stratum.constraints_rel = constraints
 
                 # Add target
                 new_stratum.targets_rel = [
@@ -858,7 +927,10 @@ def load_national_targets(
                 ]
 
                 session.add(new_stratum)
-                print(f"Created stratum and target for {constraint_var} enrollment")
+                print(
+                    "Created stratum and target for "
+                    f"{cond_target['constraint_variable']} enrollment"
+                )
 
         session.commit()
 

--- a/policyengine_us_data/utils/loss.py
+++ b/policyengine_us_data/utils/loss.py
@@ -129,6 +129,58 @@ def _add_medicare_enrollment_target(loss_matrix, targets_array, sim, time_period
     return targets_array, loss_matrix
 
 
+def _add_medicaid_enrollment_target(
+    loss_matrix,
+    targets_array,
+    sim,
+    time_period,
+    target,
+):
+    label = "nation/hhs/medicaid_enrollment"
+    enrolled = sim.calculate(
+        "medicaid_enrolled",
+        map_to="person",
+        period=time_period,
+    ).values
+    eligible = sim.calculate(
+        "is_medicaid_eligible",
+        map_to="person",
+        period=time_period,
+    ).values
+    loss_matrix[label] = sim.map_result(
+        (enrolled & eligible).astype(float),
+        "person",
+        "household",
+    )
+    targets_array.append(target)
+    return targets_array, loss_matrix
+
+
+def _add_aca_enrollment_target(
+    loss_matrix,
+    targets_array,
+    sim,
+    time_period,
+    target,
+):
+    label = "nation/gov/aca_enrollment"
+    in_tax_unit_with_aca = (
+        sim.calculate("aca_ptc", map_to="person", period=time_period).values > 0
+    )
+    eligible = sim.calculate(
+        "is_aca_ptc_eligible",
+        map_to="person",
+        period=time_period,
+    ).values
+    loss_matrix[label] = sim.map_result(
+        (in_tax_unit_with_aca & eligible).astype(float),
+        "person",
+        "household",
+    )
+    targets_array.append(target)
+    return targets_array, loss_matrix
+
+
 ACA_SPENDING_TARGETS = {
     2024: 98e9,
 }
@@ -863,18 +915,13 @@ def build_loss_matrix(dataset: type, time_period):
     loss_matrix[label] = sim.calculate("medicaid", map_to="household").values
     targets_array.append(medicaid_spending_target)
 
-    # 2. Medicaid Enrollment
-    label = "nation/hhs/medicaid_enrollment"
-    on_medicaid = (
-        sim.calculate(
-            "medicaid",  # or your enrollee flag
-            map_to="person",
-            period=time_period,
-        ).values
-        > 0
-    ).astype(int)
-    loss_matrix[label] = sim.map_result(on_medicaid, "person", "household")
-    targets_array.append(medicaid_enrollment_target)
+    targets_array, loss_matrix = _add_medicaid_enrollment_target(
+        loss_matrix,
+        targets_array,
+        sim,
+        time_period,
+        medicaid_enrollment_target,
+    )
 
     # National ACA Spending
     aca_spending_target, aca_enrollment_target, _ = _get_aca_national_targets(
@@ -887,14 +934,13 @@ def build_loss_matrix(dataset: type, time_period):
     ).values
     targets_array.append(aca_spending_target)
 
-    # National ACA Enrollment (people receiving a PTC)
-    label = "nation/gov/aca_enrollment"
-    on_ptc = (
-        sim.calculate("aca_ptc", map_to="person", period=time_period).values > 0
-    ).astype(int)
-    loss_matrix[label] = sim.map_result(on_ptc, "person", "household")
-
-    targets_array.append(aca_enrollment_target)
+    targets_array, loss_matrix = _add_aca_enrollment_target(
+        loss_matrix,
+        targets_array,
+        sim,
+        time_period,
+        aca_enrollment_target,
+    )
 
     targets_array, loss_matrix = _add_medicare_enrollment_target(
         loss_matrix,
@@ -1379,6 +1425,7 @@ def _add_agi_metric_columns(
     soi_targets = pd.read_csv(CALIBRATION_FOLDER / "agi_state.csv")
 
     agi = sim.calculate("adjusted_gross_income").values
+    is_filer = sim.calculate("tax_unit_is_filer").values > 0
     state = sim.calculate("state_code", map_to="person").values
     state = sim.map_result(state, "person", "tax_unit", how="value_from_first_person")
 
@@ -1391,11 +1438,12 @@ def _add_agi_metric_columns(
         # loop in build_loss_matrix() (the SOI targets use half-open bands
         # starting at the lower bound).
         in_band = (agi >= lower) & (agi < upper)
+        in_scope = in_state & in_band & is_filer
 
         if r.IS_COUNT:
-            metric = (in_state & in_band & (agi > 0)).astype(float)
+            metric = in_scope.astype(float)
         else:
-            metric = np.where(in_state & in_band, agi, 0.0)
+            metric = np.where(in_scope, agi, 0.0)
 
         metric = sim.map_result(metric, "tax_unit", "household")
 

--- a/tests/unit/calibration/test_loss_targets.py
+++ b/tests/unit/calibration/test_loss_targets.py
@@ -8,8 +8,11 @@ from policyengine_us_data.utils.loss import (
     AGGREGATE_LEVEL_TARGETED_VARIABLES,
     AGI_LEVEL_TARGETED_VARIABLES,
     HARD_CODED_TOTALS,
+    _add_agi_metric_columns,
+    _add_aca_enrollment_target,
     _add_ctc_targets,
     _add_irs_soi_aggregate_targets,
+    _add_medicaid_enrollment_target,
     _add_medicare_enrollment_target,
     _get_aca_national_targets,
     _get_medicaid_national_targets,
@@ -147,6 +150,31 @@ class _FakeMedicareEnrollmentSimulation:
         return np.asarray(values, dtype=np.float32)
 
 
+class _FakeNationalEnrollmentSimulation:
+    def __init__(self):
+        self.calculate_calls = []
+        self.map_result_calls = []
+
+    def calculate(self, variable, map_to=None, period=None):
+        self.calculate_calls.append((variable, map_to, period))
+        values = {
+            "medicaid_enrolled": np.array([True, True, False, True]),
+            "is_medicaid_eligible": np.array([True, False, True, True]),
+            "aca_ptc": np.array([100.0, 100.0, 0.0, 50.0]),
+            "is_aca_ptc_eligible": np.array([True, False, True, True]),
+        }
+        if variable not in values:
+            raise AssertionError(f"Unexpected variable {variable!r}")
+        assert map_to == "person"
+        return SimpleNamespace(values=values[variable])
+
+    def map_result(self, values, source_entity, target_entity, how=None):
+        self.map_result_calls.append((source_entity, target_entity, how))
+        assert source_entity == "person"
+        assert target_entity == "household"
+        return np.asarray(values, dtype=np.float32)
+
+
 class _FakeCapitalGainsSimulation:
     def __init__(self):
         self.calculate_calls = []
@@ -175,6 +203,73 @@ class _FakeCapitalGainsSimulation:
             raise AssertionError(f"Unexpected variable {variable!r}")
         assert map_to == "household"
         return _FakeArrayResult(values[variable])
+
+
+class _FakeStateAgiSimulation:
+    def calculate(self, variable, map_to=None, period=None):
+        values = {
+            "adjusted_gross_income": [-100.0, -50.0, 5_000.0, 7_000.0],
+            "tax_unit_is_filer": [1.0, 0.0, 1.0, 1.0],
+            "state_code": ["CA", "CA", "CA", "NY"],
+        }
+        if variable not in values:
+            raise AssertionError(f"Unexpected variable {variable!r}")
+        if variable == "state_code":
+            assert map_to == "person"
+            return SimpleNamespace(values=np.asarray(values[variable], dtype=object))
+        else:
+            assert map_to is None
+        return _FakeArrayResult(values[variable])
+
+    def map_result(self, values, source_entity, target_entity, how=None):
+        if source_entity == "person":
+            assert target_entity == "tax_unit"
+            assert how == "value_from_first_person"
+            return np.asarray(values)
+        assert source_entity == "tax_unit"
+        assert target_entity == "household"
+        return np.asarray(values)
+
+
+def test_state_agi_targets_are_limited_to_filers(tmp_path, monkeypatch):
+    calibration_folder = tmp_path
+    (calibration_folder / "agi_state.csv").write_text(
+        "\n".join(
+            [
+                "GEO_ID,GEO_NAME,AGI_LOWER_BOUND,AGI_UPPER_BOUND,VALUE,IS_COUNT,VARIABLE",
+                "0400000US06,CA,-inf,1.0,1,1,adjusted_gross_income/count",
+                "0400000US06,CA,-inf,1.0,-100,0,adjusted_gross_income/amount",
+                "0400000US06,CA,1.0,10000.0,1,1,adjusted_gross_income/count",
+                "0400000US06,CA,1.0,10000.0,5000,0,adjusted_gross_income/amount",
+            ]
+        )
+    )
+
+    from policyengine_us_data.utils import loss as loss_module
+
+    monkeypatch.setattr(loss_module, "CALIBRATION_FOLDER", calibration_folder)
+
+    loss_matrix = _add_agi_metric_columns(
+        pd.DataFrame(),
+        _FakeStateAgiSimulation(),
+    )
+
+    np.testing.assert_array_equal(
+        loss_matrix["state/CA/adjusted_gross_income/count/-inf_1"],
+        np.array([1.0, 0.0, 0.0, 0.0]),
+    )
+    np.testing.assert_array_equal(
+        loss_matrix["state/CA/adjusted_gross_income/amount/-inf_1"],
+        np.array([-100.0, 0.0, 0.0, 0.0]),
+    )
+    np.testing.assert_array_equal(
+        loss_matrix["state/CA/adjusted_gross_income/count/1_10000"],
+        np.array([0.0, 0.0, 1.0, 0.0]),
+    )
+    np.testing.assert_array_equal(
+        loss_matrix["state/CA/adjusted_gross_income/amount/1_10000"],
+        np.array([0.0, 0.0, 5_000.0, 0.0]),
+    )
 
 
 def test_add_ctc_targets(monkeypatch):
@@ -299,4 +394,48 @@ def test_add_medicare_enrollment_target(monkeypatch):
     np.testing.assert_array_equal(
         loss_matrix["nation/cms/medicare_enrollment"],
         np.array([1.0, 0.0, 1.0], dtype=np.float32),
+    )
+
+
+def test_add_medicaid_enrollment_target_uses_enrollment_and_eligibility():
+    sim = _FakeNationalEnrollmentSimulation()
+
+    targets, loss_matrix = _add_medicaid_enrollment_target(
+        pd.DataFrame(),
+        [],
+        sim,
+        2024,
+        72_429_055,
+    )
+
+    assert targets == [72_429_055]
+    assert sim.calculate_calls == [
+        ("medicaid_enrolled", "person", 2024),
+        ("is_medicaid_eligible", "person", 2024),
+    ]
+    np.testing.assert_array_equal(
+        loss_matrix["nation/hhs/medicaid_enrollment"],
+        np.array([1.0, 0.0, 0.0, 1.0], dtype=np.float32),
+    )
+
+
+def test_add_aca_enrollment_target_uses_positive_ptc_and_person_eligibility():
+    sim = _FakeNationalEnrollmentSimulation()
+
+    targets, loss_matrix = _add_aca_enrollment_target(
+        pd.DataFrame(),
+        [],
+        sim,
+        2024,
+        19_743_689,
+    )
+
+    assert targets == [19_743_689]
+    assert sim.calculate_calls == [
+        ("aca_ptc", "person", 2024),
+        ("is_aca_ptc_eligible", "person", 2024),
+    ]
+    np.testing.assert_array_equal(
+        loss_matrix["nation/gov/aca_enrollment"],
+        np.array([1.0, 0.0, 0.0, 1.0], dtype=np.float32),
     )

--- a/tests/unit/test_etl_aca_agi_state_targets.py
+++ b/tests/unit/test_etl_aca_agi_state_targets.py
@@ -1,0 +1,73 @@
+from sqlmodel import Session, select
+
+from policyengine_us_data.db.create_database_tables import (
+    Stratum,
+    StratumConstraint,
+    Target,
+    create_database,
+)
+from policyengine_us_data.db.etl_aca_agi_state_targets import _load_agi_state_targets
+
+
+def test_state_agi_targets_use_filer_strata(tmp_path, monkeypatch):
+    calibration_targets = tmp_path / "calibration_targets"
+    calibration_targets.mkdir()
+    (calibration_targets / "agi_state.csv").write_text(
+        "\n".join(
+            [
+                "GEO_ID,GEO_NAME,AGI_LOWER_BOUND,AGI_UPPER_BOUND,VALUE,IS_COUNT,VARIABLE",
+                "0400000US06,CA,-inf,1.0,123,1,adjusted_gross_income/count",
+                "0400000US06,CA,-inf,1.0,-456,0,adjusted_gross_income/amount",
+            ]
+        )
+    )
+    monkeypatch.setattr(
+        "policyengine_us_data.db.etl_aca_agi_state_targets.STORAGE_FOLDER",
+        tmp_path,
+    )
+
+    engine = create_database(f"sqlite:///{tmp_path / 'policy_data.db'}")
+    with Session(engine) as session:
+        state_stratum = Stratum(notes="California")
+        state_stratum.constraints_rel = [
+            StratumConstraint(
+                constraint_variable="state_fips",
+                operation="==",
+                value="6",
+            )
+        ]
+        session.add(state_stratum)
+        session.commit()
+        session.refresh(state_stratum)
+
+        _load_agi_state_targets(
+            session,
+            2024,
+            {"state": {6: state_stratum.stratum_id}},
+        )
+        session.commit()
+
+        targets = session.exec(select(Target)).all()
+        assert {target.variable for target in targets} == {
+            "tax_unit_count",
+            "adjusted_gross_income",
+        }
+
+        strata = {
+            target.variable: session.get(Stratum, target.stratum_id)
+            for target in targets
+        }
+        for stratum in strata.values():
+            constraints = {
+                (
+                    constraint.constraint_variable,
+                    constraint.operation,
+                    constraint.value,
+                )
+                for constraint in stratum.constraints_rel
+            }
+            assert ("tax_unit_is_filer", "==", "1") in constraints
+            assert ("state_fips", "==", "6") in constraints
+            assert ("adjusted_gross_income", ">=", "-inf") in constraints
+            assert ("adjusted_gross_income", "<", "1.0") in constraints
+            assert ("adjusted_gross_income", ">", "0") not in constraints

--- a/tests/unit/test_etl_irs_soi_eitc.py
+++ b/tests/unit/test_etl_irs_soi_eitc.py
@@ -1,0 +1,40 @@
+from policyengine_us_data.db.etl_irs_soi import _get_eitc_recipient_constraints
+
+
+def _constraint_tuples(geo_info):
+    return {
+        (
+            constraint.constraint_variable,
+            constraint.operation,
+            constraint.value,
+        )
+        for constraint in _get_eitc_recipient_constraints(geo_info)
+    }
+
+
+def test_national_eitc_targets_are_limited_to_recipients():
+    assert _constraint_tuples({"type": "national"}) == {
+        ("tax_unit_is_filer", "==", "1"),
+        ("eitc", ">", "0"),
+    }
+
+
+def test_state_eitc_targets_are_limited_to_state_recipients():
+    assert _constraint_tuples({"type": "state", "state_fips": 6}) == {
+        ("tax_unit_is_filer", "==", "1"),
+        ("eitc", ">", "0"),
+        ("state_fips", "==", "6"),
+    }
+
+
+def test_district_eitc_targets_are_limited_to_district_recipients():
+    assert _constraint_tuples(
+        {
+            "type": "district",
+            "congressional_district_geoid": "5000100US0601",
+        }
+    ) == {
+        ("tax_unit_is_filer", "==", "1"),
+        ("eitc", ">", "0"),
+        ("congressional_district_geoid", "==", "5000100US0601"),
+    }

--- a/tests/unit/test_etl_national_targets.py
+++ b/tests/unit/test_etl_national_targets.py
@@ -201,6 +201,132 @@ def test_load_national_targets_supports_liheap_household_counts(tmp_path, monkey
         assert liheap_target.value == 5_876_646
 
 
+def test_load_national_targets_scopes_aca_enrollment_to_eligible_ptc_recipients(
+    tmp_path, monkeypatch
+):
+    calibration_dir = tmp_path / "calibration"
+    calibration_dir.mkdir()
+    db_uri = f"sqlite:///{calibration_dir / 'policy_data.db'}"
+    engine = create_database(db_uri)
+
+    with Session(engine) as session:
+        national = _make_stratum(session, notes="United States")
+        assert national is not None
+
+    monkeypatch.setattr(
+        "policyengine_us_data.db.etl_national_targets.STORAGE_FOLDER",
+        tmp_path,
+    )
+
+    load_national_targets(
+        direct_targets_df=pd.DataFrame(),
+        tax_filer_df=pd.DataFrame(),
+        tax_expenditure_df=pd.DataFrame(),
+        conditional_targets=[
+            {
+                "constraint_variable": "aca_ptc",
+                "person_count": 19_743_689,
+                "source": "CMS marketplace data",
+                "notes": "ACA Premium Tax Credit recipients",
+                "year": 2024,
+            }
+        ],
+    )
+
+    with Session(engine) as session:
+        aca_stratum = session.exec(
+            select(Stratum).where(
+                Stratum.notes == "National ACA Premium Tax Credit Recipients"
+            )
+        ).first()
+        assert aca_stratum is not None
+
+        constraints = {
+            (
+                constraint.constraint_variable,
+                constraint.operation,
+                constraint.value,
+            )
+            for constraint in aca_stratum.constraints_rel
+        }
+        assert constraints == {
+            ("aca_ptc", ">", "0"),
+            ("is_aca_ptc_eligible", "==", "True"),
+        }
+
+        aca_target = session.exec(
+            select(Target).where(
+                Target.stratum_id == aca_stratum.stratum_id,
+                Target.variable == "person_count",
+                Target.period == 2024,
+            )
+        ).first()
+        assert aca_target is not None
+        assert aca_target.value == 19_743_689
+
+
+def test_load_national_targets_scopes_medicaid_enrollment_to_enrolled_people(
+    tmp_path, monkeypatch
+):
+    calibration_dir = tmp_path / "calibration"
+    calibration_dir.mkdir()
+    db_uri = f"sqlite:///{calibration_dir / 'policy_data.db'}"
+    engine = create_database(db_uri)
+
+    with Session(engine) as session:
+        national = _make_stratum(session, notes="United States")
+        assert national is not None
+
+    monkeypatch.setattr(
+        "policyengine_us_data.db.etl_national_targets.STORAGE_FOLDER",
+        tmp_path,
+    )
+
+    load_national_targets(
+        direct_targets_df=pd.DataFrame(),
+        tax_filer_df=pd.DataFrame(),
+        tax_expenditure_df=pd.DataFrame(),
+        conditional_targets=[
+            {
+                "constraint_variable": "medicaid_enrolled",
+                "person_count": 72_429_055,
+                "source": "CMS/HHS administrative data",
+                "notes": "Medicaid enrollment count",
+                "year": 2024,
+            }
+        ],
+    )
+
+    with Session(engine) as session:
+        medicaid_stratum = session.exec(
+            select(Stratum).where(Stratum.notes == "National Medicaid Enrollment")
+        ).first()
+        assert medicaid_stratum is not None
+
+        constraints = {
+            (
+                constraint.constraint_variable,
+                constraint.operation,
+                constraint.value,
+            )
+            for constraint in medicaid_stratum.constraints_rel
+        }
+        assert constraints == {
+            ("medicaid_enrolled", "==", "True"),
+            ("is_medicaid_eligible", "==", "True"),
+        }
+
+        medicaid_target = session.exec(
+            select(Target).where(
+                Target.stratum_id == medicaid_stratum.stratum_id,
+                Target.variable == "person_count",
+                Target.period == 2024,
+            )
+        ).first()
+        assert medicaid_target is not None
+        assert medicaid_target.value == 72_429_055
+
+
 def test_load_national_targets_supports_medicare_enrollment_counts(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary

- gate legacy state AGI calibration metrics on `tax_unit_is_filer` so SOI return-count and AGI amount targets exclude nonfilers
- scope legacy national ACA enrollment to people in positive-PTC tax units who are personally `is_aca_ptc_eligible`
- scope legacy national Medicaid enrollment to people who are `medicaid_enrolled` and `is_medicaid_eligible`, rather than using positive Medicaid dollars as a proxy
- align the policy-data DB national/state AGI, ACA enrollment, and Medicaid enrollment strata to the same domains
- require positive modeled EITC in IRS SOI EITC child-count DB strata so `tax_unit_count` targets count recipients, not all filers in an `eitc_child_count` bucket

## Root cause

Several count targets were comparing administrative/source counts to broader modeled domains. The legacy state AGI loss matrix used state and AGI bucket membership without a filer gate, even though the source is IRS SOI return data. Legacy national ACA and Medicaid enrollment used positive dollar variables as proxies for enrollment, while their state counterparts already used explicit eligibility/enrollment flags. Separately, the DB/unified EITC child-count strata used `eitc_child_count` as a domain classifier without requiring `eitc > 0`, so count targets included zero-EITC tax units such as high-income families with qualifying children.

## Validation

- `uv run ruff check policyengine_us_data/utils/loss.py policyengine_us_data/db/etl_national_targets.py tests/unit/calibration/test_loss_targets.py tests/unit/test_etl_national_targets.py policyengine_us_data/db/etl_irs_soi.py policyengine_us_data/db/etl_aca_agi_state_targets.py tests/unit/test_etl_irs_soi_eitc.py tests/unit/test_etl_aca_agi_state_targets.py`
- `uv run ruff format --check policyengine_us_data/utils/loss.py policyengine_us_data/db/etl_national_targets.py tests/unit/calibration/test_loss_targets.py tests/unit/test_etl_national_targets.py policyengine_us_data/db/etl_irs_soi.py policyengine_us_data/db/etl_aca_agi_state_targets.py tests/unit/test_etl_irs_soi_eitc.py tests/unit/test_etl_aca_agi_state_targets.py`
- `uv run pytest tests/unit/test_etl_national_targets.py tests/unit/test_etl_irs_soi_eitc.py tests/unit/test_etl_aca_agi_state_targets.py tests/unit/calibration/test_loss_targets.py tests/unit/calibration/test_eitc_extended_targets.py -q`