### PR TITLE
Assign legacy CPS blocks and SPM thresholds by geography

### DIFF
--- a/changelog.d/903.fixed.md
+++ b/changelog.d/903.fixed.md
@@ -1,0 +1,1 @@
+Assign legacy extended CPS households to Census blocks within their state and county when available, and derive SPM thresholds from the assigned geography.

--- a/policyengine_us_data/calibration/calibration_utils.py
+++ b/policyengine_us_data/calibration/calibration_utils.py
@@ -566,6 +566,20 @@ def load_cd_geoadj_values(
         if cd in rent_lookup:
             geoadj_dict[cd] = rent_lookup[cd]
         else:
+            cd_int = int(cd)
+            state_fips = cd_int // 100
+            district = cd_int % 100
+            fallback_cds = []
+            if state_fips == 11 and district == 1:
+                fallback_cds.append("1198")
+            if district == 1:
+                fallback_cds.append(str(state_fips * 100))
+            for fallback_cd in fallback_cds:
+                if fallback_cd in rent_lookup:
+                    geoadj_dict[cd] = rent_lookup[fallback_cd]
+                    break
+            if cd in geoadj_dict:
+                continue
             print(f"Warning: No rent data for CD {cd}, using geoadj=1.0")
             geoadj_dict[cd] = 1.0
 

--- a/policyengine_us_data/calibration/clone_and_assign.py
+++ b/policyengine_us_data/calibration/clone_and_assign.py
@@ -37,10 +37,10 @@ def load_global_block_distribution():
     global distribution.
 
     Returns:
-        Tuple of (block_geoids, cd_geoids, state_fips,
-        probabilities) where each is a numpy array indexed
-        by block row. Probabilities are normalized to sum
-        to 1 globally.
+        Tuple of (block_geoids, cd_geoids, state_fips, county_fips,
+        weights) where each is a numpy array indexed by block row.
+        Weights are block populations when available, otherwise the
+        legacy probability column.
 
     Raises:
         FileNotFoundError: If the CSV file does not exist.
@@ -59,14 +59,63 @@ def load_global_block_distribution():
     at_large = (district_num == 0) | ((state_fips_col == 11) & (district_num == 98))
     df.loc[at_large, "cd_geoid"] = state_fips_col[at_large] * 100 + 1
 
-    block_geoids = df["block_geoid"].values
+    block_geoids = df["block_geoid"].str.zfill(15).values
     cd_geoids = np.array(df["cd_geoid"].astype(str).tolist())
     state_fips = np.array([int(b[:2]) for b in block_geoids])
+    county_fips = np.array([b[:5] for b in block_geoids])
 
-    probs = df["probability"].values.astype(np.float64)
-    probs = probs / probs.sum()
+    weight_col = "population" if "population" in df.columns else "probability"
+    weights = df[weight_col].values.astype(np.float64)
 
-    return block_geoids, cd_geoids, state_fips, probs
+    return block_geoids, cd_geoids, state_fips, county_fips, weights
+
+
+def _group_indices(values: np.ndarray) -> dict[object, np.ndarray]:
+    order = np.argsort(values, kind="mergesort")
+    sorted_values = values[order]
+    if len(sorted_values) == 0:
+        return {}
+    starts = np.r_[0, np.flatnonzero(sorted_values[1:] != sorted_values[:-1]) + 1]
+    ends = np.r_[starts[1:], len(sorted_values)]
+    return {
+        sorted_values[start].item(): order[start:end]
+        for start, end in zip(starts, ends)
+    }
+
+
+def _normalise_county_fips(state_fips, county_fips) -> str | None:
+    if county_fips is None or pd.isna(county_fips):
+        return None
+    if isinstance(county_fips, (bytes, np.bytes_)):
+        county_fips = county_fips.decode()
+    try:
+        state_int = int(state_fips)
+        county_int = int(float(str(county_fips).strip()))
+    except (TypeError, ValueError):
+        return None
+    if county_int <= 0:
+        return None
+    if county_int >= 1_000:
+        return f"{county_int:05d}"
+    return f"{state_int * 1_000 + county_int:05d}"
+
+
+def _sample_index(
+    rng: np.random.Generator,
+    candidates: np.ndarray,
+    weights: np.ndarray,
+    probabilities_cache: dict[int, np.ndarray],
+) -> int:
+    cache_key = id(candidates)
+    if cache_key not in probabilities_cache:
+        candidate_weights = weights[candidates]
+        total = candidate_weights.sum()
+        probabilities_cache[cache_key] = (
+            candidate_weights / total
+            if total > 0
+            else np.full(len(candidates), 1 / len(candidates))
+        )
+    return int(rng.choice(candidates, p=probabilities_cache[cache_key]))
 
 
 def _build_agi_block_probs(cds, pop_probs, cd_agi_targets):
@@ -137,10 +186,11 @@ def assign_random_geography(
         GeographyAssignment with arrays of length
         n_records * n_clones.
     """
-    blocks, cds, states, probs = load_global_block_distribution()
+    blocks, cds, states, counties, weights = load_global_block_distribution()
 
     n_total = n_records * n_clones
     rng = np.random.default_rng(seed)
+    probs = weights / weights.sum()
 
     agi_probs = None
     extreme_mask = None
@@ -220,9 +270,59 @@ def assign_random_geography(
     return GeographyAssignment(
         block_geoid=assigned_blocks,
         cd_geoid=cds[indices],
-        county_fips=np.array([b[:5] for b in assigned_blocks]),
+        county_fips=counties[indices],
         state_fips=states[indices],
         n_records=n_records,
+        n_clones=n_clones,
+    )
+
+
+def assign_geography_within_state_county(
+    state_fips: np.ndarray,
+    county_fips: np.ndarray | None = None,
+    n_clones: int = 1,
+    seed: int = 42,
+) -> GeographyAssignment:
+    """Assign blocks within each record's state, and county when available.
+
+    Sampling is weighted by block population when the block distribution file
+    includes a population column, otherwise by its legacy probability weights.
+    """
+    blocks, cds, states, counties, weights = load_global_block_distribution()
+    state_groups = _group_indices(states)
+    county_groups = _group_indices(counties)
+
+    input_states = np.tile(np.asarray(state_fips, dtype=int), n_clones)
+    if county_fips is None:
+        input_counties = np.array([None] * len(input_states), dtype=object)
+    else:
+        input_counties = np.tile(np.asarray(county_fips, dtype=object), n_clones)
+
+    rng = np.random.default_rng(seed)
+    probabilities_cache: dict[int, np.ndarray] = {}
+    selected = np.empty(len(input_states), dtype=np.int64)
+    global_candidates = np.arange(len(blocks))
+
+    for i, (state, county) in enumerate(zip(input_states, input_counties)):
+        county_key = _normalise_county_fips(state, county)
+        candidates = county_groups.get(county_key) if county_key is not None else None
+        if candidates is None or len(candidates) == 0:
+            candidates = state_groups.get(int(state))
+        if candidates is None or len(candidates) == 0:
+            logger.warning(
+                "No block distribution for state=%s county=%s; using national distribution",
+                state,
+                county,
+            )
+            candidates = global_candidates
+        selected[i] = _sample_index(rng, candidates, weights, probabilities_cache)
+
+    return GeographyAssignment(
+        block_geoid=blocks[selected],
+        cd_geoid=cds[selected],
+        county_fips=counties[selected],
+        state_fips=states[selected],
+        n_records=len(state_fips),
         n_clones=n_clones,
     )
 
@@ -274,7 +374,7 @@ def load_geography(path) -> GeographyAssignment:
 @lru_cache(maxsize=1)
 def load_sorted_block_cd_lookup():
     """Load a sorted block -> CD lookup for legacy block artifacts."""
-    blocks, cds, _, _ = load_global_block_distribution()
+    blocks, cds, _, _, _ = load_global_block_distribution()
     order = np.argsort(blocks)
     return blocks[order], cds[order]
 

--- a/policyengine_us_data/calibration/puf_impute.py
+++ b/policyengine_us_data/calibration/puf_impute.py
@@ -467,6 +467,9 @@ def reconcile_ss_subcomponents(
 def puf_clone_dataset(
     data: Dict[str, Dict[int, np.ndarray]],
     state_fips: np.ndarray,
+    block_geoid: Optional[np.ndarray] = None,
+    cd_geoid: Optional[np.ndarray] = None,
+    county_fips: Optional[np.ndarray] = None,
     time_period: int = 2024,
     puf_dataset=None,
     skip_qrf: bool = False,
@@ -481,6 +484,9 @@ def puf_clone_dataset(
     Args:
         data: CPS dataset dict {variable: {time_period: array}}.
         state_fips: State FIPS per household, shape (n_households,).
+        block_geoid: Optional 15-character Census block GEOID per household.
+        cd_geoid: Optional congressional district GEOID per household.
+        county_fips: Optional 5-digit county FIPS per household.
         time_period: Tax year.
         puf_dataset: PUF dataset class or path for QRF training.
             If None, skips QRF (same as skip_qrf=True).
@@ -569,6 +575,25 @@ def puf_clone_dataset(
     new_data["state_fips"] = {
         time_period: np.concatenate([state_fips, state_fips]).astype(np.int32)
     }
+    if block_geoid is not None:
+        block_str = np.asarray([str(b).zfill(15) for b in block_geoid])
+        block_geoid = block_str.astype("S15")
+        new_data["block_geoid"] = {
+            time_period: np.concatenate([block_geoid, block_geoid])
+        }
+        tract_geoid = np.asarray([b[:11] for b in block_str]).astype("S11")
+        new_data["tract_geoid"] = {
+            time_period: np.concatenate([tract_geoid, tract_geoid])
+        }
+    if cd_geoid is not None:
+        new_data["congressional_district_geoid"] = {
+            time_period: np.concatenate([cd_geoid, cd_geoid]).astype(np.int32)
+        }
+    if county_fips is not None:
+        county_fips = np.asarray([f"{int(c):05d}" for c in county_fips]).astype("S5")
+        new_data["county_fips"] = {
+            time_period: np.concatenate([county_fips, county_fips])
+        }
 
     if y_full:
         for var in IMPUTED_VARIABLES:

--- a/policyengine_us_data/datasets/cps/extended_cps.py
+++ b/policyengine_us_data/datasets/cps/extended_cps.py
@@ -38,6 +38,78 @@ def _supports_structural_mortgage_inputs() -> bool:
     return has_policyengine_us_variables(*STRUCTURAL_MORTGAGE_VARIABLES)
 
 
+def _calculate_spm_thresholds_from_assigned_geography(
+    data: dict[str, dict[int, np.ndarray]],
+    time_period: int,
+) -> np.ndarray:
+    from policyengine_us_data.calibration.calibration_utils import (
+        load_cd_geoadj_values,
+    )
+    from policyengine_us_data.utils.spm import (
+        calculate_spm_thresholds_with_geoadj,
+    )
+
+    spm_unit_ids = data["spm_unit_id"][time_period]
+    person_spm_unit_ids = data["person_spm_unit_id"][time_period]
+    person_household_ids = data["person_household_id"][time_period]
+    household_ids = data["household_id"][time_period]
+    ages = data["age"][time_period]
+    cd_geoids = np.asarray(data["congressional_district_geoid"][time_period]).astype(
+        str
+    )
+
+    cd_geoadj_values = load_cd_geoadj_values(sorted(set(cd_geoids)))
+    household_geoadj = np.array(
+        [cd_geoadj_values.get(cd, 1.0) for cd in cd_geoids],
+        dtype=float,
+    )
+    geoadj_by_household = dict(zip(household_ids, household_geoadj))
+
+    person_df = pd.DataFrame(
+        {
+            "spm_unit_id": person_spm_unit_ids,
+            "household_id": person_household_ids,
+            "is_adult": ages >= 18,
+            "is_child": ages < 18,
+        }
+    )
+    spm_df = person_df.groupby("spm_unit_id").agg(
+        num_adults=("is_adult", "sum"),
+        num_children=("is_child", "sum"),
+        household_id=("household_id", "first"),
+    )
+    spm_df = spm_df.reindex(spm_unit_ids)
+
+    tenure = data.get("spm_unit_tenure_type", {}).get(time_period)
+    tenure_codes = np.full(len(spm_unit_ids), 3, dtype=int)
+    if tenure is not None:
+        tenure_values = np.asarray(tenure)
+        if np.issubdtype(tenure_values.dtype, np.bytes_):
+            tenure_values = np.char.decode(tenure_values, "utf-8")
+        tenure_codes = (
+            pd.Series(tenure_values)
+            .map(
+                {
+                    "OWNER_WITH_MORTGAGE": 1,
+                    "OWNER_WITHOUT_MORTGAGE": 2,
+                    "RENTER": 3,
+                }
+            )
+            .fillna(3)
+            .astype(int)
+            .values
+        )
+
+    geoadj = spm_df["household_id"].map(geoadj_by_household).fillna(1.0).values
+    return calculate_spm_thresholds_with_geoadj(
+        num_adults=spm_df["num_adults"].fillna(0).values,
+        num_children=spm_df["num_children"].fillna(0).values,
+        tenure_codes=tenure_codes,
+        geoadj=geoadj,
+        year=time_period,
+    )
+
+
 # CPS-only categorical features to donor-impute onto the PUF clone half.
 # These drive subgroup analysis and occupation-based logic, so naive donor
 # duplication dilutes the relationship between the clone's PUF-imputed
@@ -150,7 +222,6 @@ CPS_ONLY_IMPUTED_VARIABLES = [
     "spm_unit_payroll_tax_reported",
     "spm_unit_federal_tax_reported",
     "spm_unit_state_tax_reported",
-    "spm_unit_spm_threshold",
     "spm_unit_net_income_reported",
     "spm_unit_pre_subsidy_childcare_expenses",
     # Medical expenses
@@ -904,7 +975,7 @@ class ExtendedCPS(Dataset):
         from policyengine_us import Microsimulation
 
         from policyengine_us_data.calibration.clone_and_assign import (
-            load_global_block_distribution,
+            assign_geography_within_state_county,
         )
         from policyengine_us_data.calibration.puf_impute import (
             puf_clone_dataset,
@@ -919,16 +990,21 @@ class ExtendedCPS(Dataset):
         for var in data:
             data_dict[var] = {self.time_period: data[var][...]}
 
-        n_hh = len(data_dict["household_id"][self.time_period])
-        _, _, block_states, block_probs = load_global_block_distribution()
-        rng = np.random.default_rng(seed=42)
-        indices = rng.choice(len(block_states), size=n_hh, p=block_probs)
-        state_fips = block_states[indices]
+        state_fips = data_dict["state_fips"][self.time_period]
+        county_fips = data_dict.get("county_fips", {}).get(self.time_period)
+        geography = assign_geography_within_state_county(
+            state_fips=state_fips,
+            county_fips=county_fips,
+            seed=42,
+        )
 
         logger.info("PUF clone with dataset: %s", self.puf)
         new_data = puf_clone_dataset(
             data=data_dict,
-            state_fips=state_fips,
+            state_fips=geography.state_fips,
+            block_geoid=geography.block_geoid,
+            cd_geoid=geography.cd_geoid,
+            county_fips=geography.county_fips,
             time_period=self.time_period,
             puf_dataset=self.puf,
             dataset_path=str(self.cps.file_path),
@@ -983,6 +1059,13 @@ class ExtendedCPS(Dataset):
                 self.time_period,
                 had_positive_mortgage_input,
             )
+        logger.info("Calculating SPM thresholds from assigned geography")
+        new_data["spm_unit_spm_threshold"] = {
+            self.time_period: _calculate_spm_thresholds_from_assigned_geography(
+                new_data,
+                self.time_period,
+            )
+        }
         new_data = self._drop_formula_variables(new_data)
         self.save_dataset(new_data)
 
@@ -1035,6 +1118,7 @@ class ExtendedCPS(Dataset):
     # due to entity shape mismatch.
     _KEEP_FORMULA_VARS = {
         "person_id",
+        "spm_unit_spm_threshold",
         "self_employed_pension_contribution_ald",
         "self_employed_health_insurance_ald",
     }

--- a/policyengine_us_data/datasets/cps/small_enhanced_cps.py
+++ b/policyengine_us_data/datasets/cps/small_enhanced_cps.py
@@ -72,6 +72,10 @@ def create_sparse_ecps():
         dataset=EnhancedCPS_2024,
     )
     template_sim.set_input("household_weight", time_period, sparse_weights)
+    # Preserve the base-year SPM threshold when round-tripping through a
+    # dataframe. It is a formula variable in policyengine-us, but poverty
+    # projections need the input value as the geographic-adjusted anchor.
+    template_sim.calculate("spm_unit_spm_threshold", time_period)
 
     df = template_sim.to_input_dataframe()
     del template_sim

--- a/policyengine_us_data/storage/calibration_targets/make_block_cd_distributions.py
+++ b/policyengine_us_data/storage/calibration_targets/make_block_cd_distributions.py
@@ -100,8 +100,8 @@ def build_block_cd_distributions():
         print(f"Warning: {len(bad_sums)} CDs don't sum to 1.0")
 
     # Step 5: Prepare output
-    output = df[["cd_geoid", "GEOID", "probability"]].rename(
-        columns={"GEOID": "block_geoid"}
+    output = df[["cd_geoid", "GEOID", "probability", "POP20"]].rename(
+        columns={"GEOID": "block_geoid", "POP20": "population"}
     )
     output = output.sort_values(["cd_geoid", "probability"], ascending=[True, False])
 

--- a/policyengine_us_data/utils/spm.py
+++ b/policyengine_us_data/utils/spm.py
@@ -18,18 +18,17 @@ def calculate_spm_thresholds_with_geoadj(
     year: int,
 ) -> np.ndarray:
     """
-    Calculate SPM thresholds using Census-provided geographic adjustments.
+    Calculate SPM thresholds using supplied geographic adjustments.
 
-    This function uses the SPM_GEOADJ values already computed by the Census
-    Bureau, combined with spm-calculator's base thresholds and equivalence
-    scale formula. This avoids the need for a Census API key.
+    This combines geographic adjustment factors with spm-calculator's base
+    thresholds and equivalence scale formula.
 
     Args:
         num_adults: Array of number of adults (18+) in each SPM unit.
         num_children: Array of number of children (<18) in each SPM unit.
         tenure_codes: Array of Census tenure/mortgage status codes.
             1 = owner with mortgage, 2 = owner without mortgage, 3 = renter.
-        geoadj: Array of Census SPM_GEOADJ geographic adjustment factors.
+        geoadj: Array of geographic adjustment factors.
         year: The year for which to calculate thresholds.
 
     Returns:

--- a/tests/unit/calibration/test_calibration_puf_impute.py
+++ b/tests/unit/calibration/test_calibration_puf_impute.py
@@ -129,6 +129,52 @@ class TestPufCloneDataset:
         np.testing.assert_array_equal(result_states[:5], state_fips)
         np.testing.assert_array_equal(result_states[5:], state_fips)
 
+    def test_geography_fields_preserved(self):
+        data = _make_mock_data(n_persons=20, n_households=5)
+        state_fips = np.array([1, 2, 36, 6, 48])
+        block_geoid = np.array(
+            [
+                "010010001001001",
+                "020010001001001",
+                "360610001001000",
+                "060010001001001",
+                "480010001001001",
+            ]
+        )
+        cd_geoid = np.array(["101", "202", "3610", "601", "4801"])
+        county_fips = np.array(["01001", "02001", "36061", "06001", "48001"])
+
+        result = puf_clone_dataset(
+            data=data,
+            state_fips=state_fips,
+            block_geoid=block_geoid,
+            cd_geoid=cd_geoid,
+            county_fips=county_fips,
+            time_period=2024,
+            skip_qrf=True,
+        )
+
+        np.testing.assert_array_equal(
+            result["block_geoid"][2024][:5].astype(str),
+            block_geoid,
+        )
+        np.testing.assert_array_equal(
+            result["block_geoid"][2024][5:].astype(str),
+            block_geoid,
+        )
+        np.testing.assert_array_equal(
+            result["congressional_district_geoid"][2024][:5],
+            cd_geoid.astype(np.int32),
+        )
+        np.testing.assert_array_equal(
+            result["county_fips"][2024][:5].astype(str),
+            county_fips,
+        )
+        np.testing.assert_array_equal(
+            result["tract_geoid"][2024][:5].astype(str),
+            np.array([b[:11] for b in block_geoid]),
+        )
+
     def test_demographics_shared(self):
         data = _make_mock_data(n_persons=20, n_households=5)
         state_fips = np.array([1, 2, 36, 6, 48])

--- a/tests/unit/calibration/test_clone_and_assign.py
+++ b/tests/unit/calibration/test_clone_and_assign.py
@@ -194,9 +194,9 @@ class TestAssignRandomGeography:
             rec_cds = [
                 r.cd_geoid[clone * r.n_records + rec] for clone in range(r.n_clones)
             ]
-            assert len(rec_cds) == len(
-                set(rec_cds)
-            ), f"Record {rec} has duplicate CDs: {rec_cds}"
+            assert len(rec_cds) == len(set(rec_cds)), (
+                f"Record {rec} has duplicate CDs: {rec_cds}"
+            )
 
     def test_missing_file_raises(self, tmp_path):
         fake = tmp_path / "nonexistent"

--- a/tests/unit/calibration/test_clone_and_assign.py
+++ b/tests/unit/calibration/test_clone_and_assign.py
@@ -15,6 +15,7 @@ from policyengine_us_data.calibration.clone_and_assign import (
     load_global_block_distribution,
     load_sorted_block_cd_lookup,
     assign_random_geography,
+    assign_geography_within_state_county,
     double_geography_for_puf,
     reconstruct_geography_from_blocks,
     save_geography,
@@ -63,22 +64,24 @@ def _mock_distribution():
     blocks = MOCK_BLOCKS["block_geoid"].values
     cds = MOCK_BLOCKS["cd_geoid"].astype(str).values
     states = np.array([int(b[:2]) for b in blocks])
-    probs = MOCK_BLOCKS["probability"].values.astype(np.float64)
-    probs = probs / probs.sum()
-    return blocks, cds, states, probs
+    counties = np.array([b[:5] for b in blocks])
+    weights = MOCK_BLOCKS["probability"].values.astype(np.float64)
+    return blocks, cds, states, counties, weights
 
 
 class TestLoadGlobalBlockDistribution:
-    def test_loads_and_normalizes(self, tmp_path):
+    def test_loads_distribution(self, tmp_path):
         csv_path = tmp_path / "block_cd_distributions.csv.gz"
         MOCK_BLOCKS.to_csv(csv_path, index=False, compression="gzip")
         with patch(
             "policyengine_us_data.calibration.clone_and_assign.STORAGE_FOLDER",
             tmp_path,
         ):
-            blocks, cds, states, probs = load_global_block_distribution.__wrapped__()
+            blocks, cds, states, counties, weights = (
+                load_global_block_distribution.__wrapped__()
+            )
         assert len(blocks) == 9
-        np.testing.assert_almost_equal(probs.sum(), 1.0)
+        assert len(cds) == len(states) == len(counties) == len(weights) == 9
 
     def test_state_fips_extracted(self, tmp_path):
         csv_path = tmp_path / "block_cd_distributions.csv.gz"
@@ -87,10 +90,35 @@ class TestLoadGlobalBlockDistribution:
             "policyengine_us_data.calibration.clone_and_assign.STORAGE_FOLDER",
             tmp_path,
         ):
-            _, _, states, _ = load_global_block_distribution.__wrapped__()
+            _, _, states, _, _ = load_global_block_distribution.__wrapped__()
         assert states[0] == 1
         assert states[3] == 2
         assert states[5] == 36
+
+    def test_county_fips_extracted(self, tmp_path):
+        csv_path = tmp_path / "block_cd_distributions.csv.gz"
+        MOCK_BLOCKS.to_csv(csv_path, index=False, compression="gzip")
+        with patch(
+            "policyengine_us_data.calibration.clone_and_assign.STORAGE_FOLDER",
+            tmp_path,
+        ):
+            _, _, _, counties, _ = load_global_block_distribution.__wrapped__()
+        np.testing.assert_array_equal(
+            counties[[0, 3, 5]],
+            np.array(["01001", "02001", "36010"]),
+        )
+
+    def test_uses_population_column_when_available(self, tmp_path):
+        csv_path = tmp_path / "block_cd_distributions.csv.gz"
+        df = MOCK_BLOCKS.copy()
+        df["population"] = np.arange(1, len(df) + 1)
+        df.to_csv(csv_path, index=False, compression="gzip")
+        with patch(
+            "policyengine_us_data.calibration.clone_and_assign.STORAGE_FOLDER",
+            tmp_path,
+        ):
+            *_, weights = load_global_block_distribution.__wrapped__()
+        np.testing.assert_array_equal(weights, df["population"].values)
 
 
 class TestAssignRandomGeography:
@@ -166,9 +194,9 @@ class TestAssignRandomGeography:
             rec_cds = [
                 r.cd_geoid[clone * r.n_records + rec] for clone in range(r.n_clones)
             ]
-            assert len(rec_cds) == len(set(rec_cds)), (
-                f"Record {rec} has duplicate CDs: {rec_cds}"
-            )
+            assert len(rec_cds) == len(
+                set(rec_cds)
+            ), f"Record {rec} has duplicate CDs: {rec_cds}"
 
     def test_missing_file_raises(self, tmp_path):
         fake = tmp_path / "nonexistent"
@@ -179,6 +207,60 @@ class TestAssignRandomGeography:
         ):
             with pytest.raises(FileNotFoundError):
                 load_global_block_distribution.__wrapped__()
+
+
+class TestAssignGeographyWithinStateCounty:
+    @patch(
+        "policyengine_us_data.calibration.clone_and_assign"
+        ".load_global_block_distribution"
+    )
+    def test_samples_within_county_when_available(self, mock_load):
+        mock_load.return_value = _mock_distribution()
+        r = assign_geography_within_state_county(
+            state_fips=np.array([1, 2, 36]),
+            county_fips=np.array([1, 1, 10]),
+            seed=42,
+        )
+        assert all(
+            block.startswith(prefix)
+            for block, prefix in zip(
+                r.block_geoid,
+                ["01001", "02001", "36010"],
+            )
+        )
+
+    @patch(
+        "policyengine_us_data.calibration.clone_and_assign"
+        ".load_global_block_distribution"
+    )
+    def test_falls_back_to_state_when_county_missing(self, mock_load):
+        mock_load.return_value = _mock_distribution()
+        r = assign_geography_within_state_county(
+            state_fips=np.array([1, 2, 36]),
+            county_fips=np.array([999, 0, None], dtype=object),
+            seed=42,
+        )
+        assert [int(block[:2]) for block in r.block_geoid] == [1, 2, 36]
+
+    @patch(
+        "policyengine_us_data.calibration.clone_and_assign"
+        ".load_global_block_distribution"
+    )
+    def test_respects_population_weights(self, mock_load):
+        blocks = np.array(["010010001001001", "010010001001002"])
+        mock_load.return_value = (
+            blocks,
+            np.array(["101", "101"]),
+            np.array([1, 1]),
+            np.array(["01001", "01001"]),
+            np.array([99.0, 1.0]),
+        )
+        r = assign_geography_within_state_county(
+            state_fips=np.ones(500, dtype=int),
+            county_fips=np.ones(500, dtype=int),
+            seed=42,
+        )
+        assert (r.block_geoid == blocks[0]).sum() > 450
 
 
 class TestDoubleGeographyForPuf:

--- a/tests/unit/test_extended_cps.py
+++ b/tests/unit/test_extended_cps.py
@@ -25,6 +25,7 @@ from policyengine_us_data.datasets.cps.extended_cps import (
     ExtendedCPS,
     _apply_post_processing,
     _build_clone_test_frame,
+    _calculate_spm_thresholds_from_assigned_geography,
     _derive_overtime_occupation_inputs,
     _impute_clone_cps_features,
     apply_retirement_constraints,
@@ -144,6 +145,65 @@ class TestVariableListConsistency:
         assert "spm_unit_capped_work_childcare_expenses" not in set(
             CPS_ONLY_IMPUTED_VARIABLES
         )
+
+    def test_spm_threshold_is_location_derived_not_qrf_imputed(self):
+        assert "spm_unit_spm_threshold" not in set(CPS_ONLY_IMPUTED_VARIABLES)
+        assert "spm_unit_spm_threshold" in ExtendedCPS._keep_formula_vars()
+
+
+class TestSpmThresholdGeography:
+    def test_threshold_inputs_follow_assigned_household_geography(self, monkeypatch):
+        captured = {}
+
+        def fake_load_cd_geoadj_values(cds):
+            assert cds == ["101", "202"]
+            return {"101": 1.0, "202": 2.0}
+
+        def fake_calculate_spm_thresholds_with_geoadj(
+            num_adults,
+            num_children,
+            tenure_codes,
+            geoadj,
+            year,
+        ):
+            captured["num_adults"] = num_adults
+            captured["num_children"] = num_children
+            captured["tenure_codes"] = tenure_codes
+            captured["geoadj"] = geoadj
+            captured["year"] = year
+            return geoadj * 100
+
+        monkeypatch.setattr(
+            "policyengine_us_data.calibration.calibration_utils.load_cd_geoadj_values",
+            fake_load_cd_geoadj_values,
+        )
+        monkeypatch.setattr(
+            "policyengine_us_data.utils.spm.calculate_spm_thresholds_with_geoadj",
+            fake_calculate_spm_thresholds_with_geoadj,
+        )
+        data = {
+            "household_id": {2024: np.array([1, 2])},
+            "congressional_district_geoid": {2024: np.array([101, 202])},
+            "spm_unit_id": {2024: np.array([1, 2])},
+            "spm_unit_tenure_type": {
+                2024: np.array([b"RENTER", b"OWNER_WITHOUT_MORTGAGE"])
+            },
+            "person_spm_unit_id": {2024: np.array([1, 1, 2])},
+            "person_household_id": {2024: np.array([1, 1, 2])},
+            "age": {2024: np.array([30, 5, 40])},
+        }
+
+        thresholds = _calculate_spm_thresholds_from_assigned_geography(
+            data,
+            2024,
+        )
+
+        np.testing.assert_array_equal(thresholds, np.array([100.0, 200.0]))
+        np.testing.assert_array_equal(captured["num_adults"], np.array([1, 1]))
+        np.testing.assert_array_equal(captured["num_children"], np.array([1, 0]))
+        np.testing.assert_array_equal(captured["tenure_codes"], np.array([3, 2]))
+        np.testing.assert_array_equal(captured["geoadj"], np.array([1.0, 2.0]))
+        assert captured["year"] == 2024
 
 
 class TestStructuralMortgageValidation:


### PR DESCRIPTION
## Summary
- Assign legacy extended CPS households to population-weighted Census blocks within their CPS state, and within county when a county is available
- Preserve assigned block, tract, congressional district, and county geography through PUF cloning
- Recalculate SPM thresholds from assigned geography near the end of the extended CPS build and preserve the threshold through formula pruning
- Keep sparse ECPS from dropping the base-year SPM threshold during dataframe round-trip

## Verification
- python -m compileall policyengine_us_data/calibration/clone_and_assign.py policyengine_us_data/calibration/puf_impute.py policyengine_us_data/datasets/cps/extended_cps.py policyengine_us_data/datasets/cps/small_enhanced_cps.py policyengine_us_data/storage/calibration_targets/make_block_cd_distributions.py policyengine_us_data/utils/spm.py policyengine_us_data/calibration/calibration_utils.py
- python -m pytest tests/unit/calibration/test_clone_and_assign.py tests/unit/calibration/test_calibration_puf_impute.py::TestPufCloneDataset::test_geography_fields_preserved tests/unit/test_extended_cps.py::TestVariableListConsistency::test_spm_threshold_is_location_derived_not_qrf_imputed tests/unit/test_extended_cps.py::TestSpmThresholdGeography -q

## Notes
- Supersedes #902, which used a fork branch and tripped check-fork before substantive CI could run.
- A broader local run of tests/unit/calibration/test_clone_and_assign.py tests/unit/calibration/test_calibration_puf_impute.py tests/unit/test_extended_cps.py reached this patch's tests but still has existing environment/version failures around retirement parameter key k401 and microimpute.QRF.fit_predict.