### PR TITLE
Pass target groups to L0 calibration

### DIFF
--- a/changelog.d/905.changed.md
+++ b/changelog.d/905.changed.md
@@ -1,0 +1,1 @@
+Pass calibration target groups through unified L0 fitting so grouped target loss is used consistently.

--- a/policyengine_us_data/calibration/signatures.py
+++ b/policyengine_us_data/calibration/signatures.py
@@ -107,15 +107,22 @@ def build_checkpoint_signature(
     beta: float,
     lambda_l2: float,
     learning_rate: float,
+    target_groups: np.ndarray | None = None,
 ) -> dict:
     """Build a compact signature to validate calibration checkpoint resume."""
     targets_arr = np.asarray(targets, dtype=np.float64)
+    target_groups_arr = (
+        np.array([], dtype=np.int64)
+        if target_groups is None
+        else np.asarray(target_groups, dtype=np.int64)
+    )
     return {
         "n_features": int(X_sparse.shape[1]),
         "n_targets": int(len(targets_arr)),
         "x_sparse_sha256": hash_sparse_matrix(X_sparse),
         "target_names_sha256": hash_string_list(target_names),
         "targets_sha256": hashlib.sha256(targets_arr.tobytes()).hexdigest(),
+        "target_groups_sha256": hash_numpy_array(target_groups_arr),
         "lambda_l0": float(lambda_l0),
         "beta": float(beta),
         "lambda_l2": float(lambda_l2),

--- a/policyengine_us_data/calibration/unified_calibration.py
+++ b/policyengine_us_data/calibration/unified_calibration.py
@@ -40,6 +40,9 @@ from policyengine_us_data.calibration.signatures import (
     build_checkpoint_signature,
     checkpoint_signature_mismatches,
 )
+from policyengine_us_data.calibration.calibration_utils import (
+    create_target_groups,
+)
 from policyengine_us_data.pipeline_metadata import pipeline_node
 from policyengine_us_data.pipeline_schema import PipelineNode
 
@@ -739,6 +742,7 @@ def fit_l0_weights(
     initial_weights: np.ndarray = None,
     targets_df: "pd.DataFrame" = None,
     achievable: np.ndarray = None,
+    target_groups: Optional[np.ndarray] = None,
     resume_from: str = None,
     checkpoint_path: str = None,
 ) -> np.ndarray:
@@ -762,6 +766,7 @@ def fit_l0_weights(
             computed from targets_df age targets.
         targets_df: Targets DataFrame, used to compute
             initial_weights when not provided.
+        target_groups: Optional group ID per target row for balanced loss.
         resume_from: Path to a `.checkpoint.pt` file or `.npy`
             weights file to continue fitting from.
         checkpoint_path: Where to save resumable fit checkpoints.
@@ -792,6 +797,7 @@ def fit_l0_weights(
         beta=beta,
         lambda_l2=lambda_l2,
         learning_rate=learning_rate,
+        target_groups=target_groups,
     )
     checkpoint_state_dict = None
     start_epoch = 0
@@ -921,7 +927,7 @@ def fit_l0_weights(
                 model.fit(
                     M=X_sparse,
                     y=targets,
-                    target_groups=None,
+                    target_groups=target_groups,
                     lambda_l0=lambda_l0,
                     lambda_l2=lambda_l2,
                     lr=learning_rate,
@@ -1020,7 +1026,7 @@ def fit_l0_weights(
             model.fit(
                 M=X_sparse,
                 y=targets,
-                target_groups=None,
+                target_groups=target_groups,
                 lambda_l0=lambda_l0,
                 lambda_l2=lambda_l2,
                 lr=learning_rate,
@@ -1217,6 +1223,7 @@ def run_calibration(
 
         initial_weights = package.get("initial_weights")
         targets = targets_df["value"].values
+        target_groups, _ = create_target_groups(targets_df)
         row_sums = np.array(X_sparse.sum(axis=1)).flatten()
         pkg_achievable = row_sums > 0
         weights = fit_l0_weights(
@@ -1234,6 +1241,7 @@ def run_calibration(
             initial_weights=initial_weights,
             targets_df=targets_df,
             achievable=pkg_achievable,
+            target_groups=target_groups,
             resume_from=resume_from,
             checkpoint_path=checkpoint_path,
         )
@@ -1500,6 +1508,7 @@ def run_calibration(
 
     # Step 7: L0 calibration
     targets = targets_df["value"].values
+    target_groups, _ = create_target_groups(targets_df)
 
     row_sums = np.array(X_sparse.sum(axis=1)).flatten()
     achievable = row_sums > 0
@@ -1524,6 +1533,7 @@ def run_calibration(
         initial_weights=initial_weights,
         targets_df=targets_df,
         achievable=achievable,
+        target_groups=target_groups,
         resume_from=resume_from,
         checkpoint_path=checkpoint_path,
     )

--- a/tests/unit/calibration/test_unified_calibration.py
+++ b/tests/unit/calibration/test_unified_calibration.py
@@ -517,6 +517,8 @@ class TestParseArgsNewFlags:
 
 
 class FakeSparseCalibrationWeights:
+    fit_calls = []
+
     def __init__(
         self,
         n_features,
@@ -555,6 +557,7 @@ class FakeSparseCalibrationWeights:
         verbose_freq=1,
         target_groups=None,
     ):
+        type(self).fit_calls.append({"target_groups": target_groups})
         increment = float(epochs) + (self.alpha / 10.0)
         self.weights = self.weights + increment
         self.alpha = self.alpha + (10.0 * float(epochs))
@@ -578,6 +581,38 @@ class FakeSparseCalibrationWeights:
     def load_state_dict(self, state_dict):
         self.weights = state_dict["weights"].clone()
         self.alpha = state_dict["alpha"].clone()
+
+
+class TestFitTargetGroups:
+    def test_passes_target_groups_to_l0_model(self, tmp_path):
+        from policyengine_us_data.calibration.unified_calibration import (
+            fit_l0_weights,
+        )
+
+        target_groups = np.array([0, 1], dtype=np.int64)
+        FakeSparseCalibrationWeights.fit_calls = []
+
+        with patch(
+            "l0.calibration.SparseCalibrationWeights",
+            FakeSparseCalibrationWeights,
+        ):
+            weights = fit_l0_weights(
+                X_sparse=sp.csr_matrix(np.eye(2, dtype=np.float32)),
+                targets=np.array([1.0, 2.0], dtype=np.float64),
+                lambda_l0=1e-4,
+                epochs=1,
+                device="cpu",
+                target_names=["target_a", "target_b"],
+                initial_weights=np.array([1.0, 2.0], dtype=np.float64),
+                log_path=str(tmp_path / "calibration_log.csv"),
+                target_groups=target_groups,
+            )
+
+        np.testing.assert_allclose(weights, np.array([2.0, 3.0]))
+        np.testing.assert_array_equal(
+            FakeSparseCalibrationWeights.fit_calls[-1]["target_groups"],
+            target_groups,
+        )
 
 
 class TestFitResume:

--- a/tests/unit/calibration/test_unified_calibration.py
+++ b/tests/unit/calibration/test_unified_calibration.py
@@ -614,6 +614,39 @@ class TestFitTargetGroups:
             target_groups,
         )
 
+    def test_passes_target_groups_to_logged_l0_fit(self, tmp_path):
+        from policyengine_us_data.calibration.unified_calibration import (
+            fit_l0_weights,
+        )
+
+        target_groups = np.array([0, 1], dtype=np.int64)
+        FakeSparseCalibrationWeights.fit_calls = []
+
+        with patch(
+            "l0.calibration.SparseCalibrationWeights",
+            FakeSparseCalibrationWeights,
+        ):
+            weights = fit_l0_weights(
+                X_sparse=sp.csr_matrix(np.eye(2, dtype=np.float32)),
+                targets=np.array([1.0, 2.0], dtype=np.float64),
+                lambda_l0=1e-4,
+                epochs=2,
+                device="cpu",
+                target_names=["target_a", "target_b"],
+                initial_weights=np.array([1.0, 2.0], dtype=np.float64),
+                log_freq=1,
+                log_path=str(tmp_path / "calibration_log.csv"),
+                target_groups=target_groups,
+            )
+
+        np.testing.assert_allclose(weights, np.array([4.0, 5.0]))
+        assert len(FakeSparseCalibrationWeights.fit_calls) == 2
+        for fit_call in FakeSparseCalibrationWeights.fit_calls:
+            np.testing.assert_array_equal(
+                fit_call["target_groups"],
+                target_groups,
+            )
+
 
 class TestFitResume:
     def _fit_kwargs(self, tmp_path):
@@ -758,6 +791,34 @@ class TestFitResume:
                     **{
                         **kwargs,
                         "X_sparse": changed_matrix,
+                        "resume_from": str(checkpoint_path),
+                    }
+                )
+
+    def test_resume_checkpoint_rejects_changed_target_groups(self, tmp_path):
+        from policyengine_us_data.calibration.unified_calibration import (
+            default_checkpoint_path,
+            fit_l0_weights,
+        )
+
+        weights_path = tmp_path / "weights.npy"
+        checkpoint_path = default_checkpoint_path(str(weights_path))
+        kwargs = self._fit_kwargs(tmp_path)
+        kwargs["checkpoint_path"] = str(checkpoint_path)
+        kwargs["target_groups"] = np.array([0, 1], dtype=np.int64)
+
+        with patch(
+            "l0.calibration.SparseCalibrationWeights",
+            FakeSparseCalibrationWeights,
+        ):
+            first_weights = fit_l0_weights(**kwargs)
+            np.save(weights_path, first_weights)
+
+            with pytest.raises(ValueError, match="target_groups_sha256"):
+                fit_l0_weights(
+                    **{
+                        **kwargs,
+                        "target_groups": np.array([1, 0], dtype=np.int64),
                         "resume_from": str(checkpoint_path),
                     }
                 )


### PR DESCRIPTION
## Summary

This wires the existing target-group construction into the unified L0 calibration fit so national, state, and district target groups can contribute balanced loss terms instead of sending `None` to `SparseCalibrationWeights.fit`.

It also includes `target_groups` in the checkpoint compatibility signature, preventing a resume from silently reusing a checkpoint created under a different grouped-loss setup.

## Validation

- `/Users/maxghenis/PolicyEngine/policyengine-us-data/.venv/bin/python -m py_compile policyengine_us_data/calibration/unified_calibration.py policyengine_us_data/calibration/signatures.py tests/unit/calibration/test_unified_calibration.py`
- `/Users/maxghenis/PolicyEngine/policyengine-us-data/.venv/bin/python -m pytest tests/unit/calibration/test_unified_calibration.py -q`
- `git diff --check`

## Notes

The original local checkout was far behind `upstream/main`, and upstream already contains the reform-id tax expenditure plumbing. This PR is intentionally scoped to the missing L0 target-group wiring against current upstream.
