### PR TITLE
Harden US data release versioning and promotion ordering

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -66,7 +66,7 @@ The PR is valid only if the head repository is `PolicyEngine/policyengine-us-dat
 Six workflow files in `.github/workflows/`:
 
 - `pr.yaml` — fork check, lint, uv.lock freshness, towncrier fragment check, unit tests, smoke test, independent docs build, and quality guards. Integration tests trigger when files in `policyengine_us_data/`, `modal_app/`, or `tests/integration/` change. ~2–3 min for the unit path.
-- `push.yaml` — on push to main: either version-bump + PyPI publish (on `Update package version` commits), or a full Modal data build with integration tests (on everything else).
+- `push.yaml` — on push to main: functional commits create the Towncrier version-bump commit; `Update package version` commits publish PyPI, verify the package version is visible, then dispatch the full Modal data build from that exact commit.
 - `pipeline.yaml` — dispatch only, spawns the H5 generation pipeline on Modal with configurable GPU/epochs/workers.
 - `long_run_projection.yaml` — dispatch only, builds long-run CPS projection H5 files for explicit sampled years and can optionally upload them to a run-scoped Hugging Face staging prefix.
 - `local_area_publish.yaml` / `local_area_promote.yaml` — manual dispatch to build/stage local-area H5 files and promote a run-scoped US data release.

--- a/.github/scripts/verify_pypi_version.py
+++ b/.github/scripts/verify_pypi_version.py
@@ -1,0 +1,72 @@
+"""Wait until the package version in pyproject.toml is visible on PyPI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import sys
+import time
+import tomllib
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPI_JSON_TIMEOUT_SECONDS = 20
+
+
+def _package_metadata() -> tuple[str, str]:
+    with (REPO_ROOT / "pyproject.toml").open("rb") as file:
+        pyproject = tomllib.load(file)
+    project = pyproject["project"]
+    return project["name"], project["version"]
+
+
+def _normalize_package_name(package_name: str) -> str:
+    return re.sub(r"[-_.]+", "-", package_name).lower()
+
+
+def _pypi_version_exists(package_name: str, version: str) -> bool:
+    normalized_name = _normalize_package_name(package_name)
+    url = f"https://pypi.org/pypi/{normalized_name}/{version}/json"
+    try:
+        with urlopen(url, timeout=PYPI_JSON_TIMEOUT_SECONDS) as response:
+            payload = json.load(response)
+    except HTTPError as exc:
+        if exc.code == 404:
+            return False
+        raise
+    except URLError:
+        return False
+    return payload.get("info", {}).get("version") == version
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--attempts", type=int, default=20)
+    parser.add_argument("--sleep-seconds", type=int, default=15)
+    args = parser.parse_args()
+
+    package_name, version = _package_metadata()
+    for attempt in range(1, args.attempts + 1):
+        if _pypi_version_exists(package_name, version):
+            print(f"PyPI has {package_name}=={version}.")
+            return
+        print(
+            f"PyPI does not have {package_name}=={version} yet "
+            f"(attempt {attempt}/{args.attempts})."
+        )
+        if attempt < args.attempts:
+            time.sleep(args.sleep_seconds)
+
+    print(
+        f"Timed out waiting for PyPI to expose {package_name}=={version}.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -15,7 +15,6 @@ jobs:
   run-context:
     name: Run context
     runs-on: ubuntu-latest
-    if: github.event.head_commit.message != 'Update package version'
     outputs:
       run_id: ${{ steps.run-context.outputs.run_id }}
       github_run_url: ${{ steps.run-context.outputs.github_run_url }}
@@ -109,8 +108,8 @@ jobs:
     needs:
       - lint
       - run-context
-      - versioning
-    if: github.event.head_commit.message != 'Update package version'
+      - publish
+    if: github.event.head_commit.message == 'Update package version'
     permissions:
       actions: write
       contents: read
@@ -120,7 +119,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           US_DATA_RUN_ID: ${{ needs.run-context.outputs.run_id }}
-          SOURCE_SHA: ${{ needs.versioning.outputs.version_sha }}
+          SOURCE_SHA: ${{ github.sha }}
         run: bash .github/scripts/dispatch_publication_pipeline.sh
 
   # ── PyPI publish (version bump commits only) ────────────────
@@ -142,3 +141,5 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI }}
           skip-existing: true
+      - name: Verify PyPI version before data publication
+        run: python .github/scripts/verify_pypi_version.py

--- a/changelog.d/atomic-release-marker.changed.md
+++ b/changelog.d/atomic-release-marker.changed.md
@@ -1,3 +1,5 @@
 - Add a release completion marker for full US data promotions after the
   release manifest, TRACE TRO, version manifest, validation diagnostics, and
   production artifacts are present.
+- Publish and verify the `policyengine-us-data` package version before
+  launching the full data pipeline from the version-bump commit.

--- a/changelog.d/atomic-release-marker.changed.md
+++ b/changelog.d/atomic-release-marker.changed.md
@@ -1,0 +1,3 @@
+- Add a release completion marker for full US data promotions after the
+  release manifest, TRACE TRO, version manifest, validation diagnostics, and
+  production artifacts are present.

--- a/policyengine_us_data/utils/data_upload.py
+++ b/policyengine_us_data/utils/data_upload.py
@@ -37,6 +37,7 @@ from policyengine_us_data.utils.release_completion import (
     build_release_completion_marker,
     release_completion_marker_path,
     serialize_release_completion_marker,
+    validate_release_completion_marker,
 )
 from policyengine_us_data.utils.release_promotion import (
     FullReleasePromotionConfig,
@@ -1494,16 +1495,30 @@ def release_completion_marker_exists_on_hf(
     hf_repo_name: str = "policyengine/policyengine-us-data",
     hf_repo_type: str = "model",
 ) -> bool:
+    """Return True only for a valid marker at the version tag."""
     token = os.environ.get("HUGGING_FACE_TOKEN")
     try:
-        hf_hub_download(
+        local_path = hf_hub_download(
             repo_id=hf_repo_name,
             filename=release_completion_marker_path(version),
             repo_type=hf_repo_type,
             revision=version,
             token=token,
         )
-    except (EntryNotFoundError, RevisionNotFoundError):
+        with open(local_path, encoding="utf-8") as marker_file:
+            marker = json.load(marker_file)
+        validate_release_completion_marker(
+            marker,
+            version=version,
+            hf_repo_name=hf_repo_name,
+            hf_repo_type=hf_repo_type,
+        )
+    except (
+        EntryNotFoundError,
+        RevisionNotFoundError,
+        ValueError,
+        json.JSONDecodeError,
+    ):
         return False
     return True
 

--- a/policyengine_us_data/utils/data_upload.py
+++ b/policyengine_us_data/utils/data_upload.py
@@ -32,6 +32,12 @@ from policyengine_us_data.utils.release_manifest import (
     build_release_manifest,
     serialize_release_manifest,
 )
+from policyengine_us_data.utils.release_completion import (
+    VERSION_MANIFEST_PATH,
+    build_release_completion_marker,
+    release_completion_marker_path,
+    serialize_release_completion_marker,
+)
 from policyengine_us_data.utils.release_promotion import (
     FullReleasePromotionConfig,
     FullReleasePromotionDependencies,
@@ -64,6 +70,11 @@ LOCAL_AREA_FINALIZE_REQUIRED_COUNTS = {
     "districts/": 435,
     "cities/": 1,
 }
+VALIDATION_REPORT_FILENAMES = (
+    "validation_summary.json",
+    "validation_results.csv",
+    "national_validation.txt",
+)
 
 
 def _resolve_staging_run_id(run_id: str = "") -> str:
@@ -1346,6 +1357,137 @@ def upload_final_version_manifest(
     )
 
 
+def _validation_report_candidates(run_id: str) -> list[str]:
+    return [
+        f"calibration/runs/{run_id}/diagnostics/{filename}"
+        for filename in VALIDATION_REPORT_FILENAMES
+    ]
+
+
+def _resolve_validation_report_paths(
+    *,
+    repo_files: set[str],
+    run_id: str,
+    validation_report_paths: Optional[Sequence[str]],
+) -> list[str]:
+    if validation_report_paths is not None:
+        return sorted(validation_report_paths)
+    if not run_id:
+        return []
+    return sorted(
+        path for path in _validation_report_candidates(run_id) if path in repo_files
+    )
+
+
+def _missing_release_completion_paths(
+    *,
+    repo_files: set[str],
+    version: str,
+    expected_paths: Sequence[str],
+    validation_report_paths: Sequence[str],
+) -> list[str]:
+    required_paths = [
+        *expected_paths,
+        RELEASE_MANIFEST_PATH,
+        f"releases/{version}/{RELEASE_MANIFEST_PATH}",
+        TRACE_TRO_FILENAME,
+        f"releases/{version}/{TRACE_TRO_FILENAME}",
+        VERSION_MANIFEST_PATH,
+        *validation_report_paths,
+    ]
+    return sorted(path for path in required_paths if path not in repo_files)
+
+
+def upload_release_completion_marker_to_hf(
+    *,
+    version: str,
+    run_id: str,
+    released_paths: Sequence[str],
+    expected_paths: Sequence[str],
+    release_manifest: Mapping[str, Any],
+    hf_repo_name: str = "policyengine/policyengine-us-data",
+    hf_repo_type: str = "model",
+    promoted_hf: int = 0,
+    uploaded_gcs: int = 0,
+    create_tag: bool = False,
+    validation_report_paths: Optional[Sequence[str]] = None,
+) -> Dict[str, Any]:
+    """Write the final release completion marker after all release writes."""
+    token = os.environ.get("HUGGING_FACE_TOKEN")
+    api = HfApi()
+    repo_files = set(
+        api.list_repo_files(
+            repo_id=hf_repo_name,
+            repo_type=hf_repo_type,
+            token=token,
+        )
+    )
+    resolved_validation_report_paths = _resolve_validation_report_paths(
+        repo_files=repo_files,
+        run_id=run_id,
+        validation_report_paths=validation_report_paths,
+    )
+    missing_paths = _missing_release_completion_paths(
+        repo_files=repo_files,
+        version=version,
+        expected_paths=expected_paths,
+        validation_report_paths=resolved_validation_report_paths,
+    )
+    if run_id and not resolved_validation_report_paths:
+        missing_paths.append(
+            f"calibration/runs/{run_id}/diagnostics/<validation report>"
+        )
+    if missing_paths:
+        raise FileNotFoundError(
+            "Cannot mark release complete; missing required release paths: "
+            + ", ".join(sorted(missing_paths))
+        )
+
+    marker = build_release_completion_marker(
+        version=version,
+        run_id=run_id,
+        hf_repo_name=hf_repo_name,
+        hf_repo_type=hf_repo_type,
+        release_manifest=release_manifest,
+        released_paths=released_paths,
+        validation_report_paths=resolved_validation_report_paths,
+        promoted_hf=promoted_hf,
+        uploaded_gcs=uploaded_gcs,
+    )
+    parent_commit = get_repo_head_revision(
+        api=api,
+        repo_id=hf_repo_name,
+        repo_type=hf_repo_type,
+        token=token,
+    )
+    commit_info = hf_create_commit_with_retry(
+        api=api,
+        operations=[
+            CommitOperationAdd(
+                path_in_repo=release_completion_marker_path(version),
+                path_or_fileobj=BytesIO(
+                    serialize_release_completion_marker(marker),
+                ),
+            )
+        ],
+        repo_id=hf_repo_name,
+        repo_type=hf_repo_type,
+        token=token,
+        commit_message=f"Mark release {version} complete",
+        parent_commit=parent_commit,
+    )
+    if create_tag:
+        create_release_tag(
+            version=version,
+            revision=commit_info.oid,
+            hf_repo_name=hf_repo_name,
+            hf_repo_type=hf_repo_type,
+            token=token,
+            api=api,
+        )
+    return marker
+
+
 def _full_release_promotion_dependencies() -> FullReleasePromotionDependencies:
     return FullReleasePromotionDependencies(
         dedupe_preserving_order=_dedupe_preserving_order,
@@ -1357,6 +1499,7 @@ def _full_release_promotion_dependencies() -> FullReleasePromotionDependencies:
         upload_from_hf_staging_to_gcs=upload_from_hf_staging_to_gcs,
         publish_release_manifest_to_hf=publish_release_manifest_to_hf,
         upload_final_version_manifest=upload_final_version_manifest,
+        upload_release_completion_marker=upload_release_completion_marker_to_hf,
         cleanup_staging_hf=cleanup_staging_hf,
     )
 

--- a/policyengine_us_data/utils/data_upload.py
+++ b/policyengine_us_data/utils/data_upload.py
@@ -1488,6 +1488,26 @@ def upload_release_completion_marker_to_hf(
     return marker
 
 
+def release_completion_marker_exists_on_hf(
+    *,
+    version: str,
+    hf_repo_name: str = "policyengine/policyengine-us-data",
+    hf_repo_type: str = "model",
+) -> bool:
+    token = os.environ.get("HUGGING_FACE_TOKEN")
+    try:
+        hf_hub_download(
+            repo_id=hf_repo_name,
+            filename=release_completion_marker_path(version),
+            repo_type=hf_repo_type,
+            revision=version,
+            token=token,
+        )
+    except (EntryNotFoundError, RevisionNotFoundError):
+        return False
+    return True
+
+
 def _full_release_promotion_dependencies() -> FullReleasePromotionDependencies:
     return FullReleasePromotionDependencies(
         dedupe_preserving_order=_dedupe_preserving_order,
@@ -1500,6 +1520,7 @@ def _full_release_promotion_dependencies() -> FullReleasePromotionDependencies:
         publish_release_manifest_to_hf=publish_release_manifest_to_hf,
         upload_final_version_manifest=upload_final_version_manifest,
         upload_release_completion_marker=upload_release_completion_marker_to_hf,
+        release_completion_marker_exists=release_completion_marker_exists_on_hf,
         cleanup_staging_hf=cleanup_staging_hf,
     )
 

--- a/policyengine_us_data/utils/release_completion.py
+++ b/policyengine_us_data/utils/release_completion.py
@@ -40,6 +40,165 @@ def _artifacts_have_checksums(release_manifest: Mapping[str, Any]) -> bool:
     )
 
 
+def _require_mapping(value: Any, field: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"Release completion marker {field} must be an object.")
+    return value
+
+
+def _require_string(value: Any, field: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"Release completion marker {field} must be a string.")
+    return value
+
+
+def _require_string_sequence(value: Any, field: str) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise ValueError(f"Release completion marker {field} must be a list.")
+    strings = list(value)
+    if not all(isinstance(item, str) for item in strings):
+        raise ValueError(
+            f"Release completion marker {field} must contain only strings."
+        )
+    return strings
+
+
+def _require_nonnegative_int(value: Any, field: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError(
+            f"Release completion marker {field} must be a non-negative integer."
+        )
+    return value
+
+
+def _require_equal(value: Any, expected: Any, field: str) -> None:
+    if value != expected:
+        raise ValueError(
+            f"Release completion marker {field} must be {expected!r}; got {value!r}."
+        )
+
+
+def _require_paths(
+    *,
+    actual_paths: Sequence[str],
+    expected_paths: Sequence[str],
+    field: str,
+) -> None:
+    missing_paths = sorted(set(expected_paths) - set(actual_paths))
+    if missing_paths:
+        raise ValueError(
+            f"Release completion marker {field} is missing paths: "
+            + ", ".join(missing_paths)
+        )
+
+
+def validate_release_completion_marker(
+    marker: Mapping[str, Any],
+    *,
+    version: str,
+    hf_repo_name: str | None = None,
+    hf_repo_type: str | None = None,
+) -> Mapping[str, Any]:
+    """Validate that a marker certifies a complete release at a version tag."""
+    marker = _require_mapping(marker, "root")
+    _require_equal(
+        marker.get("schema_version"),
+        RELEASE_COMPLETION_SCHEMA_VERSION,
+        "schema_version",
+    )
+    _require_equal(marker.get("status"), "complete", "status")
+    _require_equal(marker.get("version"), version, "version")
+    _require_equal(
+        marker.get("marker_path"),
+        release_completion_marker_path(version),
+        "marker_path",
+    )
+    _require_string(marker.get("run_id"), "run_id")
+    _require_string(marker.get("completed_at"), "completed_at")
+
+    hf = _require_mapping(marker.get("hf"), "hf")
+    if hf_repo_name is not None:
+        _require_equal(hf.get("repo_id"), hf_repo_name, "hf.repo_id")
+    else:
+        _require_string(hf.get("repo_id"), "hf.repo_id")
+    if hf_repo_type is not None:
+        _require_equal(hf.get("repo_type"), hf_repo_type, "hf.repo_type")
+    else:
+        _require_string(hf.get("repo_type"), "hf.repo_type")
+    _require_equal(hf.get("revision"), version, "hf.revision")
+
+    required_paths = _require_mapping(
+        marker.get("required_paths"),
+        "required_paths",
+    )
+    release_manifest_paths = _require_string_sequence(
+        required_paths.get("release_manifest"),
+        "required_paths.release_manifest",
+    )
+    _require_paths(
+        actual_paths=release_manifest_paths,
+        expected_paths=[
+            "release_manifest.json",
+            f"releases/{version}/release_manifest.json",
+        ],
+        field="required_paths.release_manifest",
+    )
+    trace_tro_paths = _require_string_sequence(
+        required_paths.get("trace_tro"),
+        "required_paths.trace_tro",
+    )
+    _require_paths(
+        actual_paths=trace_tro_paths,
+        expected_paths=[
+            "trace.tro.jsonld",
+            f"releases/{version}/trace.tro.jsonld",
+        ],
+        field="required_paths.trace_tro",
+    )
+    _require_equal(
+        required_paths.get("version_manifest"),
+        VERSION_MANIFEST_PATH,
+        "required_paths.version_manifest",
+    )
+    validation_report_paths = _require_string_sequence(
+        required_paths.get("validation_reports"),
+        "required_paths.validation_reports",
+    )
+    if not validation_report_paths:
+        raise ValueError(
+            "Release completion marker required_paths.validation_reports "
+            "must not be empty."
+        )
+    artifact_paths = _require_string_sequence(
+        required_paths.get("artifacts"),
+        "required_paths.artifacts",
+    )
+    if not artifact_paths:
+        raise ValueError(
+            "Release completion marker required_paths.artifacts must not be empty."
+        )
+
+    checks = _require_mapping(marker.get("checks"), "checks")
+    _require_nonnegative_int(
+        checks.get("hf_artifacts_promoted"),
+        "checks.hf_artifacts_promoted",
+    )
+    _require_nonnegative_int(
+        checks.get("gcs_artifacts_uploaded"),
+        "checks.gcs_artifacts_uploaded",
+    )
+    for field in (
+        "release_manifest_written",
+        "trace_tro_written",
+        "version_manifest_written",
+        "validation_reports_present",
+        "release_manifest_checksums_present",
+    ):
+        _require_equal(checks.get(field), True, f"checks.{field}")
+
+    return marker
+
+
 def build_release_completion_marker(
     *,
     version: str,
@@ -68,7 +227,7 @@ def build_release_completion_marker(
         raise ValueError("A release completion marker requires validation reports.")
 
     marker_path = release_completion_marker_path(version)
-    return {
+    marker = {
         "schema_version": RELEASE_COMPLETION_SCHEMA_VERSION,
         "status": "complete",
         "version": version,
@@ -103,6 +262,13 @@ def build_release_completion_marker(
             "release_manifest_checksums_present": True,
         },
     }
+    validate_release_completion_marker(
+        marker,
+        version=version,
+        hf_repo_name=hf_repo_name,
+        hf_repo_type=hf_repo_type,
+    )
+    return marker
 
 
 def serialize_release_completion_marker(marker: Mapping[str, Any]) -> bytes:

--- a/policyengine_us_data/utils/release_completion.py
+++ b/policyengine_us_data/utils/release_completion.py
@@ -1,0 +1,109 @@
+"""Completion marker for certified US data releases."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from typing import Any, Mapping, Sequence
+
+RELEASE_COMPLETION_SCHEMA_VERSION = 1
+RELEASE_COMPLETE_FILENAME = "release-complete.json"
+VERSION_MANIFEST_PATH = "version_manifest.json"
+
+
+def release_completion_marker_path(version: str) -> str:
+    return f"releases/{version}/{RELEASE_COMPLETE_FILENAME}"
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _release_artifact_paths(release_manifest: Mapping[str, Any]) -> list[str]:
+    artifacts = release_manifest.get("artifacts", {})
+    if not isinstance(artifacts, Mapping):
+        return []
+    return sorted(
+        artifact["path"]
+        for artifact in artifacts.values()
+        if isinstance(artifact, Mapping) and isinstance(artifact.get("path"), str)
+    )
+
+
+def _artifacts_have_checksums(release_manifest: Mapping[str, Any]) -> bool:
+    artifacts = release_manifest.get("artifacts", {})
+    if not isinstance(artifacts, Mapping):
+        return False
+    return all(
+        isinstance(artifact, Mapping) and isinstance(artifact.get("sha256"), str)
+        for artifact in artifacts.values()
+    )
+
+
+def build_release_completion_marker(
+    *,
+    version: str,
+    run_id: str,
+    hf_repo_name: str,
+    hf_repo_type: str,
+    release_manifest: Mapping[str, Any],
+    released_paths: Sequence[str],
+    validation_report_paths: Sequence[str],
+    promoted_hf: int,
+    uploaded_gcs: int,
+    created_at: str | None = None,
+) -> dict[str, Any]:
+    release_manifest_paths = _release_artifact_paths(release_manifest)
+    missing_manifest_paths = sorted(set(released_paths) - set(release_manifest_paths))
+    if missing_manifest_paths:
+        raise ValueError(
+            "Release manifest is missing released artifacts: "
+            + ", ".join(missing_manifest_paths)
+        )
+    if not _artifacts_have_checksums(release_manifest):
+        raise ValueError(
+            "Release manifest artifacts must all include sha256 checksums."
+        )
+    if not validation_report_paths:
+        raise ValueError("A release completion marker requires validation reports.")
+
+    marker_path = release_completion_marker_path(version)
+    return {
+        "schema_version": RELEASE_COMPLETION_SCHEMA_VERSION,
+        "status": "complete",
+        "version": version,
+        "run_id": run_id,
+        "completed_at": created_at or _utc_timestamp(),
+        "marker_path": marker_path,
+        "hf": {
+            "repo_id": hf_repo_name,
+            "repo_type": hf_repo_type,
+            "revision": version,
+        },
+        "required_paths": {
+            "release_manifest": [
+                "release_manifest.json",
+                f"releases/{version}/release_manifest.json",
+            ],
+            "trace_tro": [
+                "trace.tro.jsonld",
+                f"releases/{version}/trace.tro.jsonld",
+            ],
+            "version_manifest": VERSION_MANIFEST_PATH,
+            "validation_reports": sorted(validation_report_paths),
+            "artifacts": sorted(released_paths),
+        },
+        "checks": {
+            "hf_artifacts_promoted": promoted_hf,
+            "gcs_artifacts_uploaded": uploaded_gcs,
+            "release_manifest_written": True,
+            "trace_tro_written": True,
+            "version_manifest_written": True,
+            "validation_reports_present": True,
+            "release_manifest_checksums_present": True,
+        },
+    }
+
+
+def serialize_release_completion_marker(marker: Mapping[str, Any]) -> bytes:
+    return (json.dumps(marker, indent=2, sort_keys=True) + "\n").encode("utf-8")

--- a/policyengine_us_data/utils/release_promotion.py
+++ b/policyengine_us_data/utils/release_promotion.py
@@ -44,6 +44,7 @@ class FullReleasePromotionDependencies:
     upload_from_hf_staging_to_gcs: Callable[..., int]
     publish_release_manifest_to_hf: Callable[..., ReleaseManifest]
     upload_final_version_manifest: Callable[..., None]
+    upload_release_completion_marker: Callable[..., ReleaseManifest]
     cleanup_staging_hf: Callable[..., int]
 
 
@@ -55,8 +56,9 @@ def promote_full_release(
 
     The order is deliberately transaction-like:
     validate staged HF inputs, copy every HF artifact in one commit, upload
-    every GCS artifact, then finalize release_manifest.json, tag the release,
-    update version_manifest.json, and only then clean staged inputs.
+    every GCS artifact, publish release_manifest.json and TRACE TRO, update
+    version_manifest.json, write the release completion marker, tag that final
+    marker commit, and only then clean staged inputs.
     """
     rel_paths = _validated_release_paths(config, deps)
     manifest_files = _manifest_files_for_release(config, rel_paths, deps)
@@ -100,9 +102,18 @@ def promote_full_release(
         version=config.version,
         hf_repo_name=config.hf_repo_name,
         hf_repo_type=config.hf_repo_type,
-        create_tag=True,
+        create_tag=False,
     )
     _upload_version_manifest(config, release_manifest, deps)
+    completion_marker = _upload_release_completion_marker(
+        config=config,
+        release_manifest=release_manifest,
+        rel_paths=rel_paths,
+        promoted_hf=promoted_hf,
+        uploaded_gcs=uploaded_gcs,
+        create_tag=True,
+        deps=deps,
+    )
 
     cleaned = _cleanup_staging_after_release(
         config=config,
@@ -118,6 +129,7 @@ def promote_full_release(
         "hf_promoted": promoted_hf,
         "gcs_uploaded": uploaded_gcs,
         "release_manifest_artifacts": len(release_manifest["artifacts"]),
+        "release_completion_marker": completion_marker.get("marker_path"),
         "staging_cleaned": cleaned,
     }
 
@@ -191,6 +203,15 @@ def _finish_already_finalized_release(
     deps: FullReleasePromotionDependencies,
 ) -> dict[str, Any]:
     _upload_version_manifest(config, finalized_manifest, deps)
+    completion_marker = _upload_release_completion_marker(
+        config=config,
+        release_manifest=finalized_manifest,
+        rel_paths=rel_paths,
+        promoted_hf=0,
+        uploaded_gcs=0,
+        create_tag=False,
+        deps=deps,
+    )
     cleaned = _cleanup_staging_after_release(
         config=config,
         rel_paths=rel_paths,
@@ -204,6 +225,7 @@ def _finish_already_finalized_release(
         "hf_promoted": 0,
         "gcs_uploaded": 0,
         "release_manifest_artifacts": len(finalized_manifest["artifacts"]),
+        "release_completion_marker": completion_marker.get("marker_path"),
         "staging_cleaned": cleaned,
         "already_finalized": True,
     }
@@ -256,6 +278,30 @@ def _upload_version_manifest(
         released_paths=_released_paths(release_manifest),
         run_id=config.run_id,
         hf_repo_name=config.hf_repo_name,
+    )
+
+
+def _upload_release_completion_marker(
+    *,
+    config: FullReleasePromotionConfig,
+    release_manifest: ReleaseManifest,
+    rel_paths: Sequence[str],
+    promoted_hf: int,
+    uploaded_gcs: int,
+    create_tag: bool,
+    deps: FullReleasePromotionDependencies,
+) -> ReleaseManifest:
+    return deps.upload_release_completion_marker(
+        version=config.version,
+        run_id=config.run_id,
+        released_paths=rel_paths,
+        expected_paths=rel_paths,
+        release_manifest=release_manifest,
+        hf_repo_name=config.hf_repo_name,
+        hf_repo_type=config.hf_repo_type,
+        promoted_hf=promoted_hf,
+        uploaded_gcs=uploaded_gcs,
+        create_tag=create_tag,
     )
 
 

--- a/policyengine_us_data/utils/release_promotion.py
+++ b/policyengine_us_data/utils/release_promotion.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Sequence
 
+from policyengine_us_data.utils.release_completion import release_completion_marker_path
+
 
 ManifestFile = tuple[Path, str]
 ReleaseManifest = dict[str, Any]
@@ -45,6 +47,7 @@ class FullReleasePromotionDependencies:
     publish_release_manifest_to_hf: Callable[..., ReleaseManifest]
     upload_final_version_manifest: Callable[..., None]
     upload_release_completion_marker: Callable[..., ReleaseManifest]
+    release_completion_marker_exists: Callable[..., bool]
     cleanup_staging_hf: Callable[..., int]
 
 
@@ -202,14 +205,8 @@ def _finish_already_finalized_release(
     finalized_manifest: ReleaseManifest,
     deps: FullReleasePromotionDependencies,
 ) -> dict[str, Any]:
-    _upload_version_manifest(config, finalized_manifest, deps)
-    completion_marker = _upload_release_completion_marker(
+    completion_marker_path = _assert_finalized_release_has_completion_marker(
         config=config,
-        release_manifest=finalized_manifest,
-        rel_paths=rel_paths,
-        promoted_hf=0,
-        uploaded_gcs=0,
-        create_tag=False,
         deps=deps,
     )
     cleaned = _cleanup_staging_after_release(
@@ -225,7 +222,7 @@ def _finish_already_finalized_release(
         "hf_promoted": 0,
         "gcs_uploaded": 0,
         "release_manifest_artifacts": len(finalized_manifest["artifacts"]),
-        "release_completion_marker": completion_marker.get("marker_path"),
+        "release_completion_marker": completion_marker_path,
         "staging_cleaned": cleaned,
         "already_finalized": True,
     }
@@ -302,6 +299,26 @@ def _upload_release_completion_marker(
         promoted_hf=promoted_hf,
         uploaded_gcs=uploaded_gcs,
         create_tag=create_tag,
+    )
+
+
+def _assert_finalized_release_has_completion_marker(
+    *,
+    config: FullReleasePromotionConfig,
+    deps: FullReleasePromotionDependencies,
+) -> str:
+    marker_path = release_completion_marker_path(config.version)
+    if deps.release_completion_marker_exists(
+        version=config.version,
+        hf_repo_name=config.hf_repo_name,
+        hf_repo_type=config.hf_repo_type,
+    ):
+        return marker_path
+
+    raise RuntimeError(
+        f"Release {config.version} is already finalized, but {marker_path} "
+        f"is not present at tag {config.version}. Refusing to mutate release "
+        "state after finalization; repair or migrate this release manually."
     )
 
 

--- a/tests/unit/utils/test_data_upload.py
+++ b/tests/unit/utils/test_data_upload.py
@@ -1,4 +1,5 @@
 import importlib
+import json
 import os
 import sys
 from pathlib import Path
@@ -671,3 +672,69 @@ def test_upload_release_completion_marker_fails_without_validation_report(
                 }
             },
         )
+
+
+def test_release_completion_marker_exists_on_hf_validates_marker(
+    monkeypatch,
+    tmp_path,
+):
+    data_upload = _load_data_upload_module()
+    marker = data_upload.build_release_completion_marker(
+        version="1.73.0",
+        run_id="run-123",
+        hf_repo_name="policyengine/policyengine-us-data",
+        hf_repo_type="model",
+        release_manifest={
+            "artifacts": {
+                "states/AL": {
+                    "path": "states/AL.h5",
+                    "sha256": "abc123",
+                }
+            }
+        },
+        released_paths=["states/AL.h5"],
+        validation_report_paths=[
+            "calibration/runs/run-123/diagnostics/validation_summary.json"
+        ],
+        promoted_hf=1,
+        uploaded_gcs=1,
+        created_at="2026-05-06T00:00:00Z",
+    )
+    marker_file = tmp_path / "release-complete.json"
+    marker_file.write_text(json.dumps(marker), encoding="utf-8")
+    downloads = []
+
+    def fake_hf_hub_download(**kwargs):
+        downloads.append(kwargs)
+        return str(marker_file)
+
+    monkeypatch.setattr(data_upload, "hf_hub_download", fake_hf_hub_download)
+
+    assert data_upload.release_completion_marker_exists_on_hf(version="1.73.0")
+    assert downloads[0]["revision"] == "1.73.0"
+
+
+def test_release_completion_marker_exists_on_hf_rejects_invalid_marker(
+    monkeypatch,
+    tmp_path,
+):
+    data_upload = _load_data_upload_module()
+    marker_file = tmp_path / "release-complete.json"
+    marker_file.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "status": "complete",
+                "version": "1.72.0",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        data_upload,
+        "hf_hub_download",
+        lambda **kwargs: str(marker_file),
+    )
+
+    assert not data_upload.release_completion_marker_exists_on_hf(version="1.73.0")

--- a/tests/unit/utils/test_data_upload.py
+++ b/tests/unit/utils/test_data_upload.py
@@ -438,10 +438,12 @@ def test_promote_full_release_orders_full_release_operations(
     monkeypatch.setattr(
         data_upload,
         "upload_release_completion_marker_to_hf",
-        lambda **kwargs: calls.append(("release_complete", kwargs.get("create_tag")))
-        or {
-            "marker_path": "releases/1.73.0/release-complete.json",
-        },
+        lambda **kwargs: (
+            calls.append(("release_complete", kwargs.get("create_tag")))
+            or {
+                "marker_path": "releases/1.73.0/release-complete.json",
+            }
+        ),
     )
     monkeypatch.setattr(
         data_upload,

--- a/tests/unit/utils/test_data_upload.py
+++ b/tests/unit/utils/test_data_upload.py
@@ -65,16 +65,22 @@ def _load_data_upload_module():
     return _DATA_UPLOAD_MODULE
 
 
-def _track_run_context_env(monkeypatch=None):
+def _track_run_context_env(monkeypatch):
     for key in _RUN_CONTEXT_ENV_KEYS:
-        os.environ.pop(key, None)
+        monkeypatch.delenv(key, raising=False)
 
 
 @pytest.fixture(autouse=True)
-def _clear_run_context_env(monkeypatch):
-    _track_run_context_env(monkeypatch)
+def _restore_run_context_env():
+    original = {
+        key: os.environ[key] for key in _RUN_CONTEXT_ENV_KEYS if key in os.environ
+    }
     yield
-    _track_run_context_env(monkeypatch)
+    for key in _RUN_CONTEXT_ENV_KEYS:
+        if key in original:
+            os.environ[key] = original[key]
+        else:
+            os.environ.pop(key, None)
 
 
 def _install_fake_hf(monkeypatch, tmp_path):
@@ -472,7 +478,7 @@ def test_promote_full_release_orders_full_release_operations(
     )
 
 
-def test_promote_full_release_can_finish_registry_after_finalized_release(
+def test_promote_full_release_verifies_marker_after_finalized_release(
     monkeypatch,
     tmp_path,
 ):
@@ -496,23 +502,21 @@ def test_promote_full_release_can_finish_registry_after_finalized_release(
     monkeypatch.setattr(
         data_upload,
         "upload_final_version_manifest",
-        lambda **kwargs: calls.append(
-            (
-                "version_manifest",
-                kwargs["released_paths"],
-                kwargs.get("run_id"),
-            )
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("already-finalized retries must not mutate registry state")
         ),
     )
     monkeypatch.setattr(
         data_upload,
         "upload_release_completion_marker_to_hf",
-        lambda **kwargs: calls.append(
-            ("release_complete", kwargs["released_paths"], kwargs.get("create_tag"))
-        )
-        or {
-            "marker_path": "releases/1.73.0/release-complete.json",
-        },
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("already-finalized retries must not write release markers")
+        ),
+    )
+    monkeypatch.setattr(
+        data_upload,
+        "release_completion_marker_exists_on_hf",
+        lambda **kwargs: calls.append(("check_marker", kwargs["version"])) or True,
     )
     monkeypatch.setattr(
         data_upload,
@@ -531,10 +535,53 @@ def test_promote_full_release_can_finish_registry_after_finalized_release(
     assert result["hf_promoted"] == 0
     assert result["gcs_uploaded"] == 0
     assert calls == [
-        ("version_manifest", ["states/AL.h5"], "run-123"),
-        ("release_complete", ["states/AL.h5"], False),
+        ("check_marker", "1.73.0"),
         ("cleanup", ["states/AL.h5"]),
     ]
+    assert result["release_completion_marker"] == (
+        "releases/1.73.0/release-complete.json"
+    )
+
+
+def test_promote_full_release_rejects_finalized_release_without_marker(
+    monkeypatch,
+    tmp_path,
+):
+    data_upload = _load_data_upload_module()
+    files = _make_files(tmp_path, ["states/AL.h5"])
+
+    monkeypatch.setattr(
+        data_upload,
+        "get_matching_finalized_release_manifest",
+        lambda *args, **kwargs: {"artifacts": {"states/AL": {"path": "states/AL.h5"}}},
+    )
+    monkeypatch.setattr(
+        data_upload,
+        "release_completion_marker_exists_on_hf",
+        lambda **kwargs: False,
+    )
+    monkeypatch.setattr(
+        data_upload,
+        "upload_final_version_manifest",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("missing marker repair must be manual")
+        ),
+    )
+    monkeypatch.setattr(
+        data_upload,
+        "upload_release_completion_marker_to_hf",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("missing marker repair must be manual")
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="repair or migrate this release manually"):
+        data_upload.promote_full_release_from_staging(
+            rel_paths=["states/AL.h5"],
+            version="1.73.0",
+            run_id="run-123",
+            files_with_paths=files,
+        )
 
 
 def test_upload_release_completion_marker_requires_release_paths(monkeypatch):

--- a/tests/unit/utils/test_data_upload.py
+++ b/tests/unit/utils/test_data_upload.py
@@ -1,4 +1,5 @@
 import importlib
+import os
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -64,9 +65,16 @@ def _load_data_upload_module():
     return _DATA_UPLOAD_MODULE
 
 
-def _track_run_context_env(monkeypatch):
+def _track_run_context_env(monkeypatch=None):
     for key in _RUN_CONTEXT_ENV_KEYS:
-        monkeypatch.delenv(key, raising=False)
+        os.environ.pop(key, None)
+
+
+@pytest.fixture(autouse=True)
+def _clear_run_context_env(monkeypatch):
+    _track_run_context_env(monkeypatch)
+    yield
+    _track_run_context_env(monkeypatch)
 
 
 def _install_fake_hf(monkeypatch, tmp_path):
@@ -422,6 +430,14 @@ def test_promote_full_release_orders_full_release_operations(
     )
     monkeypatch.setattr(
         data_upload,
+        "upload_release_completion_marker_to_hf",
+        lambda **kwargs: calls.append(("release_complete", kwargs.get("create_tag")))
+        or {
+            "marker_path": "releases/1.73.0/release-complete.json",
+        },
+    )
+    monkeypatch.setattr(
+        data_upload,
         "cleanup_staging_hf",
         lambda paths, **kwargs: calls.append("cleanup_staging") or len(paths),
     )
@@ -443,6 +459,7 @@ def test_promote_full_release_orders_full_release_operations(
         "upload_gcs",
         "release_manifest",
         ("version_manifest", "run-123"),
+        ("release_complete", True),
         "cleanup_staging",
     ]
     assert data_upload.os.environ["US_DATA_RUN_ID"] == "run-123"
@@ -450,6 +467,9 @@ def test_promote_full_release_orders_full_release_operations(
     assert result["hf_promoted"] == 3
     assert result["gcs_uploaded"] == 3
     assert result["release_manifest_artifacts"] == 3
+    assert result["release_completion_marker"] == (
+        "releases/1.73.0/release-complete.json"
+    )
 
 
 def test_promote_full_release_can_finish_registry_after_finalized_release(
@@ -486,6 +506,16 @@ def test_promote_full_release_can_finish_registry_after_finalized_release(
     )
     monkeypatch.setattr(
         data_upload,
+        "upload_release_completion_marker_to_hf",
+        lambda **kwargs: calls.append(
+            ("release_complete", kwargs["released_paths"], kwargs.get("create_tag"))
+        )
+        or {
+            "marker_path": "releases/1.73.0/release-complete.json",
+        },
+    )
+    monkeypatch.setattr(
+        data_upload,
         "cleanup_staging_hf",
         lambda paths, **kwargs: calls.append(("cleanup", list(paths))) or 0,
     )
@@ -502,5 +532,95 @@ def test_promote_full_release_can_finish_registry_after_finalized_release(
     assert result["gcs_uploaded"] == 0
     assert calls == [
         ("version_manifest", ["states/AL.h5"], "run-123"),
+        ("release_complete", ["states/AL.h5"], False),
         ("cleanup", ["states/AL.h5"]),
     ]
+
+
+def test_upload_release_completion_marker_requires_release_paths(monkeypatch):
+    data_upload = _load_data_upload_module()
+    fake_api = SimpleNamespace(
+        list_repo_files=lambda **kwargs: [
+            "states/AL.h5",
+            "release_manifest.json",
+            "releases/1.73.0/release_manifest.json",
+            "trace.tro.jsonld",
+            "releases/1.73.0/trace.tro.jsonld",
+            "version_manifest.json",
+            "calibration/runs/run-123/diagnostics/validation_summary.json",
+        ],
+        repo_info=lambda **kwargs: SimpleNamespace(sha="before"),
+        create_tag=lambda **kwargs: None,
+    )
+    commit_operations = []
+
+    monkeypatch.setattr(data_upload, "HfApi", lambda: fake_api)
+    monkeypatch.setattr(
+        data_upload,
+        "hf_create_commit_with_retry",
+        lambda **kwargs: (
+            commit_operations.extend(kwargs["operations"])
+            or SimpleNamespace(oid="after")
+        ),
+    )
+
+    marker = data_upload.upload_release_completion_marker_to_hf(
+        version="1.73.0",
+        run_id="run-123",
+        released_paths=["states/AL.h5"],
+        expected_paths=["states/AL.h5"],
+        release_manifest={
+            "artifacts": {
+                "states/AL": {
+                    "path": "states/AL.h5",
+                    "sha256": "abc123",
+                }
+            }
+        },
+        promoted_hf=1,
+        uploaded_gcs=1,
+        create_tag=True,
+    )
+
+    assert marker["status"] == "complete"
+    assert marker["marker_path"] == "releases/1.73.0/release-complete.json"
+    assert marker["required_paths"]["validation_reports"] == [
+        "calibration/runs/run-123/diagnostics/validation_summary.json"
+    ]
+    assert commit_operations[0].path_in_repo == (
+        "releases/1.73.0/release-complete.json"
+    )
+
+
+def test_upload_release_completion_marker_fails_without_validation_report(
+    monkeypatch,
+):
+    data_upload = _load_data_upload_module()
+    fake_api = SimpleNamespace(
+        list_repo_files=lambda **kwargs: [
+            "states/AL.h5",
+            "release_manifest.json",
+            "releases/1.73.0/release_manifest.json",
+            "trace.tro.jsonld",
+            "releases/1.73.0/trace.tro.jsonld",
+            "version_manifest.json",
+        ]
+    )
+
+    monkeypatch.setattr(data_upload, "HfApi", lambda: fake_api)
+
+    with pytest.raises(FileNotFoundError, match="validation report"):
+        data_upload.upload_release_completion_marker_to_hf(
+            version="1.73.0",
+            run_id="run-123",
+            released_paths=["states/AL.h5"],
+            expected_paths=["states/AL.h5"],
+            release_manifest={
+                "artifacts": {
+                    "states/AL": {
+                        "path": "states/AL.h5",
+                        "sha256": "abc123",
+                    }
+                }
+            },
+        )


### PR DESCRIPTION
Fixes #909

## Summary

This PR hardens the US data publication path so a data release version is tied to the package version that produced it.

The important CI/CD change is that the full data pipeline no longer launches from the functional commit before package publication completes. Functional pushes still create the Towncrier `Update package version` commit. On that version-bump commit, the workflow now:

1. builds the package,
2. publishes `policyengine-us-data==<version>` to PyPI,
3. verifies that exact version is visible on PyPI, and only then
4. dispatches `pipeline.yaml` with `SOURCE_SHA=${{ github.sha }}` so Modal runs from the exact version-bump commit.

This prevents bundle/data releases from being produced for a source version that failed to publish as a package.

The PR also adds release-completion hardening for full promotions:

- Adds `releases/<version>/release-complete.json` for full US data promotions.
- Requires production artifacts, release manifest, TRACE TRO, version manifest, validation diagnostics, and release-manifest checksums before accepting completion.
- Validates an existing completion marker before treating an already-finalized release as safe.
- Refuses to mutate finalized release state if the marker is missing or invalid.

Longer-term, `releases/<version>/release_manifest.json` at HF tag `<version>` should be the canonical bundle-consumable release contract. The completion marker in this PR is a release-state guard for the current promotion flow, not a replacement for the release manifest.

## Testing

- `ruff check policyengine_us_data/utils/release_completion.py policyengine_us_data/utils/release_promotion.py policyengine_us_data/utils/data_upload.py tests/unit/utils/test_data_upload.py`
- `ruff check .github/scripts/verify_pypi_version.py`
- `python -m pytest tests/unit/utils/test_data_upload.py tests/unit/test_release_manifest.py -q`
- `python -m pytest tests/unit/test_upload_completed_datasets.py tests/unit/test_pipeline_source_contracts.py -q`
- Syntax check for `.github/scripts/verify_pypi_version.py`
- `git diff --check`

Note: `uv run pytest` could not run on this Intel macOS host because the lock resolves `torch==2.9.1`, which has no compatible wheel for `macosx_15_0_x86_64`.