### PR TITLE
Add clone origin flags and ECPS diagnostics

### DIFF
--- a/changelog.d/703.fixed
+++ b/changelog.d/703.fixed
@@ -1,0 +1,1 @@
+Added explicit clone-origin flags to extended/enhanced CPS datasets and saved ECPS clone diagnostics for clone weight share, modeled-only-poor share, and extreme childcare/tax checks.

--- a/policyengine_us_data/calibration/puf_impute.py
+++ b/policyengine_us_data/calibration/puf_impute.py
@@ -27,6 +27,14 @@ from policyengine_us_data.pipeline_schema import PipelineNode
 
 logger = logging.getLogger(__name__)
 
+CLONE_ORIGIN_FLAGS = {
+    "person": "person_is_puf_clone",
+    "tax_unit": "tax_unit_is_puf_clone",
+    "spm_unit": "spm_unit_is_puf_clone",
+    "family": "family_is_puf_clone",
+    "household": "household_is_puf_clone",
+}
+
 PUF_SUBSAMPLE_TARGET = 20_000
 PUF_TOP_PERCENTILE = 99.5
 
@@ -593,6 +601,20 @@ def puf_clone_dataset(
         county_fips = np.asarray([f"{int(c):05d}" for c in county_fips]).astype("S5")
         new_data["county_fips"] = {
             time_period: np.concatenate([county_fips, county_fips])
+        }
+
+    for entity_key, flag_name in CLONE_ORIGIN_FLAGS.items():
+        id_variable = f"{entity_key}_id"
+        if id_variable not in data:
+            continue
+        n_entities = len(data[id_variable][time_period])
+        new_data[flag_name] = {
+            time_period: np.concatenate(
+                [
+                    np.zeros(n_entities, dtype=np.int8),
+                    np.ones(n_entities, dtype=np.int8),
+                ]
+            )
         }
 
     if y_full:

--- a/policyengine_us_data/datasets/cps/enhanced_cps.py
+++ b/policyengine_us_data/datasets/cps/enhanced_cps.py
@@ -779,11 +779,11 @@ class EnhancedCPS(Dataset):
                 diagnostics_payload,
             )
         except Exception:
-            logging.warning(
+            logging.exception(
                 "Unable to compute clone diagnostics for %s",
                 self.file_path,
-                exc_info=True,
             )
+            raise
 
 
 class ReweightedCPS_2024(Dataset):

--- a/policyengine_us_data/datasets/cps/enhanced_cps.py
+++ b/policyengine_us_data/datasets/cps/enhanced_cps.py
@@ -157,10 +157,41 @@ def clone_diagnostics_path(file_path: str | Path) -> Path:
     return Path(file_path).with_suffix(".clone_diagnostics.json")
 
 
+def build_clone_diagnostics_payload(
+    period_to_diagnostics: dict[int, dict[str, float]],
+) -> dict:
+    if not period_to_diagnostics:
+        raise ValueError("Expected at least one period of clone diagnostics")
+
+    ordered_periods = sorted(period_to_diagnostics)
+    if len(ordered_periods) == 1:
+        period = ordered_periods[0]
+        diagnostics = dict(period_to_diagnostics[period])
+        diagnostics["period"] = int(period)
+        return diagnostics
+
+    return {
+        "periods": {
+            str(period): period_to_diagnostics[period] for period in ordered_periods
+        }
+    }
+
+
 def write_clone_diagnostics_report(file_path: str | Path, diagnostics: dict) -> Path:
     output_path = clone_diagnostics_path(file_path)
     output_path.write_text(json.dumps(diagnostics, indent=2, sort_keys=True) + "\n")
     return output_path
+
+
+def refresh_clone_diagnostics_report(
+    file_path: str | Path,
+    diagnostics_builder,
+) -> Path:
+    output_path = clone_diagnostics_path(file_path)
+    if output_path.exists():
+        output_path.unlink()
+    diagnostics = diagnostics_builder()
+    return write_clone_diagnostics_report(file_path, diagnostics)
 
 
 def build_clone_diagnostics_for_saved_dataset(
@@ -689,14 +720,25 @@ class EnhancedCPS(Dataset):
 
         self.save_dataset(data)
         try:
-            diagnostics = build_clone_diagnostics_for_saved_dataset(
-                type(self),
-                base_year,
+            periods = list(range(self.start_year, self.end_year + 1))
+            diagnostics_payload = build_clone_diagnostics_payload(
+                {
+                    period: build_clone_diagnostics_for_saved_dataset(
+                        type(self),
+                        period,
+                    )
+                    for period in periods
+                }
             )
-            diagnostics["period"] = base_year
-            output_path = write_clone_diagnostics_report(self.file_path, diagnostics)
+            output_path = refresh_clone_diagnostics_report(
+                self.file_path,
+                lambda: diagnostics_payload,
+            )
             logging.info("Saved clone diagnostics to %s", output_path)
-            logging.info("Clone diagnostics summary: %s", diagnostics)
+            logging.info(
+                "Clone diagnostics summary: %s",
+                diagnostics_payload,
+            )
         except Exception:
             logging.warning(
                 "Unable to compute clone diagnostics for %s",

--- a/policyengine_us_data/datasets/cps/enhanced_cps.py
+++ b/policyengine_us_data/datasets/cps/enhanced_cps.py
@@ -1,3 +1,7 @@
+import json
+from pathlib import Path
+
+import h5py
 from policyengine_core.data import Dataset
 import pandas as pd
 from policyengine_us_data.utils import (
@@ -34,6 +38,173 @@ try:
     import torch
 except ImportError:
     torch = None
+
+
+def _to_numpy(value) -> np.ndarray:
+    return np.asarray(getattr(value, "values", value))
+
+
+def _weighted_share(mask, weights) -> float:
+    weights = np.asarray(weights, dtype=np.float64)
+    total_weight = float(weights.sum())
+    if total_weight <= 0:
+        return 0.0
+    mask = np.asarray(mask, dtype=bool)
+    return 100 * float(weights[mask].sum()) / total_weight
+
+
+def compute_clone_diagnostics_summary(
+    *,
+    household_is_puf_clone,
+    household_weight,
+    person_is_puf_clone,
+    person_weight,
+    person_in_poverty,
+    person_reported_in_poverty,
+    spm_unit_is_puf_clone,
+    spm_unit_weight,
+    spm_unit_capped_work_childcare_expenses,
+    spm_unit_pre_subsidy_childcare_expenses,
+    spm_unit_taxes,
+    spm_unit_market_income,
+) -> dict[str, float]:
+    household_is_puf_clone = np.asarray(household_is_puf_clone, dtype=bool)
+    household_weight = np.asarray(household_weight, dtype=np.float64)
+    person_is_puf_clone = np.asarray(person_is_puf_clone, dtype=bool)
+    person_weight = np.asarray(person_weight, dtype=np.float64)
+    person_in_poverty = np.asarray(person_in_poverty, dtype=bool)
+    person_reported_in_poverty = np.asarray(person_reported_in_poverty, dtype=bool)
+    spm_unit_is_puf_clone = np.asarray(spm_unit_is_puf_clone, dtype=bool)
+    spm_unit_weight = np.asarray(spm_unit_weight, dtype=np.float64)
+    capped_childcare = np.asarray(
+        spm_unit_capped_work_childcare_expenses, dtype=np.float64
+    )
+    pre_subsidy_childcare = np.asarray(
+        spm_unit_pre_subsidy_childcare_expenses, dtype=np.float64
+    )
+    spm_unit_taxes = np.asarray(spm_unit_taxes, dtype=np.float64)
+    spm_unit_market_income = np.asarray(spm_unit_market_income, dtype=np.float64)
+
+    poor_modeled_only = person_in_poverty & ~person_reported_in_poverty
+    clone_spm_weight = spm_unit_weight[spm_unit_is_puf_clone].sum()
+
+    return {
+        "clone_household_weight_share_pct": _weighted_share(
+            household_is_puf_clone, household_weight
+        ),
+        "clone_person_weight_share_pct": _weighted_share(
+            person_is_puf_clone, person_weight
+        ),
+        "clone_poor_modeled_only_person_weight_share_pct": _weighted_share(
+            person_is_puf_clone & poor_modeled_only,
+            person_weight,
+        ),
+        "poor_modeled_only_within_clone_person_weight_share_pct": (
+            0.0
+            if person_weight[person_is_puf_clone].sum() <= 0
+            else _weighted_share(
+                poor_modeled_only[person_is_puf_clone],
+                person_weight[person_is_puf_clone],
+            )
+        ),
+        "clone_childcare_exceeds_pre_subsidy_share_pct": (
+            0.0
+            if clone_spm_weight <= 0
+            else _weighted_share(
+                capped_childcare[spm_unit_is_puf_clone]
+                > pre_subsidy_childcare[spm_unit_is_puf_clone] + 1,
+                spm_unit_weight[spm_unit_is_puf_clone],
+            )
+        ),
+        "clone_childcare_above_5000_share_pct": (
+            0.0
+            if clone_spm_weight <= 0
+            else _weighted_share(
+                capped_childcare[spm_unit_is_puf_clone] > 5_000,
+                spm_unit_weight[spm_unit_is_puf_clone],
+            )
+        ),
+        "clone_taxes_exceed_market_income_share_pct": (
+            0.0
+            if clone_spm_weight <= 0
+            else _weighted_share(
+                spm_unit_taxes[spm_unit_is_puf_clone]
+                > spm_unit_market_income[spm_unit_is_puf_clone] + 1,
+                spm_unit_weight[spm_unit_is_puf_clone],
+            )
+        ),
+    }
+
+
+def _load_saved_period_array(
+    file_path: str | Path,
+    variable_name: str,
+    period: int,
+) -> np.ndarray:
+    with h5py.File(file_path, "r") as h5_file:
+        obj = h5_file[variable_name]
+        if isinstance(obj, h5py.Dataset):
+            return np.asarray(obj[...])
+        period_key = str(period)
+        if period_key in obj:
+            return np.asarray(obj[period_key][...])
+        if period in obj:
+            return np.asarray(obj[period][...])
+        raise KeyError(f"{variable_name} missing period {period}")
+
+
+def clone_diagnostics_path(file_path: str | Path) -> Path:
+    return Path(file_path).with_suffix(".clone_diagnostics.json")
+
+
+def write_clone_diagnostics_report(file_path: str | Path, diagnostics: dict) -> Path:
+    output_path = clone_diagnostics_path(file_path)
+    output_path.write_text(json.dumps(diagnostics, indent=2, sort_keys=True) + "\n")
+    return output_path
+
+
+def build_clone_diagnostics_for_saved_dataset(
+    dataset_cls: Type[Dataset], period: int
+) -> dict[str, float]:
+    from policyengine_us import Microsimulation
+
+    sim = Microsimulation(dataset=dataset_cls)
+    dataset_path = Path(dataset_cls.file_path)
+
+    person_reported_in_poverty = _to_numpy(
+        sim.calculate("spm_unit_net_income_reported", period=period, map_to="person")
+    ) < _to_numpy(
+        sim.calculate("spm_unit_spm_threshold", period=period, map_to="person")
+    )
+
+    return compute_clone_diagnostics_summary(
+        household_is_puf_clone=_load_saved_period_array(
+            dataset_path, "household_is_puf_clone", period
+        ),
+        household_weight=_to_numpy(sim.calculate("household_weight", period=period)),
+        person_is_puf_clone=_load_saved_period_array(
+            dataset_path, "person_is_puf_clone", period
+        ),
+        person_weight=_to_numpy(sim.calculate("person_weight", period=period)),
+        person_in_poverty=_to_numpy(
+            sim.calculate("person_in_poverty", period=period)
+        ),
+        person_reported_in_poverty=person_reported_in_poverty,
+        spm_unit_is_puf_clone=_load_saved_period_array(
+            dataset_path, "spm_unit_is_puf_clone", period
+        ),
+        spm_unit_weight=_to_numpy(sim.calculate("spm_unit_weight", period=period)),
+        spm_unit_capped_work_childcare_expenses=_to_numpy(
+            sim.calculate("spm_unit_capped_work_childcare_expenses", period=period)
+        ),
+        spm_unit_pre_subsidy_childcare_expenses=_to_numpy(
+            sim.calculate("spm_unit_pre_subsidy_childcare_expenses", period=period)
+        ),
+        spm_unit_taxes=_to_numpy(sim.calculate("spm_unit_taxes", period=period)),
+        spm_unit_market_income=_to_numpy(
+            sim.calculate("spm_unit_market_income", period=period)
+        ),
+    )
 
 
 def _get_period_array(period_values: dict, period: int) -> np.ndarray:
@@ -519,6 +690,21 @@ class EnhancedCPS(Dataset):
         logging.info("Post-generation weight validation passed")
 
         self.save_dataset(data)
+        try:
+            diagnostics = build_clone_diagnostics_for_saved_dataset(
+                type(self),
+                base_year,
+            )
+            diagnostics["period"] = base_year
+            output_path = write_clone_diagnostics_report(self.file_path, diagnostics)
+            logging.info("Saved clone diagnostics to %s", output_path)
+            logging.info("Clone diagnostics summary: %s", diagnostics)
+        except Exception:
+            logging.warning(
+                "Unable to compute clone diagnostics for %s",
+                self.file_path,
+                exc_info=True,
+            )
 
 
 class ReweightedCPS_2024(Dataset):

--- a/policyengine_us_data/datasets/cps/enhanced_cps.py
+++ b/policyengine_us_data/datasets/cps/enhanced_cps.py
@@ -194,6 +194,29 @@ def refresh_clone_diagnostics_report(
     return write_clone_diagnostics_report(file_path, diagnostics)
 
 
+def save_clone_diagnostics_report(
+    dataset_cls: Type[Dataset],
+    *,
+    start_year: int,
+    end_year: int,
+) -> tuple[Path, dict]:
+    periods = list(range(start_year, end_year + 1))
+    output_path = refresh_clone_diagnostics_report(
+        dataset_cls.file_path,
+        lambda: build_clone_diagnostics_payload(
+            {
+                period: build_clone_diagnostics_for_saved_dataset(
+                    dataset_cls,
+                    period,
+                )
+                for period in periods
+            }
+        ),
+    )
+    diagnostics_payload = json.loads(output_path.read_text())
+    return output_path, diagnostics_payload
+
+
 def build_clone_diagnostics_for_saved_dataset(
     dataset_cls: Type[Dataset], period: int
 ) -> dict[str, float]:
@@ -720,19 +743,10 @@ class EnhancedCPS(Dataset):
 
         self.save_dataset(data)
         try:
-            periods = list(range(self.start_year, self.end_year + 1))
-            diagnostics_payload = build_clone_diagnostics_payload(
-                {
-                    period: build_clone_diagnostics_for_saved_dataset(
-                        type(self),
-                        period,
-                    )
-                    for period in periods
-                }
-            )
-            output_path = refresh_clone_diagnostics_report(
-                self.file_path,
-                lambda: diagnostics_payload,
+            output_path, diagnostics_payload = save_clone_diagnostics_report(
+                type(self),
+                start_year=self.start_year,
+                end_year=self.end_year,
             )
             logging.info("Saved clone diagnostics to %s", output_path)
             logging.info(

--- a/policyengine_us_data/datasets/cps/enhanced_cps.py
+++ b/policyengine_us_data/datasets/cps/enhanced_cps.py
@@ -186,9 +186,7 @@ def build_clone_diagnostics_for_saved_dataset(
             dataset_path, "person_is_puf_clone", period
         ),
         person_weight=_to_numpy(sim.calculate("person_weight", period=period)),
-        person_in_poverty=_to_numpy(
-            sim.calculate("person_in_poverty", period=period)
-        ),
+        person_in_poverty=_to_numpy(sim.calculate("person_in_poverty", period=period)),
         person_reported_in_poverty=person_reported_in_poverty,
         spm_unit_is_puf_clone=_load_saved_period_array(
             dataset_path, "spm_unit_is_puf_clone", period

--- a/policyengine_us_data/datasets/cps/enhanced_cps.py
+++ b/policyengine_us_data/datasets/cps/enhanced_cps.py
@@ -225,6 +225,27 @@ def build_clone_diagnostics_for_saved_dataset(
     sim = Microsimulation(dataset=dataset_cls)
     dataset_path = Path(dataset_cls.file_path)
 
+    return build_clone_diagnostics_for_simulation(
+        sim,
+        dataset_path=dataset_path,
+        period=period,
+    )
+
+
+def build_clone_diagnostics_for_simulation(
+    sim,
+    *,
+    dataset_path: str | Path,
+    period: int,
+) -> dict[str, float]:
+    """Build clone diagnostics from a simulation and saved clone-flag arrays.
+
+    The enhanced CPS save path preserves zeroed person/spm-unit weight inputs on
+    the clone half. For diagnostics, always map the calibrated household weights
+    to persons/SPM units explicitly instead of reading those stale entity-level
+    weight inputs back from disk.
+    """
+
     person_reported_in_poverty = _to_numpy(
         sim.calculate("spm_unit_net_income_reported", period=period, map_to="person")
     ) < _to_numpy(
@@ -239,13 +260,17 @@ def build_clone_diagnostics_for_saved_dataset(
         person_is_puf_clone=_load_saved_period_array(
             dataset_path, "person_is_puf_clone", period
         ),
-        person_weight=_to_numpy(sim.calculate("person_weight", period=period)),
+        person_weight=_to_numpy(
+            sim.calculate("household_weight", period=period, map_to="person")
+        ),
         person_in_poverty=_to_numpy(sim.calculate("person_in_poverty", period=period)),
         person_reported_in_poverty=person_reported_in_poverty,
         spm_unit_is_puf_clone=_load_saved_period_array(
             dataset_path, "spm_unit_is_puf_clone", period
         ),
-        spm_unit_weight=_to_numpy(sim.calculate("spm_unit_weight", period=period)),
+        spm_unit_weight=_to_numpy(
+            sim.calculate("household_weight", period=period, map_to="spm_unit")
+        ),
         spm_unit_capped_work_childcare_expenses=_to_numpy(
             sim.calculate("spm_unit_capped_work_childcare_expenses", period=period)
         ),

--- a/policyengine_us_data/datasets/cps/small_enhanced_cps.py
+++ b/policyengine_us_data/datasets/cps/small_enhanced_cps.py
@@ -27,6 +27,14 @@ def _load_saved_period_array(
     raise KeyError(f"{variable_name} missing period {period}")
 
 
+def _normalize_annual_period_key(period_key) -> int:
+    if isinstance(period_key, (int, np.integer)):
+        return int(period_key)
+    if hasattr(period_key, "year"):
+        return int(period_key.year)
+    return int(str(period_key))
+
+
 def _attach_clone_origin_flags(
     data: dict[str, dict[int, np.ndarray]],
     source_dataset_path,
@@ -43,7 +51,7 @@ def _attach_clone_origin_flags(
             source_ids_by_period = {}
             source_flags_by_period = {}
             for period_key in data[id_variable]:
-                period = int(period_key)
+                period = _normalize_annual_period_key(period_key)
                 source_ids = _load_saved_period_array(source_h5, id_variable, period)
                 source_flags = _load_saved_period_array(source_h5, flag_name, period)
                 if len(source_ids) != len(source_flags):

--- a/policyengine_us_data/datasets/cps/small_enhanced_cps.py
+++ b/policyengine_us_data/datasets/cps/small_enhanced_cps.py
@@ -1,14 +1,81 @@
-import os
-import pandas as pd
-import numpy as np
 import h5py
-
+import logging
+import os
+import numpy as np
+import pandas as pd
 from policyengine_us import Microsimulation
-from policyengine_us_data.datasets import EnhancedCPS_2024
-from policyengine_us_data.storage import STORAGE_FOLDER
 from policyengine_core.enums import Enum
 from policyengine_core.data.dataset import Dataset
-import logging
+from policyengine_us_data.calibration.puf_impute import CLONE_ORIGIN_FLAGS
+from policyengine_us_data.datasets import EnhancedCPS_2024
+from policyengine_us_data.storage import STORAGE_FOLDER
+
+
+def _load_saved_period_array(
+    h5_file: h5py.File, variable_name: str, period: int
+) -> np.ndarray:
+    obj = h5_file[variable_name]
+    if isinstance(obj, h5py.Dataset):
+        return np.asarray(obj[...])
+
+    period_key = str(period)
+    if period_key in obj:
+        return np.asarray(obj[period_key][...])
+    if period in obj:
+        return np.asarray(obj[period][...])
+
+    raise KeyError(f"{variable_name} missing period {period}")
+
+
+def _attach_clone_origin_flags(
+    data: dict[str, dict[int, np.ndarray]],
+    source_dataset_path,
+) -> None:
+    with h5py.File(source_dataset_path, "r") as source_h5:
+        for entity_key, flag_name in CLONE_ORIGIN_FLAGS.items():
+            id_variable = f"{entity_key}_id"
+            if id_variable not in data:
+                raise KeyError(
+                    f"Expected {id_variable} in sampled small ECPS data "
+                    f"before attaching {flag_name}"
+                )
+
+            source_ids_by_period = {}
+            source_flags_by_period = {}
+            for period_key in data[id_variable]:
+                period = int(period_key)
+                source_ids = _load_saved_period_array(source_h5, id_variable, period)
+                source_flags = _load_saved_period_array(source_h5, flag_name, period)
+                if len(source_ids) != len(source_flags):
+                    raise ValueError(
+                        f"{flag_name} length {len(source_flags)} does not match "
+                        f"{id_variable} length {len(source_ids)} for period {period}"
+                    )
+                source_ids_by_period[period_key] = source_ids
+                source_flags_by_period[period_key] = source_flags
+
+            data[flag_name] = {}
+            for period_key, sampled_ids in data[id_variable].items():
+                source_ids = source_ids_by_period[period_key]
+                source_flags = source_flags_by_period[period_key]
+                flag_lookup = {
+                    int(entity_id): np.int8(flag_value)
+                    for entity_id, flag_value in zip(source_ids, source_flags)
+                }
+                sampled_ids = np.asarray(sampled_ids)
+                missing_ids = [
+                    int(entity_id)
+                    for entity_id in sampled_ids
+                    if int(entity_id) not in flag_lookup
+                ]
+                if missing_ids:
+                    raise KeyError(
+                        f"Missing {flag_name} values for sampled IDs {missing_ids[:5]}"
+                    )
+                data[flag_name][period_key] = np.asarray(
+                    [flag_lookup[int(entity_id)] for entity_id in sampled_ids],
+                    dtype=np.int8,
+                )
 
 
 def create_small_ecps():
@@ -51,6 +118,8 @@ def create_small_ecps():
         if len(data[variable]) == 0:
             del data[variable]
 
+    _attach_clone_origin_flags(data, EnhancedCPS_2024.file_path)
+
     with h5py.File(STORAGE_FOLDER / "small_enhanced_cps_2024.h5", "w") as f:
         for variable, periods in data.items():
             grp = f.create_group(variable)
@@ -65,7 +134,6 @@ def create_sparse_ecps():
     ecps = EnhancedCPS_2024()
     h5 = ecps.load()
     sparse_weights = h5["household_weight"][str(time_period)][:]
-    hh_ids = h5["household_id"][str(time_period)][:]
     h5.close()
 
     template_sim = Microsimulation(
@@ -82,7 +150,6 @@ def create_sparse_ecps():
 
     household_weight_column = f"household_weight__{time_period}"
     df_household_id_column = f"household_id__{time_period}"
-    df_person_id_column = f"person_id__{time_period}"
 
     # Group by household ID and get the first entry for each group
     h_df = df.groupby(df_household_id_column).first()

--- a/policyengine_us_data/storage/upload_completed_datasets.py
+++ b/policyengine_us_data/storage/upload_completed_datasets.py
@@ -185,6 +185,7 @@ def _validate_dataset_artifacts(files_with_repo_paths: list[tuple[Path, str]]) -
     for file_path, _ in files_with_repo_paths:
         validate_dataset(file_path)
 
+
 def validate_dataset(file_path: Path) -> None:
     """Validate a dataset file before upload.
 

--- a/policyengine_us_data/storage/upload_completed_datasets.py
+++ b/policyengine_us_data/storage/upload_completed_datasets.py
@@ -7,6 +7,7 @@ from policyengine_core.data import Dataset
 from policyengine_us_data.__version__ import __version__ as DATA_PACKAGE_VERSION
 from policyengine_us_data.datasets import EnhancedCPS_2024
 from policyengine_us_data.datasets.cps.cps import CPS_2024
+from policyengine_us_data.datasets.cps.enhanced_cps import clone_diagnostics_path
 from policyengine_us_data.storage import STORAGE_FOLDER
 from policyengine_us_data.utils.data_upload import (
     cleanup_staging_hf,
@@ -85,6 +86,11 @@ def _dataset_upload_specs(
         (
             EnhancedCPS_2024.file_path,
             EnhancedCPS_2024.file_path.name,
+            require_enhanced_cps,
+        ),
+        (
+            clone_diagnostics_path(EnhancedCPS_2024.file_path),
+            clone_diagnostics_path(EnhancedCPS_2024.file_path).name,
             require_enhanced_cps,
         ),
         (

--- a/policyengine_us_data/storage/upload_completed_datasets.py
+++ b/policyengine_us_data/storage/upload_completed_datasets.py
@@ -1,3 +1,5 @@
+import json
+import math
 from pathlib import Path
 
 import h5py
@@ -61,6 +63,17 @@ INCOME_GROUPS = [
 MIN_EMPLOYMENT_INCOME_SUM = 5e12  # $5 trillion
 MIN_HOUSEHOLD_WEIGHT_SUM = 100e6  # 100 million
 MAX_HOUSEHOLD_WEIGHT_SUM = 200e6  # 200 million
+
+CLONE_DIAGNOSTICS_FILENAME = "enhanced_cps_2024.clone_diagnostics.json"
+CLONE_DIAGNOSTICS_METRICS = {
+    "clone_household_weight_share_pct",
+    "clone_person_weight_share_pct",
+    "clone_poor_modeled_only_person_weight_share_pct",
+    "poor_modeled_only_within_clone_person_weight_share_pct",
+    "clone_childcare_exceeds_pre_subsidy_share_pct",
+    "clone_childcare_above_5000_share_pct",
+    "clone_taxes_exceed_market_income_share_pct",
+}
 
 
 def _resolve_run_id(run_id: str = "") -> str:
@@ -201,6 +214,10 @@ def validate_dataset(file_path: Path) -> None:
     file_path = Path(file_path)
     filename = file_path.name
 
+    if filename == CLONE_DIAGNOSTICS_FILENAME:
+        validate_clone_diagnostics(file_path)
+        return
+
     if filename not in VALIDATED_FILENAMES:
         return  # Skip validation for auxiliary files
 
@@ -317,6 +334,80 @@ def validate_dataset(file_path: Path) -> None:
     print(f"    Household weight sum: {hh_weight:,.0f}")
 
 
+def validate_clone_diagnostics(file_path: Path) -> None:
+    file_path = Path(file_path)
+    errors = []
+
+    try:
+        payload = json.loads(file_path.read_text())
+    except Exception as exc:
+        raise DatasetValidationError(
+            f"Validation failed for {file_path.name}:\n"
+            f"  - Failed to read clone diagnostics JSON: {exc}"
+        ) from exc
+
+    if not isinstance(payload, dict):
+        errors.append("Expected clone diagnostics JSON object.")
+    elif "periods" in payload:
+        periods = payload["periods"]
+        if not isinstance(periods, dict) or not periods:
+            errors.append("Expected non-empty 'periods' object.")
+        else:
+            for period, diagnostics in periods.items():
+                try:
+                    int(period)
+                except (TypeError, ValueError):
+                    errors.append(f"Period key {period!r} is not an integer year.")
+                    continue
+                errors.extend(
+                    _clone_diagnostics_errors(
+                        diagnostics,
+                        context=f"period {period}",
+                    )
+                )
+    else:
+        period = payload.get("period")
+        if isinstance(period, bool):
+            errors.append("'period' must be an integer year.")
+        else:
+            try:
+                int(period)
+            except (TypeError, ValueError):
+                errors.append("'period' must be an integer year.")
+        errors.extend(_clone_diagnostics_errors(payload, context="top-level"))
+
+    if errors:
+        raise DatasetValidationError(
+            f"Validation failed for {file_path.name}:\n"
+            + "\n".join(f"  - {e}" for e in errors)
+        )
+
+    print(f"  ✓ Validation passed for {file_path.name}")
+
+
+def _clone_diagnostics_errors(diagnostics, *, context: str) -> list[str]:
+    errors = []
+    if not isinstance(diagnostics, dict):
+        return [f"Expected clone diagnostics object for {context}."]
+
+    missing = sorted(CLONE_DIAGNOSTICS_METRICS.difference(diagnostics))
+    if missing:
+        errors.append(f"Missing clone diagnostics metric(s) in {context}: {missing}")
+
+    for metric in sorted(CLONE_DIAGNOSTICS_METRICS.intersection(diagnostics)):
+        value = diagnostics[metric]
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            errors.append(f"{context} metric {metric} must be numeric.")
+            continue
+        if not math.isfinite(float(value)):
+            errors.append(f"{context} metric {metric} must be finite.")
+            continue
+        if not 0 <= float(value) <= 100:
+            errors.append(f"{context} metric {metric} must be between 0 and 100.")
+
+    return errors
+
+
 def stage_datasets(
     require_enhanced_cps: bool = True,
     version: str | None = None,
@@ -362,6 +453,8 @@ def promote_datasets(
         if files_with_repo_paths
         else _download_staged_dataset_artifacts(rel_paths, run_id=run_id)
     )
+    if files_with_repo_paths is None:
+        _validate_dataset_artifacts(manifest_files)
     should_finalize, missing_prefixes = preflight_release_manifest_publish(
         manifest_files,
         version=version,

--- a/policyengine_us_data/storage/upload_completed_datasets.py
+++ b/policyengine_us_data/storage/upload_completed_datasets.py
@@ -101,6 +101,14 @@ def _dataset_upload_specs(
     ]
 
 
+def _enhanced_dataset_files() -> list[Path]:
+    return [
+        EnhancedCPS_2024.file_path,
+        clone_diagnostics_path(EnhancedCPS_2024.file_path),
+        STORAGE_FOLDER / "small_enhanced_cps_2024.h5",
+    ]
+
+
 def _collect_existing_dataset_artifacts(
     require_enhanced_cps: bool = True,
 ) -> list[tuple[Path, str]]:
@@ -176,7 +184,6 @@ def _validate_dataset_artifacts(files_with_repo_paths: list[tuple[Path, str]]) -
     print("\nValidating datasets...")
     for file_path, _ in files_with_repo_paths:
         validate_dataset(file_path)
-
 
 def validate_dataset(file_path: Path) -> None:
     """Validate a dataset file before upload.
@@ -469,7 +476,7 @@ def validate_all_datasets():
 def validate_built_datasets(require_enhanced_cps: bool = True):
     required_files = [CPS_2024.file_path]
     if require_enhanced_cps:
-        required_files.append(EnhancedCPS_2024.file_path)
+        required_files.extend(_enhanced_dataset_files())
 
     for file_path in required_files:
         if not file_path.exists():

--- a/policyengine_us_data/utils/dataset_validation.py
+++ b/policyengine_us_data/utils/dataset_validation.py
@@ -22,6 +22,14 @@ ENTITY_ID_VARIABLES = {
     "household": "household_id",
 }
 
+AUXILIARY_ENTITY_PREFIXES = {
+    "person_": "person",
+    "tax_unit_": "tax_unit",
+    "family_": "family",
+    "spm_unit_": "spm_unit",
+    "household_": "household",
+}
+
 
 class DatasetContractError(Exception):
     """Raised when a built dataset does not match the active country package."""
@@ -127,6 +135,24 @@ def _infer_auxiliary_entity(
     entity_counts: dict[str, int],
     file_name: str,
 ) -> str:
+    for prefix, entity_key in AUXILIARY_ENTITY_PREFIXES.items():
+        if not variable_name.startswith(prefix):
+            continue
+        expected_length = entity_counts.get(entity_key)
+        if expected_length is None:
+            raise DatasetContractError(
+                f"{file_name} contains auxiliary variable {variable_name} with a "
+                f"{entity_key}-scoped prefix, but {ENTITY_ID_VARIABLES[entity_key]} "
+                "is missing from the dataset."
+            )
+        if actual_length != expected_length:
+            raise DatasetContractError(
+                f"{file_name} contains auxiliary variable {variable_name} with "
+                f"{prefix!r} prefix and expected {entity_key} length "
+                f"{expected_length}, found {actual_length}."
+            )
+        return entity_key
+
     candidate_entities = [
         entity_key
         for entity_key, entity_count in entity_counts.items()

--- a/tests/unit/calibration/test_calibration_puf_impute.py
+++ b/tests/unit/calibration/test_calibration_puf_impute.py
@@ -37,9 +37,11 @@ def _make_mock_data(n_persons=20, n_households=5, time_period=2024):
         "household_id": {time_period: np.arange(1, n_households + 1)},
         "tax_unit_id": {time_period: np.arange(1, n_households + 1)},
         "spm_unit_id": {time_period: np.arange(1, n_households + 1)},
+        "family_id": {time_period: np.arange(1, n_households + 1)},
         "person_household_id": {time_period: household_ids_person},
         "person_tax_unit_id": {time_period: tax_unit_ids_person},
         "person_spm_unit_id": {time_period: spm_unit_ids_person},
+        "person_family_id": {time_period: household_ids_person},
         "age": {time_period: ages.astype(np.float32)},
         "is_male": {time_period: is_male.astype(np.float32)},
         "household_weight": {time_period: np.ones(n_households) * 1000},
@@ -219,6 +221,31 @@ class TestPufCloneDataset:
         }
         for var in expected:
             assert var in OVERRIDDEN_IMPUTED_VARIABLES
+
+    def test_clone_origin_flags_are_added(self):
+        data = _make_mock_data(n_persons=20, n_households=5)
+        state_fips = np.array([1, 2, 36, 6, 48])
+
+        result = puf_clone_dataset(
+            data=data,
+            state_fips=state_fips,
+            time_period=2024,
+            skip_qrf=True,
+        )
+
+        expected_lengths = {
+            "person_is_puf_clone": 20,
+            "tax_unit_is_puf_clone": 5,
+            "spm_unit_is_puf_clone": 5,
+            "family_is_puf_clone": 5,
+            "household_is_puf_clone": 5,
+        }
+
+        for variable_name, half_length in expected_lengths.items():
+            values = result[variable_name][2024]
+            assert values.dtype == np.int8
+            np.testing.assert_array_equal(values[:half_length], 0)
+            np.testing.assert_array_equal(values[half_length:], 1)
 
 
 class TestStratifiedSubsample:

--- a/tests/unit/test_dataset_validation.py
+++ b/tests/unit/test_dataset_validation.py
@@ -248,3 +248,59 @@ def test_validate_dataset_contract_rejects_entity_length_mismatch(
             microsimulation_cls=_FakeMicrosimulation,
             dataset_loader=lambda path: path,
         )
+
+
+def test_validate_dataset_contract_accepts_prefixed_auxiliary_entity(
+    tmp_path, monkeypatch
+):
+    file_path = tmp_path / "prefixed_aux.h5"
+    _write_test_h5(
+        file_path,
+        {
+            "person_id": np.array([101], dtype=np.int32),
+            "household_id": np.array([201], dtype=np.int32),
+            "household_is_puf_clone": np.array([1], dtype=np.int8),
+        },
+    )
+    monkeypatch.setattr(
+        "policyengine_us_data.utils.dataset_validation.assert_locked_policyengine_us_version",
+        lambda: PolicyEngineUSBuildInfo(version="1.587.0"),
+    )
+
+    summary = validate_dataset_contract(
+        file_path,
+        tax_benefit_system=_fake_tax_benefit_system(),
+        microsimulation_cls=_FakeMicrosimulation,
+        dataset_loader=lambda path: path,
+    )
+
+    assert summary.variable_count == 3
+
+
+def test_validate_dataset_contract_rejects_prefixed_auxiliary_length_mismatch(
+    tmp_path, monkeypatch
+):
+    file_path = tmp_path / "prefixed_aux_bad.h5"
+    _write_test_h5(
+        file_path,
+        {
+            "person_id": np.array([101], dtype=np.int32),
+            "household_id": np.array([201], dtype=np.int32),
+            "household_is_puf_clone": np.array([1, 0], dtype=np.int8),
+        },
+    )
+    monkeypatch.setattr(
+        "policyengine_us_data.utils.dataset_validation.assert_locked_policyengine_us_version",
+        lambda: PolicyEngineUSBuildInfo(version="1.587.0"),
+    )
+
+    with pytest.raises(
+        DatasetContractError,
+        match="expected household length 1, found 2",
+    ):
+        validate_dataset_contract(
+            file_path,
+            tax_benefit_system=_fake_tax_benefit_system(),
+            microsimulation_cls=_FakeMicrosimulation,
+            dataset_loader=lambda path: path,
+        )

--- a/tests/unit/test_enhanced_cps_clone_diagnostics.py
+++ b/tests/unit/test_enhanced_cps_clone_diagnostics.py
@@ -22,15 +22,15 @@ def test_compute_clone_diagnostics_summary():
     )
 
     assert diagnostics["clone_household_weight_share_pct"] == pytest.approx(10.0)
-    assert diagnostics["clone_poor_modeled_only_person_weight_share_pct"] == pytest.approx(
-        30.0
-    )
-    assert diagnostics["poor_modeled_only_within_clone_person_weight_share_pct"] == pytest.approx(
-        50.0
-    )
-    assert diagnostics["clone_childcare_exceeds_pre_subsidy_share_pct"] == pytest.approx(
-        37.5
-    )
+    assert diagnostics[
+        "clone_poor_modeled_only_person_weight_share_pct"
+    ] == pytest.approx(30.0)
+    assert diagnostics[
+        "poor_modeled_only_within_clone_person_weight_share_pct"
+    ] == pytest.approx(50.0)
+    assert diagnostics[
+        "clone_childcare_exceeds_pre_subsidy_share_pct"
+    ] == pytest.approx(37.5)
     assert diagnostics["clone_childcare_above_5000_share_pct"] == pytest.approx(100.0)
     assert diagnostics["clone_taxes_exceed_market_income_share_pct"] == pytest.approx(
         37.5

--- a/tests/unit/test_enhanced_cps_clone_diagnostics.py
+++ b/tests/unit/test_enhanced_cps_clone_diagnostics.py
@@ -1,7 +1,12 @@
+from pathlib import Path
+
 import pytest
 
 from policyengine_us_data.datasets.cps.enhanced_cps import (
+    build_clone_diagnostics_payload,
     compute_clone_diagnostics_summary,
+    clone_diagnostics_path,
+    refresh_clone_diagnostics_report,
 )
 
 
@@ -35,3 +40,46 @@ def test_compute_clone_diagnostics_summary():
     assert diagnostics["clone_taxes_exceed_market_income_share_pct"] == pytest.approx(
         37.5
     )
+
+
+def test_build_clone_diagnostics_payload_single_period():
+    payload = build_clone_diagnostics_payload(
+        {2024: {"clone_person_weight_share_pct": 12.5}}
+    )
+
+    assert payload == {
+        "period": 2024,
+        "clone_person_weight_share_pct": 12.5,
+    }
+
+
+def test_build_clone_diagnostics_payload_multiple_periods():
+    payload = build_clone_diagnostics_payload(
+        {
+            2026: {"clone_person_weight_share_pct": 20.0},
+            2024: {"clone_person_weight_share_pct": 10.0},
+        }
+    )
+
+    assert payload == {
+        "periods": {
+            "2024": {"clone_person_weight_share_pct": 10.0},
+            "2026": {"clone_person_weight_share_pct": 20.0},
+        }
+    }
+
+
+def test_refresh_clone_diagnostics_report_removes_stale_sidecar_on_failure(tmp_path):
+    file_path = tmp_path / "enhanced_cps_2024.h5"
+    file_path.write_text("placeholder")
+    stale_path = clone_diagnostics_path(file_path)
+    stale_path.write_text("stale")
+
+    def _raise():
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        refresh_clone_diagnostics_report(file_path, _raise)
+
+    assert stale_path == Path(file_path).with_suffix(".clone_diagnostics.json")
+    assert not stale_path.exists()

--- a/tests/unit/test_enhanced_cps_clone_diagnostics.py
+++ b/tests/unit/test_enhanced_cps_clone_diagnostics.py
@@ -7,6 +7,7 @@ from policyengine_us_data.datasets.cps.enhanced_cps import (
     compute_clone_diagnostics_summary,
     clone_diagnostics_path,
     refresh_clone_diagnostics_report,
+    save_clone_diagnostics_report,
 )
 
 
@@ -83,3 +84,55 @@ def test_refresh_clone_diagnostics_report_removes_stale_sidecar_on_failure(tmp_p
 
     assert stale_path == Path(file_path).with_suffix(".clone_diagnostics.json")
     assert not stale_path.exists()
+
+
+def test_save_clone_diagnostics_report_removes_stale_sidecar_on_failure(
+    tmp_path, monkeypatch
+):
+    class DummyDataset:
+        file_path = tmp_path / "enhanced_cps_2024.h5"
+
+    DummyDataset.file_path.write_text("placeholder")
+    stale_path = clone_diagnostics_path(DummyDataset.file_path)
+    stale_path.write_text("stale")
+
+    monkeypatch.setattr(
+        "policyengine_us_data.datasets.cps.enhanced_cps.build_clone_diagnostics_for_saved_dataset",
+        lambda dataset_cls, period: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        save_clone_diagnostics_report(
+            DummyDataset,
+            start_year=2024,
+            end_year=2024,
+        )
+
+    assert not stale_path.exists()
+
+
+def test_save_clone_diagnostics_report_writes_fresh_payload(tmp_path, monkeypatch):
+    class DummyDataset:
+        file_path = tmp_path / "enhanced_cps_2024.h5"
+
+    DummyDataset.file_path.write_text("placeholder")
+
+    monkeypatch.setattr(
+        "policyengine_us_data.datasets.cps.enhanced_cps.build_clone_diagnostics_for_saved_dataset",
+        lambda dataset_cls, period: {"clone_person_weight_share_pct": float(period)},
+    )
+
+    output_path, payload = save_clone_diagnostics_report(
+        DummyDataset,
+        start_year=2024,
+        end_year=2025,
+    )
+
+    assert output_path == clone_diagnostics_path(DummyDataset.file_path)
+    assert payload == {
+        "periods": {
+            "2024": {"clone_person_weight_share_pct": 2024.0},
+            "2025": {"clone_person_weight_share_pct": 2025.0},
+        }
+    }
+    assert output_path.exists()

--- a/tests/unit/test_enhanced_cps_clone_diagnostics.py
+++ b/tests/unit/test_enhanced_cps_clone_diagnostics.py
@@ -89,9 +89,7 @@ def test_build_clone_diagnostics_for_simulation_maps_household_weights(
     )
 
     assert diagnostics["clone_household_weight_share_pct"] == pytest.approx(10.0)
-    assert diagnostics["clone_person_weight_share_pct"] == pytest.approx(
-        200.0 / 11.0
-    )
+    assert diagnostics["clone_person_weight_share_pct"] == pytest.approx(200.0 / 11.0)
     assert diagnostics[
         "clone_poor_modeled_only_person_weight_share_pct"
     ] == pytest.approx(100.0 / 11.0)

--- a/tests/unit/test_enhanced_cps_clone_diagnostics.py
+++ b/tests/unit/test_enhanced_cps_clone_diagnostics.py
@@ -1,8 +1,10 @@
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 from policyengine_us_data.datasets.cps.enhanced_cps import (
+    build_clone_diagnostics_for_simulation,
     build_clone_diagnostics_payload,
     compute_clone_diagnostics_summary,
     clone_diagnostics_path,
@@ -40,6 +42,68 @@ def test_compute_clone_diagnostics_summary():
     assert diagnostics["clone_childcare_above_5000_share_pct"] == pytest.approx(100.0)
     assert diagnostics["clone_taxes_exceed_market_income_share_pct"] == pytest.approx(
         37.5
+    )
+
+
+def test_build_clone_diagnostics_for_simulation_maps_household_weights(
+    monkeypatch,
+):
+    class FakeResult:
+        def __init__(self, values):
+            self.values = np.asarray(values)
+
+    class FakeSim:
+        def calculate(self, variable, period=None, map_to=None):
+            lookup = {
+                ("spm_unit_net_income_reported", "person"): [1000.0, 300.0, 100.0],
+                ("spm_unit_spm_threshold", "person"): [500.0, 200.0, 200.0],
+                ("household_weight", None): [9.0, 1.0],
+                ("household_weight", "person"): [9.0, 1.0, 1.0],
+                ("household_weight", "spm_unit"): [9.0, 1.0],
+                # Trap values: diagnostics should not read these stale inputs.
+                ("person_weight", None): [9.0, 0.0, 0.0],
+                ("spm_unit_weight", None): [9.0, 0.0],
+                ("person_in_poverty", None): [False, True, True],
+                ("spm_unit_capped_work_childcare_expenses", None): [0.0, 6000.0],
+                ("spm_unit_pre_subsidy_childcare_expenses", None): [0.0, 5000.0],
+                ("spm_unit_taxes", None): [100.0, 9000.0],
+                ("spm_unit_market_income", None): [1000.0, 8000.0],
+            }
+            return FakeResult(lookup[(variable, map_to)])
+
+    saved_arrays = {
+        "household_is_puf_clone": np.array([False, True]),
+        "person_is_puf_clone": np.array([False, True, True]),
+        "spm_unit_is_puf_clone": np.array([False, True]),
+    }
+
+    monkeypatch.setattr(
+        "policyengine_us_data.datasets.cps.enhanced_cps._load_saved_period_array",
+        lambda dataset_path, variable_name, period: saved_arrays[variable_name],
+    )
+
+    diagnostics = build_clone_diagnostics_for_simulation(
+        FakeSim(),
+        dataset_path=Path("enhanced_cps_2024.h5"),
+        period=2024,
+    )
+
+    assert diagnostics["clone_household_weight_share_pct"] == pytest.approx(10.0)
+    assert diagnostics["clone_person_weight_share_pct"] == pytest.approx(
+        200.0 / 11.0
+    )
+    assert diagnostics[
+        "clone_poor_modeled_only_person_weight_share_pct"
+    ] == pytest.approx(100.0 / 11.0)
+    assert diagnostics[
+        "poor_modeled_only_within_clone_person_weight_share_pct"
+    ] == pytest.approx(50.0)
+    assert diagnostics[
+        "clone_childcare_exceeds_pre_subsidy_share_pct"
+    ] == pytest.approx(100.0)
+    assert diagnostics["clone_childcare_above_5000_share_pct"] == pytest.approx(100.0)
+    assert diagnostics["clone_taxes_exceed_market_income_share_pct"] == pytest.approx(
+        100.0
     )
 
 

--- a/tests/unit/test_enhanced_cps_clone_diagnostics.py
+++ b/tests/unit/test_enhanced_cps_clone_diagnostics.py
@@ -1,0 +1,37 @@
+import pytest
+
+from policyengine_us_data.datasets.cps.enhanced_cps import (
+    compute_clone_diagnostics_summary,
+)
+
+
+def test_compute_clone_diagnostics_summary():
+    diagnostics = compute_clone_diagnostics_summary(
+        household_is_puf_clone=[False, True],
+        household_weight=[9.0, 1.0],
+        person_is_puf_clone=[False, True, True],
+        person_weight=[4.0, 3.0, 3.0],
+        person_in_poverty=[False, True, True],
+        person_reported_in_poverty=[False, False, True],
+        spm_unit_is_puf_clone=[False, True, True],
+        spm_unit_weight=[2.0, 3.0, 5.0],
+        spm_unit_capped_work_childcare_expenses=[0.0, 6000.0, 7000.0],
+        spm_unit_pre_subsidy_childcare_expenses=[0.0, 5000.0, 8000.0],
+        spm_unit_taxes=[100.0, 9000.0, 200.0],
+        spm_unit_market_income=[1000.0, 8000.0, 1000.0],
+    )
+
+    assert diagnostics["clone_household_weight_share_pct"] == pytest.approx(10.0)
+    assert diagnostics["clone_poor_modeled_only_person_weight_share_pct"] == pytest.approx(
+        30.0
+    )
+    assert diagnostics["poor_modeled_only_within_clone_person_weight_share_pct"] == pytest.approx(
+        50.0
+    )
+    assert diagnostics["clone_childcare_exceeds_pre_subsidy_share_pct"] == pytest.approx(
+        37.5
+    )
+    assert diagnostics["clone_childcare_above_5000_share_pct"] == pytest.approx(100.0)
+    assert diagnostics["clone_taxes_exceed_market_income_share_pct"] == pytest.approx(
+        37.5
+    )

--- a/tests/unit/test_small_enhanced_cps.py
+++ b/tests/unit/test_small_enhanced_cps.py
@@ -1,5 +1,6 @@
 import h5py
 import numpy as np
+import pandas as pd
 import pytest
 
 from policyengine_us_data.datasets.cps.small_enhanced_cps import (
@@ -87,3 +88,43 @@ def test_attach_clone_origin_flags_rejects_missing_sampled_id(tmp_path):
 
     with pytest.raises(KeyError, match="person_is_puf_clone"):
         _attach_clone_origin_flags(sampled_data, source_path)
+
+
+def test_attach_clone_origin_flags_accepts_period_keys(tmp_path):
+    source_path = tmp_path / "enhanced_cps_2024.h5"
+    with h5py.File(source_path, "w") as h5_file:
+        _write_period_group(h5_file, "person_id", {2024: np.array([11, 12])})
+        _write_period_group(
+            h5_file,
+            "person_is_puf_clone",
+            {2024: np.array([0, 1], dtype=np.int8)},
+        )
+        for entity_name, id_base in [
+            ("tax_unit", 20),
+            ("spm_unit", 30),
+            ("family", 40),
+            ("household", 50),
+        ]:
+            _write_period_group(
+                h5_file,
+                f"{entity_name}_id",
+                {2024: np.array([id_base], dtype=np.int32)},
+            )
+            _write_period_group(
+                h5_file,
+                f"{entity_name}_is_puf_clone",
+                {2024: np.array([0], dtype=np.int8)},
+            )
+
+    period = pd.Period("2024", freq="Y")
+    sampled_data = {
+        "person_id": {period: np.array([12, 11], dtype=np.int32)},
+        "tax_unit_id": {period: np.array([20], dtype=np.int32)},
+        "spm_unit_id": {period: np.array([30], dtype=np.int32)},
+        "family_id": {period: np.array([40], dtype=np.int32)},
+        "household_id": {period: np.array([50], dtype=np.int32)},
+    }
+
+    _attach_clone_origin_flags(sampled_data, source_path)
+
+    assert sampled_data["person_is_puf_clone"][period].tolist() == [1, 0]

--- a/tests/unit/test_small_enhanced_cps.py
+++ b/tests/unit/test_small_enhanced_cps.py
@@ -1,0 +1,89 @@
+import h5py
+import numpy as np
+import pytest
+
+from policyengine_us_data.datasets.cps.small_enhanced_cps import (
+    _attach_clone_origin_flags,
+)
+
+
+def _write_period_group(
+    h5_file, variable_name: str, values_by_period: dict[int, np.ndarray]
+):
+    group = h5_file.create_group(variable_name)
+    for period, values in values_by_period.items():
+        group.create_dataset(str(period), data=values)
+
+
+def test_attach_clone_origin_flags_maps_sampled_entity_ids(tmp_path):
+    source_path = tmp_path / "enhanced_cps_2024.h5"
+    with h5py.File(source_path, "w") as h5_file:
+        _write_period_group(h5_file, "person_id", {2024: np.array([11, 12, 13])})
+        _write_period_group(
+            h5_file, "person_is_puf_clone", {2024: np.array([0, 1, 0], dtype=np.int8)}
+        )
+        _write_period_group(h5_file, "tax_unit_id", {2024: np.array([21, 22])})
+        _write_period_group(
+            h5_file, "tax_unit_is_puf_clone", {2024: np.array([1, 0], dtype=np.int8)}
+        )
+        _write_period_group(h5_file, "spm_unit_id", {2024: np.array([31, 32])})
+        _write_period_group(
+            h5_file, "spm_unit_is_puf_clone", {2024: np.array([0, 1], dtype=np.int8)}
+        )
+        _write_period_group(h5_file, "family_id", {2024: np.array([41, 42])})
+        _write_period_group(
+            h5_file, "family_is_puf_clone", {2024: np.array([1, 1], dtype=np.int8)}
+        )
+        _write_period_group(h5_file, "household_id", {2024: np.array([51, 52])})
+        _write_period_group(
+            h5_file, "household_is_puf_clone", {2024: np.array([0, 1], dtype=np.int8)}
+        )
+
+    sampled_data = {
+        "person_id": {2024: np.array([12, 11], dtype=np.int32)},
+        "tax_unit_id": {2024: np.array([22, 21], dtype=np.int32)},
+        "spm_unit_id": {2024: np.array([32, 31], dtype=np.int32)},
+        "family_id": {2024: np.array([41, 42], dtype=np.int32)},
+        "household_id": {2024: np.array([52, 51], dtype=np.int32)},
+    }
+
+    _attach_clone_origin_flags(sampled_data, source_path)
+
+    assert sampled_data["person_is_puf_clone"][2024].tolist() == [1, 0]
+    assert sampled_data["tax_unit_is_puf_clone"][2024].tolist() == [0, 1]
+    assert sampled_data["spm_unit_is_puf_clone"][2024].tolist() == [1, 0]
+    assert sampled_data["family_is_puf_clone"][2024].tolist() == [1, 1]
+    assert sampled_data["household_is_puf_clone"][2024].tolist() == [1, 0]
+
+
+def test_attach_clone_origin_flags_rejects_missing_sampled_id(tmp_path):
+    source_path = tmp_path / "enhanced_cps_2024.h5"
+    with h5py.File(source_path, "w") as h5_file:
+        for entity_name, id_base in [
+            ("person", 10),
+            ("tax_unit", 20),
+            ("spm_unit", 30),
+            ("family", 40),
+            ("household", 50),
+        ]:
+            _write_period_group(
+                h5_file,
+                f"{entity_name}_id",
+                {2024: np.array([id_base], dtype=np.int32)},
+            )
+            _write_period_group(
+                h5_file,
+                f"{entity_name}_is_puf_clone",
+                {2024: np.array([0], dtype=np.int8)},
+            )
+
+    sampled_data = {
+        "person_id": {2024: np.array([999], dtype=np.int32)},
+        "tax_unit_id": {2024: np.array([20], dtype=np.int32)},
+        "spm_unit_id": {2024: np.array([30], dtype=np.int32)},
+        "family_id": {2024: np.array([40], dtype=np.int32)},
+        "household_id": {2024: np.array([50], dtype=np.int32)},
+    }
+
+    with pytest.raises(KeyError, match="person_is_puf_clone"):
+        _attach_clone_origin_flags(sampled_data, source_path)

--- a/tests/unit/test_upload_completed_datasets.py
+++ b/tests/unit/test_upload_completed_datasets.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -16,6 +17,18 @@ from policyengine_us_data.storage.upload_completed_datasets import (
 import policyengine_us_data.utils.dataset_validation as _dv_mod
 from policyengine_us_data.utils.dataset_validation import validate_dataset_contract
 from policyengine_us_data.utils.policyengine import PolicyEngineUSBuildInfo
+
+
+VALID_CLONE_DIAGNOSTICS = {
+    "period": 2024,
+    "clone_household_weight_share_pct": 5.0,
+    "clone_person_weight_share_pct": 5.0,
+    "clone_poor_modeled_only_person_weight_share_pct": 1.0,
+    "poor_modeled_only_within_clone_person_weight_share_pct": 20.0,
+    "clone_childcare_exceeds_pre_subsidy_share_pct": 0.0,
+    "clone_childcare_above_5000_share_pct": 0.0,
+    "clone_taxes_exceed_market_income_share_pct": 0.0,
+}
 
 
 class _FakeArrayResult:
@@ -165,7 +178,7 @@ def _prepare_release_files(tmp_path, monkeypatch):
     enhanced_path = tmp_path / "enhanced_cps_2024.h5"
     enhanced_path.write_bytes(b"enhanced")
     diagnostics_path = enhanced_path.with_suffix(".clone_diagnostics.json")
-    diagnostics_path.write_bytes(b"diagnostics")
+    diagnostics_path.write_text(json.dumps(VALID_CLONE_DIAGNOSTICS))
     small_path = tmp_path / "small_enhanced_cps_2024.h5"
     small_path.write_bytes(b"small")
     calibration_dir = tmp_path / "calibration"
@@ -417,7 +430,9 @@ def test_upload_datasets_promote_only_uses_staged_artifacts(tmp_path, monkeypatc
 
     upload_datasets(promote_only=True, run_id="run-123", version="1.73.0")
 
-    assert validate_calls == []
+    assert [Path(path).name for path in validate_calls] == [
+        Path(repo_path).name for repo_path in expected_repo_paths
+    ]
     assert promote_calls == [
         (
             "hf",
@@ -510,6 +525,63 @@ def test_upload_datasets_requires_clone_diagnostics_sidecar(tmp_path, monkeypatc
 
     with pytest.raises(FileNotFoundError, match="clone_diagnostics"):
         upload_datasets(require_enhanced_cps=True)
+
+
+def test_validate_dataset_accepts_clone_diagnostics_sidecar(tmp_path):
+    file_path = tmp_path / "enhanced_cps_2024.clone_diagnostics.json"
+    file_path.write_text(json.dumps(VALID_CLONE_DIAGNOSTICS))
+
+    validate_dataset(file_path)
+
+
+def test_validate_dataset_accepts_multiperiod_clone_diagnostics(tmp_path):
+    file_path = tmp_path / "enhanced_cps_2024.clone_diagnostics.json"
+    file_path.write_text(
+        json.dumps(
+            {
+                "periods": {
+                    "2024": {
+                        key: value
+                        for key, value in VALID_CLONE_DIAGNOSTICS.items()
+                        if key != "period"
+                    }
+                }
+            }
+        )
+    )
+
+    validate_dataset(file_path)
+
+
+def test_validate_dataset_rejects_malformed_clone_diagnostics(tmp_path):
+    file_path = tmp_path / "enhanced_cps_2024.clone_diagnostics.json"
+    file_path.write_text("not-json")
+
+    with pytest.raises(DatasetValidationError, match="clone diagnostics JSON"):
+        validate_dataset(file_path)
+
+
+def test_validate_dataset_rejects_incomplete_clone_diagnostics(tmp_path):
+    file_path = tmp_path / "enhanced_cps_2024.clone_diagnostics.json"
+    payload = dict(VALID_CLONE_DIAGNOSTICS)
+    del payload["clone_household_weight_share_pct"]
+    file_path.write_text(json.dumps(payload))
+
+    with pytest.raises(
+        DatasetValidationError,
+        match="Missing clone diagnostics metric",
+    ):
+        validate_dataset(file_path)
+
+
+def test_validate_dataset_rejects_out_of_range_clone_diagnostics(tmp_path):
+    file_path = tmp_path / "enhanced_cps_2024.clone_diagnostics.json"
+    payload = dict(VALID_CLONE_DIAGNOSTICS)
+    payload["clone_household_weight_share_pct"] = 101.0
+    file_path.write_text(json.dumps(payload))
+
+    with pytest.raises(DatasetValidationError, match="between 0 and 100"):
+        validate_dataset(file_path)
 
 
 def test_validate_built_datasets_requires_clone_diagnostics_sidecar(

--- a/tests/unit/test_upload_completed_datasets.py
+++ b/tests/unit/test_upload_completed_datasets.py
@@ -163,6 +163,8 @@ def _prepare_release_files(tmp_path, monkeypatch):
     cps_path.write_bytes(b"cps")
     enhanced_path = tmp_path / "enhanced_cps_2024.h5"
     enhanced_path.write_bytes(b"enhanced")
+    diagnostics_path = enhanced_path.with_suffix(".clone_diagnostics.json")
+    diagnostics_path.write_bytes(b"diagnostics")
     small_path = tmp_path / "small_enhanced_cps_2024.h5"
     small_path.write_bytes(b"small")
     calibration_dir = tmp_path / "calibration"
@@ -177,6 +179,7 @@ def _prepare_release_files(tmp_path, monkeypatch):
     return {
         "cps": cps_path,
         "enhanced": enhanced_path,
+        "diagnostics": diagnostics_path,
         "small": small_path,
         "db": db_path,
     }
@@ -257,12 +260,14 @@ def test_upload_datasets_stages_then_promotes_release(tmp_path, monkeypatch):
         "cps_2024.h5",
         "policy_data.db",
         "enhanced_cps_2024.h5",
+        "enhanced_cps_2024.clone_diagnostics.json",
         "small_enhanced_cps_2024.h5",
     ]
     assert validated == [
         "cps_2024.h5",
         "policy_data.db",
         "enhanced_cps_2024.h5",
+        "enhanced_cps_2024.clone_diagnostics.json",
         "small_enhanced_cps_2024.h5",
     ]
     assert [repo_path for _, repo_path in stage_calls[0][0]] == expected_repo_paths
@@ -345,6 +350,7 @@ def test_upload_datasets_promote_only_uses_staged_artifacts(tmp_path, monkeypatc
         "cps_2024.h5",
         "policy_data.db",
         "enhanced_cps_2024.h5",
+        "enhanced_cps_2024.clone_diagnostics.json",
         "small_enhanced_cps_2024.h5",
     ]
 
@@ -494,3 +500,12 @@ def test_promote_datasets_preflight_failure_stops_before_production_writes(
         )
 
     assert promote_calls == []
+
+
+def test_upload_datasets_requires_clone_diagnostics_sidecar(tmp_path, monkeypatch):
+    files = _prepare_release_files(tmp_path, monkeypatch)
+    files["diagnostics"].unlink()
+    monkeypatch.setattr(upload_module, "validate_dataset", lambda file_path: None)
+
+    with pytest.raises(FileNotFoundError, match="clone_diagnostics"):
+        upload_datasets(require_enhanced_cps=True)

--- a/tests/unit/test_upload_completed_datasets.py
+++ b/tests/unit/test_upload_completed_datasets.py
@@ -11,6 +11,7 @@ from policyengine_us_data.storage.upload_completed_datasets import (
     DatasetValidationError,
     upload_datasets,
     validate_dataset,
+    validate_built_datasets,
 )
 import policyengine_us_data.utils.dataset_validation as _dv_mod
 from policyengine_us_data.utils.dataset_validation import validate_dataset_contract
@@ -509,3 +510,32 @@ def test_upload_datasets_requires_clone_diagnostics_sidecar(tmp_path, monkeypatc
 
     with pytest.raises(FileNotFoundError, match="clone_diagnostics"):
         upload_datasets(require_enhanced_cps=True)
+
+
+def test_validate_built_datasets_requires_clone_diagnostics_sidecar(
+    tmp_path, monkeypatch
+):
+    storage_folder = tmp_path / "storage"
+    cps_path = storage_folder / "cps_2024.h5"
+    enhanced_path = storage_folder / "enhanced_cps_2024.h5"
+    small_path = storage_folder / "small_enhanced_cps_2024.h5"
+
+    storage_folder.mkdir(parents=True)
+    for path in [cps_path, enhanced_path, small_path]:
+        path.write_text("placeholder")
+
+    monkeypatch.setattr(
+        upload_module,
+        "CPS_2024",
+        SimpleNamespace(file_path=cps_path),
+    )
+    monkeypatch.setattr(
+        upload_module,
+        "EnhancedCPS_2024",
+        SimpleNamespace(file_path=enhanced_path),
+    )
+    monkeypatch.setattr(upload_module, "STORAGE_FOLDER", storage_folder)
+    monkeypatch.setattr(upload_module, "validate_dataset", lambda file_path: None)
+
+    with pytest.raises(FileNotFoundError, match="clone_diagnostics"):
+        validate_built_datasets(require_enhanced_cps=True)


### PR DESCRIPTION
Revives and rebases #703 onto current main.\n\nThis keeps the diagnostics work separate from the SPM threshold and childcare-formula branches:\n- adds explicit PUF-clone origin flags across entities\n- writes ECPS clone diagnostics sidecar JSON\n- preserves clone flags in small ECPS artifacts\n- lets dataset validation handle entity-prefixed auxiliary arrays\n- includes the diagnostics sidecar in upload, promote, and validate flows\n\nLocal checks:\n- .venv/bin/python -m pytest -q tests/unit/calibration/test_calibration_puf_impute.py tests/unit/test_dataset_validation.py tests/unit/test_enhanced_cps_clone_diagnostics.py tests/unit/test_small_enhanced_cps.py tests/unit/test_upload_completed_datasets.py\n- .venv/bin/ruff check policyengine_us_data/calibration/puf_impute.py policyengine_us_data/datasets/cps/enhanced_cps.py policyengine_us_data/datasets/cps/small_enhanced_cps.py policyengine_us_data/storage/upload_completed_datasets.py policyengine_us_data/utils/dataset_validation.py tests/unit/calibration/test_calibration_puf_impute.py tests/unit/test_dataset_validation.py tests/unit/test_enhanced_cps_clone_diagnostics.py tests/unit/test_small_enhanced_cps.py tests/unit/test_upload_completed_datasets.py\n- .venv/bin/ruff format --check policyengine_us_data/calibration/puf_impute.py policyengine_us_data/datasets/cps/enhanced_cps.py policyengine_us_data/datasets/cps/small_enhanced_cps.py policyengine_us_data/storage/upload_completed_datasets.py policyengine_us_data/utils/dataset_validation.py tests/unit/calibration/test_calibration_puf_impute.py tests/unit/test_dataset_validation.py tests/unit/test_enhanced_cps_clone_diagnostics.py tests/unit/test_small_enhanced_cps.py tests/unit/test_upload_completed_datasets.py