### PR TITLE
Drop district SNAP household targets

### DIFF
--- a/changelog.d/912.removed.md
+++ b/changelog.d/912.removed.md
@@ -1,0 +1,1 @@
+Removed district SNAP household-count calibration targets sourced from ACS S2201.

--- a/policyengine_us_data/calibration/target_config.yaml
+++ b/policyengine_us_data/calibration/target_config.yaml
@@ -12,11 +12,6 @@ include:
   - variable: household_count
     geo_level: district
 
-  # === DISTRICT — SNAP household counts (ACS S2201) ===
-  - variable: household_count
-    geo_level: district
-    domain_variable: snap
-
   # === DISTRICT — dollar targets ===
   - variable: adjusted_gross_income
     geo_level: district

--- a/tests/unit/calibration/test_target_config.py
+++ b/tests/unit/calibration/test_target_config.py
@@ -378,6 +378,27 @@ class TestLoadTargetConfig:
             "domain_variable": "medicaid",
         } not in include_rules
 
+    def test_training_config_excludes_district_snap_household_count_targets(self):
+        config = load_target_config(
+            str(
+                Path(__file__).resolve().parents[3]
+                / "policyengine_us_data"
+                / "calibration"
+                / "target_config.yaml"
+            )
+        )
+
+        include_rules = config["include"]
+        assert {
+            "variable": "snap",
+            "geo_level": "state",
+        } in include_rules
+        assert {
+            "variable": "household_count",
+            "geo_level": "district",
+            "domain_variable": "snap",
+        } not in include_rules
+
     def test_training_config_includes_district_non_refundable_ctc_target(self):
         config = load_target_config(
             str(


### PR DESCRIPTION
## Summary
- remove the active district-level SNAP household-count target from training target_config.yaml
- keep the state SNAP admin dollar target active
- add a regression test so the ACS CD SNAP household rule is not reintroduced silently

## Rationale
The district SNAP household counts come from ACS S2201 survey responses, not public SNAP administrative data. They were also not scaled to state or national FNS administrative SNAP totals in the default calibration flow, so using them as hard CD targets can bake in ACS SNAP underreporting.

## Validation
- PYTHONPATH=. /Users/maxghenis/PolicyEngine/policyengine-us-data/.venv/bin/python -m pytest tests/unit/calibration/test_target_config.py -q
- /Users/maxghenis/PolicyEngine/policyengine-us-data/.venv/bin/python -m ruff check tests/unit/calibration/test_target_config.py
- load_target_config(policyengine_us_data/calibration/target_config.yaml) confirms the CD SNAP household rule is absent
- git diff --check