### PR TITLE
Implement H5 migration 4b source dataset seams

### DIFF
--- a/changelog.d/915.fixed.md
+++ b/changelog.d/915.fixed.md
@@ -1,0 +1,2 @@
+Add retry backoff for brittle public data downloads and handle NumPy string arrays
+when writing small enhanced CPS HDF5 outputs.

--- a/changelog.d/local-h5-source-dataset.added
+++ b/changelog.d/local-h5-source-dataset.added
@@ -1,0 +1,1 @@
+Added local H5 source dataset snapshot and entity graph contracts.

--- a/policyengine_us_data/build_outputs/__init__.py
+++ b/policyengine_us_data/build_outputs/__init__.py
@@ -3,5 +3,6 @@
 Modules in this package should land only when they become active runtime
 seams rather than speculative placeholders. The current early slices support
 H5 output request construction, exact calibration geography loading,
-fingerprinting, clone-weight shape contracts, and worker partitioning.
+fingerprinting, clone-weight shape contracts, worker partitioning, and source
+dataset snapshot contracts.
 """

--- a/policyengine_us_data/build_outputs/source_dataset.py
+++ b/policyengine_us_data/build_outputs/source_dataset.py
@@ -48,7 +48,9 @@ class _EntityMapsView:
     status="current",
     stability="moving",
     pathways=["local_h5"],
-    validation_commands=["uv run pytest tests/unit/build_outputs/test_source_dataset.py"],
+    validation_commands=[
+        "uv run pytest tests/unit/build_outputs/test_source_dataset.py"
+    ],
 )
 @dataclass(frozen=True)
 class EntityGraph:
@@ -367,7 +369,9 @@ def _calculation_values(calculation) -> np.ndarray:
     status="current",
     stability="moving",
     pathways=["local_h5"],
-    validation_commands=["uv run pytest tests/unit/build_outputs/test_source_dataset.py"],
+    validation_commands=[
+        "uv run pytest tests/unit/build_outputs/test_source_dataset.py"
+    ],
 )
 @dataclass
 class MicrosimulationVariableProvider:
@@ -452,7 +456,9 @@ class MicrosimulationVariableProvider:
     status="current",
     stability="moving",
     pathways=["local_h5"],
-    validation_commands=["uv run pytest tests/unit/build_outputs/test_source_dataset.py"],
+    validation_commands=[
+        "uv run pytest tests/unit/build_outputs/test_source_dataset.py"
+    ],
 )
 @dataclass
 class SourceDatasetSnapshot:

--- a/policyengine_us_data/build_outputs/source_dataset.py
+++ b/policyengine_us_data/build_outputs/source_dataset.py
@@ -72,10 +72,11 @@ class EntityGraph:
     person_household_ids: np.ndarray
     subentity_ids: Mapping[str, np.ndarray]
     person_subentity_ids: Mapping[str, np.ndarray]
-    household_to_person_indices: Mapping[int, tuple[int, ...]] | None = None
-    household_to_subentity_indices: (
-        Mapping[str, Mapping[int, tuple[int, ...]]] | None
-    ) = None
+    household_to_person_indices: Mapping[int, tuple[int, ...]] = field(init=False)
+    household_to_subentity_indices: Mapping[
+        str,
+        Mapping[int, tuple[int, ...]],
+    ] = field(init=False)
 
     def __post_init__(self) -> None:
         household_ids = _readonly_1d_array(self.household_ids, "household_ids")
@@ -447,13 +448,11 @@ class MicrosimulationVariableProvider:
     label="SourceDatasetSnapshot",
     node_type="library",
     description=("In-memory source H5 dataset contract for local H5 worker setup."),
-    source_file="policyengine_us_data/calibration/local_h5/source_dataset.py",
+    source_file="policyengine_us_data/build_outputs/source_dataset.py",
     status="current",
     stability="moving",
     pathways=["local_h5"],
-    validation_commands=[
-        "uv run pytest tests/unit/calibration/test_local_h5_source_dataset.py"
-    ],
+    validation_commands=["uv run pytest tests/unit/build_outputs/test_source_dataset.py"],
 )
 @dataclass
 class SourceDatasetSnapshot:
@@ -524,7 +523,7 @@ class SourceDatasetSnapshot:
     label="PolicyEngineDatasetReader",
     node_type="library",
     description=("PolicyEngine H5 dataset adapter for local H5 source snapshots."),
-    source_file="policyengine_us_data/calibration/local_h5/source_dataset.py",
+    source_file="policyengine_us_data/build_outputs/source_dataset.py",
     status="current",
     stability="moving",
     pathways=["local_h5"],

--- a/policyengine_us_data/build_outputs/source_dataset.py
+++ b/policyengine_us_data/build_outputs/source_dataset.py
@@ -8,6 +8,7 @@ workers may still reconstruct source state directly from raw dataset paths.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Mapping
 
 import numpy as np
@@ -15,10 +16,25 @@ from numpy.typing import ArrayLike
 
 from policyengine_us_data.pipeline_metadata import pipeline_node
 
-__all__ = ["EntityGraph", "MicrosimulationVariableProvider"]
+__all__ = [
+    "EntityGraph",
+    "MicrosimulationVariableProvider",
+    "SourceDatasetSnapshot",
+]
 
 
 DEFAULT_SUBENTITIES = ("tax_unit", "spm_unit", "family", "marital_unit")
+
+
+@dataclass(frozen=True)
+class _EntityMapsView:
+    time_period: int
+    household_ids: np.ndarray
+    person_hh_ids: np.ndarray
+    hh_to_persons: dict[int, list[int]]
+    hh_to_entity: dict[str, dict[int, list[int]]]
+    entity_id_arrays: dict[str, np.ndarray]
+    person_entity_id_arrays: dict[str, np.ndarray]
 
 
 @pipeline_node(
@@ -32,17 +48,6 @@ DEFAULT_SUBENTITIES = ("tax_unit", "spm_unit", "family", "marital_unit")
     pathways=["local_h5"],
     validation_commands=["uv run pytest tests/unit/build_outputs/test_source_dataset.py"],
 )
-@dataclass(frozen=True)
-class _EntityMapsView:
-    time_period: int
-    household_ids: np.ndarray
-    person_hh_ids: np.ndarray
-    hh_to_persons: dict[int, list[int]]
-    hh_to_entity: dict[str, dict[int, list[int]]]
-    entity_id_arrays: dict[str, np.ndarray]
-    person_entity_id_arrays: dict[str, np.ndarray]
-
-
 @dataclass(frozen=True)
 class EntityGraph:
     """Structural relationships between source dataset entities.
@@ -136,25 +141,33 @@ class EntityGraph:
             A validated `EntityGraph`.
         """
 
-        household_ids = simulation.calculate(
-            "household_id",
-            map_to="household",
-        ).values
-        person_household_ids = simulation.calculate(
-            "household_id",
-            map_to="person",
-        ).values
+        household_ids = _calculation_values(
+            simulation.calculate(
+                "household_id",
+                map_to="household",
+            )
+        )
+        person_household_ids = _calculation_values(
+            simulation.calculate(
+                "household_id",
+                map_to="person",
+            )
+        )
         subentity_ids = {}
         person_subentity_ids = {}
         for entity_key in subentities:
-            subentity_ids[entity_key] = simulation.calculate(
-                f"{entity_key}_id",
-                map_to=entity_key,
-            ).values
-            person_subentity_ids[entity_key] = simulation.calculate(
-                f"person_{entity_key}_id",
-                map_to="person",
-            ).values
+            subentity_ids[entity_key] = _calculation_values(
+                simulation.calculate(
+                    f"{entity_key}_id",
+                    map_to=entity_key,
+                )
+            )
+            person_subentity_ids[entity_key] = _calculation_values(
+                simulation.calculate(
+                    f"person_{entity_key}_id",
+                    map_to="person",
+                )
+            )
         return cls(
             household_ids=household_ids,
             person_household_ids=person_household_ids,
@@ -315,6 +328,16 @@ def _normalized_id(value) -> object:
     return value
 
 
+def _calculation_values(calculation) -> np.ndarray:
+    if hasattr(calculation, "__array__"):
+        return np.asarray(calculation)
+    if hasattr(calculation, "to_numpy"):
+        return calculation.to_numpy()
+    if hasattr(calculation, "values"):
+        return calculation.values
+    return np.asarray(calculation)
+
+
 @pipeline_node(
     id="local_h5_microsimulation_variable_provider",
     label="MicrosimulationVariableProvider",
@@ -398,3 +421,97 @@ class MicrosimulationVariableProvider:
         if holder is None:
             raise KeyError(f"Variable {variable!r} is not available")
         return holder
+
+
+@pipeline_node(
+    id="local_h5_source_dataset_snapshot",
+    label="SourceDatasetSnapshot",
+    node_type="library",
+    description=("In-memory source H5 dataset contract for local H5 worker setup."),
+    source_file="policyengine_us_data/calibration/local_h5/source_dataset.py",
+    status="current",
+    stability="moving",
+    pathways=["local_h5"],
+    validation_commands=[
+        "uv run pytest tests/unit/calibration/test_local_h5_source_dataset.py"
+    ],
+)
+@dataclass
+class SourceDatasetSnapshot:
+    """Explicit in-memory worker view of a source H5 dataset.
+
+    The snapshot groups source dataset structure and lazy variable access. It
+    does not serialize artifacts or change current worker execution paths.
+
+    Attributes:
+        dataset_path: Source H5 dataset path.
+        time_period: Default source calculation period.
+        entity_graph: Source entity relationship graph.
+        input_variables: Input variable names available from the source.
+        variable_provider: Lazy variable reader for the source simulation.
+    """
+
+    dataset_path: Path
+    time_period: int
+    entity_graph: EntityGraph
+    input_variables: frozenset[str]
+    variable_provider: MicrosimulationVariableProvider
+
+    def __post_init__(self) -> None:
+        self.dataset_path = Path(self.dataset_path)
+        self.time_period = int(self.time_period)
+        self.input_variables = frozenset(str(item) for item in self.input_variables)
+
+    @property
+    def household_ids(self) -> np.ndarray:
+        """Return source household IDs from the entity graph."""
+
+        return self.entity_graph.household_ids
+
+    @property
+    def n_households(self) -> int:
+        """Return the number of source households."""
+
+        return int(len(self.household_ids))
+
+    @classmethod
+    def from_dataset_path(cls, dataset_path: Path) -> "SourceDatasetSnapshot":
+        """Build a snapshot by opening a source H5 dataset path.
+
+        Args:
+            dataset_path: Source H5 dataset path.
+
+        Returns:
+            A `SourceDatasetSnapshot` backed by a microsimulation.
+        """
+
+        from policyengine_us import Microsimulation
+
+        path = Path(dataset_path)
+        simulation = Microsimulation(dataset=str(path))
+        return cls.from_simulation(path, simulation)
+
+    @classmethod
+    def from_simulation(
+        cls,
+        dataset_path: Path,
+        simulation,
+    ) -> "SourceDatasetSnapshot":
+        """Build a snapshot from an existing source simulation.
+
+        Args:
+            dataset_path: Source H5 dataset path.
+            simulation: Source `Microsimulation` or compatible test double.
+
+        Returns:
+            A `SourceDatasetSnapshot` using the provided simulation.
+        """
+
+        provider = MicrosimulationVariableProvider(simulation)
+        return cls(
+            dataset_path=Path(dataset_path),
+            time_period=int(simulation.default_calculation_period),
+            entity_graph=EntityGraph.from_simulation(simulation),
+            input_variables=provider.input_variables,
+            variable_provider=provider,
+        )

--- a/policyengine_us_data/build_outputs/source_dataset.py
+++ b/policyengine_us_data/build_outputs/source_dataset.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any, Mapping
 
 import numpy as np
@@ -19,6 +20,7 @@ from policyengine_us_data.pipeline_metadata import pipeline_node
 __all__ = [
     "EntityGraph",
     "MicrosimulationVariableProvider",
+    "PolicyEngineDatasetReader",
     "SourceDatasetSnapshot",
 ]
 
@@ -116,12 +118,12 @@ class EntityGraph:
         object.__setattr__(
             self,
             "household_to_person_indices",
-            household_to_person_indices,
+            _readonly_index_mapping(household_to_person_indices),
         )
         object.__setattr__(
             self,
             "household_to_subentity_indices",
-            household_to_subentity_indices,
+            _readonly_nested_index_mapping(household_to_subentity_indices),
         )
 
     @classmethod
@@ -240,13 +242,30 @@ def _readonly_1d_array(values: ArrayLike, name: str) -> np.ndarray:
 def _readonly_array_mapping(
     values: Mapping[str, ArrayLike],
     name: str,
-) -> dict[str, np.ndarray]:
+) -> Mapping[str, np.ndarray]:
     normalized: dict[str, np.ndarray] = {}
     for key, value in values.items():
         if not isinstance(key, str) or not key:
             raise ValueError(f"{name} keys must be non-empty strings")
         normalized[key] = _readonly_1d_array(value, f"{name}[{key!r}]")
-    return normalized
+    return MappingProxyType(normalized)
+
+
+def _readonly_index_mapping(
+    values: Mapping[int, tuple[int, ...]],
+) -> Mapping[int, tuple[int, ...]]:
+    return MappingProxyType(dict(values))
+
+
+def _readonly_nested_index_mapping(
+    values: Mapping[str, Mapping[int, tuple[int, ...]]],
+) -> Mapping[str, Mapping[int, tuple[int, ...]]]:
+    return MappingProxyType(
+        {
+            entity_key: MappingProxyType(dict(membership))
+            for entity_key, membership in values.items()
+        }
+    )
 
 
 def _build_household_to_person_indices(
@@ -475,23 +494,6 @@ class SourceDatasetSnapshot:
         return int(len(self.household_ids))
 
     @classmethod
-    def from_dataset_path(cls, dataset_path: Path) -> "SourceDatasetSnapshot":
-        """Build a snapshot by opening a source H5 dataset path.
-
-        Args:
-            dataset_path: Source H5 dataset path.
-
-        Returns:
-            A `SourceDatasetSnapshot` backed by a microsimulation.
-        """
-
-        from policyengine_us import Microsimulation
-
-        path = Path(dataset_path)
-        simulation = Microsimulation(dataset=str(path))
-        return cls.from_simulation(path, simulation)
-
-    @classmethod
     def from_simulation(
         cls,
         dataset_path: Path,
@@ -515,3 +517,37 @@ class SourceDatasetSnapshot:
             input_variables=provider.input_variables,
             variable_provider=provider,
         )
+
+
+@pipeline_node(
+    id="local_h5_policyengine_dataset_reader",
+    label="PolicyEngineDatasetReader",
+    node_type="library",
+    description=("PolicyEngine H5 dataset adapter for local H5 source snapshots."),
+    source_file="policyengine_us_data/calibration/local_h5/source_dataset.py",
+    status="current",
+    stability="moving",
+    pathways=["local_h5"],
+    validation_commands=[
+        "uv run pytest tests/integration/local_h5/test_worker_script_tiny_fixture.py"
+    ],
+)
+@dataclass(frozen=True)
+class PolicyEngineDatasetReader:
+    """Read PolicyEngine source H5 files into `SourceDatasetSnapshot` objects."""
+
+    def load(self, dataset_path: Path) -> SourceDatasetSnapshot:
+        """Open a source H5 dataset and return its in-memory snapshot.
+
+        Args:
+            dataset_path: Source H5 dataset path.
+
+        Returns:
+            A `SourceDatasetSnapshot` backed by a PolicyEngine microsimulation.
+        """
+
+        from policyengine_us import Microsimulation
+
+        path = Path(dataset_path)
+        simulation = Microsimulation(dataset=str(path))
+        return SourceDatasetSnapshot.from_simulation(path, simulation)

--- a/policyengine_us_data/build_outputs/source_dataset.py
+++ b/policyengine_us_data/build_outputs/source_dataset.py
@@ -1,0 +1,315 @@
+"""Source dataset contracts for local H5 publication.
+
+This module defines the in-memory source dataset structures used by later
+local H5 migration slices. It is intentionally pure at this stage: current
+workers may still reconstruct source state directly from raw dataset paths.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+from policyengine_us_data.pipeline_metadata import pipeline_node
+
+__all__ = ["EntityGraph"]
+
+
+DEFAULT_SUBENTITIES = ("tax_unit", "spm_unit", "family", "marital_unit")
+
+
+@pipeline_node(
+    id="local_h5_entity_graph",
+    label="EntityGraph",
+    node_type="library",
+    description=("Explicit source-dataset entity spine for local H5 worker setup."),
+    source_file="policyengine_us_data/build_outputs/source_dataset.py",
+    status="current",
+    stability="moving",
+    pathways=["local_h5"],
+    validation_commands=["uv run pytest tests/unit/build_outputs/test_source_dataset.py"],
+)
+@dataclass(frozen=True)
+class _EntityMapsView:
+    time_period: int
+    household_ids: np.ndarray
+    person_hh_ids: np.ndarray
+    hh_to_persons: dict[int, list[int]]
+    hh_to_entity: dict[str, dict[int, list[int]]]
+    entity_id_arrays: dict[str, np.ndarray]
+    person_entity_id_arrays: dict[str, np.ndarray]
+
+
+@dataclass(frozen=True)
+class EntityGraph:
+    """Structural relationships between source dataset entities.
+
+    `EntityGraph` is the canonical in-memory shape for the source entity spine.
+    It stores raw ID arrays plus derived household-membership maps so later H5
+    builder seams can select households without rebuilding joins.
+
+    Attributes:
+        household_ids: Source household IDs, one per household row.
+        person_household_ids: Household ID for each source person row.
+        subentity_ids: Entity IDs by subentity key, such as `tax_unit`.
+        person_subentity_ids: Entity ID for each source person row by subentity.
+        household_to_person_indices: Household row index to person row indices.
+        household_to_subentity_indices: Subentity key to household row index to
+            subentity row indices.
+    """
+
+    household_ids: np.ndarray
+    person_household_ids: np.ndarray
+    subentity_ids: Mapping[str, np.ndarray]
+    person_subentity_ids: Mapping[str, np.ndarray]
+    household_to_person_indices: Mapping[int, tuple[int, ...]] | None = None
+    household_to_subentity_indices: (
+        Mapping[str, Mapping[int, tuple[int, ...]]] | None
+    ) = None
+
+    def __post_init__(self) -> None:
+        household_ids = _readonly_1d_array(self.household_ids, "household_ids")
+        person_household_ids = _readonly_1d_array(
+            self.person_household_ids,
+            "person_household_ids",
+        )
+        subentity_ids = _readonly_array_mapping(self.subentity_ids, "subentity_ids")
+        person_subentity_ids = _readonly_array_mapping(
+            self.person_subentity_ids,
+            "person_subentity_ids",
+        )
+
+        if set(subentity_ids) != set(person_subentity_ids):
+            raise ValueError(
+                "subentity_ids and person_subentity_ids must have matching keys"
+            )
+        for entity_key, person_entity_ids in person_subentity_ids.items():
+            if person_entity_ids.shape[0] != person_household_ids.shape[0]:
+                raise ValueError(
+                    f"person_subentity_ids[{entity_key!r}] length "
+                    "must equal person_household_ids length"
+                )
+
+        household_to_person_indices = _build_household_to_person_indices(
+            household_ids,
+            person_household_ids,
+        )
+        household_to_subentity_indices = _build_household_to_subentity_indices(
+            household_ids=household_ids,
+            person_household_ids=person_household_ids,
+            subentity_ids=subentity_ids,
+            person_subentity_ids=person_subentity_ids,
+        )
+
+        object.__setattr__(self, "household_ids", household_ids)
+        object.__setattr__(self, "person_household_ids", person_household_ids)
+        object.__setattr__(self, "subentity_ids", subentity_ids)
+        object.__setattr__(self, "person_subentity_ids", person_subentity_ids)
+        object.__setattr__(
+            self,
+            "household_to_person_indices",
+            household_to_person_indices,
+        )
+        object.__setattr__(
+            self,
+            "household_to_subentity_indices",
+            household_to_subentity_indices,
+        )
+
+    @classmethod
+    def from_simulation(
+        cls,
+        simulation,
+        *,
+        subentities: tuple[str, ...] = DEFAULT_SUBENTITIES,
+    ) -> "EntityGraph":
+        """Build an `EntityGraph` from a `policyengine_us.Microsimulation`.
+
+        Args:
+            simulation: Source dataset simulation.
+            subentities: Subentity keys to include.
+
+        Returns:
+            A validated `EntityGraph`.
+        """
+
+        household_ids = simulation.calculate(
+            "household_id",
+            map_to="household",
+        ).values
+        person_household_ids = simulation.calculate(
+            "household_id",
+            map_to="person",
+        ).values
+        subentity_ids = {}
+        person_subentity_ids = {}
+        for entity_key in subentities:
+            subentity_ids[entity_key] = simulation.calculate(
+                f"{entity_key}_id",
+                map_to=entity_key,
+            ).values
+            person_subentity_ids[entity_key] = simulation.calculate(
+                f"person_{entity_key}_id",
+                map_to="person",
+            ).values
+        return cls(
+            household_ids=household_ids,
+            person_household_ids=person_household_ids,
+            subentity_ids=subentity_ids,
+            person_subentity_ids=person_subentity_ids,
+        )
+
+    @classmethod
+    def from_entity_maps(cls, entity_maps) -> "EntityGraph":
+        """Build an `EntityGraph` from existing `entity_clone.EntityMaps`.
+
+        Args:
+            entity_maps: Current compatibility map object.
+
+        Returns:
+            A validated `EntityGraph`.
+        """
+
+        return cls(
+            household_ids=entity_maps.household_ids,
+            person_household_ids=entity_maps.person_hh_ids,
+            subentity_ids=entity_maps.entity_id_arrays,
+            person_subentity_ids=entity_maps.person_entity_id_arrays,
+        )
+
+    def to_entity_maps(self, time_period: int):
+        """Convert to an `entity_clone.EntityMaps`-compatible object.
+
+        Args:
+            time_period: Dataset period to store on the compatibility object.
+
+        Returns:
+            An object with the same attributes consumed by existing
+            `entity_clone` helpers.
+        """
+
+        return _EntityMapsView(
+            time_period=int(time_period),
+            household_ids=self.household_ids,
+            person_hh_ids=self.person_household_ids,
+            hh_to_persons={
+                household_index: list(person_indices)
+                for household_index, person_indices in (
+                    self.household_to_person_indices or {}
+                ).items()
+            },
+            hh_to_entity={
+                entity_key: {
+                    household_index: list(entity_indices)
+                    for household_index, entity_indices in membership.items()
+                }
+                for entity_key, membership in (
+                    self.household_to_subentity_indices or {}
+                ).items()
+            },
+            entity_id_arrays=dict(self.subentity_ids),
+            person_entity_id_arrays=dict(self.person_subentity_ids),
+        )
+
+
+def _readonly_1d_array(values: ArrayLike, name: str) -> np.ndarray:
+    array = np.asarray(values)
+    if array.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional")
+    normalized = np.array(array, copy=True)
+    normalized.setflags(write=False)
+    return normalized
+
+
+def _readonly_array_mapping(
+    values: Mapping[str, ArrayLike],
+    name: str,
+) -> dict[str, np.ndarray]:
+    normalized: dict[str, np.ndarray] = {}
+    for key, value in values.items():
+        if not isinstance(key, str) or not key:
+            raise ValueError(f"{name} keys must be non-empty strings")
+        normalized[key] = _readonly_1d_array(value, f"{name}[{key!r}]")
+    return normalized
+
+
+def _build_household_to_person_indices(
+    household_ids: np.ndarray,
+    person_household_ids: np.ndarray,
+) -> dict[int, tuple[int, ...]]:
+    household_id_to_index = _unique_id_index(household_ids, "household_ids")
+    membership: dict[int, list[int]] = {
+        household_index: [] for household_index in range(len(household_ids))
+    }
+    for person_index, household_id in enumerate(person_household_ids):
+        household_index = household_id_to_index.get(_normalized_id(household_id))
+        if household_index is None:
+            raise ValueError(
+                "person_household_ids contains an ID not present in household_ids"
+            )
+        membership[household_index].append(person_index)
+    return {
+        household_index: tuple(person_indices)
+        for household_index, person_indices in membership.items()
+    }
+
+
+def _build_household_to_subentity_indices(
+    *,
+    household_ids: np.ndarray,
+    person_household_ids: np.ndarray,
+    subentity_ids: Mapping[str, np.ndarray],
+    person_subentity_ids: Mapping[str, np.ndarray],
+) -> dict[str, dict[int, tuple[int, ...]]]:
+    household_id_to_index = _unique_id_index(household_ids, "household_ids")
+    all_memberships: dict[str, dict[int, tuple[int, ...]]] = {}
+
+    for entity_key, entity_ids in subentity_ids.items():
+        entity_id_to_index = _unique_id_index(
+            entity_ids,
+            f"subentity_ids[{entity_key!r}]",
+        )
+        membership_sets: dict[int, set[int]] = {
+            household_index: set() for household_index in range(len(household_ids))
+        }
+        for person_index, person_entity_id in enumerate(
+            person_subentity_ids[entity_key]
+        ):
+            household_index = household_id_to_index.get(
+                _normalized_id(person_household_ids[person_index])
+            )
+            if household_index is None:
+                raise ValueError(
+                    "person_household_ids contains an ID not present in household_ids"
+                )
+            entity_index = entity_id_to_index.get(_normalized_id(person_entity_id))
+            if entity_index is None:
+                raise ValueError(
+                    f"person_subentity_ids[{entity_key!r}] contains an ID "
+                    f"not present in subentity_ids[{entity_key!r}]"
+                )
+            membership_sets[household_index].add(entity_index)
+        all_memberships[entity_key] = {
+            household_index: tuple(sorted(entity_indices))
+            for household_index, entity_indices in membership_sets.items()
+        }
+    return all_memberships
+
+
+def _unique_id_index(values: np.ndarray, name: str) -> dict[object, int]:
+    index: dict[object, int] = {}
+    for row_index, value in enumerate(values):
+        normalized = _normalized_id(value)
+        if normalized in index:
+            raise ValueError(f"{name} must contain unique IDs")
+        index[normalized] = row_index
+    return index
+
+
+def _normalized_id(value) -> object:
+    if isinstance(value, np.generic):
+        return value.item()
+    return value

--- a/policyengine_us_data/build_outputs/source_dataset.py
+++ b/policyengine_us_data/build_outputs/source_dataset.py
@@ -7,15 +7,15 @@ workers may still reconstruct source state directly from raw dataset paths.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Mapping
 
 import numpy as np
 from numpy.typing import ArrayLike
 
 from policyengine_us_data.pipeline_metadata import pipeline_node
 
-__all__ = ["EntityGraph"]
+__all__ = ["EntityGraph", "MicrosimulationVariableProvider"]
 
 
 DEFAULT_SUBENTITIES = ("tax_unit", "spm_unit", "family", "marital_unit")
@@ -313,3 +313,88 @@ def _normalized_id(value) -> object:
     if isinstance(value, np.generic):
         return value.item()
     return value
+
+
+@pipeline_node(
+    id="local_h5_microsimulation_variable_provider",
+    label="MicrosimulationVariableProvider",
+    node_type="library",
+    description=("Lazy source variable access wrapper for local H5 source snapshots."),
+    source_file="policyengine_us_data/build_outputs/source_dataset.py",
+    status="current",
+    stability="moving",
+    pathways=["local_h5"],
+    validation_commands=["uv run pytest tests/unit/build_outputs/test_source_dataset.py"],
+)
+@dataclass
+class MicrosimulationVariableProvider:
+    """Lazy holder-backed variable reader for a source microsimulation.
+
+    The provider intentionally reads arrays only when callers request a
+    variable/period pair. It caches the normalized array for repeated access
+    while keeping construction lightweight.
+
+    Attributes:
+        simulation: Source `policyengine_us.Microsimulation` or a compatible
+            test double with `input_variables` and `get_holder(...)`.
+    """
+
+    simulation: Any
+    _array_cache: dict[tuple[str, str], np.ndarray] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+    )
+
+    @property
+    def input_variables(self) -> frozenset[str]:
+        """Return the source simulation input variable inventory."""
+
+        return frozenset(str(variable) for variable in self.simulation.input_variables)
+
+    def known_periods(self, variable: str) -> tuple[Any, ...]:
+        """Return periods known to the source holder for `variable`.
+
+        Args:
+            variable: Variable name to inspect.
+
+        Returns:
+            Tuple of holder periods.
+        """
+
+        holder = self._get_holder(variable)
+        return tuple(holder.get_known_periods())
+
+    def get_array(self, variable: str, period: Any | None = None) -> np.ndarray:
+        """Return one source variable array, loading and caching it lazily.
+
+        Args:
+            variable: Variable name to load.
+            period: Holder period. If omitted, the first known period is used.
+
+        Returns:
+            A read-only numpy array copy of the holder values.
+        """
+
+        holder = self._get_holder(variable)
+        if period is None:
+            periods = tuple(holder.get_known_periods())
+            if not periods:
+                raise ValueError(f"Variable {variable!r} has no known periods")
+            period = periods[0]
+
+        cache_key = (str(variable), str(period))
+        if cache_key not in self._array_cache:
+            array = np.array(holder.get_array(period), copy=True)
+            array.setflags(write=False)
+            self._array_cache[cache_key] = array
+        return self._array_cache[cache_key]
+
+    def _get_holder(self, variable: str):
+        try:
+            holder = self.simulation.get_holder(variable)
+        except Exception as exc:
+            raise KeyError(f"Variable {variable!r} is not available") from exc
+        if holder is None:
+            raise KeyError(f"Variable {variable!r} is not available")
+        return holder

--- a/policyengine_us_data/datasets/cps/small_enhanced_cps.py
+++ b/policyengine_us_data/datasets/cps/small_enhanced_cps.py
@@ -9,6 +9,7 @@ from policyengine_core.data.dataset import Dataset
 from policyengine_us_data.calibration.puf_impute import CLONE_ORIGIN_FLAGS
 from policyengine_us_data.datasets import EnhancedCPS_2024
 from policyengine_us_data.storage import STORAGE_FOLDER
+from policyengine_us_data.utils.h5 import to_h5_values
 
 
 def _load_saved_period_array(
@@ -108,18 +109,16 @@ def create_small_ecps():
     data = {}
     for variable in simulation.tax_benefit_system.variables:
         data[variable] = {}
+        is_string_like = simulation.tax_benefit_system.variables.get(
+            variable
+        ).value_type in (Enum, str)
         for time_period in simulation.get_holder(variable).get_known_periods():
             values = simulation.get_holder(variable).get_array(time_period)
-            if simulation.tax_benefit_system.variables.get(variable).value_type in (
-                Enum,
-                str,
-            ):
-                if hasattr(values, "decode_to_str"):
-                    values = values.decode_to_str().astype("S")
-                else:
-                    values = values.astype("S")
-            else:
-                values = np.array(values)
+            values = to_h5_values(
+                values,
+                is_string_like=is_string_like,
+                variable=variable,
+            )
             if values is not None:
                 data[variable][time_period] = values
 
@@ -184,17 +183,17 @@ def create_sparse_ecps():
     data = {}
     for variable in sim.tax_benefit_system.variables:
         data[variable] = {}
+        is_string_like = sim.tax_benefit_system.variables.get(variable).value_type in (
+            Enum,
+            str,
+        )
         for time_period in sim.get_holder(variable).get_known_periods():
             values = sim.get_holder(variable).get_array(time_period)
-            if (
-                sim.tax_benefit_system.variables.get(variable).value_type in (Enum, str)
-                and variable != "county_fips"
-            ):
-                values = values.decode_to_str().astype("S")
-            elif variable == "county_fips":
-                values = values.astype("int32")
-            else:
-                values = np.array(values)
+            values = to_h5_values(
+                values,
+                is_string_like=is_string_like,
+                variable=variable,
+            )
             if values is not None:
                 data[variable][time_period] = values
 

--- a/policyengine_us_data/db/etl_pregnancy.py
+++ b/policyengine_us_data/db/etl_pregnancy.py
@@ -19,7 +19,6 @@ Data sources:
 import logging
 
 import pandas as pd
-import requests
 from sqlmodel import Session, create_engine
 
 from policyengine_us_data.storage import STORAGE_FOLDER
@@ -33,6 +32,7 @@ from policyengine_us_data.utils.db import (
     get_geographic_strata,
     etl_argparser,
 )
+from policyengine_us_data.utils.http import get_with_exponential_backoff
 from policyengine_us_data.utils.raw_cache import (
     is_cached,
     save_json,
@@ -134,8 +134,7 @@ def extract_cdc_births(year: int) -> pd.DataFrame:
         )
         url = f"{CDC_VSRR_BASE}?{params}"
         logger.info(f"Fetching CDC VSRR births for {year}")
-        resp = requests.get(url, timeout=30)
-        resp.raise_for_status()
+        resp = get_with_exponential_backoff(url, timeout=30)
         rows = resp.json()
         if not rows:
             raise ValueError(f"No CDC VSRR birth data returned for {year}")
@@ -184,8 +183,7 @@ def extract_female_population(year: int) -> pd.DataFrame:
         var_ids = ",".join([f"B01001_{i:03d}E" for i in range(30, 39)])
         url = f"https://api.census.gov/data/{year}/acs/acs1?get={var_ids}&for=state:*"
         logger.info(f"Fetching ACS B01001 female 15-44 for {year}")
-        resp = requests.get(url, timeout=30)
-        resp.raise_for_status()
+        resp = get_with_exponential_backoff(url, timeout=30)
         data = resp.json()
         save_json(cache_file, data)
 

--- a/policyengine_us_data/utils/census.py
+++ b/policyengine_us_data/utils/census.py
@@ -1,8 +1,8 @@
 import logging
-import requests
 
 import pandas as pd
 
+from policyengine_us_data.utils.http import get_with_exponential_backoff
 from policyengine_us_data.utils.raw_cache import (
     is_cached,
     save_json,
@@ -144,8 +144,7 @@ def get_census_docs(year):
         return load_json(cache_file)
 
     logger.info(f"Downloading census docs for {year}")
-    docs_response = requests.get(docs_url)
-    docs_response.raise_for_status()
+    docs_response = get_with_exponential_backoff(docs_url, timeout=30)
     data = docs_response.json()
     save_json(cache_file, data)
     return data
@@ -177,7 +176,8 @@ def pull_acs_table(group: str, geo: str, year: int) -> pd.DataFrame:
     url = f"{base}?get=group({group})&for={geo_q}"
 
     logger.info(f"Downloading ACS table {group} ({geo}) for {year}")
-    data = requests.get(url).json()
+    response = get_with_exponential_backoff(url, timeout=30)
+    data = response.json()
     save_json(cache_file, data)
     headers, rows = data[0], data[1:]
     df = pd.DataFrame(rows, columns=headers)

--- a/policyengine_us_data/utils/h5.py
+++ b/policyengine_us_data/utils/h5.py
@@ -1,0 +1,14 @@
+"""HDF5 serialization helpers."""
+
+import numpy as np
+
+
+def to_h5_values(values, *, is_string_like: bool, variable: str):
+    """Normalize PolicyEngine holder arrays and ndarray values for HDF5."""
+    if is_string_like and variable != "county_fips":
+        if hasattr(values, "decode_to_str"):
+            values = values.decode_to_str()
+        return values.astype("S")
+    if variable == "county_fips":
+        return values.astype("int32")
+    return np.array(values)

--- a/policyengine_us_data/utils/http.py
+++ b/policyengine_us_data/utils/http.py
@@ -1,0 +1,56 @@
+"""HTTP helpers for brittle public data-source requests."""
+
+import logging
+import time
+from collections.abc import Callable
+from typing import Any
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+
+
+def get_with_exponential_backoff(
+    url: str,
+    *,
+    timeout: int | float = 30,
+    max_attempts: int = 5,
+    initial_wait_seconds: int | float = 30,
+    max_wait_seconds: int | float = 240,
+    retry_statuses: set[int] | frozenset[int] = RETRYABLE_STATUS_CODES,
+    sleep: Callable[[int | float], None] = time.sleep,
+    session: Any = requests,
+    **kwargs: Any,
+) -> requests.Response:
+    """GET a URL, retrying transient failures with capped exponential backoff."""
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be at least 1")
+
+    wait_seconds = initial_wait_seconds
+    for attempt in range(1, max_attempts + 1):
+        try:
+            response = session.get(url, timeout=timeout, **kwargs)
+            response.raise_for_status()
+            return response
+        except requests.HTTPError as exc:
+            response = exc.response
+            status_code = response.status_code if response is not None else None
+            if status_code not in retry_statuses or attempt == max_attempts:
+                raise
+        except requests.RequestException:
+            if attempt == max_attempts:
+                raise
+
+        logger.warning(
+            "Request failed for %s (attempt %s/%s); retrying in %.0f seconds",
+            url,
+            attempt,
+            max_attempts,
+            wait_seconds,
+        )
+        sleep(wait_seconds)
+        wait_seconds = min(wait_seconds * 2, max_wait_seconds)
+
+    raise RuntimeError(f"Request failed after {max_attempts} attempts: {url}")

--- a/tests/integration/local_h5/fixtures.py
+++ b/tests/integration/local_h5/fixtures.py
@@ -51,7 +51,8 @@ def fixture_household_count() -> int:
 
     sim = Microsimulation(dataset=str(FIXTURE_DATASET_PATH))
     try:
-        return int(len(sim.calculate("household_id", map_to="household").values))
+        household_ids = np.asarray(sim.calculate("household_id", map_to="household"))
+        return int(len(household_ids))
     finally:
         del sim
 

--- a/tests/integration/local_h5/test_worker_script_tiny_fixture.py
+++ b/tests/integration/local_h5/test_worker_script_tiny_fixture.py
@@ -8,11 +8,11 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from policyengine_us_data.calibration.local_h5.source_dataset import (
+from policyengine_us_data.build_outputs.source_dataset import (
     DEFAULT_SUBENTITIES,
     PolicyEngineDatasetReader,
 )
-from policyengine_us_data.calibration.local_h5.weights import CloneWeightMatrix
+from policyengine_us_data.build_outputs.weights import CloneWeightMatrix
 from tests.integration.local_h5.fixtures import (
     build_request,
     seed_local_h5_artifacts,

--- a/tests/integration/local_h5/test_worker_script_tiny_fixture.py
+++ b/tests/integration/local_h5/test_worker_script_tiny_fixture.py
@@ -10,7 +10,7 @@ import pytest
 
 from policyengine_us_data.calibration.local_h5.source_dataset import (
     DEFAULT_SUBENTITIES,
-    SourceDatasetSnapshot,
+    PolicyEngineDatasetReader,
 )
 from policyengine_us_data.calibration.local_h5.weights import CloneWeightMatrix
 from tests.integration.local_h5.fixtures import (
@@ -87,7 +87,7 @@ def _run_worker(
 def test_tiny_fixture_source_snapshot_matches_worker_artifacts(tmp_path):
     artifacts = seed_local_h5_artifacts(tmp_path / "source-snapshot")
 
-    snapshot = SourceDatasetSnapshot.from_dataset_path(artifacts.dataset_path)
+    snapshot = PolicyEngineDatasetReader().load(artifacts.dataset_path)
     weights = CloneWeightMatrix.from_vector(
         np.load(artifacts.weights_path),
         n_records=snapshot.n_households,

--- a/tests/integration/local_h5/test_worker_script_tiny_fixture.py
+++ b/tests/integration/local_h5/test_worker_script_tiny_fixture.py
@@ -5,8 +5,14 @@ import subprocess
 import sys
 from pathlib import Path
 
+import numpy as np
 import pytest
 
+from policyengine_us_data.calibration.local_h5.source_dataset import (
+    DEFAULT_SUBENTITIES,
+    SourceDatasetSnapshot,
+)
+from policyengine_us_data.calibration.local_h5.weights import CloneWeightMatrix
 from tests.integration.local_h5.fixtures import (
     build_request,
     seed_local_h5_artifacts,
@@ -14,8 +20,12 @@ from tests.integration.local_h5.fixtures import (
 
 pytestmark = pytest.mark.integration
 
-pytest.importorskip("scipy")
-pytest.importorskip("spm_calculator")
+pytest.importorskip("policyengine_us")
+
+
+def _require_worker_dependencies() -> None:
+    pytest.importorskip("scipy")
+    pytest.importorskip("spm_calculator")
 
 
 def _run_worker(
@@ -29,6 +39,7 @@ def _run_worker(
     target_config: Path | None = None,
     validation_config: Path | None = None,
 ) -> dict:
+    _require_worker_dependencies()
     if not isinstance(requests, (list, tuple)):
         requests = (requests,)
     cmd = [
@@ -71,6 +82,34 @@ def _run_worker(
         check=True,
     )
     return json.loads(result.stdout)
+
+
+def test_tiny_fixture_source_snapshot_matches_worker_artifacts(tmp_path):
+    artifacts = seed_local_h5_artifacts(tmp_path / "source-snapshot")
+
+    snapshot = SourceDatasetSnapshot.from_dataset_path(artifacts.dataset_path)
+    weights = CloneWeightMatrix.from_vector(
+        np.load(artifacts.weights_path),
+        n_records=snapshot.n_households,
+    )
+
+    assert snapshot.n_households == artifacts.n_records
+    assert snapshot.variable_provider.get_array(
+        "household_id",
+        snapshot.time_period,
+    ).shape == (artifacts.n_records,)
+    assert weights.n_records == snapshot.n_households
+    assert weights.n_clones == artifacts.n_clones
+
+    assert set(snapshot.entity_graph.subentity_ids) == set(DEFAULT_SUBENTITIES)
+    assert len(snapshot.entity_graph.household_to_person_indices) == (
+        artifacts.n_records
+    )
+    for entity_key in DEFAULT_SUBENTITIES:
+        assert (
+            len(snapshot.entity_graph.household_to_subentity_indices[entity_key])
+            == artifacts.n_records
+        )
 
 
 def test_worker_builds_district_h5_from_saved_geography(tmp_path):

--- a/tests/support/build_outputs/source_dataset.py
+++ b/tests/support/build_outputs/source_dataset.py
@@ -58,6 +58,7 @@ def load_source_dataset_exports():
         "MicrosimulationVariableProvider": (
             source_dataset_module.MicrosimulationVariableProvider
         ),
+        "PolicyEngineDatasetReader": source_dataset_module.PolicyEngineDatasetReader,
         "SourceDatasetSnapshot": source_dataset_module.SourceDatasetSnapshot,
     }
 

--- a/tests/support/build_outputs/source_dataset.py
+++ b/tests/support/build_outputs/source_dataset.py
@@ -55,6 +55,9 @@ def load_source_dataset_exports():
     return {
         "module": source_dataset_module,
         "EntityGraph": source_dataset_module.EntityGraph,
+        "MicrosimulationVariableProvider": (
+            source_dataset_module.MicrosimulationVariableProvider
+        ),
     }
 
 
@@ -73,3 +76,35 @@ def make_entity_graph_arrays():
             "spm_unit": np.array([300, 300, 400], dtype=np.int64),
         },
     }
+
+
+class FakeHolder:
+    """Small holder test double for lazy-provider tests."""
+
+    def __init__(self, arrays_by_period):
+        self.arrays_by_period = dict(arrays_by_period)
+        self.known_period_calls = 0
+        self.get_array_calls = []
+
+    def get_known_periods(self):
+        self.known_period_calls += 1
+        return tuple(self.arrays_by_period)
+
+    def get_array(self, period):
+        self.get_array_calls.append(period)
+        return self.arrays_by_period[period]
+
+
+class FakeSimulation:
+    """Small simulation test double for lazy-provider tests."""
+
+    def __init__(self, holders):
+        self.holders = dict(holders)
+        self.input_variables = frozenset(holders)
+        self.get_holder_calls = []
+
+    def get_holder(self, variable):
+        self.get_holder_calls.append(variable)
+        if variable not in self.holders:
+            raise KeyError(variable)
+        return self.holders[variable]

--- a/tests/support/build_outputs/source_dataset.py
+++ b/tests/support/build_outputs/source_dataset.py
@@ -2,65 +2,7 @@
 
 from __future__ import annotations
 
-import importlib.util
-import sys
-from pathlib import Path
-from types import ModuleType
-
 import numpy as np
-
-
-def _ensure_package(name: str, path: Path) -> None:
-    """Register a synthetic package so local imports resolve from disk."""
-
-    package = sys.modules.get(name)
-    if package is None:
-        package = ModuleType(name)
-        package.__path__ = [str(path)]
-        sys.modules[name] = package
-        return
-    package.__path__ = [str(path)]
-
-
-def _load_module(name: str, path: Path):
-    """Load one module from disk under a specific fully-qualified name."""
-
-    sys.modules.pop(name, None)
-    spec = importlib.util.spec_from_file_location(name, path)
-    module = importlib.util.module_from_spec(spec)
-    assert spec is not None
-    assert spec.loader is not None
-    sys.modules[name] = module
-    spec.loader.exec_module(module)
-    return module
-
-
-def load_source_dataset_exports():
-    """Load the source dataset module under a synthetic package name."""
-
-    build_outputs_root = (
-        Path(__file__).resolve().parents[3] / "policyengine_us_data" / "build_outputs"
-    )
-    package_name = "build_outputs_source_dataset_fixture"
-
-    for name in list(sys.modules):
-        if name == package_name or name.startswith(f"{package_name}."):
-            sys.modules.pop(name, None)
-
-    _ensure_package(package_name, build_outputs_root)
-    source_dataset_module = _load_module(
-        f"{package_name}.source_dataset",
-        build_outputs_root / "source_dataset.py",
-    )
-    return {
-        "module": source_dataset_module,
-        "EntityGraph": source_dataset_module.EntityGraph,
-        "MicrosimulationVariableProvider": (
-            source_dataset_module.MicrosimulationVariableProvider
-        ),
-        "PolicyEngineDatasetReader": source_dataset_module.PolicyEngineDatasetReader,
-        "SourceDatasetSnapshot": source_dataset_module.SourceDatasetSnapshot,
-    }
 
 
 def make_entity_graph_arrays():

--- a/tests/support/build_outputs/source_dataset.py
+++ b/tests/support/build_outputs/source_dataset.py
@@ -58,6 +58,7 @@ def load_source_dataset_exports():
         "MicrosimulationVariableProvider": (
             source_dataset_module.MicrosimulationVariableProvider
         ),
+        "SourceDatasetSnapshot": source_dataset_module.SourceDatasetSnapshot,
     }
 
 
@@ -101,6 +102,7 @@ class FakeSimulation:
     def __init__(self, holders):
         self.holders = dict(holders)
         self.input_variables = frozenset(holders)
+        self.default_calculation_period = 2023
         self.get_holder_calls = []
 
     def get_holder(self, variable):
@@ -108,3 +110,20 @@ class FakeSimulation:
         if variable not in self.holders:
             raise KeyError(variable)
         return self.holders[variable]
+
+    def calculate(self, variable, map_to=None):
+        holder_variable = (
+            "person_household_id"
+            if variable == "household_id" and map_to == "person"
+            else variable
+        )
+        holder = self.get_holder(holder_variable)
+        period = next(iter(holder.arrays_by_period))
+        return FakeCalculation(holder.arrays_by_period[period])
+
+
+class FakeCalculation:
+    """Small calculation result object with a ``values`` attribute."""
+
+    def __init__(self, values):
+        self.values = np.asarray(values)

--- a/tests/support/build_outputs/source_dataset.py
+++ b/tests/support/build_outputs/source_dataset.py
@@ -1,0 +1,75 @@
+"""Fixture helpers for build-output source dataset tests."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import numpy as np
+
+
+def _ensure_package(name: str, path: Path) -> None:
+    """Register a synthetic package so local imports resolve from disk."""
+
+    package = sys.modules.get(name)
+    if package is None:
+        package = ModuleType(name)
+        package.__path__ = [str(path)]
+        sys.modules[name] = package
+        return
+    package.__path__ = [str(path)]
+
+
+def _load_module(name: str, path: Path):
+    """Load one module from disk under a specific fully-qualified name."""
+
+    sys.modules.pop(name, None)
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_source_dataset_exports():
+    """Load the source dataset module under a synthetic package name."""
+
+    build_outputs_root = (
+        Path(__file__).resolve().parents[3] / "policyengine_us_data" / "build_outputs"
+    )
+    package_name = "build_outputs_source_dataset_fixture"
+
+    for name in list(sys.modules):
+        if name == package_name or name.startswith(f"{package_name}."):
+            sys.modules.pop(name, None)
+
+    _ensure_package(package_name, build_outputs_root)
+    source_dataset_module = _load_module(
+        f"{package_name}.source_dataset",
+        build_outputs_root / "source_dataset.py",
+    )
+    return {
+        "module": source_dataset_module,
+        "EntityGraph": source_dataset_module.EntityGraph,
+    }
+
+
+def make_entity_graph_arrays():
+    """Return small valid entity graph arrays with two households."""
+
+    return {
+        "household_ids": np.array([10, 20], dtype=np.int64),
+        "person_household_ids": np.array([10, 10, 20], dtype=np.int64),
+        "subentity_ids": {
+            "tax_unit": np.array([100, 200], dtype=np.int64),
+            "spm_unit": np.array([300, 400], dtype=np.int64),
+        },
+        "person_subentity_ids": {
+            "tax_unit": np.array([100, 100, 200], dtype=np.int64),
+            "spm_unit": np.array([300, 300, 400], dtype=np.int64),
+        },
+    }

--- a/tests/unit/build_outputs/test_source_dataset.py
+++ b/tests/unit/build_outputs/test_source_dataset.py
@@ -3,18 +3,16 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+from policyengine_us_data.build_outputs.source_dataset import (
+    EntityGraph,
+    MicrosimulationVariableProvider,
+    SourceDatasetSnapshot,
+)
 from tests.support.build_outputs.source_dataset import (
     FakeHolder,
     FakeSimulation,
-    load_source_dataset_exports,
     make_entity_graph_arrays,
 )
-
-
-exports = load_source_dataset_exports()
-EntityGraph = exports["EntityGraph"]
-MicrosimulationVariableProvider = exports["MicrosimulationVariableProvider"]
-SourceDatasetSnapshot = exports["SourceDatasetSnapshot"]
 
 
 def _tuple_map(mapping):

--- a/tests/unit/build_outputs/test_source_dataset.py
+++ b/tests/unit/build_outputs/test_source_dataset.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import numpy as np
 import pytest
 
@@ -12,6 +14,9 @@ from tests.support.build_outputs.source_dataset import (
 exports = load_source_dataset_exports()
 EntityGraph = exports["EntityGraph"]
 MicrosimulationVariableProvider = exports["MicrosimulationVariableProvider"]
+SourceDatasetSnapshot = exports["SourceDatasetSnapshot"]
+
+FIXTURE_PATH = Path(__file__).parents[2] / "integration" / "test_fixture_50hh.h5"
 
 
 def _tuple_map(mapping):
@@ -158,3 +163,51 @@ def test_variable_provider_rejects_variables_without_periods():
 
     with pytest.raises(ValueError, match="no known periods"):
         provider.get_array("age")
+
+
+def test_source_dataset_snapshot_builds_from_existing_simulation():
+    simulation = FakeSimulation(
+        {
+            "household_id": FakeHolder({2023: np.array([10, 20])}),
+            "person_household_id": FakeHolder({2023: np.array([10, 10, 20])}),
+            "tax_unit_id": FakeHolder({2023: np.array([100, 200])}),
+            "spm_unit_id": FakeHolder({2023: np.array([300, 400])}),
+            "family_id": FakeHolder({2023: np.array([500, 600])}),
+            "marital_unit_id": FakeHolder({2023: np.array([700, 800, 900])}),
+            "person_tax_unit_id": FakeHolder({2023: np.array([100, 100, 200])}),
+            "person_spm_unit_id": FakeHolder({2023: np.array([300, 300, 400])}),
+            "person_family_id": FakeHolder({2023: np.array([500, 500, 600])}),
+            "person_marital_unit_id": FakeHolder({2023: np.array([700, 800, 900])}),
+        }
+    )
+
+    snapshot = SourceDatasetSnapshot.from_simulation(
+        Path("source.h5"),
+        simulation,
+    )
+
+    assert snapshot.dataset_path == Path("source.h5")
+    assert snapshot.time_period == 2023
+    assert snapshot.n_households == 2
+    assert np.array_equal(snapshot.household_ids, np.array([10, 20]))
+    assert "household_id" in snapshot.input_variables
+    assert snapshot.variable_provider.get_array("household_id", 2023).shape == (2,)
+
+
+def test_source_dataset_snapshot_builds_from_tiny_h5_fixture():
+    pytest.importorskip("policyengine_us")
+    from policyengine_us_data.calibration.local_h5.weights import CloneWeightMatrix
+
+    snapshot = SourceDatasetSnapshot.from_dataset_path(FIXTURE_PATH)
+    weights = CloneWeightMatrix.from_vector(
+        np.ones(snapshot.n_households, dtype=np.float32),
+        n_records=snapshot.n_households,
+    )
+
+    assert snapshot.dataset_path == FIXTURE_PATH
+    assert snapshot.time_period == 2023
+    assert snapshot.n_households == 50
+    assert "household_id" in snapshot.input_variables
+    assert snapshot.entity_graph.person_household_ids.shape[0] > snapshot.n_households
+    assert weights.n_clones == 1
+    assert snapshot.variable_provider.get_array("household_id", 2023).shape == (50,)

--- a/tests/unit/build_outputs/test_source_dataset.py
+++ b/tests/unit/build_outputs/test_source_dataset.py
@@ -2,6 +2,8 @@ import numpy as np
 import pytest
 
 from tests.support.build_outputs.source_dataset import (
+    FakeHolder,
+    FakeSimulation,
     load_source_dataset_exports,
     make_entity_graph_arrays,
 )
@@ -9,6 +11,7 @@ from tests.support.build_outputs.source_dataset import (
 
 exports = load_source_dataset_exports()
 EntityGraph = exports["EntityGraph"]
+MicrosimulationVariableProvider = exports["MicrosimulationVariableProvider"]
 
 
 def _tuple_map(mapping):
@@ -98,3 +101,60 @@ def test_entity_graph_round_trips_through_entity_maps():
     assert _tuple_map(
         roundtrip.household_to_subentity_indices["tax_unit"]
     ) == _tuple_map(graph.household_to_subentity_indices["tax_unit"])
+
+
+def test_variable_provider_does_not_load_variables_on_construction():
+    simulation = FakeSimulation(
+        {
+            "household_id": FakeHolder({2023: np.array([1, 2])}),
+            "age": FakeHolder({2023: np.array([40, 12, 8])}),
+        }
+    )
+
+    provider = MicrosimulationVariableProvider(simulation)
+
+    assert provider.input_variables == frozenset({"household_id", "age"})
+    assert simulation.get_holder_calls == []
+    assert simulation.holders["household_id"].get_array_calls == []
+    assert simulation.holders["age"].get_array_calls == []
+
+
+def test_variable_provider_loads_and_caches_requested_array():
+    holder = FakeHolder({2023: np.array([40, 12, 8])})
+    simulation = FakeSimulation({"age": holder})
+    provider = MicrosimulationVariableProvider(simulation)
+
+    first = provider.get_array("age", 2023)
+    second = provider.get_array("age", 2023)
+
+    assert np.array_equal(first, np.array([40, 12, 8]))
+    assert first is second
+    assert simulation.get_holder_calls == ["age", "age"]
+    assert holder.get_array_calls == [2023]
+    with pytest.raises(ValueError, match="read-only"):
+        first[0] = 99
+
+
+def test_variable_provider_uses_first_known_period_when_period_is_omitted():
+    holder = FakeHolder({2023: np.array([1, 2]), 2024: np.array([3, 4])})
+    provider = MicrosimulationVariableProvider(FakeSimulation({"household_id": holder}))
+
+    values = provider.get_array("household_id")
+
+    assert np.array_equal(values, np.array([1, 2]))
+    assert holder.known_period_calls == 1
+    assert holder.get_array_calls == [2023]
+
+
+def test_variable_provider_rejects_missing_variables():
+    provider = MicrosimulationVariableProvider(FakeSimulation({}))
+
+    with pytest.raises(KeyError, match="missing"):
+        provider.get_array("missing", 2023)
+
+
+def test_variable_provider_rejects_variables_without_periods():
+    provider = MicrosimulationVariableProvider(FakeSimulation({"age": FakeHolder({})}))
+
+    with pytest.raises(ValueError, match="no known periods"):
+        provider.get_array("age")

--- a/tests/unit/build_outputs/test_source_dataset.py
+++ b/tests/unit/build_outputs/test_source_dataset.py
@@ -1,0 +1,100 @@
+import numpy as np
+import pytest
+
+from tests.support.build_outputs.source_dataset import (
+    load_source_dataset_exports,
+    make_entity_graph_arrays,
+)
+
+
+exports = load_source_dataset_exports()
+EntityGraph = exports["EntityGraph"]
+
+
+def _tuple_map(mapping):
+    return {
+        int(key): tuple(int(value) for value in values)
+        for key, values in mapping.items()
+    }
+
+
+def test_entity_graph_builds_household_membership_maps():
+    graph = EntityGraph(**make_entity_graph_arrays())
+
+    assert _tuple_map(graph.household_to_person_indices) == {
+        0: (0, 1),
+        1: (2,),
+    }
+    assert _tuple_map(graph.household_to_subentity_indices["tax_unit"]) == {
+        0: (0,),
+        1: (1,),
+    }
+    assert _tuple_map(graph.household_to_subentity_indices["spm_unit"]) == {
+        0: (0,),
+        1: (1,),
+    }
+
+
+def test_entity_graph_copies_arrays_and_exposes_read_only_storage():
+    arrays = make_entity_graph_arrays()
+    graph = EntityGraph(**arrays)
+
+    arrays["household_ids"][0] = 99
+
+    assert graph.household_ids[0] == 10
+    with pytest.raises(ValueError, match="read-only"):
+        graph.household_ids[0] = 99
+    with pytest.raises(ValueError, match="read-only"):
+        graph.subentity_ids["tax_unit"][0] = 99
+
+
+def test_entity_graph_rejects_unknown_person_household_ids():
+    arrays = make_entity_graph_arrays()
+    arrays["person_household_ids"] = np.array([10, 999, 20], dtype=np.int64)
+
+    with pytest.raises(ValueError, match="person_household_ids"):
+        EntityGraph(**arrays)
+
+
+def test_entity_graph_rejects_unknown_person_subentity_ids():
+    arrays = make_entity_graph_arrays()
+    arrays["person_subentity_ids"]["tax_unit"] = np.array(
+        [100, 999, 200],
+        dtype=np.int64,
+    )
+
+    with pytest.raises(ValueError, match="person_subentity_ids\\['tax_unit'\\]"):
+        EntityGraph(**arrays)
+
+
+def test_entity_graph_rejects_mismatched_subentity_keys():
+    arrays = make_entity_graph_arrays()
+    arrays["person_subentity_ids"].pop("spm_unit")
+
+    with pytest.raises(ValueError, match="matching keys"):
+        EntityGraph(**arrays)
+
+
+def test_entity_graph_rejects_duplicate_ids():
+    arrays = make_entity_graph_arrays()
+    arrays["household_ids"] = np.array([10, 10], dtype=np.int64)
+
+    with pytest.raises(ValueError, match="household_ids must contain unique IDs"):
+        EntityGraph(**arrays)
+
+
+def test_entity_graph_round_trips_through_entity_maps():
+    graph = EntityGraph(**make_entity_graph_arrays())
+
+    entity_maps = graph.to_entity_maps(time_period=2023)
+    roundtrip = EntityGraph.from_entity_maps(entity_maps)
+
+    assert entity_maps.time_period == 2023
+    assert np.array_equal(roundtrip.household_ids, graph.household_ids)
+    assert np.array_equal(roundtrip.person_household_ids, graph.person_household_ids)
+    assert _tuple_map(roundtrip.household_to_person_indices) == _tuple_map(
+        graph.household_to_person_indices
+    )
+    assert _tuple_map(
+        roundtrip.household_to_subentity_indices["tax_unit"]
+    ) == _tuple_map(graph.household_to_subentity_indices["tax_unit"])

--- a/tests/unit/build_outputs/test_source_dataset.py
+++ b/tests/unit/build_outputs/test_source_dataset.py
@@ -16,8 +16,6 @@ EntityGraph = exports["EntityGraph"]
 MicrosimulationVariableProvider = exports["MicrosimulationVariableProvider"]
 SourceDatasetSnapshot = exports["SourceDatasetSnapshot"]
 
-FIXTURE_PATH = Path(__file__).parents[2] / "integration" / "test_fixture_50hh.h5"
-
 
 def _tuple_map(mapping):
     return {
@@ -54,6 +52,12 @@ def test_entity_graph_copies_arrays_and_exposes_read_only_storage():
         graph.household_ids[0] = 99
     with pytest.raises(ValueError, match="read-only"):
         graph.subentity_ids["tax_unit"][0] = 99
+    with pytest.raises(TypeError):
+        graph.subentity_ids["tax_unit"] = np.array([1, 2])
+    with pytest.raises(TypeError):
+        graph.household_to_person_indices[0] = ()
+    with pytest.raises(TypeError):
+        graph.household_to_subentity_indices["tax_unit"][0] = ()
 
 
 def test_entity_graph_rejects_unknown_person_household_ids():
@@ -192,22 +196,3 @@ def test_source_dataset_snapshot_builds_from_existing_simulation():
     assert np.array_equal(snapshot.household_ids, np.array([10, 20]))
     assert "household_id" in snapshot.input_variables
     assert snapshot.variable_provider.get_array("household_id", 2023).shape == (2,)
-
-
-def test_source_dataset_snapshot_builds_from_tiny_h5_fixture():
-    pytest.importorskip("policyengine_us")
-    from policyengine_us_data.calibration.local_h5.weights import CloneWeightMatrix
-
-    snapshot = SourceDatasetSnapshot.from_dataset_path(FIXTURE_PATH)
-    weights = CloneWeightMatrix.from_vector(
-        np.ones(snapshot.n_households, dtype=np.float32),
-        n_records=snapshot.n_households,
-    )
-
-    assert snapshot.dataset_path == FIXTURE_PATH
-    assert snapshot.time_period == 2023
-    assert snapshot.n_households == 50
-    assert "household_id" in snapshot.input_variables
-    assert snapshot.entity_graph.person_household_ids.shape[0] > snapshot.n_households
-    assert weights.n_clones == 1
-    assert snapshot.variable_provider.get_array("household_id", 2023).shape == (50,)

--- a/tests/unit/calibration/test_entity_clone.py
+++ b/tests/unit/calibration/test_entity_clone.py
@@ -12,6 +12,7 @@ from policyengine_us_data.calibration.entity_clone import (
     build_household_entity_maps,
     materialize_clone_household_chunk,
 )
+from policyengine_us_data.build_outputs.source_dataset import EntityGraph
 
 
 FIXTURE_PATH = Path(__file__).parents[2] / "integration" / "test_fixture_50hh.h5"
@@ -132,6 +133,23 @@ def test_materialize_clone_household_chunk_drops_legacy_spm_threshold_input(
     with h5py.File(output_path, "r") as h5:
         assert "spm_unit_spm_threshold" not in h5
         assert "spm_unit_geographic_adjustment" not in h5
+
+
+def test_entity_graph_adapter_matches_household_entity_maps(fixture_entity_maps):
+    graph = EntityGraph.from_entity_maps(fixture_entity_maps)
+    roundtrip = graph.to_entity_maps(time_period=fixture_entity_maps.time_period)
+
+    assert np.array_equal(roundtrip.household_ids, fixture_entity_maps.household_ids)
+    assert np.array_equal(roundtrip.person_hh_ids, fixture_entity_maps.person_hh_ids)
+    assert roundtrip.hh_to_persons == {
+        key: list(value) for key, value in graph.household_to_person_indices.items()
+    }
+    for entity_key, entity_ids in fixture_entity_maps.entity_id_arrays.items():
+        assert np.array_equal(roundtrip.entity_id_arrays[entity_key], entity_ids)
+        assert roundtrip.hh_to_entity[entity_key] == {
+            key: list(value)
+            for key, value in graph.household_to_subentity_indices[entity_key].items()
+        }
 
 
 def test_materialize_clone_household_chunk_keeps_clone_specific_block_geoids(

--- a/tests/unit/datasets/test_small_enhanced_cps.py
+++ b/tests/unit/datasets/test_small_enhanced_cps.py
@@ -1,0 +1,44 @@
+import numpy as np
+
+from policyengine_us_data.utils.h5 import to_h5_values
+
+
+class EncodedArray:
+    def __init__(self, values):
+        self.values = np.asarray(values)
+
+    def decode_to_str(self):
+        return self.values
+
+
+def test_to_h5_values_encodes_decodable_string_arrays():
+    values = to_h5_values(
+        EncodedArray(["a", "b"]),
+        is_string_like=True,
+        variable="example",
+    )
+
+    assert values.dtype.kind == "S"
+    assert values.tolist() == [b"a", b"b"]
+
+
+def test_to_h5_values_encodes_plain_numpy_string_arrays():
+    values = to_h5_values(
+        np.asarray(["a", "b"]),
+        is_string_like=True,
+        variable="example",
+    )
+
+    assert values.dtype.kind == "S"
+    assert values.tolist() == [b"a", b"b"]
+
+
+def test_to_h5_values_preserves_county_fips_as_int32():
+    values = to_h5_values(
+        np.asarray(["01001", "01003"]),
+        is_string_like=True,
+        variable="county_fips",
+    )
+
+    assert values.dtype == np.int32
+    assert values.tolist() == [1001, 1003]

--- a/tests/unit/db/test_etl_pregnancy.py
+++ b/tests/unit/db/test_etl_pregnancy.py
@@ -1,0 +1,50 @@
+from policyengine_us_data.db import etl_pregnancy
+
+
+class DummyResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def test_extract_female_population_uses_retrying_http_helper(monkeypatch):
+    monkeypatch.setattr(etl_pregnancy, "is_cached", lambda filename: False)
+    monkeypatch.setattr(etl_pregnancy, "save_json", lambda filename, data: None)
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append((url, kwargs))
+        return DummyResponse(
+            [
+                [
+                    "B01001_030E",
+                    "B01001_031E",
+                    "B01001_032E",
+                    "B01001_033E",
+                    "B01001_034E",
+                    "B01001_035E",
+                    "B01001_036E",
+                    "B01001_037E",
+                    "B01001_038E",
+                    "state",
+                ],
+                ["1", "2", "3", "4", "5", "6", "7", "8", "9", "01"],
+            ]
+        )
+
+    monkeypatch.setattr(etl_pregnancy, "get_with_exponential_backoff", fake_get)
+
+    result = etl_pregnancy.extract_female_population(2023)
+
+    assert result.to_dict("records") == [{"state_abbrev": "AL", "female_15_44": 45}]
+    assert calls == [
+        (
+            "https://api.census.gov/data/2023/acs/acs1?get="
+            "B01001_030E,B01001_031E,B01001_032E,B01001_033E,"
+            "B01001_034E,B01001_035E,B01001_036E,B01001_037E,"
+            "B01001_038E&for=state:*",
+            {"timeout": 30},
+        )
+    ]

--- a/tests/unit/utils/test_http.py
+++ b/tests/unit/utils/test_http.py
@@ -1,0 +1,81 @@
+import requests
+import pytest
+
+from policyengine_us_data.utils.http import get_with_exponential_backoff
+
+
+class DummyResponse:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(response=self)
+
+    def json(self):
+        return self._payload
+
+
+class DummySession:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def get(self, url, **kwargs):
+        self.calls.append((url, kwargs))
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+def test_get_with_exponential_backoff_retries_transient_statuses():
+    session = DummySession(
+        [
+            DummyResponse(503),
+            DummyResponse(502),
+            DummyResponse(200, {"ok": True}),
+        ]
+    )
+    sleeps = []
+
+    response = get_with_exponential_backoff(
+        "https://example.test/data",
+        session=session,
+        sleep=sleeps.append,
+    )
+
+    assert response.json() == {"ok": True}
+    assert len(session.calls) == 3
+    assert sleeps == [30, 60]
+
+
+def test_get_with_exponential_backoff_caps_wait_at_four_minutes():
+    session = DummySession([DummyResponse(503)] * 5)
+    sleeps = []
+
+    with pytest.raises(requests.HTTPError):
+        get_with_exponential_backoff(
+            "https://example.test/data",
+            session=session,
+            sleep=sleeps.append,
+        )
+
+    assert len(session.calls) == 5
+    assert sleeps == [30, 60, 120, 240]
+
+
+def test_get_with_exponential_backoff_does_not_retry_non_transient_statuses():
+    session = DummySession([DummyResponse(404)])
+    sleeps = []
+
+    with pytest.raises(requests.HTTPError):
+        get_with_exponential_backoff(
+            "https://example.test/missing",
+            session=session,
+            sleep=sleeps.append,
+        )
+
+    assert len(session.calls) == 1
+    assert sleeps == []


### PR DESCRIPTION
Fixes #915

## Summary
- Add the 4b local H5 source dataset seam: entity graph contract, lazy variable provider, source dataset snapshots, source metadata, and integration coverage for worker-script tiny fixtures.
- Add dataset build runtime resilience for transient public-data download failures.
- Fix small enhanced CPS HDF5 serialization for plain NumPy string arrays.
- Add targeted unit/integration coverage and changelog fragments.

## Verification
- uv tool run ruff format --check .
- uv tool run ruff check policyengine_us_data/calibration/local_h5/source_dataset.py policyengine_us_data/utils/http.py policyengine_us_data/utils/h5.py policyengine_us_data/utils/census.py policyengine_us_data/db/etl_pregnancy.py policyengine_us_data/datasets/cps/small_enhanced_cps.py tests/unit/calibration/test_local_h5_source_dataset.py tests/unit/calibration/fixtures/test_local_h5_source_dataset.py tests/integration/local_h5/fixtures.py tests/integration/local_h5/test_worker_script_tiny_fixture.py tests/unit/utils/test_http.py tests/unit/db/test_etl_pregnancy.py tests/unit/datasets/test_small_enhanced_cps.py
- uv tool run towncrier check --compare-with origin/main
- .venv-test/bin/python -m pytest tests/unit/calibration/test_local_h5_source_dataset.py tests/unit/utils/test_http.py tests/unit/db/test_etl_pregnancy.py tests/unit/datasets/test_small_enhanced_cps.py -q
- .venv-test/bin/python -m pytest tests/integration/local_h5/test_worker_script_tiny_fixture.py -q

Note: uv run pytest is blocked locally on macOS x86_64 by the torch==2.9.1 wheel constraint before pytest starts.