### PR TITLE
Store SPM geographic adjustments instead of thresholds

### DIFF
--- a/changelog.d/spm-geographic-adjustment.changed.md
+++ b/changelog.d/spm-geographic-adjustment.changed.md
@@ -1,0 +1,1 @@
+Store SPM geographic adjustment inputs instead of materialized CPS SPM thresholds.

--- a/policyengine_us_data/calibration/calibration_utils.py
+++ b/policyengine_us_data/calibration/calibration_utils.py
@@ -11,8 +11,6 @@ from scipy import sparse
 from policyengine_us_data.utils.spm import (
     TENURE_CODE_MAP,
     calculate_geoadj_from_rent,
-    get_spm_reference_thresholds,
-    spm_equivalence_scale,
 )
 from policyengine_us.variables.household.demographic.geographic.state_name import (
     StateName,
@@ -182,13 +180,6 @@ STATE_FIPS_TO_CODE = {
     54: StateCode.WV,
     55: StateCode.WI,
     56: StateCode.WY,
-}
-
-# SPM Tenure Type Mappings
-SPM_TENURE_STRING_TO_CODE = {
-    "OWNER_WITH_MORTGAGE": 1,
-    "OWNER_WITHOUT_MORTGAGE": 2,
-    "RENTER": 3,
 }
 
 
@@ -596,66 +587,3 @@ def load_cd_geoadj_values(
             geoadj_dict[cd] = {tenure: 1.0 for tenure in tenure_keys}
 
     return geoadj_dict
-
-
-def calculate_spm_thresholds_vectorized(
-    person_ages: np.ndarray,
-    person_spm_unit_ids: np.ndarray,
-    spm_unit_tenure_types: np.ndarray,
-    spm_unit_geoadj: np.ndarray,
-    year: int,
-) -> np.ndarray:
-    """Calculate SPM thresholds for cloned SPM units from raw arrays.
-
-    Works without a Microsimulation instance. Counts adults/children
-    per SPM unit from person-level arrays, then computes
-    base_threshold * equivalence_scale * geoadj for each unit.
-
-    Args:
-        person_ages: Age per cloned person.
-        person_spm_unit_ids: New SPM unit ID per cloned person
-            (0-based contiguous).
-        spm_unit_tenure_types: Tenure type string per cloned SPM
-            unit (e.g. b"RENTER", b"OWNER_WITH_MORTGAGE").
-        spm_unit_geoadj: Geographic adjustment factor per cloned
-            SPM unit.
-        year: Tax year for base threshold lookup.
-
-    Returns:
-        Float32 array of SPM thresholds, one per SPM unit.
-    """
-    person_ages = np.asarray(person_ages)
-    person_spm_unit_ids = np.asarray(person_spm_unit_ids)
-    spm_unit_tenure_types = np.asarray(spm_unit_tenure_types)
-    spm_unit_geoadj = np.asarray(spm_unit_geoadj, dtype=np.float64)
-
-    n_units = len(spm_unit_tenure_types)
-
-    # Count adults and children per SPM unit
-    is_adult = person_ages >= 18
-    num_adults = np.zeros(n_units, dtype=np.int32)
-    num_children = np.zeros(n_units, dtype=np.int32)
-    np.add.at(num_adults, person_spm_unit_ids, is_adult.astype(np.int32))
-    np.add.at(num_children, person_spm_unit_ids, (~is_adult).astype(np.int32))
-
-    # Map tenure type strings to codes
-    tenure_codes = np.full(n_units, 3, dtype=np.int32)
-    for tenure_str, code in SPM_TENURE_STRING_TO_CODE.items():
-        tenure_bytes = (
-            tenure_str.encode() if isinstance(tenure_str, str) else tenure_str
-        )
-        mask = spm_unit_tenure_types == tenure_bytes
-        if not mask.any():
-            mask = spm_unit_tenure_types == tenure_str
-        tenure_codes[mask] = code
-
-    base_thresholds = get_spm_reference_thresholds(year)
-
-    thresholds = np.zeros(n_units, dtype=np.float32)
-    for i in range(n_units):
-        tenure_str = TENURE_CODE_MAP.get(int(tenure_codes[i]), "renter")
-        base = base_thresholds[tenure_str]
-        equiv_scale = spm_equivalence_scale(int(num_adults[i]), int(num_children[i]))
-        thresholds[i] = base * equiv_scale * spm_unit_geoadj[i]
-
-    return thresholds

--- a/policyengine_us_data/calibration/entity_clone.py
+++ b/policyengine_us_data/calibration/entity_clone.py
@@ -21,7 +21,6 @@ from policyengine_us_data.calibration.block_assignment import (
     derive_geography_from_blocks,
 )
 from policyengine_us_data.calibration.calibration_utils import (
-    calculate_spm_thresholds_vectorized,
     load_cd_geoadj_values,
 )
 from policyengine_us_data.utils.spm import geoadj_for_tenure
@@ -270,8 +269,9 @@ def materialize_clone_household_chunk(
     clone_geo = {k: v[block_inv] for k, v in unique_geo.items()}
 
     vars_to_save = set(sim.input_variables)
+    vars_to_save.discard("spm_unit_spm_threshold")
     vars_to_save.add("county")
-    vars_to_save.add("spm_unit_spm_threshold")
+    vars_to_save.add("spm_unit_geographic_adjustment")
     vars_to_save.add("congressional_district_geoid")
     for geo_var in [
         "block_geoid",
@@ -385,7 +385,6 @@ def materialize_clone_household_chunk(
         entities_per_clone["spm_unit"],
     )
 
-    person_ages = sim.calculate("age", map_to="person").values[person_clone_idx]
     spm_tenure_holder = sim.get_holder("spm_unit_tenure_type")
     spm_tenure_periods = spm_tenure_holder.get_known_periods()
     if spm_tenure_periods:
@@ -413,14 +412,8 @@ def materialize_clone_household_chunk(
         dtype=np.float64,
     )
 
-    data["spm_unit_spm_threshold"] = {
-        time_period: calculate_spm_thresholds_vectorized(
-            person_ages=person_ages,
-            person_spm_unit_ids=new_person_entity_ids["spm_unit"],
-            spm_unit_tenure_types=spm_tenure_cloned,
-            spm_unit_geoadj=spm_unit_geoadj,
-            year=time_period,
-        ),
+    data["spm_unit_geographic_adjustment"] = {
+        time_period: spm_unit_geoadj.astype(np.float32),
     }
 
     if apply_takeup:

--- a/policyengine_us_data/calibration/publish_local_area.py
+++ b/policyengine_us_data/calibration/publish_local_area.py
@@ -31,7 +31,6 @@ from policyengine_us_data.utils.data_upload import (
 from policyengine_us_data.calibration.calibration_utils import (
     STATE_CODES,
     load_cd_geoadj_values,
-    calculate_spm_thresholds_vectorized,
 )
 from policyengine_us_data.calibration.block_assignment import (
     derive_geography_from_blocks,
@@ -515,8 +514,9 @@ def build_h5(
 
     # === Determine variables to save ===
     vars_to_save = set(sim.input_variables)
+    vars_to_save.discard("spm_unit_spm_threshold")
     vars_to_save.add("county")
-    vars_to_save.add("spm_unit_spm_threshold")
+    vars_to_save.add("spm_unit_geographic_adjustment")
     vars_to_save.add("congressional_district_geoid")
     for gv in [
         "block_geoid",
@@ -650,17 +650,14 @@ def build_h5(
         time_period: clone_cd_geoids,
     }
 
-    # === SPM threshold recalculation ===
-    print("Recalculating SPM thresholds...")
+    # === SPM geographic adjustment assignment ===
+    print("Assigning SPM geographic adjustments...")
     unique_cds_list = sorted(set(active_clone_cds))
     cd_geoadj_values = load_cd_geoadj_values(unique_cds_list)
     spm_clone_ids = np.repeat(
         np.arange(n_clones, dtype=np.int64),
         entities_per_clone["spm_unit"],
     )
-
-    # Get cloned person ages and SPM tenure types
-    person_ages = sim.calculate("age", map_to="person").values[person_clone_idx]
 
     spm_tenure_holder = sim.get_holder("spm_unit_tenure_type")
     spm_tenure_periods = spm_tenure_holder.get_known_periods()
@@ -690,15 +687,8 @@ def build_h5(
         dtype=np.float64,
     )
 
-    new_spm_thresholds = calculate_spm_thresholds_vectorized(
-        person_ages=person_ages,
-        person_spm_unit_ids=new_person_entity_ids["spm_unit"],
-        spm_unit_tenure_types=spm_tenure_cloned,
-        spm_unit_geoadj=spm_unit_geoadj,
-        year=time_period,
-    )
-    data["spm_unit_spm_threshold"] = {
-        time_period: new_spm_thresholds,
+    data["spm_unit_geographic_adjustment"] = {
+        time_period: spm_unit_geoadj.astype(np.float32),
     }
 
     # === Apply calibration takeup draws ===

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -1385,7 +1385,7 @@ def add_personal_income_variables(cps: h5py.File, person: DataFrame, year: int):
         id="add_spm_variables",
         label="Add SPM Variables",
         node_type="library",
-        description="Populate CPS supplemental poverty measure variables and thresholds.",
+        description="Populate CPS supplemental poverty measure variables and geographic adjustments.",
         source_file="policyengine_us_data/datasets/cps/cps.py",
         status="current",
         stability="moving",
@@ -1394,10 +1394,6 @@ def add_personal_income_variables(cps: h5py.File, person: DataFrame, year: int):
     )
 )
 def add_spm_variables(self, cps: h5py.File, spm_unit: DataFrame) -> None:
-    from policyengine_us_data.utils.spm import (
-        calculate_spm_thresholds_with_geoadj,
-    )
-
     SPM_RENAMES = dict(
         spm_unit_total_income_reported="SPM_TOTVAL",
         snap_reported="SPM_SNAPSUB",
@@ -1419,15 +1415,8 @@ def add_spm_variables(self, cps: h5py.File, spm_unit: DataFrame) -> None:
         if asec_variable in spm_unit.columns:
             cps[openfisca_variable] = spm_unit[asec_variable]
 
-    # Calculate SPM thresholds using spm-calculator with Census-provided
-    # geographic adjustment factors (SPM_GEOADJ)
-    cps["spm_unit_spm_threshold"] = calculate_spm_thresholds_with_geoadj(
-        num_adults=spm_unit["SPM_NUMADULTS"].values,
-        num_children=spm_unit["SPM_NUMKIDS"].values,
-        tenure_codes=spm_unit["SPM_TENMORTSTATUS"].values,
-        geoadj=spm_unit["SPM_GEOADJ"].values,
-        year=self.time_period,
-    )
+    if "SPM_GEOADJ" in spm_unit.columns:
+        cps["spm_unit_geographic_adjustment"] = spm_unit["SPM_GEOADJ"].values
 
     if "SPM_TENMORTSTATUS" in spm_unit.columns:
         tenure_map = {

--- a/policyengine_us_data/datasets/cps/extended_cps.py
+++ b/policyengine_us_data/datasets/cps/extended_cps.py
@@ -68,7 +68,7 @@ def _supports_structural_mortgage_inputs() -> bool:
     return has_policyengine_us_variables(*STRUCTURAL_MORTGAGE_VARIABLES)
 
 
-def _calculate_spm_thresholds_from_assigned_geography(
+def _calculate_spm_geographic_adjustments_from_assigned_geography(
     data: dict[str, dict[int, np.ndarray]],
     time_period: int,
 ) -> np.ndarray:
@@ -76,8 +76,6 @@ def _calculate_spm_thresholds_from_assigned_geography(
         load_cd_geoadj_values,
     )
     from policyengine_us_data.utils.spm import (
-        TENURE_CODE_MAP,
-        calculate_spm_thresholds_with_geoadj,
         geoadj_for_tenure,
     )
 
@@ -85,7 +83,6 @@ def _calculate_spm_thresholds_from_assigned_geography(
     person_spm_unit_ids = data["person_spm_unit_id"][time_period]
     person_household_ids = data["person_household_id"][time_period]
     household_ids = data["household_id"][time_period]
-    ages = data["age"][time_period]
     cd_geoids = np.asarray(data["congressional_district_geoid"][time_period]).astype(
         str
     )
@@ -97,56 +94,33 @@ def _calculate_spm_thresholds_from_assigned_geography(
         {
             "spm_unit_id": person_spm_unit_ids,
             "household_id": person_household_ids,
-            "is_adult": ages >= 18,
-            "is_child": ages < 18,
         }
     )
     spm_df = person_df.groupby("spm_unit_id").agg(
-        num_adults=("is_adult", "sum"),
-        num_children=("is_child", "sum"),
         household_id=("household_id", "first"),
     )
     spm_df = spm_df.reindex(spm_unit_ids)
 
     tenure = data.get("spm_unit_tenure_type", {}).get(time_period)
-    tenure_codes = np.full(len(spm_unit_ids), 3, dtype=int)
+    tenure_values = np.full(len(spm_unit_ids), "RENTER", dtype="U30")
     if tenure is not None:
         tenure_values = np.asarray(tenure)
         if np.issubdtype(tenure_values.dtype, np.bytes_):
             tenure_values = np.char.decode(tenure_values, "utf-8")
-        tenure_codes = (
-            pd.Series(tenure_values)
-            .map(
-                {
-                    "OWNER_WITH_MORTGAGE": 1,
-                    "OWNER_WITHOUT_MORTGAGE": 2,
-                    "RENTER": 3,
-                }
-            )
-            .fillna(3)
-            .astype(int)
-            .values
-        )
+        tenure_values = pd.Series(tenure_values).fillna("RENTER").astype(str).values
 
-    geoadj = np.array(
+    return np.array(
         [
             geoadj_for_tenure(
                 cd_geoadj_values.get(cd_by_household.get(household_id), 1.0),
-                TENURE_CODE_MAP.get(int(tenure_code), "renter"),
+                tenure_type,
             )
-            for household_id, tenure_code in zip(
+            for household_id, tenure_type in zip(
                 spm_df["household_id"].values,
-                tenure_codes,
+                tenure_values,
             )
         ],
         dtype=float,
-    )
-    return calculate_spm_thresholds_with_geoadj(
-        num_adults=spm_df["num_adults"].fillna(0).values,
-        num_children=spm_df["num_children"].fillna(0).values,
-        tenure_codes=tenure_codes,
-        geoadj=geoadj,
-        year=time_period,
     )
 
 
@@ -965,9 +939,9 @@ class ExtendedCPS(Dataset):
                 self.time_period,
                 had_positive_mortgage_input,
             )
-        logger.info("Calculating SPM thresholds from assigned geography")
-        new_data["spm_unit_spm_threshold"] = {
-            self.time_period: _calculate_spm_thresholds_from_assigned_geography(
+        logger.info("Calculating SPM geographic adjustments from assigned geography")
+        new_data["spm_unit_geographic_adjustment"] = {
+            self.time_period: _calculate_spm_geographic_adjustments_from_assigned_geography(
                 new_data,
                 self.time_period,
             )
@@ -1243,8 +1217,8 @@ class ExtendedCPS(Dataset):
     # due to entity shape mismatch.
     _KEEP_FORMULA_VARS = {
         "person_id",
-        "spm_unit_spm_threshold",
         "weeks_worked",
+        "spm_unit_geographic_adjustment",
         "self_employed_pension_contribution_ald",
         "self_employed_health_insurance_ald",
     }

--- a/policyengine_us_data/datasets/cps/small_enhanced_cps.py
+++ b/policyengine_us_data/datasets/cps/small_enhanced_cps.py
@@ -148,10 +148,6 @@ def create_sparse_ecps():
         dataset=EnhancedCPS_2024,
     )
     template_sim.set_input("household_weight", time_period, sparse_weights)
-    # Preserve the base-year SPM threshold when round-tripping through a
-    # dataframe. It is a formula variable in policyengine-us, but poverty
-    # projections need the input value as the geographic-adjusted anchor.
-    template_sim.calculate("spm_unit_spm_threshold", time_period)
 
     df = template_sim.to_input_dataframe()
     del template_sim

--- a/policyengine_us_data/utils/spm.py
+++ b/policyengine_us_data/utils/spm.py
@@ -1,65 +1,7 @@
-"""SPM threshold calculation utilities aligned with Census reference data."""
-
-from functools import lru_cache
+"""SPM geographic adjustment utilities aligned with Census rent data."""
 
 import numpy as np
-from policyengine_us import CountryTaxBenefitSystem
 
-PUBLISHED_SPM_REFERENCE_THRESHOLDS = {
-    2015: {
-        "renter": 25_155.0,
-        "owner_with_mortgage": 24_859.0,
-        "owner_without_mortgage": 20_639.0,
-    },
-    2016: {
-        "renter": 25_558.0,
-        "owner_with_mortgage": 25_248.0,
-        "owner_without_mortgage": 20_943.0,
-    },
-    2017: {
-        "renter": 26_213.0,
-        "owner_with_mortgage": 25_897.0,
-        "owner_without_mortgage": 21_527.0,
-    },
-    2018: {
-        "renter": 26_905.0,
-        "owner_with_mortgage": 26_565.0,
-        "owner_without_mortgage": 22_095.0,
-    },
-    2019: {
-        "renter": 27_515.0,
-        "owner_with_mortgage": 27_172.0,
-        "owner_without_mortgage": 22_600.0,
-    },
-    2020: {
-        "renter": 28_881.0,
-        "owner_with_mortgage": 28_533.0,
-        "owner_without_mortgage": 23_948.0,
-    },
-    2021: {
-        "renter": 31_453.0,
-        "owner_with_mortgage": 31_089.0,
-        "owner_without_mortgage": 26_022.0,
-    },
-    2022: {
-        "renter": 33_402.0,
-        "owner_with_mortgage": 32_949.0,
-        "owner_without_mortgage": 27_679.0,
-    },
-    2023: {
-        "renter": 36_606.0,
-        "owner_with_mortgage": 36_192.0,
-        "owner_without_mortgage": 30_347.0,
-    },
-    2024: {
-        "renter": 39_430.0,
-        "owner_with_mortgage": 39_068.0,
-        "owner_without_mortgage": 32_586.0,
-    },
-}
-
-LATEST_PUBLISHED_SPM_THRESHOLD_YEAR = max(PUBLISHED_SPM_REFERENCE_THRESHOLDS)
-REFERENCE_RAW_SCALE = 3**0.7
 TENURE_HOUSING_SHARES = {
     "owner_with_mortgage": 0.434,
     "owner_without_mortgage": 0.323,
@@ -77,70 +19,6 @@ SPM_TENURE_TYPE_TO_REFERENCE_KEY = {
     "OWNER_WITHOUT_MORTGAGE": "owner_without_mortgage",
     "RENTER": "renter",
 }
-
-
-@lru_cache(maxsize=1)
-def _get_cpi_u_parameter():
-    system = CountryTaxBenefitSystem()
-    return system.parameters.gov.bls.cpi.cpi_u
-
-
-def spm_equivalence_scale(num_adults, num_children):
-    """Return the SPM equivalence scale relative to two adults and two kids."""
-    scalar_input = np.isscalar(num_adults) and np.isscalar(num_children)
-    adults, children = np.broadcast_arrays(
-        np.asarray(num_adults, dtype=float),
-        np.asarray(num_children, dtype=float),
-    )
-
-    raw = np.zeros_like(adults, dtype=float)
-    has_people = (adults + children) > 0
-    with_children = has_people & (children > 0)
-
-    single_adult_with_children = with_children & (adults <= 1)
-    raw[single_adult_with_children] = (
-        1.0 + 0.8 + 0.5 * np.maximum(children[single_adult_with_children] - 1, 0)
-    ) ** 0.7
-
-    multi_adult_with_children = with_children & ~single_adult_with_children
-    raw[multi_adult_with_children] = (
-        adults[multi_adult_with_children] + 0.5 * children[multi_adult_with_children]
-    ) ** 0.7
-
-    no_children = has_people & ~with_children
-    one_adult = no_children & (adults <= 1)
-    two_adults = no_children & (adults == 2)
-    larger_adult_units = no_children & (adults > 2)
-
-    raw[one_adult] = 1.0
-    raw[two_adults] = 1.41
-    raw[larger_adult_units] = adults[larger_adult_units] ** 0.7
-
-    result = raw / REFERENCE_RAW_SCALE
-    if scalar_input:
-        return float(result)
-    return result
-
-
-def get_spm_reference_thresholds(year: int) -> dict[str, float]:
-    if year in PUBLISHED_SPM_REFERENCE_THRESHOLDS:
-        return PUBLISHED_SPM_REFERENCE_THRESHOLDS[year].copy()
-
-    earliest_year = min(PUBLISHED_SPM_REFERENCE_THRESHOLDS)
-    if year < earliest_year:
-        raise ValueError(
-            f"No published SPM reference thresholds for {year}. "
-            f"Earliest available year is {earliest_year}."
-        )
-
-    cpi_u = _get_cpi_u_parameter()
-    factor = float(
-        cpi_u(f"{year}-02-01") / cpi_u(f"{LATEST_PUBLISHED_SPM_THRESHOLD_YEAR}-02-01")
-    )
-    latest_thresholds = PUBLISHED_SPM_REFERENCE_THRESHOLDS[
-        LATEST_PUBLISHED_SPM_THRESHOLD_YEAR
-    ]
-    return {tenure: value * factor for tenure, value in latest_thresholds.items()}
 
 
 def calculate_geoadj_from_rent(
@@ -172,40 +50,3 @@ def geoadj_for_tenure(geoadj_values, tenure_type) -> float:
         else reference_key_for_spm_tenure_type(tenure_type)
     )
     return float(geoadj_values.get(reference_key, 1.0))
-
-
-def calculate_spm_thresholds_with_geoadj(
-    num_adults: np.ndarray,
-    num_children: np.ndarray,
-    tenure_codes: np.ndarray,
-    geoadj: np.ndarray,
-    year: int,
-) -> np.ndarray:
-    """
-    Calculate SPM thresholds using supplied geographic adjustments.
-
-    Args:
-        num_adults: Array of number of adults (18+) in each SPM unit.
-        num_children: Array of number of children (<18) in each SPM unit.
-        tenure_codes: Array of Census tenure/mortgage status codes.
-            1 = owner with mortgage, 2 = owner without mortgage, 3 = renter.
-        geoadj: Array of geographic adjustment factors.
-        year: The year for which to calculate thresholds.
-
-    Returns:
-        Array of SPM threshold values.
-    """
-    num_adults = np.asarray(num_adults)
-    num_children = np.asarray(num_children)
-    tenure_codes = np.asarray(tenure_codes)
-    geoadj = np.asarray(geoadj, dtype=float)
-
-    base_thresholds = get_spm_reference_thresholds(year)
-    bases = np.array(
-        [
-            base_thresholds[TENURE_CODE_MAP.get(int(tenure_code), "renter")]
-            for tenure_code in tenure_codes
-        ],
-        dtype=float,
-    )
-    return bases * spm_equivalence_scale(num_adults, num_children) * geoadj

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us>=1.683.0",
+    "policyengine-us>=1.689.0",
     # policyengine-core 3.26.0 includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/tests/integration/support/tiny_stage_3.py
+++ b/tests/integration/support/tiny_stage_3.py
@@ -50,7 +50,7 @@ STAGE_3_GROUP_VARIABLES = tuple(
             "tax_unit_is_joint",
             "spm_unit_total_income_reported",
             "spm_unit_net_income_reported",
-            "spm_unit_spm_threshold",
+            "spm_unit_geographic_adjustment",
             "spm_unit_capped_housing_subsidy_reported",
             "snap_reported",
             "household_is_puf_clone",
@@ -77,7 +77,7 @@ STAGE_4_INPUT_VARIABLES = (
     "tax_unit_is_joint",
     "spm_unit_total_income_reported",
     "spm_unit_net_income_reported",
-    "spm_unit_spm_threshold",
+    "spm_unit_geographic_adjustment",
     "is_puf_clone",
 )
 
@@ -262,8 +262,8 @@ def _extended_group_arrays(
         "spm_unit_net_income_reported": np.round(total_income * 0.85, 2).astype(
             np.float32
         ),
-        "spm_unit_spm_threshold": (
-            25_000 + tax_unit_count_dependents.astype(np.float32) * 5_000
+        "spm_unit_geographic_adjustment": (
+            1.0 + tax_unit_count_dependents.astype(np.float32) * 0.02
         ).astype(np.float32),
         "spm_unit_capped_housing_subsidy_reported": np.where(
             arrays["tenure_type"] == b"RENTED",

--- a/tests/integration/test_chunked_matrix_builder.py
+++ b/tests/integration/test_chunked_matrix_builder.py
@@ -223,15 +223,6 @@ def test_build_matrix_chunked_smoke_on_fixture(
         "policyengine_us_data.calibration.entity_clone.load_cd_geoadj_values",
         lambda cds: {cd: 1.0 for cd in cds},
     )
-    monkeypatch.setattr(
-        "policyengine_us_data.calibration.entity_clone."
-        "calculate_spm_thresholds_vectorized",
-        lambda **kwargs: np.ones(
-            len(kwargs["spm_unit_tenure_types"]),
-            dtype=np.float32,
-        ),
-    )
-
     sim = Microsimulation(dataset=str(FIXTURE_PATH))
     n_records, geography = _build_chunked_test_geography(sim)
     builder = _build_chunked_test_builder(chunked_smoke_db)
@@ -267,15 +258,6 @@ def test_build_matrix_chunked_matches_precomputed_builder(
         "policyengine_us_data.calibration.entity_clone.load_cd_geoadj_values",
         lambda cds: {cd: 1.0 for cd in cds},
     )
-    monkeypatch.setattr(
-        "policyengine_us_data.calibration.entity_clone."
-        "calculate_spm_thresholds_vectorized",
-        lambda **kwargs: np.ones(
-            len(kwargs["spm_unit_tenure_types"]),
-            dtype=np.float32,
-        ),
-    )
-
     sim = Microsimulation(dataset=str(FIXTURE_PATH))
     _, geography = _build_chunked_test_geography(sim)
     builder = _build_chunked_test_builder(chunked_smoke_db)
@@ -316,15 +298,6 @@ def test_build_matrix_chunked_matches_precomputed_builder_for_aca_ptc(
         "policyengine_us_data.calibration.entity_clone.load_cd_geoadj_values",
         lambda cds: {cd: 1.0 for cd in cds},
     )
-    monkeypatch.setattr(
-        "policyengine_us_data.calibration.entity_clone."
-        "calculate_spm_thresholds_vectorized",
-        lambda **kwargs: np.ones(
-            len(kwargs["spm_unit_tenure_types"]),
-            dtype=np.float32,
-        ),
-    )
-
     sim = Microsimulation(dataset=str(FIXTURE_PATH))
     _, geography = _build_chunked_test_geography(sim)
     builder = _build_chunked_test_builder(chunked_entity_target_db)
@@ -365,15 +338,6 @@ def test_build_matrix_chunked_resume_reuses_matching_manifest(
         "policyengine_us_data.calibration.entity_clone.load_cd_geoadj_values",
         lambda cds: {cd: 1.0 for cd in cds},
     )
-    monkeypatch.setattr(
-        "policyengine_us_data.calibration.entity_clone."
-        "calculate_spm_thresholds_vectorized",
-        lambda **kwargs: np.ones(
-            len(kwargs["spm_unit_tenure_types"]),
-            dtype=np.float32,
-        ),
-    )
-
     sim = Microsimulation(dataset=str(FIXTURE_PATH))
     _, geography = _build_chunked_test_geography(sim)
     builder = _build_chunked_test_builder(chunked_smoke_db)
@@ -414,15 +378,6 @@ def test_build_matrix_chunked_resume_rejects_lineage_mismatch(
         "policyengine_us_data.calibration.entity_clone.load_cd_geoadj_values",
         lambda cds: {cd: 1.0 for cd in cds},
     )
-    monkeypatch.setattr(
-        "policyengine_us_data.calibration.entity_clone."
-        "calculate_spm_thresholds_vectorized",
-        lambda **kwargs: np.ones(
-            len(kwargs["spm_unit_tenure_types"]),
-            dtype=np.float32,
-        ),
-    )
-
     sim = Microsimulation(dataset=str(FIXTURE_PATH))
     _, geography = _build_chunked_test_geography(sim)
     builder = _build_chunked_test_builder(chunked_smoke_db)
@@ -460,15 +415,6 @@ def test_build_matrix_chunked_resume_rejects_cached_chunk_range_mismatch(
         "policyengine_us_data.calibration.entity_clone.load_cd_geoadj_values",
         lambda cds: {cd: 1.0 for cd in cds},
     )
-    monkeypatch.setattr(
-        "policyengine_us_data.calibration.entity_clone."
-        "calculate_spm_thresholds_vectorized",
-        lambda **kwargs: np.ones(
-            len(kwargs["spm_unit_tenure_types"]),
-            dtype=np.float32,
-        ),
-    )
-
     sim = Microsimulation(dataset=str(FIXTURE_PATH))
     _, geography = _build_chunked_test_geography(sim)
     builder = _build_chunked_test_builder(chunked_smoke_db)

--- a/tests/integration/test_tiny_stage_3_artifacts.py
+++ b/tests/integration/test_tiny_stage_3_artifacts.py
@@ -95,7 +95,7 @@ def test_tiny_extended_cps_derives_stage_4_contract_variables(tmp_path):
     assert (arrays["pre_tax_contributions"] >= 0).all()
     assert (arrays["spm_unit_total_income_reported"] >= 0).all()
     assert (arrays["spm_unit_net_income_reported"] >= 0).all()
-    assert (arrays["spm_unit_spm_threshold"] > 0).all()
+    assert (arrays["spm_unit_geographic_adjustment"] > 0).all()
 
 
 def test_tiny_extended_cps_digest_is_stable_for_same_inputs(tmp_path):

--- a/tests/unit/calibration/test_entity_clone.py
+++ b/tests/unit/calibration/test_entity_clone.py
@@ -69,16 +69,6 @@ def test_materialize_clone_household_chunk_preserves_entity_joins(
         "policyengine_us_data.calibration.entity_clone.load_cd_geoadj_values",
         lambda cds: {cd: 1.0 for cd in cds},
     )
-    monkeypatch.setattr(
-        "policyengine_us_data.calibration.entity_clone."
-        "calculate_spm_thresholds_vectorized",
-        lambda **kwargs: np.full(
-            len(kwargs["spm_unit_tenure_types"]),
-            12000.0,
-            dtype=np.float32,
-        ),
-    )
-
     output_path = tmp_path / "clone_chunk.h5"
     summary = materialize_clone_household_chunk(
         sim=fixture_sim,
@@ -106,12 +96,52 @@ def test_materialize_clone_household_chunk_preserves_entity_joins(
         household_id = h5["household_id"]["2023"][:]
         assert np.array_equal(household_id, np.array([0, 1, 2], dtype=np.int32))
         assert set(person_household_id).issubset(set(household_id))
+        spm_geoadj = h5["spm_unit_geographic_adjustment"]["2023"][:]
+        np.testing.assert_allclose(spm_geoadj, 1.0)
+        assert "spm_unit_spm_threshold" not in h5
 
         for entity_key in ("tax_unit", "spm_unit", "family", "marital_unit"):
             entity_ids = h5[f"{entity_key}_id"]["2023"][:]
             person_entity_ids = h5[f"person_{entity_key}_id"]["2023"][:]
             assert len(entity_ids) == len(set(entity_ids))
             assert set(person_entity_ids).issubset(set(entity_ids))
+
+
+def test_materialize_clone_household_chunk_drops_legacy_spm_threshold_input(
+    tmp_path,
+    monkeypatch,
+    fixture_sim,
+    fixture_entity_maps,
+):
+    original_input_variables = list(fixture_sim.input_variables)
+    fixture_sim.input_variables.append("spm_unit_spm_threshold")
+    monkeypatch.setattr(
+        "policyengine_us_data.calibration.entity_clone.derive_geography_from_blocks",
+        _fake_geography_from_blocks,
+    )
+    monkeypatch.setattr(
+        "policyengine_us_data.calibration.entity_clone.load_cd_geoadj_values",
+        lambda cds: {cd: 1.0 for cd in cds},
+    )
+
+    output_path = tmp_path / "legacy_threshold_input.h5"
+    try:
+        materialize_clone_household_chunk(
+            sim=fixture_sim,
+            entity_maps=fixture_entity_maps,
+            active_hh=np.array([0], dtype=np.int64),
+            active_blocks=np.array(["371830501001001"], dtype="U15"),
+            active_cd_geoids=np.array(["3701"], dtype=str),
+            active_clone_indices=np.array([0], dtype=np.int64),
+            output_path=output_path,
+            apply_takeup=False,
+        )
+    finally:
+        fixture_sim.input_variables = original_input_variables
+
+    with h5py.File(output_path, "r") as h5:
+        assert "spm_unit_spm_threshold" not in h5
+        assert "spm_unit_geographic_adjustment" in h5
 
 
 def test_materialize_clone_household_chunk_keeps_clone_specific_block_geoids(
@@ -128,15 +158,6 @@ def test_materialize_clone_household_chunk_keeps_clone_specific_block_geoids(
         "policyengine_us_data.calibration.entity_clone.load_cd_geoadj_values",
         lambda cds: {cd: 1.0 for cd in cds},
     )
-    monkeypatch.setattr(
-        "policyengine_us_data.calibration.entity_clone."
-        "calculate_spm_thresholds_vectorized",
-        lambda **kwargs: np.ones(
-            len(kwargs["spm_unit_tenure_types"]),
-            dtype=np.float32,
-        ),
-    )
-
     output_path = tmp_path / "clone_specific_blocks.h5"
     materialize_clone_household_chunk(
         sim=fixture_sim,
@@ -171,15 +192,6 @@ def test_materialize_clone_household_chunk_writes_non_ascii_county_as_index(
         "policyengine_us_data.calibration.entity_clone.load_cd_geoadj_values",
         lambda cds: {cd: 1.0 for cd in cds},
     )
-    monkeypatch.setattr(
-        "policyengine_us_data.calibration.entity_clone."
-        "calculate_spm_thresholds_vectorized",
-        lambda **kwargs: np.ones(
-            len(kwargs["spm_unit_tenure_types"]),
-            dtype=np.float32,
-        ),
-    )
-
     output_path = tmp_path / "non_ascii_county.h5"
     materialize_clone_household_chunk(
         sim=fixture_sim,

--- a/tests/unit/calibration/test_spm_thresholds.py
+++ b/tests/unit/calibration/test_spm_thresholds.py
@@ -1,13 +1,11 @@
 import numpy as np
 import pandas as pd
 import pytest
-from policyengine_us import CountryTaxBenefitSystem
 
 from policyengine_us_data.calibration.calibration_utils import (
-    calculate_spm_thresholds_vectorized,
     load_cd_geoadj_values,
 )
-from policyengine_us_data.utils.spm import calculate_spm_thresholds_with_geoadj
+from policyengine_us_data.utils.spm import geoadj_for_tenure
 
 
 def test_load_cd_geoadj_values_returns_tenure_specific_lookup(monkeypatch):
@@ -30,29 +28,15 @@ def test_load_cd_geoadj_values_returns_tenure_specific_lookup(monkeypatch):
     assert geoadj_lookup["101"]["owner_without_mortgage"] == pytest.approx(1.1615)
 
 
-def test_calculate_spm_thresholds_vectorized_uses_cpi_fallback_for_future_year():
-    thresholds = calculate_spm_thresholds_vectorized(
-        person_ages=np.array([40, 35, 10, 8]),
-        person_spm_unit_ids=np.array([0, 0, 0, 0]),
-        spm_unit_tenure_types=np.array([b"RENTER"]),
-        spm_unit_geoadj=np.array([1.1]),
-        year=2027,
-    )
+def test_geoadj_for_tenure_accepts_policyengine_tenure_bytes():
+    geoadj_lookup = {
+        "renter": 1.1,
+        "owner_with_mortgage": 1.2,
+        "owner_without_mortgage": 1.3,
+    }
 
-    cpi_u = CountryTaxBenefitSystem().parameters.gov.bls.cpi.cpi_u
-    cpi_ratio = float(cpi_u("2027-02-01") / cpi_u("2024-02-01"))
-    expected = 39_430.0 * cpi_ratio * 1.1
-
-    assert thresholds[0] == pytest.approx(expected)
-
-
-def test_calculate_spm_thresholds_with_geoadj_uses_published_reference_thresholds():
-    thresholds = calculate_spm_thresholds_with_geoadj(
-        num_adults=np.array([2]),
-        num_children=np.array([2]),
-        tenure_codes=np.array([3]),
-        geoadj=np.array([1.0]),
-        year=2024,
-    )
-
-    assert thresholds[0] == pytest.approx(39_430.0)
+    assert geoadj_for_tenure(geoadj_lookup, np.bytes_("RENTER")) == pytest.approx(1.1)
+    assert geoadj_for_tenure(
+        geoadj_lookup,
+        np.bytes_("OWNER_WITH_MORTGAGE"),
+    ) == pytest.approx(1.2)

--- a/tests/unit/test_extended_cps.py
+++ b/tests/unit/test_extended_cps.py
@@ -26,7 +26,7 @@ from policyengine_us_data.datasets.cps.extended_cps import (
     ExtendedCPS,
     _apply_post_processing,
     _build_clone_test_frame,
-    _calculate_spm_thresholds_from_assigned_geography,
+    _calculate_spm_geographic_adjustments_from_assigned_geography,
     _derive_overtime_occupation_inputs,
     _impute_clone_cps_features,
     apply_retirement_constraints,
@@ -152,18 +152,17 @@ class TestVariableListConsistency:
     def test_weeks_worked_is_cps_only_imputed_for_clone_records(self):
         assert "weeks_worked" in set(CPS_ONLY_IMPUTED_VARIABLES)
 
-    def test_spm_threshold_is_location_derived_not_qrf_imputed(self):
+    def test_spm_threshold_is_formula_output_not_qrf_imputed(self):
         assert "spm_unit_spm_threshold" not in set(CPS_ONLY_IMPUTED_VARIABLES)
-        assert "spm_unit_spm_threshold" in ExtendedCPS._keep_formula_vars()
+        assert "spm_unit_spm_threshold" not in ExtendedCPS._keep_formula_vars()
+        assert "spm_unit_geographic_adjustment" in ExtendedCPS._keep_formula_vars()
 
     def test_weeks_worked_is_preserved_for_future_year_formulas(self):
         assert "weeks_worked" in ExtendedCPS._keep_formula_vars()
 
 
 class TestSpmThresholdGeography:
-    def test_threshold_inputs_follow_assigned_household_geography(self, monkeypatch):
-        captured = {}
-
+    def test_geoadj_inputs_follow_assigned_household_geography(self, monkeypatch):
         def fake_load_cd_geoadj_values(cds):
             assert cds == ["101", "202"]
             return {
@@ -179,27 +178,9 @@ class TestSpmThresholdGeography:
                 },
             }
 
-        def fake_calculate_spm_thresholds_with_geoadj(
-            num_adults,
-            num_children,
-            tenure_codes,
-            geoadj,
-            year,
-        ):
-            captured["num_adults"] = num_adults
-            captured["num_children"] = num_children
-            captured["tenure_codes"] = tenure_codes
-            captured["geoadj"] = geoadj
-            captured["year"] = year
-            return geoadj * 100
-
         monkeypatch.setattr(
             "policyengine_us_data.calibration.calibration_utils.load_cd_geoadj_values",
             fake_load_cd_geoadj_values,
-        )
-        monkeypatch.setattr(
-            "policyengine_us_data.utils.spm.calculate_spm_thresholds_with_geoadj",
-            fake_calculate_spm_thresholds_with_geoadj,
         )
         data = {
             "household_id": {2024: np.array([1, 2])},
@@ -213,17 +194,12 @@ class TestSpmThresholdGeography:
             "age": {2024: np.array([30, 5, 40])},
         }
 
-        thresholds = _calculate_spm_thresholds_from_assigned_geography(
+        geoadj = _calculate_spm_geographic_adjustments_from_assigned_geography(
             data,
             2024,
         )
 
-        np.testing.assert_array_equal(thresholds, np.array([100.0, 400.0]))
-        np.testing.assert_array_equal(captured["num_adults"], np.array([1, 1]))
-        np.testing.assert_array_equal(captured["num_children"], np.array([1, 0]))
-        np.testing.assert_array_equal(captured["tenure_codes"], np.array([3, 2]))
-        np.testing.assert_array_equal(captured["geoadj"], np.array([1.0, 4.0]))
-        assert captured["year"] == 2024
+        np.testing.assert_array_equal(geoadj, np.array([1.0, 4.0]))
 
 
 class TestStructuralMortgageValidation:

--- a/uv.lock
+++ b/uv.lock
@@ -2122,7 +2122,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.686.1"
+version = "1.689.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2132,9 +2132,9 @@ dependencies = [
     { name = "tables" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/06/d0a23255386fbef24aecc9e583a86dcb797ea791d526b5a4ef90d12a12af/policyengine_us-1.686.1.tar.gz", hash = "sha256:476e4f10c00c2deb0ba250e92ac75d845ec941afd576be599a38efe281216b54", size = 9459480, upload-time = "2026-05-05T16:20:50.665Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/34/acbf001b0bdfe84e0be6f9c563d4e5f39a14989602b0afad94a70985587b/policyengine_us-1.689.0.tar.gz", hash = "sha256:360ddfe388aa92804ceb90be456edc379d062721d0ae5ce93331d0cd4c7b35b5", size = 9468113, upload-time = "2026-05-07T20:49:07.448Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/51/2ac9ac4685740e45a14db451531de151d20283bc344776a42abf54223ca8/policyengine_us-1.686.1-py3-none-any.whl", hash = "sha256:f947c284357545033ab98d9cdef215603aefdd85cfb80ca9f6c05afd5663e935", size = 9939597, upload-time = "2026-05-05T16:20:47.615Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/7a/5cc03917b5ee34343b5fef0c7aee04c2910f3cdee3f3ac41b5fae5577472/policyengine_us-1.689.0-py3-none-any.whl", hash = "sha256:9e7250074f9e6bccb00864f6b26b7f5f19e345ec24240762f60aab5ad0271734", size = 9960376, upload-time = "2026-05-07T20:49:04.717Z" },
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.0,<3.27" },
-    { name = "policyengine-us", specifier = ">=1.683.0" },
+    { name = "policyengine-us", specifier = ">=1.689.0" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },


### PR DESCRIPTION
## Summary
- Stop materializing CPS/local spm_unit_spm_threshold values in us-data.
- Store spm_unit_geographic_adjustment inputs from CPS SPM_GEOADJ and assigned local/CD geography instead.
- Remove duplicated SPM threshold/reference-threshold math from us-data now that policyengine-us 1.689.0 owns the threshold formula.
- Drop legacy spm_unit_spm_threshold inputs from local clone outputs if older source datasets contain them.

## Dependency
- Requires policyengine-us>=1.689.0, which includes spm_unit_geographic_adjustment and the updated SPM threshold formula.

## Tests
- uv run ruff check policyengine_us_data/utils/spm.py policyengine_us_data/calibration/calibration_utils.py policyengine_us_data/calibration/entity_clone.py policyengine_us_data/calibration/publish_local_area.py policyengine_us_data/datasets/cps/cps.py policyengine_us_data/datasets/cps/extended_cps.py policyengine_us_data/datasets/cps/small_enhanced_cps.py tests/unit/test_extended_cps.py tests/unit/calibration/test_spm_thresholds.py tests/unit/calibration/test_entity_clone.py tests/integration/test_chunked_matrix_builder.py tests/integration/support/tiny_stage_3.py tests/integration/test_tiny_stage_3_artifacts.py
- uv run pytest tests/unit/calibration/test_spm_thresholds.py tests/unit/test_extended_cps.py tests/unit/calibration/test_entity_clone.py tests/integration/test_tiny_stage_3_artifacts.py tests/integration/test_chunked_matrix_builder.py