### PR TITLE
Emit Stage 1 dataset build contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format test test-unit test-integration install download upload docker documentation data validate-data calibrate calibrate-build publish-local-area upload-calibration upload-dataset push-to-modal build-data-modal build-matrices calibrate-modal calibrate-modal-national calibrate-both stage-h5s stage-national-h5 stage-all-h5s pipeline validate-staging validate-staging-full upload-validation check-staging check-sanity clean build paper clean-paper presentations database database-refresh promote-dataset promote build-h5s validate-local refresh-soi-targets push-pr-branch
+.PHONY: all format lint test test-unit test-integration install download upload docker documentation data validate-data calibrate calibrate-build publish-local-area upload-calibration upload-dataset push-to-modal build-data-modal build-matrices calibrate-modal calibrate-modal-national calibrate-both stage-h5s stage-national-h5 stage-all-h5s pipeline validate-staging validate-staging-full upload-validation check-staging check-sanity clean build paper clean-paper presentations database database-refresh promote-dataset promote build-h5s validate-local refresh-soi-targets push-pr-branch
 
 SOI_SOURCE_YEAR ?= 2021
 SOI_TARGET_YEAR ?= 2023
@@ -23,6 +23,9 @@ all: data test
 format:
 	ruff format .
 	mdformat --wrap 100 docs/
+
+lint:
+	ruff format --check .
 
 test:
 	pytest

--- a/changelog.d/919.added
+++ b/changelog.d/919.added
@@ -1,0 +1,1 @@
+Stage 1 now emits a semantic `dataset_build_output.json` contract alongside copied pipeline artifacts.

--- a/docs/engineering/skills/github-prs.md
+++ b/docs/engineering/skills/github-prs.md
@@ -17,11 +17,13 @@ Before creating or sharing a PR:
    already exists.
 3. Put `Fixes #ISSUE_NUMBER` as the first line of the PR description, using the
    issue number from the issue created or found in the previous step.
-4. Push the current branch to the canonical repository:
+4. Run the repository lint target:
+   `make lint`.
+5. Push the current branch to the canonical repository:
    `make push-pr-branch`.
-5. Create the PR from that same repository:
+6. Create the PR from that same repository:
    `gh pr create --repo PolicyEngine/policyengine-us-data --head "$(git branch --show-current)" --base main`.
-6. Verify the PR head repository:
+7. Verify the PR head repository:
    `gh pr view <PR> --repo PolicyEngine/policyengine-us-data --json headRepositoryOwner,headRepository`.
 
 The PR is valid only if the head repository is

--- a/docs/engineering/skills/github-prs.md
+++ b/docs/engineering/skills/github-prs.md
@@ -17,13 +17,16 @@ Before creating or sharing a PR:
    already exists.
 3. Put `Fixes #ISSUE_NUMBER` as the first line of the PR description, using the
    issue number from the issue created or found in the previous step.
-4. Run the repository lint target:
+4. Add a Towncrier changelog fragment under `changelog.d/` using the issue
+   number and the appropriate configured type, for example
+   `changelog.d/ISSUE_NUMBER.added`.
+5. Run the repository lint target:
    `make lint`.
-5. Push the current branch to the canonical repository:
+6. Push the current branch to the canonical repository:
    `make push-pr-branch`.
-6. Create the PR from that same repository:
+7. Create the PR from that same repository:
    `gh pr create --repo PolicyEngine/policyengine-us-data --head "$(git branch --show-current)" --base main`.
-7. Verify the PR head repository:
+8. Verify the PR head repository:
    `gh pr view <PR> --repo PolicyEngine/policyengine-us-data --json headRepositoryOwner,headRepository`.
 
 The PR is valid only if the head repository is

--- a/docs/engineering/skills/github-prs.md
+++ b/docs/engineering/skills/github-prs.md
@@ -13,11 +13,15 @@ Before creating or sharing a PR:
 
 1. Confirm the canonical repository is reachable:
    `gh repo view PolicyEngine/policyengine-us-data --json nameWithOwner`.
-2. Push the current branch to the canonical repository:
+2. Open a GitHub issue for the work, or verify that an appropriate issue
+   already exists.
+3. Put `Fixes #ISSUE_NUMBER` as the first line of the PR description, using the
+   issue number from the issue created or found in the previous step.
+4. Push the current branch to the canonical repository:
    `make push-pr-branch`.
-3. Create the PR from that same repository:
+5. Create the PR from that same repository:
    `gh pr create --repo PolicyEngine/policyengine-us-data --head "$(git branch --show-current)" --base main`.
-4. Verify the PR head repository:
+6. Verify the PR head repository:
    `gh pr view <PR> --repo PolicyEngine/policyengine-us-data --json headRepositoryOwner,headRepository`.
 
 The PR is valid only if the head repository is

--- a/modal_app/data_build.py
+++ b/modal_app/data_build.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 import sys
 import threading
+from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -20,8 +21,15 @@ for _p in (_baked, _local):
         sys.path.insert(0, _p)
 
 from modal_app.images import cpu_image as image  # noqa: E402
+from policyengine_us_data.__version__ import __version__ as DATA_PACKAGE_VERSION  # noqa: E402
 from policyengine_us_data.pipeline_metadata import pipeline_node  # noqa: E402
 from policyengine_us_data.pipeline_schema import PipelineNode  # noqa: E402
+from policyengine_us_data.stage_contracts import (  # noqa: E402
+    DATASET_BUILD_OUTPUT_CONTRACT_FILENAME,
+    StageContract,
+    build_dataset_build_output_contract,
+    write_contract,
+)
 from policyengine_us_data.utils.run_context import (  # noqa: E402
     resolve_run_id,
 )
@@ -134,6 +142,17 @@ VALIDATION_MODULES = [
 def _python_cmd(*args: str) -> list[str]:
     """Build a command that uses the current interpreter."""
     return [sys.executable, *args]
+
+
+def _utc_timestamp(value: datetime | None = None) -> str:
+    """Render a UTC timestamp for persisted pipeline metadata."""
+    value = value or datetime.now(timezone.utc)
+    return (
+        value.astimezone(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
 
 
 def setup_gcp_credentials():
@@ -473,6 +492,40 @@ def run_tests_with_checkpoints(
         print(f"Checkpointed: {module} passed")
 
 
+def write_dataset_build_contract(
+    *,
+    artifacts_dir: Path,
+    run_id: str,
+    code_sha: str,
+    checkpoint_stats: Mapping[str, int],
+    started_at: str | None,
+    completed_at: str,
+    duration_s: float | None,
+    upload_requested: bool,
+    stage_only: bool,
+    skip_enhanced_cps: bool,
+) -> StageContract:
+    """Write the Stage 1 semantic handoff contract next to copied artifacts."""
+    contract = build_dataset_build_output_contract(
+        artifacts_dir=artifacts_dir,
+        run_id=run_id,
+        code_sha=code_sha,
+        package_version=DATA_PACKAGE_VERSION,
+        checkpoint_stats=checkpoint_stats,
+        started_at=started_at,
+        completed_at=completed_at,
+        duration_s=duration_s,
+        upload_requested=upload_requested,
+        stage_only=stage_only,
+        skip_enhanced_cps=skip_enhanced_cps,
+    )
+    write_contract(
+        contract,
+        artifacts_dir / DATASET_BUILD_OUTPUT_CONTRACT_FILENAME,
+    )
+    return contract
+
+
 @app.function(
     image=image,
     secrets=[hf_secret, gcp_secret],
@@ -559,13 +612,14 @@ def build_datasets(
     commit = get_current_commit()
     log_path = Path("build_log.txt")
     log_file = open(log_path, "w")
-    started = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+    started_at_dt = datetime.now(timezone.utc)
+    started = _utc_timestamp(started_at_dt)
     log_file.write(
         f"{'=' * 40}\n"
         f" Data Build Log\n"
         f" Branch:  {branch}\n"
         f" Commit:  {commit[:8]}\n"
-        f" Started: {started}\n"
+        f" Started (UTC): {started}\n"
         f"{'=' * 40}\n"
     )
     log_file.flush()
@@ -787,9 +841,23 @@ def build_datasets(
         )
         print("  Copied calibration_weights.npy")
     shutil.copy2(log_path, artifacts_dir / "build_log.txt")
+    checkpoint_snapshot = checkpoint_stats.snapshot()
     with open(artifacts_dir / "data_build_checkpoint_stats.json", "w") as f:
-        json.dump(checkpoint_stats.snapshot(), f, indent=2, sort_keys=True)
+        json.dump(checkpoint_snapshot, f, indent=2, sort_keys=True)
     log_file.close()
+    completed_at_dt = datetime.now(timezone.utc)
+    write_dataset_build_contract(
+        artifacts_dir=artifacts_dir,
+        run_id=run_id,
+        code_sha=commit,
+        checkpoint_stats=checkpoint_snapshot,
+        started_at=started,
+        completed_at=_utc_timestamp(completed_at_dt),
+        duration_s=(completed_at_dt - started_at_dt).total_seconds(),
+        upload_requested=upload,
+        stage_only=stage_only,
+        skip_enhanced_cps=skip_enhanced_cps,
+    )
     pipeline_volume.commit()
     print("Pipeline artifacts committed to shared volume")
 

--- a/policyengine_us_data/stage_contracts/__init__.py
+++ b/policyengine_us_data/stage_contracts/__init__.py
@@ -31,6 +31,11 @@ from .constants import (
     ValidationReportStatus,
 )
 from .contracts import StageContract
+from .dataset_build import (
+    DATASET_BUILD_OUTPUT_CONTRACT_FILENAME,
+    DATASET_BUILD_OUTPUT_CONTRACT_TYPE,
+    build_dataset_build_output_contract,
+)
 from .diagnostics import DiagnosticRef
 from .execution import ExecutionRecord, ReuseSummary
 from .fingerprints import (
@@ -69,6 +74,8 @@ __all__ = [
     "ArtifactRef",
     "CANONICAL_STAGE_IDS",
     "CONTRACT_TYPE_BY_STAGE_ID",
+    "DATASET_BUILD_OUTPUT_CONTRACT_FILENAME",
+    "DATASET_BUILD_OUTPUT_CONTRACT_TYPE",
     "DiagnosticRef",
     "DiagnosticSeverity",
     "ExecutionRecord",
@@ -90,6 +97,7 @@ __all__ = [
     "ValidationFindingStatus",
     "ValidationReport",
     "ValidationReportStatus",
+    "build_dataset_build_output_contract",
     "canonicalize_for_fingerprint",
     "contract_from_json",
     "contract_to_json",

--- a/policyengine_us_data/stage_contracts/dataset_build.py
+++ b/policyengine_us_data/stage_contracts/dataset_build.py
@@ -1,0 +1,370 @@
+"""Stage 1 dataset-build contract assembly."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from policyengine_us_data.utils.step_manifest import sha256_file
+
+from .artifacts import ArtifactRef
+from .contracts import StageContract
+from .execution import ExecutionRecord, ReuseSummary
+from .fingerprints import fingerprint_material
+from .stages import STAGE_1_BUILD_DATASETS, contract_type_for_stage
+from .substages import SubstageRecord
+
+DATASET_BUILD_OUTPUT_CONTRACT_FILENAME = "dataset_build_output.json"
+DATASET_BUILD_OUTPUT_CONTRACT_TYPE = contract_type_for_stage(STAGE_1_BUILD_DATASETS)
+
+
+@dataclass(frozen=True, kw_only=True)
+class _Stage1ArtifactSpec:
+    filename: str
+    logical_name: str
+    artifact_family: str
+    substage_id: str
+    period: int | None = None
+    required: bool = True
+    required_for_stage_2: bool = False
+    yearless_alias: bool = False
+    skip_when_enhanced_cps_skipped: bool = False
+
+
+_STAGE_1_ARTIFACTS: tuple[_Stage1ArtifactSpec, ...] = (
+    _Stage1ArtifactSpec(
+        filename="acs_2022.h5",
+        logical_name="acs_2022",
+        artifact_family="dataset",
+        period=2022,
+        substage_id="1b_base_dataset_construction",
+    ),
+    _Stage1ArtifactSpec(
+        filename="irs_puf_2015.h5",
+        logical_name="irs_puf_2015",
+        artifact_family="dataset",
+        period=2015,
+        substage_id="1b_base_dataset_construction",
+    ),
+    _Stage1ArtifactSpec(
+        filename="cps_2024.h5",
+        logical_name="cps_2024",
+        artifact_family="dataset",
+        period=2024,
+        substage_id="1b_base_dataset_construction",
+    ),
+    _Stage1ArtifactSpec(
+        filename="puf_2024.h5",
+        logical_name="puf_2024",
+        artifact_family="dataset",
+        period=2024,
+        substage_id="1b_base_dataset_construction",
+    ),
+    _Stage1ArtifactSpec(
+        filename="extended_cps_2024.h5",
+        logical_name="extended_cps_2024",
+        artifact_family="dataset",
+        period=2024,
+        substage_id="1c_extended_cps_puf_clone",
+    ),
+    _Stage1ArtifactSpec(
+        filename="enhanced_cps_2024.h5",
+        logical_name="enhanced_cps_2024",
+        artifact_family="dataset",
+        period=2024,
+        substage_id="1d_enhanced_cps_reweighting",
+        skip_when_enhanced_cps_skipped=True,
+    ),
+    _Stage1ArtifactSpec(
+        filename="small_enhanced_cps_2024.h5",
+        logical_name="small_enhanced_cps_2024",
+        artifact_family="dataset",
+        period=2024,
+        substage_id="1d_enhanced_cps_reweighting",
+        skip_when_enhanced_cps_skipped=True,
+    ),
+    _Stage1ArtifactSpec(
+        filename="stratified_extended_cps_2024.h5",
+        logical_name="stratified_extended_cps_2024",
+        artifact_family="dataset",
+        period=2024,
+        substage_id="1e_stratified_cps",
+    ),
+    _Stage1ArtifactSpec(
+        filename="source_imputed_stratified_extended_cps_2024.h5",
+        logical_name="source_imputed_stratified_extended_cps_2024",
+        artifact_family="dataset",
+        period=2024,
+        substage_id="1f_source_imputation",
+        required_for_stage_2=True,
+    ),
+    _Stage1ArtifactSpec(
+        filename="source_imputed_stratified_extended_cps.h5",
+        logical_name="source_imputed_stratified_extended_cps",
+        artifact_family="dataset",
+        period=2024,
+        substage_id="1f_source_imputation",
+        required_for_stage_2=True,
+        yearless_alias=True,
+    ),
+    _Stage1ArtifactSpec(
+        filename="policy_data.db",
+        logical_name="policy_data_db",
+        artifact_family="target_database",
+        substage_id="1g_stage_base_datasets",
+        required_for_stage_2=True,
+    ),
+    _Stage1ArtifactSpec(
+        filename="build_log.txt",
+        logical_name="build_log",
+        artifact_family="log",
+        substage_id="1g_stage_base_datasets",
+    ),
+    _Stage1ArtifactSpec(
+        filename="data_build_checkpoint_stats.json",
+        logical_name="data_build_checkpoint_stats",
+        artifact_family="execution_metadata",
+        substage_id="1g_stage_base_datasets",
+    ),
+)
+
+_SUBSTAGE_IDS = (
+    "1a_raw_data_download",
+    "1b_base_dataset_construction",
+    "1c_extended_cps_puf_clone",
+    "1d_enhanced_cps_reweighting",
+    "1e_stratified_cps",
+    "1f_source_imputation",
+    "1g_stage_base_datasets",
+)
+
+
+def build_dataset_build_output_contract(
+    *,
+    artifacts_dir: Path,
+    run_id: str,
+    code_sha: str,
+    package_version: str | None,
+    checkpoint_stats: Mapping[str, int],
+    started_at: str | None,
+    completed_at: str,
+    duration_s: float | None = None,
+    upload_requested: bool = False,
+    stage_only: bool = False,
+    skip_enhanced_cps: bool = False,
+) -> StageContract:
+    """Build the Stage 1 handoff contract from copied pipeline artifacts."""
+
+    artifacts_dir = Path(artifacts_dir)
+    parameters = {
+        "period": 2024,
+        "skip_enhanced_cps": skip_enhanced_cps,
+        "stage_only": stage_only,
+        "upload_requested": upload_requested,
+    }
+    outputs = _stage_1_outputs(
+        artifacts_dir=artifacts_dir,
+        skip_enhanced_cps=skip_enhanced_cps,
+    )
+    execution = _execution_record(
+        checkpoint_stats=checkpoint_stats,
+        started_at=started_at,
+        completed_at=completed_at,
+        duration_s=duration_s,
+    )
+    fingerprint = _fingerprint_for_dataset_build(
+        code_sha=code_sha,
+        package_version=package_version,
+        parameters=parameters,
+        outputs=outputs,
+    )
+    return StageContract(
+        contract_type=DATASET_BUILD_OUTPUT_CONTRACT_TYPE,
+        stage_id=STAGE_1_BUILD_DATASETS,
+        run_id=run_id,
+        created_at=completed_at,
+        code_sha=code_sha,
+        package_version=package_version,
+        outputs=outputs,
+        parameters=parameters,
+        fingerprint=fingerprint,
+        substages=_stage_1_substages(
+            outputs=outputs,
+            skip_enhanced_cps=skip_enhanced_cps,
+        ),
+        execution=execution,
+        metadata={
+            "artifact_count": len(outputs),
+            "artifact_directory": str(artifacts_dir),
+            "contract_file": DATASET_BUILD_OUTPUT_CONTRACT_FILENAME,
+        },
+    )
+
+
+def _stage_1_outputs(
+    *,
+    artifacts_dir: Path,
+    skip_enhanced_cps: bool,
+) -> tuple[ArtifactRef, ...]:
+    outputs: list[ArtifactRef] = []
+    missing_required: list[str] = []
+    for spec in _STAGE_1_ARTIFACTS:
+        if skip_enhanced_cps and spec.skip_when_enhanced_cps_skipped:
+            continue
+        artifact_path = artifacts_dir / spec.filename
+        if not artifact_path.exists():
+            if spec.required:
+                missing_required.append(spec.filename)
+            continue
+        metadata = {
+            "artifact_family": spec.artifact_family,
+            "substage_id": spec.substage_id,
+        }
+        if spec.period is not None:
+            metadata["period"] = spec.period
+        if spec.required_for_stage_2:
+            metadata["required_for_stage_2"] = True
+        if spec.yearless_alias:
+            metadata["yearless_alias"] = True
+        outputs.append(
+            _artifact_ref_from_path(
+                logical_name=spec.logical_name,
+                path=artifact_path,
+                metadata=metadata,
+            )
+        )
+    if missing_required:
+        raise FileNotFoundError(
+            "Missing Stage 1 handoff artifact(s): "
+            + ", ".join(sorted(missing_required))
+        )
+    return tuple(outputs)
+
+
+def _artifact_ref_from_path(
+    *,
+    logical_name: str,
+    path: Path,
+    metadata: Mapping[str, Any],
+) -> ArtifactRef:
+    return ArtifactRef(
+        logical_name=logical_name,
+        uri=path.resolve().as_uri(),
+        sha256=f"sha256:{sha256_file(path)}",
+        size_bytes=path.stat().st_size,
+        media_type=_media_type_for_path(path),
+        metadata=metadata,
+    )
+
+
+def _media_type_for_path(path: Path) -> str:
+    suffix = path.suffix.lower()
+    if suffix == ".h5":
+        return "application/x-hdf5"
+    if suffix == ".db":
+        return "application/vnd.sqlite3"
+    if suffix == ".json":
+        return "application/json"
+    if suffix == ".txt":
+        return "text/plain"
+    return "application/octet-stream"
+
+
+def _stage_1_substages(
+    *,
+    outputs: tuple[ArtifactRef, ...],
+    skip_enhanced_cps: bool,
+) -> tuple[SubstageRecord, ...]:
+    output_by_substage: dict[str, list[ArtifactRef]] = {
+        substage_id: [] for substage_id in _SUBSTAGE_IDS
+    }
+    for artifact in outputs:
+        substage_id = artifact.metadata.get("substage_id")
+        if isinstance(substage_id, str) and substage_id in output_by_substage:
+            output_by_substage[substage_id].append(artifact)
+
+    records: list[SubstageRecord] = []
+    for substage_id in _SUBSTAGE_IDS:
+        status = "completed"
+        if substage_id == "1d_enhanced_cps_reweighting" and skip_enhanced_cps:
+            status = "skipped"
+        reuse_mode = "checkpointable"
+        if substage_id in {
+            "1a_raw_data_download",
+        }:
+            reuse_mode = "observed_only"
+        elif substage_id in {
+            "1e_stratified_cps",
+            "1f_source_imputation",
+            "1g_stage_base_datasets",
+        }:
+            reuse_mode = "handoff"
+        records.append(
+            SubstageRecord(
+                substage_id=substage_id,
+                status=status,
+                outputs=tuple(output_by_substage[substage_id]),
+                reuse_mode=reuse_mode,
+            )
+        )
+    return tuple(records)
+
+
+def _execution_record(
+    *,
+    checkpoint_stats: Mapping[str, int],
+    started_at: str | None,
+    completed_at: str,
+    duration_s: float | None,
+) -> ExecutionRecord:
+    reuse_summary = ReuseSummary(
+        expected_outputs=int(checkpoint_stats.get("expected_outputs", 0)),
+        valid_reused_outputs=int(checkpoint_stats.get("valid_reused_outputs", 0)),
+        recomputed_outputs=int(checkpoint_stats.get("recomputed_outputs", 0)),
+        invalid_outputs=int(checkpoint_stats.get("invalid_outputs", 0)),
+    )
+    return ExecutionRecord(
+        status="completed",
+        started_at=started_at,
+        completed_at=completed_at,
+        duration_s=float(duration_s) if duration_s is not None else None,
+        reuse_decision=_reuse_decision(checkpoint_stats),
+        reuse_summary=reuse_summary,
+    )
+
+
+def _reuse_decision(checkpoint_stats: Mapping[str, int]) -> str:
+    reused = int(checkpoint_stats.get("valid_reused_outputs", 0))
+    recomputed = int(checkpoint_stats.get("recomputed_outputs", 0))
+    if reused and recomputed:
+        return "partially_reused"
+    if reused:
+        return "reused"
+    return "computed"
+
+
+def _fingerprint_for_dataset_build(
+    *,
+    code_sha: str,
+    package_version: str | None,
+    parameters: Mapping[str, Any],
+    outputs: tuple[ArtifactRef, ...],
+):
+    material = {
+        "stage_id": STAGE_1_BUILD_DATASETS,
+        "contract_type": DATASET_BUILD_OUTPUT_CONTRACT_TYPE,
+        "code_sha": code_sha,
+        "package_version": package_version,
+        "parameters": parameters,
+        "outputs": [
+            {
+                "logical_name": output.logical_name,
+                "sha256": output.sha256,
+                "size_bytes": output.size_bytes,
+            }
+            for output in sorted(outputs, key=lambda item: item.logical_name)
+        ],
+    }
+    return fingerprint_material(material)

--- a/tests/unit/test_dataset_build_stage_contract.py
+++ b/tests/unit/test_dataset_build_stage_contract.py
@@ -1,0 +1,171 @@
+from pathlib import Path
+
+from policyengine_us_data.stage_contracts import (
+    StageContract,
+    contract_from_json,
+    contract_to_json,
+)
+from policyengine_us_data.stage_contracts.dataset_build import (
+    DATASET_BUILD_OUTPUT_CONTRACT_FILENAME,
+    build_dataset_build_output_contract,
+)
+
+_ARTIFACT_BYTES = {
+    "acs_2022.h5": b"acs",
+    "irs_puf_2015.h5": b"irs",
+    "cps_2024.h5": b"cps",
+    "puf_2024.h5": b"puf",
+    "extended_cps_2024.h5": b"extended",
+    "enhanced_cps_2024.h5": b"enhanced",
+    "small_enhanced_cps_2024.h5": b"small",
+    "stratified_extended_cps_2024.h5": b"stratified",
+    "source_imputed_stratified_extended_cps_2024.h5": b"source-year",
+    "source_imputed_stratified_extended_cps.h5": b"source-alias",
+    "policy_data.db": b"sqlite",
+    "build_log.txt": b"log",
+    "data_build_checkpoint_stats.json": b'{"expected_outputs": 3}',
+}
+
+
+def _write_artifacts(
+    artifacts_dir: Path,
+    *,
+    include_enhanced_cps: bool = True,
+) -> None:
+    artifacts_dir.mkdir(exist_ok=True)
+    for filename, payload in _ARTIFACT_BYTES.items():
+        if not include_enhanced_cps and filename in {
+            "enhanced_cps_2024.h5",
+            "small_enhanced_cps_2024.h5",
+        }:
+            continue
+        (artifacts_dir / filename).write_bytes(payload)
+
+
+def _contract(
+    artifacts_dir: Path,
+    *,
+    run_id: str = "run-a",
+    skip_enhanced_cps: bool = False,
+) -> StageContract:
+    return build_dataset_build_output_contract(
+        artifacts_dir=artifacts_dir,
+        run_id=run_id,
+        code_sha="abc123",
+        package_version="1.98.2",
+        checkpoint_stats={
+            "expected_outputs": 4,
+            "valid_reused_outputs": 1,
+            "recomputed_outputs": 3,
+            "invalid_outputs": 0,
+        },
+        started_at="2026-05-08T12:00:00Z",
+        completed_at="2026-05-08T12:01:00Z",
+        duration_s=60.0,
+        upload_requested=True,
+        stage_only=False,
+        skip_enhanced_cps=skip_enhanced_cps,
+    )
+
+
+def test_dataset_build_contract_records_stage_1_handoff_artifacts(tmp_path):
+    _write_artifacts(tmp_path)
+
+    contract = _contract(tmp_path)
+
+    assert contract.stage_id == "1_build_datasets"
+    assert contract.contract_type == "dataset_build_output"
+    assert contract.run_id == "run-a"
+    logical_names = {artifact.logical_name for artifact in contract.outputs}
+    assert {
+        "source_imputed_stratified_extended_cps",
+        "source_imputed_stratified_extended_cps_2024",
+        "policy_data_db",
+        "build_log",
+        "data_build_checkpoint_stats",
+    } <= logical_names
+    assert all(artifact.sha256.startswith("sha256:") for artifact in contract.outputs)
+    assert all(artifact.uri.startswith("file://") for artifact in contract.outputs)
+
+
+def test_dataset_build_contract_records_substage_shape(tmp_path):
+    _write_artifacts(tmp_path)
+
+    contract = _contract(tmp_path)
+
+    assert [record.substage_id for record in contract.substages] == [
+        "1a_raw_data_download",
+        "1b_base_dataset_construction",
+        "1c_extended_cps_puf_clone",
+        "1d_enhanced_cps_reweighting",
+        "1e_stratified_cps",
+        "1f_source_imputation",
+        "1g_stage_base_datasets",
+    ]
+    records = {record.substage_id: record for record in contract.substages}
+    assert records["1d_enhanced_cps_reweighting"].status == "completed"
+    assert records["1f_source_imputation"].reuse_mode == "handoff"
+    assert {
+        artifact.logical_name for artifact in records["1g_stage_base_datasets"].outputs
+    } >= {"policy_data_db", "build_log", "data_build_checkpoint_stats"}
+
+
+def test_dataset_build_contract_omits_enhanced_cps_when_skipped(tmp_path):
+    _write_artifacts(tmp_path, include_enhanced_cps=False)
+
+    contract = _contract(tmp_path, skip_enhanced_cps=True)
+
+    logical_names = {artifact.logical_name for artifact in contract.outputs}
+    assert "enhanced_cps_2024" not in logical_names
+    assert "small_enhanced_cps_2024" not in logical_names
+    records = {record.substage_id: record for record in contract.substages}
+    assert records["1d_enhanced_cps_reweighting"].status == "skipped"
+    assert records["1d_enhanced_cps_reweighting"].outputs == ()
+
+
+def test_dataset_build_contract_rejects_missing_required_stage_1_artifact(tmp_path):
+    _write_artifacts(tmp_path)
+    (tmp_path / "acs_2022.h5").unlink()
+
+    try:
+        _contract(tmp_path)
+    except FileNotFoundError as exc:
+        assert "acs_2022.h5" in str(exc)
+    else:
+        raise AssertionError("Missing Stage 1 artifact should fail")
+
+
+def test_dataset_build_contract_execution_records_checkpoint_summary(tmp_path):
+    _write_artifacts(tmp_path)
+
+    contract = _contract(tmp_path)
+
+    assert contract.execution.status == "completed"
+    assert contract.execution.reuse_decision == "partially_reused"
+    assert contract.execution.reuse_summary.expected_outputs == 4
+    assert contract.execution.reuse_summary.valid_reused_outputs == 1
+    assert contract.execution.reuse_summary.recomputed_outputs == 3
+    assert contract.execution.reuse_summary.invalid_outputs == 0
+
+
+def test_dataset_build_contract_json_round_trip_is_deterministic(tmp_path):
+    _write_artifacts(tmp_path)
+    contract = _contract(tmp_path)
+
+    payload = contract_to_json(contract)
+
+    assert payload == contract_to_json(contract_from_json(payload))
+    assert contract_from_json(payload) == contract
+
+
+def test_dataset_build_contract_fingerprint_excludes_run_id(tmp_path):
+    _write_artifacts(tmp_path)
+
+    first = _contract(tmp_path, run_id="run-a")
+    second = _contract(tmp_path, run_id="run-b")
+
+    assert first.fingerprint == second.fingerprint
+
+
+def test_dataset_build_contract_filename_is_stable():
+    assert DATASET_BUILD_OUTPUT_CONTRACT_FILENAME == "dataset_build_output.json"

--- a/tests/unit/test_modal_data_build.py
+++ b/tests/unit/test_modal_data_build.py
@@ -1,6 +1,9 @@
 import importlib
 import sys
+from datetime import datetime, timedelta, timezone
 from types import ModuleType, SimpleNamespace
+
+from policyengine_us_data.stage_contracts import read_contract
 
 
 def _load_data_build_module():
@@ -220,3 +223,57 @@ def test_run_cps_then_puf_phase_uses_sequential_checkpointed_builds(
             None,
         ),
     ]
+
+
+def test_write_dataset_build_contract_writes_stage_1_handoff(tmp_path):
+    data_build = _load_data_build_module()
+    artifacts = {
+        "acs_2022.h5": b"acs",
+        "irs_puf_2015.h5": b"irs",
+        "cps_2024.h5": b"cps",
+        "puf_2024.h5": b"puf",
+        "extended_cps_2024.h5": b"extended",
+        "stratified_extended_cps_2024.h5": b"stratified",
+        "source_imputed_stratified_extended_cps_2024.h5": b"source-year",
+        "source_imputed_stratified_extended_cps.h5": b"source-alias",
+        "policy_data.db": b"sqlite",
+        "build_log.txt": b"log",
+        "data_build_checkpoint_stats.json": b"{}",
+    }
+    for filename, payload in artifacts.items():
+        (tmp_path / filename).write_bytes(payload)
+
+    contract = data_build.write_dataset_build_contract(
+        artifacts_dir=tmp_path,
+        run_id="run-123",
+        code_sha="abc123",
+        checkpoint_stats={
+            "expected_outputs": 2,
+            "valid_reused_outputs": 0,
+            "recomputed_outputs": 2,
+            "invalid_outputs": 0,
+        },
+        started_at="2026-05-08T12:00:00Z",
+        completed_at="2026-05-08T12:00:30Z",
+        duration_s=30.0,
+        upload_requested=False,
+        stage_only=True,
+        skip_enhanced_cps=True,
+    )
+
+    contract_path = tmp_path / "dataset_build_output.json"
+    assert contract_path.exists()
+    assert read_contract(contract_path) == contract
+    assert contract.stage_id == "1_build_datasets"
+    assert contract.parameters["stage_only"] is True
+
+
+def test_utc_timestamp_renders_zulu_time_for_build_log():
+    data_build = _load_data_build_module()
+    budapest_summer = timezone(timedelta(hours=2))
+
+    rendered = data_build._utc_timestamp(
+        datetime(2026, 7, 1, 12, 30, 45, tzinfo=budapest_summer)
+    )
+
+    assert rendered == "2026-07-01T10:30:45Z"


### PR DESCRIPTION
Fixes #919

## Summary
- Emit `dataset_build_output.json` from Stage 1 after artifacts are copied into the pipeline volume.
- Add a typed Stage 1 artifact spec registry, complete artifact checks, deterministic fingerprints, substage records, and checkpoint execution metadata.
- Update PR guidance to require an issue, a top-line `Fixes #ISSUE_NUMBER` in PR descriptions, a Towncrier changelog fragment, and `make lint` before opening or sharing PRs.
- Add a Makefile `lint` target aligned with the existing CI lint job (`ruff format --check .`).
- Add `changelog.d/919.added` for the Stage 1 dataset build contract.

## Testing
- `make lint`
- `uv run --no-sync towncrier check --compare-with origin/main`
- `uv run --no-sync pytest tests/unit/test_dataset_build_stage_contract.py tests/unit/test_modal_data_build.py tests/unit/test_stage_contracts.py`
- `uv run --no-sync ruff check policyengine_us_data/stage_contracts/dataset_build.py policyengine_us_data/stage_contracts/__init__.py modal_app/data_build.py tests/unit/test_dataset_build_stage_contract.py tests/unit/test_modal_data_build.py`
- `uv run --no-sync ruff format --check policyengine_us_data/stage_contracts/dataset_build.py policyengine_us_data/stage_contracts/__init__.py modal_app/data_build.py tests/unit/test_dataset_build_stage_contract.py tests/unit/test_modal_data_build.py`