### PR TITLE
Stop PUF clone imputation for tax output variables

### DIFF
--- a/changelog.d/921.fixed.md
+++ b/changelog.d/921.fixed.md
@@ -1,0 +1,1 @@
+Removed PUF reported/calculated tax output variables from donor-support imputation and export save paths.

--- a/docs/appendix.md
+++ b/docs/appendix.md
@@ -47,7 +47,7 @@ for iteration in range(5000):
 
 ### Table A1: Complete List of Imputed Variables
 
-#### Variables Imputed from IRS Public Use File (70 variables)
+#### Variables Imputed from IRS Public Use File (57 variables)
 
 **Income Variables:**
 
@@ -63,12 +63,12 @@ for iteration in range(5000):
 - qualified_dividend_income
 - non_qualified_dividend_income
 - rental_income
-- taxable_unemployment_compensation
 - taxable_interest_income
 - tax_exempt_interest_income
 - estate_income
 - miscellaneous_income
 - farm_income
+- partnership_se_income
 - alimony_income
 - farm_rent_income
 - non_sch_d_capital_gains
@@ -90,22 +90,12 @@ for iteration in range(5000):
 - health_savings_account_ald
 - student_loan_interest
 - investment_income_elected_form_4952
-- early_withdrawal_penalty
 - educator_expense
 - deductible_mortgage_interest
 
 **Tax Credits:**
 
 - cdcc_relevant_expenses
-- foreign_tax_credit
-- american_opportunity_credit
-- general_business_credit
-- energy_efficient_home_improvement_credit
-- amt_foreign_tax_credit
-- excess_withheld_payroll_tax
-- savers_credit
-- prior_year_minimum_tax_credit
-- other_credits
 
 **Qualified Business Income Variables:**
 
@@ -133,9 +123,22 @@ within the same record.
 
 **Other Tax Variables:**
 
-- traditional_ira_contributions
 - qualified_tuition_expenses
 - casualty_loss
+
+#### PUF Reported/Calculated Tax Outputs Excluded from Donor Imputation
+
+- taxable_unemployment_compensation
+- foreign_tax_credit
+- american_opportunity_credit
+- general_business_credit
+- energy_efficient_home_improvement_credit
+- amt_foreign_tax_credit
+- excess_withheld_payroll_tax
+- savers_credit
+- early_withdrawal_penalty
+- prior_year_minimum_tax_credit
+- other_credits
 - unreported_payroll_tax
 - recapture_of_investment_credit
 

--- a/policyengine_us_data/calibration/create_stratified_cps.py
+++ b/policyengine_us_data/calibration/create_stratified_cps.py
@@ -14,6 +14,9 @@ import h5py
 from policyengine_us import Microsimulation
 from policyengine_core.data.dataset import Dataset
 from policyengine_core.enums import Enum
+from policyengine_us_data.datasets.puf.variable_roles import (
+    PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES,
+)
 from policyengine_us_data.pipeline_metadata import pipeline_node
 from policyengine_us_data.pipeline_schema import PipelineNode
 
@@ -298,7 +301,7 @@ def create_stratified_cps_dataset(
     data = {}
 
     # Only save input variables (not calculated/derived variables)
-    input_vars = set(sim.input_variables)
+    input_vars = set(sim.input_variables) - PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES
     print(f"Found {len(input_vars)} input variables to save")
 
     for variable in stratified_sim.tax_benefit_system.variables:

--- a/policyengine_us_data/calibration/entity_clone.py
+++ b/policyengine_us_data/calibration/entity_clone.py
@@ -20,6 +20,9 @@ import numpy as np
 from policyengine_us_data.calibration.block_assignment import (
     derive_geography_from_blocks,
 )
+from policyengine_us_data.datasets.puf.variable_roles import (
+    PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES,
+)
 from policyengine_us_data.utils.takeup import (
     _sum_person_values_to_tax_units,
     apply_block_takeup_to_arrays,
@@ -264,7 +267,9 @@ def materialize_clone_household_chunk(
     unique_geo = derive_geography_from_blocks(unique_blocks)
     clone_geo = {k: v[block_inv] for k, v in unique_geo.items()}
 
-    vars_to_save = set(sim.input_variables)
+    vars_to_save = (
+        set(sim.input_variables) - PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES
+    )
     vars_to_save.discard("spm_unit_spm_threshold")
     vars_to_save.add("county")
     vars_to_save.add("congressional_district_geoid")

--- a/policyengine_us_data/calibration/publish_local_area.py
+++ b/policyengine_us_data/calibration/publish_local_area.py
@@ -34,6 +34,9 @@ from policyengine_us_data.calibration.calibration_utils import (
 from policyengine_us_data.calibration.block_assignment import (
     derive_geography_from_blocks,
 )
+from policyengine_us_data.datasets.puf.variable_roles import (
+    PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES,
+)
 from policyengine_us_data.utils.takeup import (
     SIMPLE_TAKEUP_VARS,
     _sum_person_values_to_tax_units,
@@ -511,7 +514,9 @@ def build_h5(
     clone_geo = {k: v[block_inv] for k, v in unique_geo.items()}
 
     # === Determine variables to save ===
-    vars_to_save = set(sim.input_variables)
+    vars_to_save = (
+        set(sim.input_variables) - PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES
+    )
     vars_to_save.discard("spm_unit_spm_threshold")
     vars_to_save.add("county")
     vars_to_save.add("congressional_district_geoid")

--- a/policyengine_us_data/calibration/puf_impute.py
+++ b/policyengine_us_data/calibration/puf_impute.py
@@ -22,6 +22,9 @@ import yaml
 from policyengine_us_data.utils.retirement_limits import (
     get_retirement_limits,
 )
+from policyengine_us_data.datasets.puf.variable_roles import (
+    PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES,
+)
 from policyengine_us_data.pipeline_metadata import pipeline_node
 from policyengine_us_data.pipeline_schema import PipelineNode
 
@@ -72,7 +75,6 @@ IMPUTED_VARIABLES = [
     "charitable_cash_donations",
     "self_employed_pension_contribution_ald",
     "unrecaptured_section_1250_gain",
-    "taxable_unemployment_compensation",
     "taxable_interest_income",
     "domestic_production_ald",
     "self_employed_health_insurance_ald",
@@ -81,10 +83,8 @@ IMPUTED_VARIABLES = [
     "cdcc_relevant_expenses",
     "tax_exempt_interest_income",
     "salt_refund_income",
-    "foreign_tax_credit",
     "estate_income",
     "charitable_non_cash_donations",
-    "american_opportunity_credit",
     "miscellaneous_income",
     "alimony_expense",
     "farm_income",
@@ -92,23 +92,13 @@ IMPUTED_VARIABLES = [
     "alimony_income",
     "health_savings_account_ald",
     "non_sch_d_capital_gains",
-    "general_business_credit",
-    "energy_efficient_home_improvement_credit",
-    "amt_foreign_tax_credit",
-    "excess_withheld_payroll_tax",
-    "savers_credit",
     "student_loan_interest",
     "investment_income_elected_form_4952",
-    "early_withdrawal_penalty",
-    "prior_year_minimum_tax_credit",
     "farm_rent_income",
     "qualified_tuition_expenses",
     "educator_expense",
     "long_term_capital_gains_on_collectibles",
-    "other_credits",
     "casualty_loss",
-    "unreported_payroll_tax",
-    "recapture_of_investment_credit",
     "deductible_mortgage_interest",
     "qualified_reit_and_ptp_income",
     "qualified_bdc_income",
@@ -141,36 +131,23 @@ OVERRIDDEN_IMPUTED_VARIABLES = [
     "charitable_cash_donations",
     "self_employed_pension_contribution_ald",
     "unrecaptured_section_1250_gain",
-    "taxable_unemployment_compensation",
     "domestic_production_ald",
     "self_employed_health_insurance_ald",
     "cdcc_relevant_expenses",
     "salt_refund_income",
-    "foreign_tax_credit",
     "estate_income",
     "charitable_non_cash_donations",
-    "american_opportunity_credit",
     "miscellaneous_income",
     "alimony_expense",
     "health_savings_account_ald",
     "non_sch_d_capital_gains",
-    "general_business_credit",
-    "energy_efficient_home_improvement_credit",
-    "amt_foreign_tax_credit",
-    "excess_withheld_payroll_tax",
-    "savers_credit",
     "student_loan_interest",
     "investment_income_elected_form_4952",
-    "early_withdrawal_penalty",
-    "prior_year_minimum_tax_credit",
     "farm_rent_income",
     "qualified_tuition_expenses",
     "educator_expense",
     "long_term_capital_gains_on_collectibles",
-    "other_credits",
     "casualty_loss",
-    "unreported_payroll_tax",
-    "recapture_of_investment_credit",
     "deductible_mortgage_interest",
     "qualified_reit_and_ptp_income",
     "qualified_bdc_income",
@@ -558,6 +535,10 @@ def puf_clone_dataset(
 
     new_data = {}
     for variable, time_dict in data.items():
+        if variable in PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES:
+            logger.info("Dropping PUF tax-output variable: %s", variable)
+            continue
+
         values = time_dict[time_period]
 
         if variable in OVERRIDDEN_IMPUTED_VARIABLES and y_override:
@@ -697,7 +678,11 @@ def _impute_weeks_unemployed(
     X_train = cps_sim.calculate_dataframe(WEEKS_PREDICTORS)
     X_train["weeks_unemployed"] = cps_weeks
 
-    if "taxable_unemployment_compensation" in puf_imputations:
+    puf_unemployment_compensation = puf_imputations.get("unemployment_compensation")
+    if puf_unemployment_compensation is None and "unemployment_compensation" in data:
+        puf_unemployment_compensation = data["unemployment_compensation"][time_period]
+
+    if puf_unemployment_compensation is not None:
         cps_uc = cps_sim.calculate("unemployment_compensation").values
         X_train["unemployment_compensation"] = cps_uc
         WEEKS_PREDICTORS = WEEKS_PREDICTORS + ["unemployment_compensation"]
@@ -706,10 +691,8 @@ def _impute_weeks_unemployed(
         [p for p in WEEKS_PREDICTORS if p != "unemployment_compensation"]
     )
 
-    if "taxable_unemployment_compensation" in puf_imputations:
-        X_test["unemployment_compensation"] = puf_imputations[
-            "taxable_unemployment_compensation"
-        ]
+    if puf_unemployment_compensation is not None:
+        X_test["unemployment_compensation"] = puf_unemployment_compensation
 
     del cps_sim
 

--- a/policyengine_us_data/datasets/cps/extended_cps.py
+++ b/policyengine_us_data/datasets/cps/extended_cps.py
@@ -888,24 +888,21 @@ class ExtendedCPS(Dataset):
 
     @classmethod
     def _impute_aotc_eligibility_inputs(cls, data, time_period):
-        """Convert imputed tax-unit AOTC amounts to person eligibility inputs."""
+        """Convert AOTC source signals to person eligibility inputs."""
         credit = data.get("american_opportunity_credit", {}).get(time_period)
         tax_unit_ids = data.get("tax_unit_id", {}).get(time_period)
         person_tax_unit_ids = data.get("person_tax_unit_id", {}).get(time_period)
         tuition = data.get("qualified_tuition_expenses", {}).get(time_period)
-        if (
-            credit is None
-            or tax_unit_ids is None
-            or person_tax_unit_ids is None
-            or tuition is None
-        ):
+        if tax_unit_ids is None or person_tax_unit_ids is None or tuition is None:
             return data
 
-        credit = np.asarray(credit)
+        credit = np.asarray(credit) if credit is not None else None
         tax_unit_ids = np.asarray(tax_unit_ids)
         person_tax_unit_ids = np.asarray(person_tax_unit_ids)
         tuition = np.array(tuition, copy=True)
-        if len(credit) != len(tax_unit_ids) or len(tuition) != len(person_tax_unit_ids):
+        if (credit is not None and len(credit) != len(tax_unit_ids)) or len(
+            tuition
+        ) != len(person_tax_unit_ids):
             logger.warning(
                 "Skipping AOTC eligibility imputation due to entity length mismatch"
             )
@@ -926,54 +923,64 @@ class ExtendedCPS(Dataset):
             else np.zeros(len(person_tax_unit_ids), dtype=bool)
         )
 
-        positive_credit = credit > 0
-        if not positive_credit.any():
-            return data
-
-        positive_credit_units = tax_unit_ids[positive_credit]
-        credit_by_tax_unit_id = dict(zip(tax_unit_ids, credit))
         adjusted_tuition_count = 0
-        max_student_credit = maximum_american_opportunity_credit_per_student(
-            time_period
-        )
-        for tax_unit_id in positive_credit_units:
-            member_indices = np.flatnonzero(person_tax_unit_ids == tax_unit_id)
-            if member_indices.size == 0 or max_student_credit <= 0:
-                continue
+        signal_tax_unit_count = 0
+        if credit is not None:
+            positive_credit = credit > 0
+            if not positive_credit.any():
+                return data
 
-            tuition_indices = member_indices[tuition[member_indices] > 0]
-            candidate_groups = []
-            if tuition_indices.size > 0:
-                candidate_groups.append(tuition_indices)
-            candidate_groups.extend(
-                (
-                    member_indices[full_time[member_indices]],
-                    member_indices[dependent[member_indices]],
-                    member_indices,
-                )
+            positive_credit_units = tax_unit_ids[positive_credit]
+            signal_tax_unit_count = int(positive_credit.sum())
+            credit_by_tax_unit_id = dict(zip(tax_unit_ids, credit))
+            max_student_credit = maximum_american_opportunity_credit_per_student(
+                time_period
             )
-            ordered_candidates = []
-            seen = set()
-            for group in candidate_groups:
-                for index in group:
-                    if index not in seen:
-                        ordered_candidates.append(index)
-                        seen.add(index)
+            for tax_unit_id in positive_credit_units:
+                member_indices = np.flatnonzero(person_tax_unit_ids == tax_unit_id)
+                if member_indices.size == 0 or max_student_credit <= 0:
+                    continue
 
-            remaining_credit = float(credit_by_tax_unit_id[tax_unit_id])
-            for selected in ordered_candidates:
-                if remaining_credit <= 0:
-                    break
-                student_credit = min(remaining_credit, max_student_credit)
-                target_tuition = qualifying_expenses_from_american_opportunity_credit(
-                    student_credit,
-                    time_period,
+                tuition_indices = member_indices[tuition[member_indices] > 0]
+                candidate_groups = []
+                if tuition_indices.size > 0:
+                    candidate_groups.append(tuition_indices)
+                candidate_groups.extend(
+                    (
+                        member_indices[full_time[member_indices]],
+                        member_indices[dependent[member_indices]],
+                        member_indices,
+                    )
                 )
-                if tuition[selected] != target_tuition:
-                    adjusted_tuition_count += 1
-                aotc_student[selected] = True
-                tuition[selected] = target_tuition
-                remaining_credit -= student_credit
+                ordered_candidates = []
+                seen = set()
+                for group in candidate_groups:
+                    for index in group:
+                        if index not in seen:
+                            ordered_candidates.append(index)
+                            seen.add(index)
+
+                remaining_credit = float(credit_by_tax_unit_id[tax_unit_id])
+                for selected in ordered_candidates:
+                    if remaining_credit <= 0:
+                        break
+                    student_credit = min(remaining_credit, max_student_credit)
+                    target_tuition = (
+                        qualifying_expenses_from_american_opportunity_credit(
+                            student_credit,
+                            time_period,
+                        )
+                    )
+                    if tuition[selected] != target_tuition:
+                        adjusted_tuition_count += 1
+                    aotc_student[selected] = True
+                    tuition[selected] = target_tuition
+                    remaining_credit -= student_credit
+        else:
+            aotc_student = tuition > 0
+            if not aotc_student.any():
+                return data
+            signal_tax_unit_count = len(np.unique(person_tax_unit_ids[aotc_student]))
 
         if not _supports_aotc_eligibility_inputs():
             existing = data.get("is_eligible_for_american_opportunity_credit", {}).get(
@@ -992,7 +999,7 @@ class ExtendedCPS(Dataset):
                 "eligibility input for %d people across %d tax units "
                 "and adjusted tuition for %d people",
                 int(aotc_student.sum()),
-                int(positive_credit.sum()),
+                signal_tax_unit_count,
                 adjusted_tuition_count,
             )
             return data
@@ -1043,7 +1050,7 @@ class ExtendedCPS(Dataset):
             "AOTC eligibility imputation populated inputs for %d people "
             "across %d tax units and adjusted tuition for %d people",
             int(aotc_student.sum()),
-            int(positive_credit.sum()),
+            signal_tax_unit_count,
             adjusted_tuition_count,
         )
         return data
@@ -1209,6 +1216,9 @@ class ExtendedCPS(Dataset):
         preserved under the correct input-variable name.
         """
         from policyengine_us import CountryTaxBenefitSystem
+        from policyengine_us_data.datasets.puf.variable_roles import (
+            PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES,
+        )
 
         tbs = CountryTaxBenefitSystem()
 
@@ -1227,17 +1237,20 @@ class ExtendedCPS(Dataset):
                         data[add_var] = data.pop(name)
                     break
 
-        formula_vars = {
+        calculated_vars = {
             name
             for name, var in tbs.variables.items()
             if (hasattr(var, "formulas") and len(var.formulas) > 0)
             or getattr(var, "adds", None)
             or getattr(var, "subtracts", None)
-        } - cls._keep_formula_vars()
-        dropped = sorted(set(data.keys()) & formula_vars)
+        }
+        drop_vars = (
+            calculated_vars | PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES
+        ) - cls._keep_formula_vars()
+        dropped = sorted(set(data.keys()) & drop_vars)
         if dropped:
             logger.info(
-                "Dropping %d formula variables: %s",
+                "Dropping %d calculated/source-output variables: %s",
                 len(dropped),
                 dropped,
             )

--- a/policyengine_us_data/datasets/puf/variable_roles.py
+++ b/policyengine_us_data/datasets/puf/variable_roles.py
@@ -1,0 +1,26 @@
+"""Role classifications for PUF-sourced PolicyEngine variables."""
+
+REPORTED_CALCULATED_TAX_OUTPUT_ROLE = "reported_calculated_tax_output"
+
+PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES = frozenset(
+    (
+        "taxable_unemployment_compensation",
+        "foreign_tax_credit",
+        "american_opportunity_credit",
+        "general_business_credit",
+        "energy_efficient_home_improvement_credit",
+        "amt_foreign_tax_credit",
+        "excess_withheld_payroll_tax",
+        "savers_credit",
+        "early_withdrawal_penalty",
+        "prior_year_minimum_tax_credit",
+        "other_credits",
+        "unreported_payroll_tax",
+        "recapture_of_investment_credit",
+    )
+)
+
+PUF_SOURCE_VARIABLE_ROLES = {
+    variable: REPORTED_CALCULATED_TAX_OUTPUT_ROLE
+    for variable in PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES
+}

--- a/tests/unit/calibration/test_calibration_puf_impute.py
+++ b/tests/unit/calibration/test_calibration_puf_impute.py
@@ -7,14 +7,21 @@ so tests don't require real CPS/PUF datasets.
 import numpy as np
 import pandas as pd
 
+from policyengine_us_data.calibration import puf_impute as puf_impute_module
 from policyengine_us_data.calibration.puf_impute import (
     DEMOGRAPHIC_PREDICTORS,
     IMPUTED_VARIABLES,
     OVERRIDDEN_IMPUTED_VARIABLES,
     _impute_retirement_contributions,
+    _impute_weeks_unemployed,
     _log_stratified_subsample,
     _stratified_subsample_index,
     puf_clone_dataset,
+)
+from policyengine_us_data.datasets.puf.variable_roles import (
+    PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES,
+    PUF_SOURCE_VARIABLE_ROLES,
+    REPORTED_CALCULATED_TAX_OUTPUT_ROLE,
 )
 
 
@@ -204,6 +211,62 @@ class TestPufCloneDataset:
         for var in OVERRIDDEN_IMPUTED_VARIABLES:
             assert var in IMPUTED_VARIABLES
 
+    def test_reported_calculated_tax_outputs_not_imputed(self):
+        expected = {
+            "taxable_unemployment_compensation",
+            "foreign_tax_credit",
+            "american_opportunity_credit",
+            "general_business_credit",
+            "energy_efficient_home_improvement_credit",
+            "amt_foreign_tax_credit",
+            "excess_withheld_payroll_tax",
+            "savers_credit",
+            "early_withdrawal_penalty",
+            "prior_year_minimum_tax_credit",
+            "other_credits",
+            "unreported_payroll_tax",
+            "recapture_of_investment_credit",
+        }
+        blocked = PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES
+        assert blocked == expected
+        assert all(
+            PUF_SOURCE_VARIABLE_ROLES[var] == REPORTED_CALCULATED_TAX_OUTPUT_ROLE
+            for var in blocked
+        )
+        assert blocked.isdisjoint(IMPUTED_VARIABLES)
+        assert blocked.isdisjoint(OVERRIDDEN_IMPUTED_VARIABLES)
+
+    def test_reported_calculated_tax_outputs_not_emitted(self, monkeypatch):
+        data = _make_mock_data(n_persons=20, n_households=5)
+        data["general_business_credit"] = {2024: np.ones(20, dtype=np.float32)}
+        y_full = {var: np.ones(20, dtype=np.float32) for var in IMPUTED_VARIABLES}
+        y_full.update(
+            {
+                var: np.ones(20, dtype=np.float32)
+                for var in PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES
+            }
+        )
+
+        def fake_run_qrf_imputation(*args, **kwargs):
+            return y_full, {}
+
+        monkeypatch.setattr(
+            puf_impute_module,
+            "_run_qrf_imputation",
+            fake_run_qrf_imputation,
+        )
+
+        result = puf_clone_dataset(
+            data=data,
+            state_fips=np.array([1, 2, 36, 6, 48]),
+            time_period=2024,
+            puf_dataset=object(),
+            skip_qrf=False,
+        )
+
+        for var in PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES:
+            assert var not in result
+
     def test_sstb_qbi_split_variables_imputed(self):
         expected = {
             "sstb_self_employment_income",
@@ -379,6 +442,57 @@ def test_retirement_imputation_caps_se_pension_using_sstb_income(monkeypatch):
         result["self_employed_pension_contributions"],
         np.array([25.0, 25.0]),
     )
+
+
+def test_weeks_imputation_uses_unemployment_compensation_input(monkeypatch):
+    class FakeMicrosimulation:
+        def __init__(self, dataset):
+            self.dataset = dataset
+
+        def calculate(self, variable):
+            if variable == "weeks_unemployed":
+                return pd.Series([0.0, 12.0, 0.0])
+            if variable == "unemployment_compensation":
+                return pd.Series([0.0, 500.0, 0.0])
+            raise ValueError(variable)
+
+        def calculate_dataframe(self, columns):
+            return pd.DataFrame({column: [0.0, 1.0, 0.0] for column in columns})
+
+    class FakeQRF:
+        def __init__(self, **kwargs):
+            pass
+
+        def fit_predict(
+            self,
+            X_train,
+            X_test,
+            predictors,
+            imputed_variables,
+            n_jobs,
+        ):
+            assert "unemployment_compensation" in predictors
+            assert "unemployment_compensation" in X_train
+            np.testing.assert_array_equal(
+                X_test["unemployment_compensation"].to_numpy(),
+                np.array([0.0, 100.0, 0.0]),
+            )
+            return pd.DataFrame({"weeks_unemployed": [5.0, 6.0, 7.0]})
+
+    monkeypatch.setattr("policyengine_us.Microsimulation", FakeMicrosimulation)
+    monkeypatch.setattr("microimpute.models.qrf.QRF", FakeQRF)
+
+    result = _impute_weeks_unemployed(
+        data={
+            "person_id": {2024: np.array([1, 2, 3])},
+            "unemployment_compensation": {2024: np.array([0.0, 100.0, 0.0])},
+        },
+        puf_imputations={},
+        time_period=2024,
+        dataset_path="ignored.h5",
+    )
+
+    np.testing.assert_array_equal(result, np.array([0.0, 6.0, 0.0]))
 
 
 def test_log_handles_grouped_currency_threshold(caplog):

--- a/tests/unit/test_extended_cps.py
+++ b/tests/unit/test_extended_cps.py
@@ -34,6 +34,9 @@ from policyengine_us_data.datasets.cps.extended_cps import (
 from policyengine_us_data.datasets.cps.tipped_occupation import (
     derive_treasury_tipped_occupation_code,
 )
+from policyengine_us_data.datasets.puf.variable_roles import (
+    PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES,
+)
 from policyengine_us_data.datasets.org import ORG_IMPUTED_VARIABLES
 from policyengine_us_data.utils.aotc import (
     get_american_opportunity_credit_amount_scale,
@@ -159,6 +162,19 @@ class TestVariableListConsistency:
     def test_weeks_worked_is_preserved_for_future_year_formulas(self):
         assert "weeks_worked" in ExtendedCPS._keep_formula_vars()
 
+    def test_reported_calculated_tax_outputs_dropped_before_export(self):
+        data = {
+            var: {2024: np.array([1.0])}
+            for var in PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES
+        }
+        data["person_id"] = {2024: np.array([1])}
+
+        result = ExtendedCPS._drop_formula_variables(data)
+
+        assert "person_id" in result
+        for var in PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES:
+            assert var not in result
+
 
 class TestStructuralMortgageValidation:
     def test_positive_mortgage_input_ignores_non_mortgage_interest_deduction(self):
@@ -220,6 +236,32 @@ class TestAOTCEligibilityInputImputation:
         np.testing.assert_array_equal(
             result["qualified_tuition_expenses"][2024],
             np.array([1_200.0]),
+        )
+
+    def test_uses_tuition_signal_when_aotc_output_is_absent(
+        self,
+        pe_us_supports_aotc_inputs,
+    ):
+        data = {
+            "tax_unit_id": {2024: np.array([1, 2])},
+            "person_tax_unit_id": {2024: np.array([1, 1, 2])},
+            "qualified_tuition_expenses": {2024: np.array([1_200.0, 0.0, 900.0])},
+        }
+
+        result = ExtendedCPS._impute_aotc_eligibility_inputs(data, 2024)
+
+        expected = np.array([True, False, True])
+        for variable in (
+            "is_pursuing_credential_for_american_opportunity_credit",
+            "attends_eligible_educational_institution_for_american_opportunity_credit",
+            "is_enrolled_at_least_half_time_for_american_opportunity_credit",
+            "has_american_opportunity_credit_1098_t_or_exception",
+            "has_american_opportunity_credit_institution_ein",
+        ):
+            np.testing.assert_array_equal(result[variable][2024], expected)
+        np.testing.assert_array_equal(
+            result["qualified_tuition_expenses"][2024],
+            np.array([1_200.0, 0.0, 900.0]),
         )
 
     def test_marks_tuition_members_in_positive_aotc_tax_units(


### PR DESCRIPTION
## Summary
- classify PUF reported/calculated tax output variables separately from donor-support imputation inputs
- remove those variables from PUF clone QRF target lists and drop them from clone/export save paths
- update the appendix list and add tests for imputation and export exclusions

Fixes #921

## Tests
- uv run ruff check policyengine_us_data/calibration/puf_impute.py policyengine_us_data/datasets/puf/variable_roles.py policyengine_us_data/datasets/cps/extended_cps.py policyengine_us_data/calibration/create_stratified_cps.py policyengine_us_data/calibration/entity_clone.py policyengine_us_data/calibration/publish_local_area.py tests/unit/calibration/test_calibration_puf_impute.py tests/unit/test_extended_cps.py
- uv run pytest tests/unit/calibration/test_calibration_puf_impute.py tests/unit/test_extended_cps.py -q
- uv run pytest tests/unit/calibration/test_create_stratified_cps.py tests/unit/calibration/test_entity_clone.py tests/unit/calibration/test_publish_local_area.py -q