### PR TITLE
Remove ACS SPM threshold materialization

### DIFF
--- a/changelog.d/acs-spm-threshold-formula.changed.md
+++ b/changelog.d/acs-spm-threshold-formula.changed.md
@@ -1,0 +1,1 @@
+Removed dead ACS code that materialized SPM thresholds instead of leaving them to PolicyEngine US formulas.

--- a/policyengine_us_data/datasets/acs/acs.py
+++ b/policyengine_us_data/datasets/acs/acs.py
@@ -96,11 +96,6 @@ class ACS(Dataset):
         )
 
     @staticmethod
-    def add_spm_variables(acs: h5py.File, spm_unit: DataFrame) -> None:
-        acs["spm_unit_net_income_reported"] = spm_unit.SPM_RESOURCES
-        acs["spm_unit_spm_threshold"] = spm_unit.SPM_POVTHRESHOLD
-
-    @staticmethod
     def add_household_variables(acs: h5py.File, household: DataFrame) -> None:
         acs["household_vehicles_owned"] = household.VEH
         acs["state_fips"] = acs["household_state_fips"] = household.ST.astype(int)


### PR DESCRIPTION
## Summary
- remove dead ACS code that wrote `spm_unit_spm_threshold`
- keep SPM thresholds fully formula-owned by `policyengine-us`

## Tests
- `uv run ruff check policyengine_us_data/datasets/acs/acs.py`
- `uv run pytest tests/unit/datasets/test_acs_tax_unit_construction.py tests/integration/test_tiny_stage_1_artifacts.py`