### PR TITLE
Fix long-run donor support calibration

### DIFF
--- a/changelog.d/925.fixed.md
+++ b/changelog.d/925.fixed.md
@@ -1,0 +1,1 @@
+Fixed long-run donor-composite support calibration to use the active tax assumption and realized clone support values for Social Security and taxable payroll.

--- a/policyengine_us_data/datasets/cps/long_term/README.md
+++ b/policyengine_us_data/datasets/cps/long_term/README.md
@@ -9,14 +9,11 @@ Run projections using `run_household_projection.py`:
 # Recommended: named profile with core-threshold tax assumption and TOB targeted
 python run_household_projection.py 2100 --profile ss-payroll-tob --target-source trustees_2025_current_law --save-h5
 
-# Experimental: donor-backed late-year support augmentation for tail-year runs
-python run_household_projection.py 2075 2100 --profile ss-payroll-tob --target-source trustees_2025_current_law --support-augmentation-profile donor-backed-synthetic-v1 --support-augmentation-target-year 2100 --allow-validation-failures
-
 # Experimental: role-based donor composites assembled into late-year support
-python run_household_projection.py 2075 2100 --profile ss-payroll-tob --target-source trustees_2025_current_law --support-augmentation-profile donor-backed-composite-v1 --support-augmentation-target-year 2100 --allow-validation-failures
+python run_household_projection.py 2075 2100 --profile ss-payroll-tob --target-source trustees_2025_current_law --support-augmentation-profile donor-backed-composite-v1 --support-augmentation-target-year 2100 --support-augmentation-blueprint-base-weight-scale 5.0
 
 # Experimental: target-year blueprint calibration over donor-composite support
-python run_household_projection.py 2100 2100 --profile ss-payroll-tob --target-source trustees_2025_current_law --support-augmentation-profile donor-backed-composite-v1 --support-augmentation-target-year 2100 --support-augmentation-blueprint-base-weight-scale 0.5 --allow-validation-failures --save-h5
+python run_household_projection.py 2100 2100 --profile ss-payroll-tob --target-source trustees_2025_current_law --support-augmentation-profile donor-backed-composite-v1 --support-augmentation-target-year 2100 --support-augmentation-blueprint-base-weight-scale 5.0 --save-h5
 
 # IPF with only age distribution constraints (faster, less accurate)
 python run_household_projection.py 2050 --profile age-only
@@ -55,7 +52,7 @@ python run_long_term_production.py \
 - `--support-augmentation-donors-per-target`: Number of nearest real donor tax units per synthetic target (default `5`).
 - `--support-augmentation-max-distance`: Maximum donor-match distance retained for cloning (default `3.0`).
 - `--support-augmentation-clone-weight-scale`: Baseline weight multiplier applied to each donor-backed clone (default `0.1`).
-- `--support-augmentation-blueprint-base-weight-scale`: When donor-composite augmentation is active at its target year, scales the original household priors before replacing clone priors with synthetic blueprint shares (default `0.5`).
+- `--support-augmentation-blueprint-base-weight-scale`: When donor-composite augmentation is active at its target year, scales the original household priors before replacing clone priors with synthetic blueprint shares (default `5.0`).
 - `--greg`: Use GREG calibration instead of IPF
 - `--use-ss`: Include Social Security benefit totals as calibration target (requires `--greg`)
 - `--use-payroll`: Include taxable payroll totals as calibration target (requires `--greg`)
@@ -143,8 +140,8 @@ python run_long_term_production.py \
 - The actual-row augmented dataset builder is now available in the runner as `donor-backed-composite-v1`
 - Current status:
   - Fixing the long-run payroll-cap bug in `policyengine-us` changed the picture materially. With the correct SSA wage base extended through `2100`, the donor-composite synthetic support is exact-feasible and dense at the archetype level.
-  - The runner now supports a target-year calibration blueprint for donor-composite augmentation. At the augmentation target year, it can calibrate against the exact clone blueprints and synthetic prior shares while still auditing the realized rows.
-  - In the current `2100` probe, that blueprint path gets actual age + SS + taxable payroll very close while keeping support quality in range: with `--support-augmentation-blueprint-base-weight-scale 0.5`, actual payroll miss is about `-0.86%`, ESS about `102.5`, top-10 weight share about `24.4%`, and top-100 share about `68.4%`.
+  - The runner now supports a target-year calibration blueprint for donor-composite augmentation. At the augmentation target year, it applies target age composition to clone rows, uses realized PolicyEngine Social Security and payroll values for the same rows, and keeps synthetic prior shares for clone households.
+  - In the current `2075` OACT probe, that blueprint path hits actual Social Security, taxable payroll, and TOB targets exactly with nonnegative weights when `--support-augmentation-blueprint-base-weight-scale 5.0`.
   - The runner now also has a dynamic mode, `--support-augmentation-align-to-run-year`, that rebuilds donor-composite support for each run year and writes per-year augmentation reports.
   - This is still experimental. The blueprint path is now structurally capable of handling year-specific support, but the full `2075-2100` production sweep still needs runtime tuning and caching work.
 

--- a/policyengine_us_data/datasets/cps/long_term/prototype_synthetic_2100_support.py
+++ b/policyengine_us_data/datasets/cps/long_term/prototype_synthetic_2100_support.py
@@ -442,8 +442,9 @@ def build_tax_unit_summary(
     dataset: str | Dataset,
     *,
     period: int,
+    reform: object | None = None,
 ) -> pd.DataFrame:
-    sim = Microsimulation(dataset=dataset)
+    sim = Microsimulation(dataset=dataset, reform=reform)
     input_df = sim.to_input_dataframe()
 
     person_df = pd.DataFrame(
@@ -533,8 +534,12 @@ def build_tax_unit_summary(
     return pd.DataFrame(rows)
 
 
-def build_actual_tax_unit_summary(base_dataset: str) -> pd.DataFrame:
-    return build_tax_unit_summary(base_dataset, period=BASE_YEAR)
+def build_actual_tax_unit_summary(
+    base_dataset: str,
+    *,
+    reform: object | None = None,
+) -> pd.DataFrame:
+    return build_tax_unit_summary(base_dataset, period=BASE_YEAR, reform=reform)
 
 
 def attach_person_uprating_factors(
@@ -586,8 +591,12 @@ def attach_person_uprating_factors(
     return df
 
 
-def load_base_aggregates(base_dataset: str) -> dict[str, float]:
-    sim = Microsimulation(dataset=base_dataset)
+def load_base_aggregates(
+    base_dataset: str,
+    *,
+    reform: object | None = None,
+) -> dict[str, float]:
+    sim = Microsimulation(dataset=base_dataset, reform=reform)
     household_series = sim.calculate(
         "household_id", period=BASE_YEAR, map_to="household"
     )
@@ -874,15 +883,16 @@ def build_role_composite_calibration_blueprint(
     hh_id_to_idx: dict[int, int],
     baseline_weights: np.ndarray,
     base_weight_scale: float = 0.5,
+    ss_values_actual: np.ndarray | None = None,
+    payroll_values_actual: np.ndarray | None = None,
 ) -> dict[str, object] | None:
     """
     Build target-year calibration overrides for donor-composite clones.
 
-    Donor-composite augmentation produces realized microdata rows that are close
-    to the synthetic target support but not numerically identical. At the
-    augmentation target year we can calibrate against the exact clone
-    blueprints, using the synthetic solution as priors, while still applying
-    the resulting household weights to the realized rows.
+    Donor-composite augmentation produces realized microdata rows that match
+    the synthetic target ages exactly, while payroll and Social Security values
+    should come from the actual PolicyEngine run when available. This keeps the
+    calibration contract aligned with the rows that downstream scoring uses.
     """
     target_year = augmentation_report.get("target_year")
     clone_reports = augmentation_report.get("clone_household_reports")
@@ -916,8 +926,16 @@ def build_role_composite_calibration_blueprint(
             ages.append(int(spouse_age))
         ages.extend(int(age) for age in clone_report.get("target_dependent_ages", []))
         age_overrides[idx] = age_bucket_vector(ages, age_bins)
-        ss_overrides[idx] = float(clone_report["target_ss_total"])
-        payroll_overrides[idx] = float(clone_report["target_payroll_total"])
+        ss_overrides[idx] = (
+            float(ss_values_actual[idx])
+            if ss_values_actual is not None
+            else float(clone_report["target_ss_total"])
+        )
+        payroll_overrides[idx] = (
+            float(payroll_values_actual[idx])
+            if payroll_values_actual is not None
+            else float(clone_report["target_payroll_total"])
+        )
         prior_weights[idx] = (
             clone_total_prior_weight
             * float(clone_report["per_clone_weight_share_pct"])
@@ -2171,16 +2189,17 @@ def build_donor_backed_augmented_input_dataframe(
     donors_per_target: int = 5,
     max_distance_for_clone: float = 3.0,
     clone_weight_scale: float = 0.1,
+    reform: object | None = None,
 ) -> tuple[pd.DataFrame, dict[str, object]]:
-    sim = Microsimulation(dataset=base_dataset)
+    sim = Microsimulation(dataset=base_dataset, reform=reform)
     input_df = attach_person_uprating_factors(
         sim.to_input_dataframe(),
         sim,
         base_year=base_year,
         target_year=target_year,
     )
-    actual_summary = build_actual_tax_unit_summary(base_dataset)
-    base_aggregates = load_base_aggregates(base_dataset)
+    actual_summary = build_actual_tax_unit_summary(base_dataset, reform=reform)
+    base_aggregates = load_base_aggregates(base_dataset, reform=reform)
     ss_scale = load_ssa_benefit_projections(target_year) / max(
         base_aggregates["weighted_ss_total"],
         1.0,
@@ -2315,16 +2334,17 @@ def build_role_composite_augmented_input_dataframe(
     max_older_distance: float = 3.0,
     max_worker_distance: float = 3.0,
     clone_weight_scale: float = 0.1,
+    reform: object | None = None,
 ) -> tuple[pd.DataFrame, dict[str, object]]:
-    sim = Microsimulation(dataset=base_dataset)
+    sim = Microsimulation(dataset=base_dataset, reform=reform)
     input_df = attach_person_uprating_factors(
         sim.to_input_dataframe(),
         sim,
         base_year=base_year,
         target_year=target_year,
     )
-    actual_summary = build_actual_tax_unit_summary(base_dataset)
-    base_aggregates = load_base_aggregates(base_dataset)
+    actual_summary = build_actual_tax_unit_summary(base_dataset, reform=reform)
+    base_aggregates = load_base_aggregates(base_dataset, reform=reform)
     ss_scale = load_ssa_benefit_projections(target_year) / max(
         base_aggregates["weighted_ss_total"],
         1.0,
@@ -2530,6 +2550,7 @@ def build_role_composite_augmented_dataset(
     max_older_distance: float = 3.0,
     max_worker_distance: float = 3.0,
     clone_weight_scale: float = 0.1,
+    reform: object | None = None,
 ) -> tuple[Dataset, dict[str, object]]:
     augmented_df, report = build_role_composite_augmented_input_dataframe(
         base_dataset=base_dataset,
@@ -2540,6 +2561,7 @@ def build_role_composite_augmented_dataset(
         max_older_distance=max_older_distance,
         max_worker_distance=max_worker_distance,
         clone_weight_scale=clone_weight_scale,
+        reform=reform,
     )
     return Dataset.from_dataframe(augmented_df, base_year), report
 
@@ -2553,6 +2575,7 @@ def build_donor_backed_augmented_dataset(
     donors_per_target: int = 5,
     max_distance_for_clone: float = 3.0,
     clone_weight_scale: float = 0.1,
+    reform: object | None = None,
 ) -> tuple[Dataset, dict[str, object]]:
     augmented_df, report = build_donor_backed_augmented_input_dataframe(
         base_dataset=base_dataset,
@@ -2562,6 +2585,7 @@ def build_donor_backed_augmented_dataset(
         donors_per_target=donors_per_target,
         max_distance_for_clone=max_distance_for_clone,
         clone_weight_scale=clone_weight_scale,
+        reform=reform,
     )
     return Dataset.from_dataframe(augmented_df, base_year), report
 

--- a/policyengine_us_data/datasets/cps/long_term/run_household_projection.py
+++ b/policyengine_us_data/datasets/cps/long_term/run_household_projection.py
@@ -30,8 +30,8 @@ Examples:
     python run_household_projection.py 2045 2045 --profile ss --target-source trustees_2025_current_law --save-h5
     python run_household_projection.py 2025 2100 --profile ss-payroll-tob --target-source trustees_2025_current_law --save-h5
     python run_household_projection.py 2075 2100 --profile ss-payroll-tob --target-source trustees_2025_current_law --support-augmentation-profile donor-backed-synthetic-v1 --support-augmentation-target-year 2100 --allow-validation-failures
-    python run_household_projection.py 2100 2100 --profile ss-payroll-tob --target-source trustees_2025_current_law --support-augmentation-profile donor-backed-composite-v1 --support-augmentation-target-year 2100 --support-augmentation-blueprint-base-weight-scale 0.5 --allow-validation-failures --save-h5
-    python run_household_projection.py 2075 2100 --profile ss-payroll-tob --target-source trustees_2025_current_law --support-augmentation-profile donor-backed-composite-v1 --support-augmentation-align-to-run-year --support-augmentation-blueprint-base-weight-scale 0.5 --allow-validation-failures
+    python run_household_projection.py 2100 2100 --profile ss-payroll-tob --target-source trustees_2025_current_law --support-augmentation-profile donor-backed-composite-v1 --support-augmentation-target-year 2100 --support-augmentation-blueprint-base-weight-scale 5.0 --save-h5
+    python run_household_projection.py 2075 2100 --profile ss-payroll-tob --target-source trustees_2025_current_law --support-augmentation-profile donor-backed-composite-v1 --support-augmentation-align-to-run-year --support-augmentation-blueprint-base-weight-scale 5.0
     python run_household_projection.py 2025 2100 --profile ss-payroll-tob --target-source oact_2025_08_05_provisional --save-h5
 """
 
@@ -565,7 +565,7 @@ if "--support-augmentation-clone-weight-scale" in sys.argv:
     SUPPORT_AUGMENTATION_CLONE_WEIGHT_SCALE = float(sys.argv[weight_scale_index + 1])
     del sys.argv[weight_scale_index : weight_scale_index + 2]
 
-SUPPORT_AUGMENTATION_BLUEPRINT_BASE_WEIGHT_SCALE = 0.5
+SUPPORT_AUGMENTATION_BLUEPRINT_BASE_WEIGHT_SCALE = 5.0
 if "--support-augmentation-blueprint-base-weight-scale" in sys.argv:
     blueprint_scale_index = sys.argv.index(
         "--support-augmentation-blueprint-base-weight-scale"
@@ -802,6 +802,7 @@ def _build_support_augmentation(
             donors_per_target=SUPPORT_AUGMENTATION_DONORS_PER_TARGET,
             max_distance_for_clone=SUPPORT_AUGMENTATION_MAX_DISTANCE,
             clone_weight_scale=SUPPORT_AUGMENTATION_CLONE_WEIGHT_SCALE,
+            reform=ACTIVE_LONG_RUN_TAX_REFORM,
         )
     else:
         augmented_dataset, augmentation_report = build_augmented_dataset(
@@ -1245,6 +1246,8 @@ for year_idx in range(n_years):
             hh_id_to_idx=current_hh_id_to_idx,
             baseline_weights=baseline_weights,
             base_weight_scale=SUPPORT_AUGMENTATION_BLUEPRINT_BASE_WEIGHT_SCALE,
+            ss_values_actual=ss_values_actual,
+            payroll_values_actual=payroll_values_actual,
         )
         if calibration_blueprint is not None:
             calibration_baseline_weights = calibration_blueprint["baseline_weights"]

--- a/policyengine_us_data/datasets/cps/long_term/support_augmentation.py
+++ b/policyengine_us_data/datasets/cps/long_term/support_augmentation.py
@@ -466,6 +466,7 @@ def build_targeted_donor_augmented_dataset(
     donors_per_target: int = 5,
     max_distance_for_clone: float = 3.0,
     clone_weight_scale: float = 0.1,
+    reform: Any | None = None,
 ) -> tuple[Dataset, dict[str, Any]]:
     if profile not in TARGETED_DONOR_SUPPORT_AUGMENTATION_PROFILES:
         valid = ", ".join(sorted(TARGETED_DONOR_SUPPORT_AUGMENTATION_PROFILES))
@@ -494,6 +495,7 @@ def build_targeted_donor_augmented_dataset(
             donors_per_target=donors_per_target,
             max_distance_for_clone=max_distance_for_clone,
             clone_weight_scale=clone_weight_scale,
+            reform=reform,
         )
     else:
         augmented_dataset, report = build_role_composite_augmented_dataset(
@@ -505,6 +507,7 @@ def build_targeted_donor_augmented_dataset(
             max_older_distance=max_distance_for_clone,
             max_worker_distance=max_distance_for_clone,
             clone_weight_scale=clone_weight_scale,
+            reform=reform,
         )
 
     report["profile"] = profile
@@ -521,6 +524,8 @@ def build_targeted_role_composite_calibration_blueprint(
     hh_id_to_idx: dict[int, int],
     baseline_weights: np.ndarray,
     base_weight_scale: float = 0.5,
+    ss_values_actual: np.ndarray | None = None,
+    payroll_values_actual: np.ndarray | None = None,
 ) -> dict[str, Any] | None:
     try:
         from .prototype_synthetic_2100_support import (
@@ -538,6 +543,8 @@ def build_targeted_role_composite_calibration_blueprint(
         hh_id_to_idx=hh_id_to_idx,
         baseline_weights=baseline_weights,
         base_weight_scale=base_weight_scale,
+        ss_values_actual=ss_values_actual,
+        payroll_values_actual=payroll_values_actual,
     )
 
 

--- a/tests/unit/test_long_term_calibration_contract.py
+++ b/tests/unit/test_long_term_calibration_contract.py
@@ -185,6 +185,43 @@ def test_targeted_donor_support_builder_rejects_unknown_profile():
         )
 
 
+@pytest.mark.parametrize(
+    ("profile", "builder_name"),
+    [
+        ("donor-backed-synthetic-v1", "build_donor_backed_augmented_dataset"),
+        ("donor-backed-composite-v1", "build_role_composite_augmented_dataset"),
+    ],
+)
+def test_targeted_donor_support_builder_forwards_reform(
+    monkeypatch,
+    profile,
+    builder_name,
+):
+    from policyengine_us_data.datasets.cps.long_term import (
+        prototype_synthetic_2100_support as prototype_module,
+    )
+
+    reform = {"gov.irs.uprating": {"2035-01-01.2100-12-31": "gov.ssa.nawi"}}
+    calls = {}
+
+    def fake_builder(**kwargs):
+        calls["reform"] = kwargs.get("reform")
+        return object(), {}
+
+    monkeypatch.setattr(prototype_module, builder_name, fake_builder)
+
+    _, report = build_targeted_donor_augmented_dataset(
+        base_dataset="unused.h5",
+        base_year=2024,
+        target_year=2075,
+        profile=profile,
+        reform=reform,
+    )
+
+    assert calls["reform"] is reform
+    assert report["profile"] == profile
+
+
 def test_support_augmentation_clones_households_with_new_ids():
     import pandas as pd
 
@@ -553,6 +590,36 @@ def test_role_composite_calibration_blueprint_reweights_clone_priors():
     assert blueprint["age_overrides"][2].sum() == pytest.approx(1.0)
     assert blueprint["summary"]["clone_household_count"] == 2
     assert blueprint["summary"]["base_weight_scale"] == pytest.approx(0.5)
+
+
+def test_role_composite_blueprint_prefers_realized_support_values():
+    report = {
+        "target_year": 2100,
+        "clone_household_reports": [
+            {
+                "clone_household_id": 1001,
+                "target_head_age": 70,
+                "target_spouse_age": None,
+                "target_dependent_ages": [],
+                "target_ss_total": 20_000.0,
+                "target_payroll_total": 50_000.0,
+                "per_clone_weight_share_pct": 10.0,
+            }
+        ],
+    }
+    blueprint = build_role_composite_calibration_blueprint(
+        report,
+        year=2100,
+        age_bins=build_age_bins(n_ages=86, bucket_size=5),
+        hh_id_to_idx={1001: 1},
+        baseline_weights=np.array([100.0, 200.0]),
+        ss_values_actual=np.array([1_000.0, 21_000.0]),
+        payroll_values_actual=np.array([2_000.0, 55_000.0]),
+    )
+
+    assert blueprint is not None
+    assert blueprint["ss_overrides"] == {1: 21_000.0}
+    assert blueprint["payroll_overrides"] == {1: 55_000.0}
 
 
 def test_legacy_flags_map_to_named_profile():


### PR DESCRIPTION
## Summary
- pass the active long-run tax reform into targeted donor support generation so clone support uses the same assumptions as final projection/scoring
- calibrate donor-composite clone SS/payroll overrides using realized PolicyEngine row values while retaining the target age blueprint and clone priors
- increase the default donor-composite blueprint base prior scale to 5.0 and update the long-run docs

## Validation
- Subagent final review: no blockers or serious risks
- pytest tests/unit/test_long_term_calibration_contract.py -q (51 passed)
- 2075 OACT sentinel saved artifact: validation_passed=true, calibration_quality=exact, no validation issues; ESS 310.030, top-10 weight share 12.698%; SS/payroll/OASDI TOB/HI TOB errors ~0
- 2100 OACT sentinel saved artifact: validation_passed=true, calibration_quality=exact, no validation issues; ESS 312.358, top-10 weight share 12.732%; SS/payroll/OASDI TOB/HI TOB errors ~0

Final local sentinel artifacts:
- /Users/maxghenis/PolicyEngine/crfb-tob-impacts/projected_datasets_snapshots/sentinel-20260508-oact-final-2075-usdata-1bc3b570-peus-4281529bc4/2075.h5
- /Users/maxghenis/PolicyEngine/crfb-tob-impacts/projected_datasets_snapshots/sentinel-20260508-oact-final-2100-usdata-1bc3b570-peus-4281529bc4/2100.h5