### PR TITLE
Emit Stage 2 calibration package contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,12 +31,14 @@ Before creating or sharing any PR, all developers and agents must:
    `gh repo view PolicyEngine/policyengine-us-data --json nameWithOwner`.
 2. Push the branch to that repository, for example:
    `git push upstream HEAD:<branch-name>`.
-3. Create the PR from the same repository, for example:
-   `gh pr create --repo PolicyEngine/policyengine-us-data --head <branch-name> --base main`.
-4. Verify the PR head repository before reporting it:
-   `gh pr view <PR> --repo PolicyEngine/policyengine-us-data --json headRepositoryOwner,headRepository`.
+3. Create the PR as a draft from the same repository, for example:
+   `gh pr create --draft --repo PolicyEngine/policyengine-us-data --head <branch-name> --base main`.
+4. Verify the PR is draft and the head repository is canonical before reporting
+   it:
+   `gh pr view <PR> --repo PolicyEngine/policyengine-us-data --json isDraft,headRepositoryOwner,headRepository`.
 
-The PR is valid only if the head repository is `PolicyEngine/policyengine-us-data`.
+The PR is valid only if `isDraft` is `true` and the head repository is
+`PolicyEngine/policyengine-us-data`.
 If you cannot push to the canonical repository, stop and ask for access. Do not
 create a fork PR as a fallback. If you accidentally create one, immediately
-close it and replace it with a same-repository PR.
+close it and replace it with a same-repository draft PR.

--- a/changelog.d/926.added
+++ b/changelog.d/926.added
@@ -1,0 +1,2 @@
+Stage 2 now emits and validates a semantic `calibration_package_contract.json`
+sidecar next to `calibration_package.pkl`.

--- a/docs/engineering/skills/github-prs.md
+++ b/docs/engineering/skills/github-prs.md
@@ -24,16 +24,18 @@ Before creating or sharing a PR:
    `make lint`.
 6. Push the current branch to the canonical repository:
    `make push-pr-branch`.
-7. Create the PR from that same repository:
-   `gh pr create --repo PolicyEngine/policyengine-us-data --head "$(git branch --show-current)" --base main`.
-8. Verify the PR head repository:
-   `gh pr view <PR> --repo PolicyEngine/policyengine-us-data --json headRepositoryOwner,headRepository`.
+7. Create the PR as a draft from that same repository:
+   `gh pr create --draft --repo PolicyEngine/policyengine-us-data --head "$(git branch --show-current)" --base main`.
+8. Verify the PR is draft and the head repository is canonical:
+   `gh pr view <PR> --repo PolicyEngine/policyengine-us-data --json isDraft,headRepositoryOwner,headRepository`.
+9. Leave the PR as draft unless a maintainer explicitly asks for it to be
+   marked ready for review.
 
-The PR is valid only if the head repository is
+The PR is valid only if `isDraft` is `true` and the head repository is
 `PolicyEngine/policyengine-us-data`. If you cannot push to the canonical
 repository, stop and ask for access. Do not create a fork PR as a fallback. If
 you accidentally create one, close it immediately and replace it with a
-same-repository PR.
+same-repository draft PR.
 
 ## PR title
 

--- a/modal_app/remote_calibration_runner.py
+++ b/modal_app/remote_calibration_runner.py
@@ -422,16 +422,20 @@ def _build_package_impl(
 
     from policyengine_us_data.stage_contracts.calibration_package import (
         CALIBRATION_PACKAGE_CONTRACT_FILENAME,
+        load_calibration_package_payload,
         validate_calibration_package_contract,
     )
 
     contract_path = f"{artifacts}/{CALIBRATION_PACKAGE_CONTRACT_FILENAME}"
+    package = load_calibration_package_payload(Path(pkg_path))
     validate_calibration_package_contract(
         package_path=Path(pkg_path),
         contract_path=Path(contract_path),
+        package=package,
         dataset_path=Path(dataset_path),
         db_path=Path(db_path),
     )
+    del package
 
     sidecar_ok = _write_package_sidecar(pkg_path)
     if not sidecar_ok:

--- a/modal_app/remote_calibration_runner.py
+++ b/modal_app/remote_calibration_runner.py
@@ -422,20 +422,16 @@ def _build_package_impl(
 
     from policyengine_us_data.stage_contracts.calibration_package import (
         CALIBRATION_PACKAGE_CONTRACT_FILENAME,
-        load_calibration_package_payload,
-        validate_calibration_package_contract,
+        validate_persisted_calibration_package_contract,
     )
 
     contract_path = f"{artifacts}/{CALIBRATION_PACKAGE_CONTRACT_FILENAME}"
-    package = load_calibration_package_payload(Path(pkg_path))
-    validate_calibration_package_contract(
+    validate_persisted_calibration_package_contract(
         package_path=Path(pkg_path),
         contract_path=Path(contract_path),
-        package=package,
         dataset_path=Path(dataset_path),
         db_path=Path(db_path),
     )
-    del package
 
     sidecar_ok = _write_package_sidecar(pkg_path)
     if not sidecar_ok:

--- a/modal_app/remote_calibration_runner.py
+++ b/modal_app/remote_calibration_runner.py
@@ -420,6 +420,19 @@ def _build_package_impl(
     if build_rc != 0:
         raise RuntimeError(f"Package build failed with code {build_rc}")
 
+    from policyengine_us_data.stage_contracts.calibration_package import (
+        CALIBRATION_PACKAGE_CONTRACT_FILENAME,
+        validate_calibration_package_contract,
+    )
+
+    contract_path = f"{artifacts}/{CALIBRATION_PACKAGE_CONTRACT_FILENAME}"
+    validate_calibration_package_contract(
+        package_path=Path(pkg_path),
+        contract_path=Path(contract_path),
+        dataset_path=Path(dataset_path),
+        db_path=Path(db_path),
+    )
+
     sidecar_ok = _write_package_sidecar(pkg_path)
     if not sidecar_ok:
         print(

--- a/policyengine_us_data/calibration/unified_calibration.py
+++ b/policyengine_us_data/calibration/unified_calibration.py
@@ -30,6 +30,7 @@ import builtins
 import logging
 import os
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Optional
 
@@ -69,6 +70,42 @@ LEARNING_RATE = 0.15
 DEFAULT_EPOCHS = 100
 DEFAULT_N_CLONES = 430
 DEFAULT_TARGET_CONFIG_PATH = Path(__file__).resolve().parent / "target_config.yaml"
+
+
+def _utc_now_isoformat() -> str:
+    """Return a compact UTC timestamp for contract metadata."""
+
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _calibration_package_contract_parameters(
+    *,
+    workers: int,
+    n_clones: int,
+    target_config_path: str | None,
+    skip_county: bool,
+    skip_source_impute: bool,
+    skip_takeup_rerandomize: bool,
+    chunked_matrix: bool,
+    chunk_size: int,
+    parallel: bool,
+    num_matrix_workers: int,
+) -> dict:
+    """Return Stage 2 parameters that affect package construction."""
+
+    parallel_matrix = bool(chunked_matrix and parallel)
+    return {
+        "workers": workers if not chunked_matrix else None,
+        "n_clones": n_clones,
+        "target_config": target_config_path,
+        "skip_county": skip_county,
+        "skip_source_impute": skip_source_impute,
+        "skip_takeup_rerandomize": skip_takeup_rerandomize,
+        "chunked_matrix": chunked_matrix,
+        "chunk_size": chunk_size if chunked_matrix else None,
+        "parallel_matrix": parallel_matrix,
+        "num_matrix_workers": num_matrix_workers if parallel_matrix else None,
+    }
 
 
 def get_git_provenance() -> dict:
@@ -1303,6 +1340,7 @@ def run_calibration(
     """
     import time
 
+    started_at = _utc_now_isoformat()
     t0 = time.time()
 
     # Early exit: load pre-built package
@@ -1547,8 +1585,6 @@ def run_calibration(
     # Step 6b: Save the calibration package. By default this is the
     # minimal package selected by target_config.yaml; use
     # --all-active-targets to build a broad diagnostic package.
-    import datetime
-
     metadata = {
         "dataset_path": dataset_path,
         "db_path": db_path,
@@ -1556,7 +1592,7 @@ def run_calibration(
         "n_records": X_sparse.shape[1],
         "base_n_records": n_records,
         "seed": seed,
-        "created_at": datetime.datetime.now().isoformat(),
+        "created_at": _utc_now_isoformat(),
         "target_config_path": target_config_path,
         "package_scope": "minimal" if target_config else "all_active_targets",
         "matrix_builder": "chunked" if chunked_matrix else "precompute",
@@ -1573,20 +1609,63 @@ def run_calibration(
             Path(target_config_path)
         )
 
+    initial_weights = compute_initial_weights(X_sparse, targets_df)
     if package_output_path:
-        full_initial_weights = compute_initial_weights(X_sparse, targets_df)
+        package_payload = {
+            "X_sparse": X_sparse,
+            "targets_df": targets_df,
+            "target_names": target_names,
+            "metadata": metadata,
+            "initial_weights": initial_weights,
+            "cd_geoid": geography.cd_geoid,
+            "block_geoid": geography.block_geoid,
+        }
         save_calibration_package(
             package_output_path,
             X_sparse,
             targets_df,
             target_names,
             metadata,
-            initial_weights=full_initial_weights,
+            initial_weights=initial_weights,
             cd_geoid=geography.cd_geoid,
             block_geoid=geography.block_geoid,
         )
+        from policyengine_us_data.stage_contracts.calibration_package import (
+            validate_calibration_package_contract,
+            write_calibration_package_contract,
+        )
 
-    initial_weights = compute_initial_weights(X_sparse, targets_df)
+        completed_at = _utc_now_isoformat()
+        write_calibration_package_contract(
+            package_path=Path(package_output_path),
+            dataset_path=Path(dataset_path),
+            db_path=Path(db_path),
+            package=package_payload,
+            parameters=_calibration_package_contract_parameters(
+                workers=workers,
+                n_clones=n_clones,
+                target_config_path=target_config_path,
+                skip_county=skip_county,
+                skip_source_impute=skip_source_impute,
+                skip_takeup_rerandomize=skip_takeup_rerandomize,
+                chunked_matrix=chunked_matrix,
+                chunk_size=chunk_size,
+                parallel=parallel,
+                num_matrix_workers=num_matrix_workers,
+            ),
+            run_id=run_id,
+            started_at=started_at,
+            completed_at=completed_at,
+            duration_s=round(time.time() - t0, 1),
+            code_sha=metadata.get("git_commit"),
+            package_version=metadata.get("package_version"),
+        )
+        validate_calibration_package_contract(
+            package_path=Path(package_output_path),
+            package=package_payload,
+            dataset_path=Path(dataset_path),
+            db_path=Path(db_path),
+        )
 
     if build_only:
         from policyengine_us_data.calibration.validate_package import (

--- a/policyengine_us_data/calibration/unified_calibration.py
+++ b/policyengine_us_data/calibration/unified_calibration.py
@@ -45,6 +45,9 @@ from policyengine_us_data.calibration.calibration_utils import (
     create_target_groups,
 )
 from policyengine_us_data.pipeline_metadata import pipeline_node
+from policyengine_us_data.stage_contracts.calibration_package import (
+    CalibrationPackageParameters,
+)
 from policyengine_us_data.pipeline_schema import PipelineNode
 
 logging.basicConfig(
@@ -90,22 +93,21 @@ def _calibration_package_contract_parameters(
     chunk_size: int,
     parallel: bool,
     num_matrix_workers: int,
-) -> dict:
+) -> CalibrationPackageParameters:
     """Return Stage 2 parameters that affect package construction."""
 
-    parallel_matrix = bool(chunked_matrix and parallel)
-    return {
-        "workers": workers if not chunked_matrix else None,
-        "n_clones": n_clones,
-        "target_config": target_config_path,
-        "skip_county": skip_county,
-        "skip_source_impute": skip_source_impute,
-        "skip_takeup_rerandomize": skip_takeup_rerandomize,
-        "chunked_matrix": chunked_matrix,
-        "chunk_size": chunk_size if chunked_matrix else None,
-        "parallel_matrix": parallel_matrix,
-        "num_matrix_workers": num_matrix_workers if parallel_matrix else None,
-    }
+    return CalibrationPackageParameters.from_runtime_args(
+        workers=workers,
+        n_clones=n_clones,
+        target_config_path=target_config_path,
+        skip_county=skip_county,
+        skip_source_impute=skip_source_impute,
+        skip_takeup_rerandomize=skip_takeup_rerandomize,
+        chunked_matrix=chunked_matrix,
+        chunk_size=chunk_size,
+        parallel=parallel,
+        num_matrix_workers=num_matrix_workers,
+    )
 
 
 def get_git_provenance() -> dict:

--- a/policyengine_us_data/calibration/unified_calibration.py
+++ b/policyengine_us_data/calibration/unified_calibration.py
@@ -189,7 +189,11 @@ def check_package_staleness(metadata: dict) -> None:
     if created:
         try:
             built_dt = datetime.datetime.fromisoformat(created)
-            age = datetime.datetime.now() - built_dt
+            if built_dt.tzinfo is None:
+                built_dt = built_dt.replace(tzinfo=datetime.UTC)
+            age = datetime.datetime.now(datetime.UTC) - built_dt.astimezone(
+                datetime.UTC
+            )
             if age.days > 7:
                 print(f"WARNING: Package is {age.days} days old (built {created})")
         except Exception:

--- a/policyengine_us_data/stage_contracts/__init__.py
+++ b/policyengine_us_data/stage_contracts/__init__.py
@@ -19,6 +19,7 @@ from .calibration_package import (
     load_calibration_package_payload,
     summarize_calibration_package,
     validate_calibration_package_contract,
+    validate_persisted_calibration_package_contract,
     write_calibration_package_contract,
 )
 from .constants import (
@@ -122,6 +123,7 @@ __all__ = [
     "summarize_calibration_package",
     "substage_ids_for_stage",
     "validate_calibration_package_contract",
+    "validate_persisted_calibration_package_contract",
     "write_calibration_package_contract",
     "write_contract",
 ]

--- a/policyengine_us_data/stage_contracts/__init__.py
+++ b/policyengine_us_data/stage_contracts/__init__.py
@@ -12,6 +12,15 @@ This package is intentionally dependency-light and has no Modal dependency.
 """
 
 from .artifacts import ArtifactRef
+from .calibration_package import (
+    CALIBRATION_PACKAGE_CONTRACT_FILENAME,
+    CALIBRATION_PACKAGE_CONTRACT_TYPE,
+    build_calibration_package_contract,
+    load_calibration_package_payload,
+    summarize_calibration_package,
+    validate_calibration_package_contract,
+    write_calibration_package_contract,
+)
 from .constants import (
     CONTRACT_FINGERPRINT_ALGORITHM,
     CONTRACT_SCHEMA_VERSION,
@@ -73,6 +82,8 @@ __all__ = [
     "VALIDATION_REPORT_STATUSES",
     "ArtifactRef",
     "CANONICAL_STAGE_IDS",
+    "CALIBRATION_PACKAGE_CONTRACT_FILENAME",
+    "CALIBRATION_PACKAGE_CONTRACT_TYPE",
     "CONTRACT_TYPE_BY_STAGE_ID",
     "DATASET_BUILD_OUTPUT_CONTRACT_FILENAME",
     "DATASET_BUILD_OUTPUT_CONTRACT_TYPE",
@@ -97,6 +108,7 @@ __all__ = [
     "ValidationFindingStatus",
     "ValidationReport",
     "ValidationReportStatus",
+    "build_calibration_package_contract",
     "build_dataset_build_output_contract",
     "canonicalize_for_fingerprint",
     "contract_from_json",
@@ -105,7 +117,11 @@ __all__ = [
     "fingerprint_material",
     "is_canonical_stage_id",
     "is_canonical_substage_id",
+    "load_calibration_package_payload",
     "read_contract",
+    "summarize_calibration_package",
     "substage_ids_for_stage",
+    "validate_calibration_package_contract",
+    "write_calibration_package_contract",
     "write_contract",
 ]

--- a/policyengine_us_data/stage_contracts/__init__.py
+++ b/policyengine_us_data/stage_contracts/__init__.py
@@ -15,6 +15,8 @@ from .artifacts import ArtifactRef
 from .calibration_package import (
     CALIBRATION_PACKAGE_CONTRACT_FILENAME,
     CALIBRATION_PACKAGE_CONTRACT_TYPE,
+    CalibrationPackageParameters,
+    CalibrationPackageSummary,
     build_calibration_package_contract,
     load_calibration_package_payload,
     summarize_calibration_package,
@@ -85,6 +87,8 @@ __all__ = [
     "CANONICAL_STAGE_IDS",
     "CALIBRATION_PACKAGE_CONTRACT_FILENAME",
     "CALIBRATION_PACKAGE_CONTRACT_TYPE",
+    "CalibrationPackageParameters",
+    "CalibrationPackageSummary",
     "CONTRACT_TYPE_BY_STAGE_ID",
     "DATASET_BUILD_OUTPUT_CONTRACT_FILENAME",
     "DATASET_BUILD_OUTPUT_CONTRACT_TYPE",

--- a/policyengine_us_data/stage_contracts/calibration_package.py
+++ b/policyengine_us_data/stage_contracts/calibration_package.py
@@ -163,7 +163,7 @@ def build_calibration_package_contract(
     return StageContract(
         contract_type=CALIBRATION_PACKAGE_CONTRACT_TYPE,
         stage_id=STAGE_2_BUILD_CALIBRATION_PACKAGE,
-        run_id=run_id,
+        run_id=run_id or None,
         created_at=completed_at,
         code_sha=code_sha,
         package_version=package_version,

--- a/policyengine_us_data/stage_contracts/calibration_package.py
+++ b/policyengine_us_data/stage_contracts/calibration_package.py
@@ -251,10 +251,7 @@ def validate_calibration_package_contract(
     if contract.stage_id != STAGE_2_BUILD_CALIBRATION_PACKAGE:
         raise ValueError(f"Invalid Stage 2 contract stage_id: {contract.stage_id!r}")
     if contract.contract_type != CALIBRATION_PACKAGE_CONTRACT_TYPE:
-        raise ValueError(
-            "Invalid Stage 2 contract type: "
-            f"{contract.contract_type!r}"
-        )
+        raise ValueError(f"Invalid Stage 2 contract type: {contract.contract_type!r}")
     _assert_artifact_matches_file(
         _single_artifact(contract.outputs, "calibration_package"),
         package_path,

--- a/policyengine_us_data/stage_contracts/calibration_package.py
+++ b/policyengine_us_data/stage_contracts/calibration_package.py
@@ -10,6 +10,10 @@ from typing import Any
 from policyengine_us_data.utils.step_manifest import sha256_file
 
 from .artifacts import ArtifactRef
+from .calibration_package_schema import (
+    CalibrationPackageParameters,
+    CalibrationPackageSummary,
+)
 from .contracts import StageContract
 from .execution import ExecutionRecord, ReuseSummary
 from .fingerprints import canonicalize_for_fingerprint, fingerprint_material
@@ -24,7 +28,9 @@ CALIBRATION_PACKAGE_CONTRACT_TYPE = contract_type_for_stage(
 CALIBRATION_PACKAGE_SUBSTAGE_ID = "2a_matrix_build_calibration_target_construction"
 
 
-def summarize_calibration_package(package: Mapping[str, Any]) -> Mapping[str, Any]:
+def summarize_calibration_package(
+    package: Mapping[str, Any],
+) -> CalibrationPackageSummary:
     """Return a contract-safe summary of a calibration package pickle payload."""
 
     matrix = _required_package_value(package, "X_sparse")
@@ -44,37 +50,36 @@ def summarize_calibration_package(package: Mapping[str, Any]) -> Mapping[str, An
     nnz = int(matrix.nnz)
     density = nnz / (n_targets * n_columns) if n_targets * n_columns else 0.0
 
-    summary: dict[str, Any] = {
-        "matrix_shape": (n_targets, n_columns),
-        "matrix_nnz": nnz,
-        "matrix_density": float(density),
-        "n_targets": int(len(targets_df)),
-        "n_columns": n_columns,
-        "target_name_count": int(len(target_names)),
-        "dataset_sha256": _optional_metadata_string(metadata, "dataset_sha256"),
-        "db_sha256": _optional_metadata_string(metadata, "db_sha256"),
-        "target_config_path": _optional_metadata_string(
+    return CalibrationPackageSummary(
+        matrix_shape=(n_targets, n_columns),
+        matrix_nnz=nnz,
+        matrix_density=float(density),
+        n_targets=int(len(targets_df)),
+        n_columns=n_columns,
+        target_name_count=int(len(target_names)),
+        dataset_sha256=_optional_metadata_string(metadata, "dataset_sha256"),
+        db_sha256=_optional_metadata_string(metadata, "db_sha256"),
+        target_config_path=_optional_metadata_string(
             metadata,
             "target_config_path",
         ),
-        "target_config_sha256": _optional_metadata_string(
+        target_config_sha256=_optional_metadata_string(
             metadata,
             "target_config_sha256",
         ),
-        "n_clones": _optional_metadata_int(metadata, "n_clones"),
-        "seed": _optional_metadata_int(metadata, "seed"),
-        "base_n_records": _optional_metadata_int(metadata, "base_n_records"),
-        "package_scope": _optional_metadata_string(metadata, "package_scope"),
-        "matrix_builder": _optional_metadata_string(metadata, "matrix_builder"),
-        "chunk_size": _optional_metadata_int(metadata, "chunk_size"),
-        "chunk_dir": _optional_metadata_string(metadata, "chunk_dir"),
-        "has_initial_weights": package.get("initial_weights") is not None,
-        "has_cd_geoid": package.get("cd_geoid") is not None,
-        "has_block_geoid": package.get("block_geoid") is not None,
-        "cd_geoid_length": _optional_len(package.get("cd_geoid")),
-        "block_geoid_length": _optional_len(package.get("block_geoid")),
-    }
-    return summary
+        n_clones=_optional_metadata_int(metadata, "n_clones"),
+        seed=_optional_metadata_int(metadata, "seed"),
+        base_n_records=_optional_metadata_int(metadata, "base_n_records"),
+        package_scope=_optional_metadata_string(metadata, "package_scope"),
+        matrix_builder=_optional_metadata_string(metadata, "matrix_builder"),
+        chunk_size=_optional_metadata_int(metadata, "chunk_size"),
+        chunk_dir=_optional_metadata_string(metadata, "chunk_dir"),
+        has_initial_weights=package.get("initial_weights") is not None,
+        has_cd_geoid=package.get("cd_geoid") is not None,
+        has_block_geoid=package.get("block_geoid") is not None,
+        cd_geoid_length=_optional_len(package.get("cd_geoid")),
+        block_geoid_length=_optional_len(package.get("block_geoid")),
+    )
 
 
 def build_calibration_package_contract(
@@ -83,7 +88,7 @@ def build_calibration_package_contract(
     dataset_path: Path,
     db_path: Path,
     package: Mapping[str, Any],
-    parameters: Mapping[str, Any],
+    parameters: CalibrationPackageParameters | Mapping[str, Any],
     run_id: str | None,
     completed_at: str,
     started_at: str | None = None,
@@ -100,8 +105,10 @@ def build_calibration_package_contract(
     _require_existing_file(dataset_path, "source dataset")
     _require_existing_file(db_path, "target database")
 
+    parameter_schema = _calibration_package_parameters(parameters)
+    parameter_payload = parameter_schema.to_dict()
     metadata = _package_metadata(package)
-    package_summary = summarize_calibration_package(package)
+    package_summary = summarize_calibration_package(package).to_dict()
     inputs = (
         _artifact_ref_from_path(
             logical_name="source_imputed_stratified_extended_cps",
@@ -156,7 +163,7 @@ def build_calibration_package_contract(
             "contract_type": CALIBRATION_PACKAGE_CONTRACT_TYPE,
             "inputs": inputs,
             "outputs": outputs,
-            "parameters": parameters,
+            "parameters": parameter_payload,
             "package_summary": package_summary,
         }
     )
@@ -169,7 +176,7 @@ def build_calibration_package_contract(
         package_version=package_version,
         inputs=inputs,
         outputs=outputs,
-        parameters=parameters,
+        parameters=parameter_payload,
         fingerprint=fingerprint,
         substages=(
             SubstageRecord(
@@ -177,7 +184,7 @@ def build_calibration_package_contract(
                 status="completed",
                 inputs=inputs,
                 outputs=outputs,
-                parameters=parameters,
+                parameters=parameter_payload,
                 fingerprint=fingerprint,
                 reuse_mode="handoff",
             ),
@@ -197,7 +204,7 @@ def write_calibration_package_contract(
     dataset_path: Path,
     db_path: Path,
     package: Mapping[str, Any],
-    parameters: Mapping[str, Any],
+    parameters: CalibrationPackageParameters | Mapping[str, Any],
     run_id: str | None,
     completed_at: str,
     started_at: str | None = None,
@@ -272,10 +279,12 @@ def validate_calibration_package_contract(
         raise ValueError("package is required to validate calibration package summary")
 
     expected_summary = canonicalize_for_fingerprint(
-        summarize_calibration_package(package)
+        summarize_calibration_package(package).to_dict()
     )
     actual_summary = canonicalize_for_fingerprint(
-        contract.metadata.get("package_summary", {})
+        CalibrationPackageSummary.from_dict(
+            contract.metadata.get("package_summary", {})
+        ).to_dict()
     )
     if actual_summary != expected_summary:
         raise ValueError("Calibration package contract summary does not match pickle")
@@ -349,6 +358,14 @@ def _optional_len(value: Any) -> int | None:
     if value is None:
         return None
     return int(len(value))
+
+
+def _calibration_package_parameters(
+    parameters: CalibrationPackageParameters | Mapping[str, Any],
+) -> CalibrationPackageParameters:
+    if isinstance(parameters, CalibrationPackageParameters):
+        return parameters
+    return CalibrationPackageParameters.from_dict(parameters)
 
 
 def _require_existing_file(path: Path, label: str) -> None:

--- a/policyengine_us_data/stage_contracts/calibration_package.py
+++ b/policyengine_us_data/stage_contracts/calibration_package.py
@@ -180,7 +180,6 @@ def build_calibration_package_contract(
                 parameters=parameters,
                 fingerprint=fingerprint,
                 reuse_mode="handoff",
-                metadata={"package_summary": package_summary},
             ),
         ),
         execution=execution,
@@ -270,7 +269,7 @@ def validate_calibration_package_contract(
             Path(db_path),
         )
     if package is None:
-        return contract
+        raise ValueError("package is required to validate calibration package summary")
 
     expected_summary = canonicalize_for_fingerprint(
         summarize_calibration_package(package)

--- a/policyengine_us_data/stage_contracts/calibration_package.py
+++ b/policyengine_us_data/stage_contracts/calibration_package.py
@@ -282,6 +282,25 @@ def validate_calibration_package_contract(
     return contract
 
 
+def validate_persisted_calibration_package_contract(
+    *,
+    package_path: Path,
+    contract_path: Path | None = None,
+    dataset_path: Path | None = None,
+    db_path: Path | None = None,
+) -> StageContract:
+    """Validate a persisted Stage 2 sidecar against its pickle payload."""
+
+    package = load_calibration_package_payload(package_path)
+    return validate_calibration_package_contract(
+        package_path=package_path,
+        contract_path=contract_path,
+        package=package,
+        dataset_path=dataset_path,
+        db_path=db_path,
+    )
+
+
 def load_calibration_package_payload(package_path: Path) -> Mapping[str, Any]:
     """Load a calibration package pickle for sidecar validation."""
 

--- a/policyengine_us_data/stage_contracts/calibration_package.py
+++ b/policyengine_us_data/stage_contracts/calibration_package.py
@@ -1,0 +1,401 @@
+"""Stage 2 calibration-package contract assembly and validation."""
+
+from __future__ import annotations
+
+import pickle
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from policyengine_us_data.utils.step_manifest import sha256_file
+
+from .artifacts import ArtifactRef
+from .contracts import StageContract
+from .execution import ExecutionRecord, ReuseSummary
+from .fingerprints import canonicalize_for_fingerprint, fingerprint_material
+from .io import read_contract, write_contract
+from .stages import STAGE_2_BUILD_CALIBRATION_PACKAGE, contract_type_for_stage
+from .substages import SubstageRecord
+
+CALIBRATION_PACKAGE_CONTRACT_FILENAME = "calibration_package_contract.json"
+CALIBRATION_PACKAGE_CONTRACT_TYPE = contract_type_for_stage(
+    STAGE_2_BUILD_CALIBRATION_PACKAGE
+)
+CALIBRATION_PACKAGE_SUBSTAGE_ID = "2a_matrix_build_calibration_target_construction"
+
+
+def summarize_calibration_package(package: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return a contract-safe summary of a calibration package pickle payload."""
+
+    matrix = _required_package_value(package, "X_sparse")
+    targets_df = _required_package_value(package, "targets_df")
+    target_names = _required_package_value(package, "target_names")
+    metadata = _package_metadata(package)
+
+    try:
+        n_targets, n_columns = matrix.shape
+    except (AttributeError, ValueError) as exc:
+        raise ValueError("X_sparse must expose a two-dimensional shape") from exc
+    if not hasattr(matrix, "nnz"):
+        raise ValueError("X_sparse must expose nnz")
+
+    n_targets = int(n_targets)
+    n_columns = int(n_columns)
+    nnz = int(matrix.nnz)
+    density = nnz / (n_targets * n_columns) if n_targets * n_columns else 0.0
+
+    summary: dict[str, Any] = {
+        "matrix_shape": (n_targets, n_columns),
+        "matrix_nnz": nnz,
+        "matrix_density": float(density),
+        "n_targets": int(len(targets_df)),
+        "n_columns": n_columns,
+        "target_name_count": int(len(target_names)),
+        "dataset_sha256": _optional_metadata_string(metadata, "dataset_sha256"),
+        "db_sha256": _optional_metadata_string(metadata, "db_sha256"),
+        "target_config_path": _optional_metadata_string(
+            metadata,
+            "target_config_path",
+        ),
+        "target_config_sha256": _optional_metadata_string(
+            metadata,
+            "target_config_sha256",
+        ),
+        "n_clones": _optional_metadata_int(metadata, "n_clones"),
+        "seed": _optional_metadata_int(metadata, "seed"),
+        "base_n_records": _optional_metadata_int(metadata, "base_n_records"),
+        "package_scope": _optional_metadata_string(metadata, "package_scope"),
+        "matrix_builder": _optional_metadata_string(metadata, "matrix_builder"),
+        "chunk_size": _optional_metadata_int(metadata, "chunk_size"),
+        "chunk_dir": _optional_metadata_string(metadata, "chunk_dir"),
+        "has_initial_weights": package.get("initial_weights") is not None,
+        "has_cd_geoid": package.get("cd_geoid") is not None,
+        "has_block_geoid": package.get("block_geoid") is not None,
+        "cd_geoid_length": _optional_len(package.get("cd_geoid")),
+        "block_geoid_length": _optional_len(package.get("block_geoid")),
+    }
+    return summary
+
+
+def build_calibration_package_contract(
+    *,
+    package_path: Path,
+    dataset_path: Path,
+    db_path: Path,
+    package: Mapping[str, Any],
+    parameters: Mapping[str, Any],
+    run_id: str | None,
+    completed_at: str,
+    started_at: str | None = None,
+    duration_s: float | None = None,
+    code_sha: str | None = None,
+    package_version: str | None = None,
+) -> StageContract:
+    """Build the Stage 2 handoff contract from a calibration package."""
+
+    package_path = Path(package_path)
+    dataset_path = Path(dataset_path)
+    db_path = Path(db_path)
+    _require_existing_file(package_path, "calibration package")
+    _require_existing_file(dataset_path, "source dataset")
+    _require_existing_file(db_path, "target database")
+
+    metadata = _package_metadata(package)
+    package_summary = summarize_calibration_package(package)
+    inputs = (
+        _artifact_ref_from_path(
+            logical_name="source_imputed_stratified_extended_cps",
+            path=dataset_path,
+            metadata={
+                "artifact_family": "dataset",
+                "substage_id": CALIBRATION_PACKAGE_SUBSTAGE_ID,
+                "required_for_stage_2": True,
+            },
+        ),
+        _artifact_ref_from_path(
+            logical_name="policy_data_db",
+            path=db_path,
+            metadata={
+                "artifact_family": "target_database",
+                "substage_id": CALIBRATION_PACKAGE_SUBSTAGE_ID,
+                "required_for_stage_2": True,
+            },
+        ),
+    )
+    outputs = (
+        _artifact_ref_from_path(
+            logical_name="calibration_package",
+            path=package_path,
+            metadata={
+                "artifact_family": "calibration_package",
+                "substage_id": CALIBRATION_PACKAGE_SUBSTAGE_ID,
+            },
+        ),
+    )
+    code_sha = code_sha or _optional_metadata_string(metadata, "git_commit")
+    package_version = package_version or _optional_metadata_string(
+        metadata,
+        "package_version",
+    )
+    execution = ExecutionRecord(
+        status="completed",
+        started_at=started_at,
+        completed_at=completed_at,
+        duration_s=duration_s,
+        reuse_decision="not_applicable",
+        reuse_summary=ReuseSummary(
+            expected_outputs=1,
+            valid_reused_outputs=0,
+            recomputed_outputs=1,
+            invalid_outputs=0,
+        ),
+    )
+    fingerprint = fingerprint_material(
+        {
+            "stage_id": STAGE_2_BUILD_CALIBRATION_PACKAGE,
+            "contract_type": CALIBRATION_PACKAGE_CONTRACT_TYPE,
+            "inputs": inputs,
+            "outputs": outputs,
+            "parameters": parameters,
+            "package_summary": package_summary,
+        }
+    )
+    return StageContract(
+        contract_type=CALIBRATION_PACKAGE_CONTRACT_TYPE,
+        stage_id=STAGE_2_BUILD_CALIBRATION_PACKAGE,
+        run_id=run_id,
+        created_at=completed_at,
+        code_sha=code_sha,
+        package_version=package_version,
+        inputs=inputs,
+        outputs=outputs,
+        parameters=parameters,
+        fingerprint=fingerprint,
+        substages=(
+            SubstageRecord(
+                substage_id=CALIBRATION_PACKAGE_SUBSTAGE_ID,
+                status="completed",
+                inputs=inputs,
+                outputs=outputs,
+                parameters=parameters,
+                fingerprint=fingerprint,
+                reuse_mode="handoff",
+                metadata={"package_summary": package_summary},
+            ),
+        ),
+        execution=execution,
+        metadata={
+            "artifact_count": len(inputs) + len(outputs),
+            "contract_file": CALIBRATION_PACKAGE_CONTRACT_FILENAME,
+            "package_summary": package_summary,
+        },
+    )
+
+
+def write_calibration_package_contract(
+    *,
+    package_path: Path,
+    dataset_path: Path,
+    db_path: Path,
+    package: Mapping[str, Any],
+    parameters: Mapping[str, Any],
+    run_id: str | None,
+    completed_at: str,
+    started_at: str | None = None,
+    duration_s: float | None = None,
+    code_sha: str | None = None,
+    package_version: str | None = None,
+    contract_path: Path | None = None,
+) -> StageContract:
+    """Write and return the Stage 2 calibration-package contract."""
+
+    package_path = Path(package_path)
+    contract = build_calibration_package_contract(
+        package_path=package_path,
+        dataset_path=Path(dataset_path),
+        db_path=Path(db_path),
+        package=package,
+        parameters=parameters,
+        run_id=run_id,
+        completed_at=completed_at,
+        started_at=started_at,
+        duration_s=duration_s,
+        code_sha=code_sha,
+        package_version=package_version,
+    )
+    write_contract(
+        contract,
+        contract_path or package_path.with_name(CALIBRATION_PACKAGE_CONTRACT_FILENAME),
+    )
+    return contract
+
+
+def validate_calibration_package_contract(
+    *,
+    package_path: Path,
+    contract_path: Path | None = None,
+    package: Mapping[str, Any] | None = None,
+    dataset_path: Path | None = None,
+    db_path: Path | None = None,
+) -> StageContract:
+    """Validate that a Stage 2 sidecar describes the calibration package."""
+
+    package_path = Path(package_path)
+    contract_path = contract_path or package_path.with_name(
+        CALIBRATION_PACKAGE_CONTRACT_FILENAME
+    )
+    _require_existing_file(package_path, "calibration package")
+    _require_existing_file(contract_path, "calibration package contract")
+
+    contract = read_contract(contract_path)
+    if contract.stage_id != STAGE_2_BUILD_CALIBRATION_PACKAGE:
+        raise ValueError(f"Invalid Stage 2 contract stage_id: {contract.stage_id!r}")
+    if contract.contract_type != CALIBRATION_PACKAGE_CONTRACT_TYPE:
+        raise ValueError(
+            "Invalid Stage 2 contract type: "
+            f"{contract.contract_type!r}"
+        )
+    _assert_artifact_matches_file(
+        _single_artifact(contract.outputs, "calibration_package"),
+        package_path,
+    )
+    if dataset_path is not None:
+        _assert_artifact_matches_file(
+            _single_artifact(
+                contract.inputs,
+                "source_imputed_stratified_extended_cps",
+            ),
+            Path(dataset_path),
+        )
+    if db_path is not None:
+        _assert_artifact_matches_file(
+            _single_artifact(contract.inputs, "policy_data_db"),
+            Path(db_path),
+        )
+    if package is None:
+        return contract
+
+    expected_summary = canonicalize_for_fingerprint(
+        summarize_calibration_package(package)
+    )
+    actual_summary = canonicalize_for_fingerprint(
+        contract.metadata.get("package_summary", {})
+    )
+    if actual_summary != expected_summary:
+        raise ValueError("Calibration package contract summary does not match pickle")
+    return contract
+
+
+def load_calibration_package_payload(package_path: Path) -> Mapping[str, Any]:
+    """Load a calibration package pickle for sidecar validation."""
+
+    with Path(package_path).open("rb") as handle:
+        package = pickle.load(handle)
+    if not isinstance(package, Mapping):
+        raise ValueError("Calibration package pickle must contain a mapping")
+    return package
+
+
+def _required_package_value(package: Mapping[str, Any], key: str) -> Any:
+    if key not in package:
+        raise ValueError(f"Calibration package missing required key: {key}")
+    return package[key]
+
+
+def _package_metadata(package: Mapping[str, Any]) -> Mapping[str, Any]:
+    metadata = package.get("metadata", {})
+    if metadata is None:
+        return {}
+    if not isinstance(metadata, Mapping):
+        raise ValueError("Calibration package metadata must be a mapping")
+    return metadata
+
+
+def _optional_metadata_string(
+    metadata: Mapping[str, Any],
+    key: str,
+) -> str | None:
+    value = metadata.get(key)
+    if value is None:
+        return None
+    return str(value)
+
+
+def _optional_metadata_int(metadata: Mapping[str, Any], key: str) -> int | None:
+    value = metadata.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError(f"Calibration package metadata {key!r} must be an integer")
+    return int(value)
+
+
+def _optional_len(value: Any) -> int | None:
+    if value is None:
+        return None
+    return int(len(value))
+
+
+def _require_existing_file(path: Path, label: str) -> None:
+    if not path.exists():
+        raise FileNotFoundError(f"Missing {label}: {path}")
+    if not path.is_file():
+        raise ValueError(f"{label} is not a file: {path}")
+
+
+def _artifact_ref_from_path(
+    *,
+    logical_name: str,
+    path: Path,
+    metadata: Mapping[str, Any],
+) -> ArtifactRef:
+    return ArtifactRef(
+        logical_name=logical_name,
+        uri=path.resolve().as_uri(),
+        sha256=f"sha256:{sha256_file(path)}",
+        size_bytes=path.stat().st_size,
+        media_type=_media_type_for_path(path),
+        metadata=metadata,
+    )
+
+
+def _media_type_for_path(path: Path) -> str:
+    suffix = path.suffix.lower()
+    if suffix == ".h5":
+        return "application/x-hdf5"
+    if suffix == ".db":
+        return "application/vnd.sqlite3"
+    if suffix == ".json":
+        return "application/json"
+    if suffix == ".pkl":
+        return "application/python-pickle"
+    return "application/octet-stream"
+
+
+def _single_artifact(
+    artifacts: tuple[ArtifactRef, ...],
+    logical_name: str,
+) -> ArtifactRef:
+    matches = [
+        artifact for artifact in artifacts if artifact.logical_name == logical_name
+    ]
+    if len(matches) != 1:
+        raise ValueError(
+            f"Expected one artifact named {logical_name!r}, found {len(matches)}"
+        )
+    return matches[0]
+
+
+def _assert_artifact_matches_file(artifact: ArtifactRef, path: Path) -> None:
+    _require_existing_file(path, artifact.logical_name)
+    expected_sha = f"sha256:{sha256_file(path)}"
+    if artifact.sha256 != expected_sha:
+        raise ValueError(
+            f"Artifact {artifact.logical_name!r} checksum mismatch: "
+            f"{artifact.sha256!r} != {expected_sha!r}"
+        )
+    if artifact.size_bytes != path.stat().st_size:
+        raise ValueError(
+            f"Artifact {artifact.logical_name!r} size mismatch: "
+            f"{artifact.size_bytes!r} != {path.stat().st_size!r}"
+        )

--- a/policyengine_us_data/stage_contracts/calibration_package_schema.py
+++ b/policyengine_us_data/stage_contracts/calibration_package_schema.py
@@ -1,0 +1,412 @@
+"""Typed schemas for Stage 2 calibration-package contract payloads."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from math import isfinite
+from typing import Any
+
+CALIBRATION_PACKAGE_PARAMETER_KEYS = frozenset(
+    {
+        "chunk_size",
+        "chunked_matrix",
+        "n_clones",
+        "num_matrix_workers",
+        "parallel_matrix",
+        "skip_county",
+        "skip_source_impute",
+        "skip_takeup_rerandomize",
+        "target_config",
+        "workers",
+    }
+)
+CALIBRATION_PACKAGE_SUMMARY_KEYS = frozenset(
+    {
+        "base_n_records",
+        "block_geoid_length",
+        "cd_geoid_length",
+        "chunk_dir",
+        "chunk_size",
+        "dataset_sha256",
+        "db_sha256",
+        "has_block_geoid",
+        "has_cd_geoid",
+        "has_initial_weights",
+        "matrix_builder",
+        "matrix_density",
+        "matrix_nnz",
+        "matrix_shape",
+        "n_clones",
+        "n_columns",
+        "n_targets",
+        "package_scope",
+        "seed",
+        "target_config_path",
+        "target_config_sha256",
+        "target_name_count",
+    }
+)
+
+
+@dataclass(frozen=True, kw_only=True)
+class CalibrationPackageParameters:
+    """Canonical parameters that affect Stage 2 package construction."""
+
+    workers: int | None
+    n_clones: int
+    target_config: str | None
+    skip_county: bool
+    skip_source_impute: bool
+    skip_takeup_rerandomize: bool
+    chunked_matrix: bool
+    chunk_size: int | None
+    parallel_matrix: bool
+    num_matrix_workers: int | None
+
+    def __post_init__(self) -> None:
+        _validate_positive_int(self.n_clones, "n_clones")
+        _validate_optional_positive_int(self.workers, "workers")
+        _validate_optional_positive_int(self.chunk_size, "chunk_size")
+        _validate_optional_positive_int(
+            self.num_matrix_workers,
+            "num_matrix_workers",
+        )
+        _validate_bool(self.skip_county, "skip_county")
+        _validate_bool(self.skip_source_impute, "skip_source_impute")
+        _validate_bool(self.skip_takeup_rerandomize, "skip_takeup_rerandomize")
+        _validate_bool(self.chunked_matrix, "chunked_matrix")
+        _validate_bool(self.parallel_matrix, "parallel_matrix")
+        if self.target_config is not None and not isinstance(self.target_config, str):
+            raise ValueError("target_config must be a string or None")
+        if self.chunked_matrix:
+            if self.workers is not None:
+                raise ValueError("workers must be None when chunked_matrix is true")
+            if self.chunk_size is None:
+                raise ValueError("chunk_size is required when chunked_matrix is true")
+        else:
+            if self.workers is None:
+                raise ValueError("workers is required when chunked_matrix is false")
+            if self.chunk_size is not None:
+                raise ValueError("chunk_size must be None when chunked_matrix is false")
+            if self.parallel_matrix:
+                raise ValueError("parallel_matrix requires chunked_matrix")
+        if self.parallel_matrix and self.num_matrix_workers is None:
+            raise ValueError(
+                "num_matrix_workers is required when parallel_matrix is true"
+            )
+        if not self.parallel_matrix and self.num_matrix_workers is not None:
+            raise ValueError(
+                "num_matrix_workers must be None when parallel_matrix is false"
+            )
+
+    @classmethod
+    def from_runtime_args(
+        cls,
+        *,
+        workers: int,
+        n_clones: int,
+        target_config_path: str | None,
+        skip_county: bool,
+        skip_source_impute: bool,
+        skip_takeup_rerandomize: bool,
+        chunked_matrix: bool,
+        chunk_size: int,
+        parallel: bool,
+        num_matrix_workers: int,
+    ) -> "CalibrationPackageParameters":
+        """Build canonical Stage 2 parameters from runtime CLI arguments."""
+
+        parallel_matrix = bool(chunked_matrix and parallel)
+        return cls(
+            workers=workers if not chunked_matrix else None,
+            n_clones=n_clones,
+            target_config=target_config_path,
+            skip_county=skip_county,
+            skip_source_impute=skip_source_impute,
+            skip_takeup_rerandomize=skip_takeup_rerandomize,
+            chunked_matrix=chunked_matrix,
+            chunk_size=chunk_size if chunked_matrix else None,
+            parallel_matrix=parallel_matrix,
+            num_matrix_workers=num_matrix_workers if parallel_matrix else None,
+        )
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: Mapping[str, Any],
+    ) -> "CalibrationPackageParameters":
+        """Parse Stage 2 parameter JSON into a typed schema object."""
+
+        if not isinstance(data, Mapping):
+            raise ValueError("calibration package parameters must be a mapping")
+        _require_exact_keys(
+            data,
+            "calibration package parameters",
+            CALIBRATION_PACKAGE_PARAMETER_KEYS,
+        )
+        return cls(
+            workers=_optional_int_field(data, "workers"),
+            n_clones=_required_int_field(data, "n_clones"),
+            target_config=_optional_string_field(data, "target_config"),
+            skip_county=_required_bool_field(data, "skip_county"),
+            skip_source_impute=_required_bool_field(data, "skip_source_impute"),
+            skip_takeup_rerandomize=_required_bool_field(
+                data,
+                "skip_takeup_rerandomize",
+            ),
+            chunked_matrix=_required_bool_field(data, "chunked_matrix"),
+            chunk_size=_optional_int_field(data, "chunk_size"),
+            parallel_matrix=_required_bool_field(data, "parallel_matrix"),
+            num_matrix_workers=_optional_int_field(data, "num_matrix_workers"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return deterministic JSON-compatible Stage 2 parameters."""
+
+        return {
+            "chunk_size": self.chunk_size,
+            "chunked_matrix": self.chunked_matrix,
+            "n_clones": self.n_clones,
+            "num_matrix_workers": self.num_matrix_workers,
+            "parallel_matrix": self.parallel_matrix,
+            "skip_county": self.skip_county,
+            "skip_source_impute": self.skip_source_impute,
+            "skip_takeup_rerandomize": self.skip_takeup_rerandomize,
+            "target_config": self.target_config,
+            "workers": self.workers,
+        }
+
+
+@dataclass(frozen=True, kw_only=True)
+class CalibrationPackageSummary:
+    """Canonical summary of the persisted Stage 2 calibration package."""
+
+    matrix_shape: tuple[int, int]
+    matrix_nnz: int
+    matrix_density: float
+    n_targets: int
+    n_columns: int
+    target_name_count: int
+    dataset_sha256: str | None
+    db_sha256: str | None
+    target_config_path: str | None
+    target_config_sha256: str | None
+    n_clones: int | None
+    seed: int | None
+    base_n_records: int | None
+    package_scope: str | None
+    matrix_builder: str | None
+    chunk_size: int | None
+    chunk_dir: str | None
+    has_initial_weights: bool
+    has_cd_geoid: bool
+    has_block_geoid: bool
+    cd_geoid_length: int | None
+    block_geoid_length: int | None
+
+    def __post_init__(self) -> None:
+        if len(self.matrix_shape) != 2:
+            raise ValueError("matrix_shape must have two entries")
+        for index, value in enumerate(self.matrix_shape):
+            _validate_non_negative_int(value, f"matrix_shape[{index}]")
+        _validate_non_negative_int(self.matrix_nnz, "matrix_nnz")
+        _validate_non_negative_float(self.matrix_density, "matrix_density")
+        _validate_non_negative_int(self.n_targets, "n_targets")
+        _validate_non_negative_int(self.n_columns, "n_columns")
+        _validate_non_negative_int(self.target_name_count, "target_name_count")
+        _validate_optional_non_negative_int(self.n_clones, "n_clones")
+        _validate_optional_non_negative_int(self.seed, "seed")
+        _validate_optional_non_negative_int(self.base_n_records, "base_n_records")
+        _validate_optional_non_negative_int(self.chunk_size, "chunk_size")
+        _validate_optional_non_negative_int(self.cd_geoid_length, "cd_geoid_length")
+        _validate_optional_non_negative_int(
+            self.block_geoid_length,
+            "block_geoid_length",
+        )
+        _validate_bool(self.has_initial_weights, "has_initial_weights")
+        _validate_bool(self.has_cd_geoid, "has_cd_geoid")
+        _validate_bool(self.has_block_geoid, "has_block_geoid")
+        for key in (
+            "dataset_sha256",
+            "db_sha256",
+            "target_config_path",
+            "target_config_sha256",
+            "package_scope",
+            "matrix_builder",
+            "chunk_dir",
+        ):
+            value = getattr(self, key)
+            if value is not None and not isinstance(value, str):
+                raise ValueError(f"{key} must be a string or None")
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "CalibrationPackageSummary":
+        """Parse package summary JSON into a typed schema object."""
+
+        if not isinstance(data, Mapping):
+            raise ValueError("calibration package summary must be a mapping")
+        _require_exact_keys(
+            data,
+            "calibration package summary",
+            CALIBRATION_PACKAGE_SUMMARY_KEYS,
+        )
+        return cls(
+            matrix_shape=_matrix_shape_field(data, "matrix_shape"),
+            matrix_nnz=_required_int_field(data, "matrix_nnz"),
+            matrix_density=_required_float_field(data, "matrix_density"),
+            n_targets=_required_int_field(data, "n_targets"),
+            n_columns=_required_int_field(data, "n_columns"),
+            target_name_count=_required_int_field(data, "target_name_count"),
+            dataset_sha256=_optional_string_field(data, "dataset_sha256"),
+            db_sha256=_optional_string_field(data, "db_sha256"),
+            target_config_path=_optional_string_field(data, "target_config_path"),
+            target_config_sha256=_optional_string_field(
+                data,
+                "target_config_sha256",
+            ),
+            n_clones=_optional_int_field(data, "n_clones"),
+            seed=_optional_int_field(data, "seed"),
+            base_n_records=_optional_int_field(data, "base_n_records"),
+            package_scope=_optional_string_field(data, "package_scope"),
+            matrix_builder=_optional_string_field(data, "matrix_builder"),
+            chunk_size=_optional_int_field(data, "chunk_size"),
+            chunk_dir=_optional_string_field(data, "chunk_dir"),
+            has_initial_weights=_required_bool_field(data, "has_initial_weights"),
+            has_cd_geoid=_required_bool_field(data, "has_cd_geoid"),
+            has_block_geoid=_required_bool_field(data, "has_block_geoid"),
+            cd_geoid_length=_optional_int_field(data, "cd_geoid_length"),
+            block_geoid_length=_optional_int_field(data, "block_geoid_length"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return deterministic JSON-compatible package summary."""
+
+        return {
+            "base_n_records": self.base_n_records,
+            "block_geoid_length": self.block_geoid_length,
+            "cd_geoid_length": self.cd_geoid_length,
+            "chunk_dir": self.chunk_dir,
+            "chunk_size": self.chunk_size,
+            "dataset_sha256": self.dataset_sha256,
+            "db_sha256": self.db_sha256,
+            "has_block_geoid": self.has_block_geoid,
+            "has_cd_geoid": self.has_cd_geoid,
+            "has_initial_weights": self.has_initial_weights,
+            "matrix_builder": self.matrix_builder,
+            "matrix_density": self.matrix_density,
+            "matrix_nnz": self.matrix_nnz,
+            "matrix_shape": self.matrix_shape,
+            "n_clones": self.n_clones,
+            "n_columns": self.n_columns,
+            "n_targets": self.n_targets,
+            "package_scope": self.package_scope,
+            "seed": self.seed,
+            "target_config_path": self.target_config_path,
+            "target_config_sha256": self.target_config_sha256,
+            "target_name_count": self.target_name_count,
+        }
+
+
+def _require_exact_keys(
+    data: Mapping[str, Any],
+    label: str,
+    expected_keys: frozenset[str],
+) -> None:
+    keys = {str(key) for key in data}
+    missing = sorted(expected_keys - keys)
+    unexpected = sorted(keys - expected_keys)
+    if missing:
+        raise ValueError(f"{label} missing required key: {missing[0]}")
+    if unexpected:
+        raise ValueError(f"{label} has unexpected key: {unexpected[0]}")
+
+
+def _required_int_field(data: Mapping[str, Any], key: str) -> int:
+    value = data[key]
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"Calibration package field {key!r} must be an integer")
+    return value
+
+
+def _optional_int_field(data: Mapping[str, Any], key: str) -> int | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(
+            f"Calibration package field {key!r} must be an integer or None"
+        )
+    return value
+
+
+def _optional_string_field(data: Mapping[str, Any], key: str) -> str | None:
+    value = data.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError(f"Calibration package field {key!r} must be a string or None")
+    return value
+
+
+def _required_float_field(data: Mapping[str, Any], key: str) -> float:
+    value = data[key]
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"Calibration package field {key!r} must be numeric")
+    return float(value)
+
+
+def _matrix_shape_field(data: Mapping[str, Any], key: str) -> tuple[int, int]:
+    value = data[key]
+    if not isinstance(value, tuple | list) or len(value) != 2:
+        raise ValueError("matrix_shape must have two entries")
+    first, second = value
+    if isinstance(first, bool) or not isinstance(first, int):
+        raise ValueError("matrix_shape entries must be integers")
+    if isinstance(second, bool) or not isinstance(second, int):
+        raise ValueError("matrix_shape entries must be integers")
+    return (first, second)
+
+
+def _required_bool_field(data: Mapping[str, Any], key: str) -> bool:
+    value = data[key]
+    _validate_bool(value, key)
+    return value
+
+
+def _validate_bool(value: Any, key: str) -> None:
+    if not isinstance(value, bool):
+        raise ValueError(f"Calibration package field {key!r} must be a boolean")
+
+
+def _validate_positive_int(value: Any, key: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(
+            f"Calibration package field {key!r} must be a positive integer"
+        )
+
+
+def _validate_optional_positive_int(value: Any, key: str) -> None:
+    if value is not None:
+        _validate_positive_int(value, key)
+
+
+def _validate_non_negative_int(value: Any, key: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(
+            f"Calibration package field {key!r} must be a non-negative integer"
+        )
+
+
+def _validate_optional_non_negative_int(value: Any, key: str) -> None:
+    if value is not None:
+        _validate_non_negative_int(value, key)
+
+
+def _validate_non_negative_float(value: Any, key: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"Calibration package field {key!r} must be numeric")
+    if not isfinite(float(value)) or value < 0:
+        raise ValueError(
+            f"Calibration package field {key!r} must be a finite non-negative number"
+        )

--- a/tests/unit/calibration/test_unified_calibration.py
+++ b/tests/unit/calibration/test_unified_calibration.py
@@ -42,6 +42,7 @@ from policyengine_us_data.calibration.clone_and_assign import (
 )
 from policyengine_us_data.calibration.unified_calibration import (
     _calibration_package_contract_parameters,
+    check_package_staleness,
 )
 
 
@@ -91,6 +92,25 @@ def test_calibration_package_contract_parameters_ignore_unused_chunk_options():
     assert params["chunk_size"] is None
     assert params["parallel_matrix"] is False
     assert params["num_matrix_workers"] is None
+
+
+def test_check_package_staleness_warns_for_old_utc_timestamp(
+    capsys,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "policyengine_us_data.calibration.unified_calibration.get_git_provenance",
+        lambda: {"git_branch": "main"},
+    )
+
+    check_package_staleness(
+        {
+            "created_at": "2000-01-01T00:00:00Z",
+            "git_branch": "main",
+        }
+    )
+
+    assert "WARNING: Package is" in capsys.readouterr().out
 
 
 class TestForbesStateOverrides:

--- a/tests/unit/calibration/test_unified_calibration.py
+++ b/tests/unit/calibration/test_unified_calibration.py
@@ -40,6 +40,57 @@ from policyengine_us_data.utils.takeup import (
 from policyengine_us_data.calibration.clone_and_assign import (
     GeographyAssignment,
 )
+from policyengine_us_data.calibration.unified_calibration import (
+    _calibration_package_contract_parameters,
+)
+
+
+def test_calibration_package_contract_parameters_track_effective_matrix_mode():
+    params = _calibration_package_contract_parameters(
+        workers=8,
+        n_clones=430,
+        target_config_path="policyengine_us_data/calibration/target_config.yaml",
+        skip_county=True,
+        skip_source_impute=True,
+        skip_takeup_rerandomize=False,
+        chunked_matrix=True,
+        chunk_size=25_000,
+        parallel=True,
+        num_matrix_workers=50,
+    )
+
+    assert params == {
+        "workers": None,
+        "n_clones": 430,
+        "target_config": "policyengine_us_data/calibration/target_config.yaml",
+        "skip_county": True,
+        "skip_source_impute": True,
+        "skip_takeup_rerandomize": False,
+        "chunked_matrix": True,
+        "chunk_size": 25_000,
+        "parallel_matrix": True,
+        "num_matrix_workers": 50,
+    }
+
+
+def test_calibration_package_contract_parameters_ignore_unused_chunk_options():
+    params = _calibration_package_contract_parameters(
+        workers=8,
+        n_clones=430,
+        target_config_path=None,
+        skip_county=True,
+        skip_source_impute=True,
+        skip_takeup_rerandomize=False,
+        chunked_matrix=False,
+        chunk_size=25_000,
+        parallel=True,
+        num_matrix_workers=50,
+    )
+
+    assert params["workers"] == 8
+    assert params["chunk_size"] is None
+    assert params["parallel_matrix"] is False
+    assert params["num_matrix_workers"] is None
 
 
 class TestForbesStateOverrides:

--- a/tests/unit/calibration/test_unified_calibration.py
+++ b/tests/unit/calibration/test_unified_calibration.py
@@ -44,6 +44,9 @@ from policyengine_us_data.calibration.unified_calibration import (
     _calibration_package_contract_parameters,
     check_package_staleness,
 )
+from policyengine_us_data.stage_contracts.calibration_package import (
+    CalibrationPackageParameters,
+)
 
 
 def test_calibration_package_contract_parameters_track_effective_matrix_mode():
@@ -60,7 +63,8 @@ def test_calibration_package_contract_parameters_track_effective_matrix_mode():
         num_matrix_workers=50,
     )
 
-    assert params == {
+    assert isinstance(params, CalibrationPackageParameters)
+    assert params.to_dict() == {
         "workers": None,
         "n_clones": 430,
         "target_config": "policyengine_us_data/calibration/target_config.yaml",
@@ -88,10 +92,10 @@ def test_calibration_package_contract_parameters_ignore_unused_chunk_options():
         num_matrix_workers=50,
     )
 
-    assert params["workers"] == 8
-    assert params["chunk_size"] is None
-    assert params["parallel_matrix"] is False
-    assert params["num_matrix_workers"] is None
+    assert params.to_dict()["workers"] == 8
+    assert params.to_dict()["chunk_size"] is None
+    assert params.to_dict()["parallel_matrix"] is False
+    assert params.to_dict()["num_matrix_workers"] is None
 
 
 def test_check_package_staleness_warns_for_old_utc_timestamp(

--- a/tests/unit/test_calibration_package_stage_contract.py
+++ b/tests/unit/test_calibration_package_stage_contract.py
@@ -173,7 +173,7 @@ def test_calibration_package_contract_records_single_substage(tmp_path):
     assert substage.status == "completed"
     assert substage.reuse_mode == "handoff"
     assert substage.outputs[0].logical_name == "calibration_package"
-    assert substage.metadata["package_summary"]["matrix_shape"] == (2, 3)
+    assert substage.metadata == {}
 
 
 def test_calibration_package_contract_json_round_trip_is_deterministic(tmp_path):
@@ -302,6 +302,27 @@ def test_validate_calibration_package_contract_fails_on_package_checksum(tmp_pat
         assert "checksum mismatch" in str(exc)
     else:
         raise AssertionError("Stale calibration package checksum should fail")
+
+
+def test_validate_calibration_package_contract_requires_package_for_summary(tmp_path):
+    dataset_path, db_path, package_path = _write_inputs(tmp_path)
+    package = _write_package(package_path)
+    write_calibration_package_contract(
+        package_path=package_path,
+        dataset_path=dataset_path,
+        db_path=db_path,
+        package=package,
+        parameters=_parameters(),
+        run_id="run-a",
+        completed_at="2026-05-08T12:02:00Z",
+    )
+
+    try:
+        validate_calibration_package_contract(package_path=package_path)
+    except ValueError as exc:
+        assert "package is required" in str(exc)
+    else:
+        raise AssertionError("Package payload should be required for full validation")
 
 
 def test_load_calibration_package_payload_rejects_non_mapping(tmp_path):

--- a/tests/unit/test_calibration_package_stage_contract.py
+++ b/tests/unit/test_calibration_package_stage_contract.py
@@ -12,6 +12,8 @@ from policyengine_us_data.stage_contracts import (
 )
 from policyengine_us_data.stage_contracts.calibration_package import (
     CALIBRATION_PACKAGE_CONTRACT_FILENAME,
+    CalibrationPackageParameters,
+    CalibrationPackageSummary,
     build_calibration_package_contract,
     load_calibration_package_payload,
     summarize_calibration_package,
@@ -85,6 +87,8 @@ def _parameters() -> dict:
         "n_clones": 430,
         "target_config": "policyengine_us_data/calibration/target_config.yaml",
         "skip_county": True,
+        "skip_source_impute": True,
+        "skip_takeup_rerandomize": False,
         "chunked_matrix": True,
         "chunk_size": 25_000,
         "parallel_matrix": False,
@@ -125,6 +129,81 @@ def test_calibration_package_contract_records_stage_2_handoff(tmp_path):
     }
     assert all(artifact.sha256.startswith("sha256:") for artifact in contract.inputs)
     assert contract.outputs[0].media_type == "application/python-pickle"
+
+
+def test_calibration_package_parameters_parse_runtime_args():
+    params = CalibrationPackageParameters.from_runtime_args(
+        workers=8,
+        n_clones=430,
+        target_config_path="policyengine_us_data/calibration/target_config.yaml",
+        skip_county=True,
+        skip_source_impute=True,
+        skip_takeup_rerandomize=False,
+        chunked_matrix=True,
+        chunk_size=25_000,
+        parallel=True,
+        num_matrix_workers=50,
+    )
+
+    assert params.to_dict() == {
+        "chunk_size": 25_000,
+        "chunked_matrix": True,
+        "n_clones": 430,
+        "num_matrix_workers": 50,
+        "parallel_matrix": True,
+        "skip_county": True,
+        "skip_source_impute": True,
+        "skip_takeup_rerandomize": False,
+        "target_config": "policyengine_us_data/calibration/target_config.yaml",
+        "workers": None,
+    }
+
+
+def test_calibration_package_parameters_reject_inconsistent_chunk_shape():
+    try:
+        CalibrationPackageParameters(
+            workers=8,
+            n_clones=430,
+            target_config=None,
+            skip_county=True,
+            skip_source_impute=True,
+            skip_takeup_rerandomize=False,
+            chunked_matrix=True,
+            chunk_size=25_000,
+            parallel_matrix=False,
+            num_matrix_workers=None,
+        )
+    except ValueError as exc:
+        assert "workers must be None" in str(exc)
+    else:
+        raise AssertionError("Inconsistent chunked parameter shape should fail")
+
+
+def test_calibration_package_summary_round_trips_through_schema():
+    summary = summarize_calibration_package(_package())
+
+    assert isinstance(summary, CalibrationPackageSummary)
+    assert CalibrationPackageSummary.from_dict(summary.to_dict()) == summary
+
+
+def test_calibration_package_contract_rejects_invalid_parameter_mapping(tmp_path):
+    dataset_path, db_path, package_path = _write_inputs(tmp_path)
+    package = _write_package(package_path)
+
+    try:
+        build_calibration_package_contract(
+            package_path=package_path,
+            dataset_path=dataset_path,
+            db_path=db_path,
+            package=package,
+            parameters={"workers": 1},
+            run_id="run-a",
+            completed_at="2026-05-08T12:02:00Z",
+        )
+    except ValueError as exc:
+        assert "missing required key" in str(exc)
+    else:
+        raise AssertionError("Invalid parameter mapping should fail")
 
 
 def test_calibration_package_contract_normalizes_empty_run_id_to_none(tmp_path):
@@ -188,7 +267,7 @@ def test_calibration_package_contract_json_round_trip_is_deterministic(tmp_path)
 
 
 def test_calibration_package_summary_omits_bulky_payloads():
-    summary = summarize_calibration_package(_package())
+    summary = summarize_calibration_package(_package()).to_dict()
 
     assert "X_sparse" not in summary
     assert "targets_df" not in summary
@@ -204,7 +283,7 @@ def test_calibration_package_summary_handles_empty_matrix():
     package["targets_df"] = package["targets_df"].iloc[0:0]
     package["target_names"] = []
 
-    summary = summarize_calibration_package(package)
+    summary = summarize_calibration_package(package).to_dict()
 
     assert summary["matrix_shape"] == (0, 0)
     assert summary["matrix_nnz"] == 0

--- a/tests/unit/test_calibration_package_stage_contract.py
+++ b/tests/unit/test_calibration_package_stage_contract.py
@@ -126,6 +126,23 @@ def test_calibration_package_contract_records_stage_2_handoff(tmp_path):
     assert contract.outputs[0].media_type == "application/python-pickle"
 
 
+def test_calibration_package_contract_normalizes_empty_run_id_to_none(tmp_path):
+    dataset_path, db_path, package_path = _write_inputs(tmp_path)
+    package = _write_package(package_path)
+
+    contract = build_calibration_package_contract(
+        package_path=package_path,
+        dataset_path=dataset_path,
+        db_path=db_path,
+        package=package,
+        parameters=_parameters(),
+        run_id="",
+        completed_at="2026-05-08T12:02:00Z",
+    )
+
+    assert contract.run_id is None
+
+
 def test_calibration_package_contract_records_matrix_summary(tmp_path):
     contract = _contract(tmp_path)
 

--- a/tests/unit/test_calibration_package_stage_contract.py
+++ b/tests/unit/test_calibration_package_stage_contract.py
@@ -16,6 +16,7 @@ from policyengine_us_data.stage_contracts.calibration_package import (
     load_calibration_package_payload,
     summarize_calibration_package,
     validate_calibration_package_contract,
+    validate_persisted_calibration_package_contract,
     write_calibration_package_contract,
 )
 
@@ -253,6 +254,28 @@ def test_write_and_validate_calibration_package_contract(tmp_path):
         dataset_path=dataset_path,
         db_path=db_path,
     )
+    assert validated == contract
+
+
+def test_validate_persisted_calibration_package_contract_loads_pickle(tmp_path):
+    dataset_path, db_path, package_path = _write_inputs(tmp_path)
+    package = _write_package(package_path)
+    contract = write_calibration_package_contract(
+        package_path=package_path,
+        dataset_path=dataset_path,
+        db_path=db_path,
+        package=package,
+        parameters=_parameters(),
+        run_id="run-a",
+        completed_at="2026-05-08T12:02:00Z",
+    )
+
+    validated = validate_persisted_calibration_package_contract(
+        package_path=package_path,
+        dataset_path=dataset_path,
+        db_path=db_path,
+    )
+
     assert validated == contract
 
 

--- a/tests/unit/test_calibration_package_stage_contract.py
+++ b/tests/unit/test_calibration_package_stage_contract.py
@@ -1,0 +1,300 @@
+import pickle
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from scipy import sparse
+
+from policyengine_us_data.stage_contracts import (
+    StageContract,
+    contract_from_json,
+    contract_to_json,
+)
+from policyengine_us_data.stage_contracts.calibration_package import (
+    CALIBRATION_PACKAGE_CONTRACT_FILENAME,
+    build_calibration_package_contract,
+    load_calibration_package_payload,
+    summarize_calibration_package,
+    validate_calibration_package_contract,
+    write_calibration_package_contract,
+)
+
+
+def _write_inputs(tmp_path: Path) -> tuple[Path, Path, Path]:
+    dataset_path = tmp_path / "source_imputed_stratified_extended_cps.h5"
+    db_path = tmp_path / "policy_data.db"
+    package_path = tmp_path / "calibration_package.pkl"
+    dataset_path.write_bytes(b"dataset")
+    db_path.write_bytes(b"sqlite")
+    return dataset_path, db_path, package_path
+
+
+def _package() -> dict:
+    matrix = sparse.csr_matrix(
+        np.array(
+            [
+                [1.0, 0.0, 2.0],
+                [0.0, 3.0, 0.0],
+            ]
+        )
+    )
+    return {
+        "X_sparse": matrix,
+        "targets_df": pd.DataFrame(
+            {
+                "value": [100.0, 200.0],
+                "domain_variable": ["state", "state"],
+                "variable": ["income_tax", "snap"],
+                "geo_level": ["state", "state"],
+                "geographic_id": ["01", "02"],
+            }
+        ),
+        "target_names": ["state_income_tax_01", "state_snap_02"],
+        "metadata": {
+            "dataset_sha256": "sha256:dataset",
+            "db_sha256": "sha256:db",
+            "target_config_path": "policyengine_us_data/calibration/target_config.yaml",
+            "target_config_sha256": "sha256:target-config",
+            "n_clones": 430,
+            "seed": 42,
+            "base_n_records": 1,
+            "package_scope": "minimal",
+            "matrix_builder": "chunked",
+            "chunk_size": 25_000,
+            "chunk_dir": "/pipeline/artifacts/run-a/matrix_build",
+            "git_commit": "abc123",
+            "package_version": "1.98.2",
+        },
+        "initial_weights": np.array([1.0, 1.0, 1.0]),
+        "cd_geoid": np.array(["0101", "0102", "0201"]),
+        "block_geoid": np.array(["010010001", "010010002", "020010001"]),
+    }
+
+
+def _write_package(path: Path, package: dict | None = None) -> dict:
+    package = package or _package()
+    with path.open("wb") as handle:
+        pickle.dump(package, handle)
+    return package
+
+
+def _parameters() -> dict:
+    return {
+        "workers": None,
+        "n_clones": 430,
+        "target_config": "policyengine_us_data/calibration/target_config.yaml",
+        "skip_county": True,
+        "chunked_matrix": True,
+        "chunk_size": 25_000,
+        "parallel_matrix": False,
+        "num_matrix_workers": None,
+    }
+
+
+def _contract(tmp_path: Path) -> StageContract:
+    dataset_path, db_path, package_path = _write_inputs(tmp_path)
+    package = _write_package(package_path)
+    return build_calibration_package_contract(
+        package_path=package_path,
+        dataset_path=dataset_path,
+        db_path=db_path,
+        package=package,
+        parameters=_parameters(),
+        run_id="run-a",
+        started_at="2026-05-08T12:00:00Z",
+        completed_at="2026-05-08T12:02:00Z",
+        duration_s=120.0,
+    )
+
+
+def test_calibration_package_contract_records_stage_2_handoff(tmp_path):
+    contract = _contract(tmp_path)
+
+    assert contract.stage_id == "2_build_calibration_package"
+    assert contract.contract_type == "calibration_package"
+    assert contract.run_id == "run-a"
+    assert contract.code_sha == "abc123"
+    assert contract.package_version == "1.98.2"
+    assert {artifact.logical_name for artifact in contract.inputs} == {
+        "source_imputed_stratified_extended_cps",
+        "policy_data_db",
+    }
+    assert {artifact.logical_name for artifact in contract.outputs} == {
+        "calibration_package"
+    }
+    assert all(artifact.sha256.startswith("sha256:") for artifact in contract.inputs)
+    assert contract.outputs[0].media_type == "application/python-pickle"
+
+
+def test_calibration_package_contract_records_matrix_summary(tmp_path):
+    contract = _contract(tmp_path)
+
+    summary = contract.metadata["package_summary"]
+
+    assert summary["matrix_shape"] == (2, 3)
+    assert summary["matrix_nnz"] == 3
+    assert summary["matrix_density"] == 0.5
+    assert summary["n_targets"] == 2
+    assert summary["target_name_count"] == 2
+    assert summary["target_config_sha256"] == "sha256:target-config"
+    assert summary["n_clones"] == 430
+    assert summary["seed"] == 42
+    assert summary["matrix_builder"] == "chunked"
+    assert summary["has_initial_weights"] is True
+    assert summary["has_cd_geoid"] is True
+    assert summary["has_block_geoid"] is True
+    assert summary["cd_geoid_length"] == 3
+    assert summary["block_geoid_length"] == 3
+
+
+def test_calibration_package_contract_records_single_substage(tmp_path):
+    contract = _contract(tmp_path)
+
+    assert len(contract.substages) == 1
+    substage = contract.substages[0]
+    assert substage.substage_id == "2a_matrix_build_calibration_target_construction"
+    assert substage.status == "completed"
+    assert substage.reuse_mode == "handoff"
+    assert substage.outputs[0].logical_name == "calibration_package"
+    assert substage.metadata["package_summary"]["matrix_shape"] == (2, 3)
+
+
+def test_calibration_package_contract_json_round_trip_is_deterministic(tmp_path):
+    contract = _contract(tmp_path)
+
+    payload = contract_to_json(contract)
+    restored = contract_from_json(payload)
+
+    assert restored == contract
+    assert contract_to_json(restored) == payload
+
+
+def test_calibration_package_summary_omits_bulky_payloads():
+    summary = summarize_calibration_package(_package())
+
+    assert "X_sparse" not in summary
+    assert "targets_df" not in summary
+    assert "target_names" not in summary
+    assert "initial_weights" not in summary
+    assert "cd_geoid" not in summary
+    assert "block_geoid" not in summary
+
+
+def test_calibration_package_summary_handles_empty_matrix():
+    package = _package()
+    package["X_sparse"] = sparse.csr_matrix((0, 0))
+    package["targets_df"] = package["targets_df"].iloc[0:0]
+    package["target_names"] = []
+
+    summary = summarize_calibration_package(package)
+
+    assert summary["matrix_shape"] == (0, 0)
+    assert summary["matrix_nnz"] == 0
+    assert summary["matrix_density"] == 0.0
+
+
+def test_calibration_package_contract_rejects_missing_artifact(tmp_path):
+    dataset_path, db_path, package_path = _write_inputs(tmp_path)
+    package = _package()
+
+    try:
+        build_calibration_package_contract(
+            package_path=package_path,
+            dataset_path=dataset_path,
+            db_path=db_path,
+            package=package,
+            parameters=_parameters(),
+            run_id="run-a",
+            completed_at="2026-05-08T12:02:00Z",
+        )
+    except FileNotFoundError as exc:
+        assert "calibration package" in str(exc)
+    else:
+        raise AssertionError("Missing calibration package should fail")
+
+
+def test_write_and_validate_calibration_package_contract(tmp_path):
+    dataset_path, db_path, package_path = _write_inputs(tmp_path)
+    package = _write_package(package_path)
+
+    contract = write_calibration_package_contract(
+        package_path=package_path,
+        dataset_path=dataset_path,
+        db_path=db_path,
+        package=package,
+        parameters=_parameters(),
+        run_id="run-a",
+        completed_at="2026-05-08T12:02:00Z",
+    )
+
+    contract_path = tmp_path / CALIBRATION_PACKAGE_CONTRACT_FILENAME
+    assert contract_path.exists()
+    validated = validate_calibration_package_contract(
+        package_path=package_path,
+        contract_path=contract_path,
+        package=package,
+        dataset_path=dataset_path,
+        db_path=db_path,
+    )
+    assert validated == contract
+
+
+def test_validate_calibration_package_contract_fails_on_stale_summary(tmp_path):
+    dataset_path, db_path, package_path = _write_inputs(tmp_path)
+    package = _write_package(package_path)
+    write_calibration_package_contract(
+        package_path=package_path,
+        dataset_path=dataset_path,
+        db_path=db_path,
+        package=package,
+        parameters=_parameters(),
+        run_id="run-a",
+        completed_at="2026-05-08T12:02:00Z",
+    )
+    changed_package = _package()
+    changed_package["X_sparse"] = sparse.csr_matrix(np.ones((3, 3)))
+
+    try:
+        validate_calibration_package_contract(
+            package_path=package_path,
+            package=changed_package,
+        )
+    except ValueError as exc:
+        assert "summary does not match" in str(exc)
+    else:
+        raise AssertionError("Stale calibration package summary should fail")
+
+
+def test_validate_calibration_package_contract_fails_on_package_checksum(tmp_path):
+    dataset_path, db_path, package_path = _write_inputs(tmp_path)
+    package = _write_package(package_path)
+    write_calibration_package_contract(
+        package_path=package_path,
+        dataset_path=dataset_path,
+        db_path=db_path,
+        package=package,
+        parameters=_parameters(),
+        run_id="run-a",
+        completed_at="2026-05-08T12:02:00Z",
+    )
+    package_path.write_bytes(b"not the original pickle")
+
+    try:
+        validate_calibration_package_contract(package_path=package_path)
+    except ValueError as exc:
+        assert "checksum mismatch" in str(exc)
+    else:
+        raise AssertionError("Stale calibration package checksum should fail")
+
+
+def test_load_calibration_package_payload_rejects_non_mapping(tmp_path):
+    package_path = tmp_path / "calibration_package.pkl"
+    with package_path.open("wb") as handle:
+        pickle.dump(["not", "a", "mapping"], handle)
+
+    try:
+        load_calibration_package_payload(package_path)
+    except ValueError as exc:
+        assert "must contain a mapping" in str(exc)
+    else:
+        raise AssertionError("Non-mapping package payload should fail")

--- a/tests/unit/test_remote_calibration_runner.py
+++ b/tests/unit/test_remote_calibration_runner.py
@@ -140,22 +140,13 @@ def test_build_package_impl_sets_volume_chunk_dir_for_parallel_matrix(
 
     captured = {}
 
-    def fake_validate_contract(**kwargs):
+    def fake_validate_persisted_contract(**kwargs):
         captured["contract_validation"] = kwargs
 
-    def fake_load_package(path):
-        captured["loaded_package_path"] = path
-        return {"package": "payload"}
-
     monkeypatch.setattr(
         calibration_package,
-        "load_calibration_package_payload",
-        fake_load_package,
-    )
-    monkeypatch.setattr(
-        calibration_package,
-        "validate_calibration_package_contract",
-        fake_validate_contract,
+        "validate_persisted_calibration_package_contract",
+        fake_validate_persisted_contract,
     )
 
     def fake_run_streaming(cmd, env=None, label=""):
@@ -214,9 +205,5 @@ def test_build_package_impl_sets_volume_chunk_dir_for_parallel_matrix(
     assert captured["contract_validation"]["db_path"] == (
         artifacts_dir / "policy_data.db"
     )
-    assert captured["loaded_package_path"] == (
-        artifacts_dir / "calibration_package.pkl"
-    )
-    assert captured["contract_validation"]["package"] == {"package": "payload"}
     volume.reload.assert_called_once()
     volume.commit.assert_called_once()

--- a/tests/unit/test_remote_calibration_runner.py
+++ b/tests/unit/test_remote_calibration_runner.py
@@ -143,6 +143,15 @@ def test_build_package_impl_sets_volume_chunk_dir_for_parallel_matrix(
     def fake_validate_contract(**kwargs):
         captured["contract_validation"] = kwargs
 
+    def fake_load_package(path):
+        captured["loaded_package_path"] = path
+        return {"package": "payload"}
+
+    monkeypatch.setattr(
+        calibration_package,
+        "load_calibration_package_payload",
+        fake_load_package,
+    )
     monkeypatch.setattr(
         calibration_package,
         "validate_calibration_package_contract",
@@ -205,5 +214,9 @@ def test_build_package_impl_sets_volume_chunk_dir_for_parallel_matrix(
     assert captured["contract_validation"]["db_path"] == (
         artifacts_dir / "policy_data.db"
     )
+    assert captured["loaded_package_path"] == (
+        artifacts_dir / "calibration_package.pkl"
+    )
+    assert captured["contract_validation"]["package"] == {"package": "payload"}
     volume.reload.assert_called_once()
     volume.commit.assert_called_once()

--- a/tests/unit/test_remote_calibration_runner.py
+++ b/tests/unit/test_remote_calibration_runner.py
@@ -136,8 +136,18 @@ def test_build_package_impl_sets_volume_chunk_dir_for_parallel_matrix(
     monkeypatch.setattr(remote_runner, "pipeline_vol", volume)
     monkeypatch.setattr(remote_runner, "_setup_repo", lambda: None)
     monkeypatch.setattr(remote_runner, "_write_package_sidecar", lambda _: True)
+    from policyengine_us_data.stage_contracts import calibration_package
 
     captured = {}
+
+    def fake_validate_contract(**kwargs):
+        captured["contract_validation"] = kwargs
+
+    monkeypatch.setattr(
+        calibration_package,
+        "validate_calibration_package_contract",
+        fake_validate_contract,
+    )
 
     def fake_run_streaming(cmd, env=None, label=""):
         captured["cmd"] = cmd
@@ -182,6 +192,18 @@ def test_build_package_impl_sets_volume_chunk_dir_for_parallel_matrix(
     assert (
         captured["env"]["US_DATA_PIPELINE_VOLUME_NAME"]
         == "pipeline-artifacts-bench-run"
+    )
+    assert captured["contract_validation"]["package_path"] == (
+        artifacts_dir / "calibration_package.pkl"
+    )
+    assert captured["contract_validation"]["contract_path"] == (
+        artifacts_dir / "calibration_package_contract.json"
+    )
+    assert captured["contract_validation"]["dataset_path"] == (
+        artifacts_dir / "source_imputed_stratified_extended_cps.h5"
+    )
+    assert captured["contract_validation"]["db_path"] == (
+        artifacts_dir / "policy_data.db"
     )
     volume.reload.assert_called_once()
     volume.commit.assert_called_once()

--- a/tests/unit/test_stage_contracts.py
+++ b/tests/unit/test_stage_contracts.py
@@ -1193,6 +1193,8 @@ def test_stage_contract_package_exports_public_api():
     import policyengine_us_data.stage_contracts as contracts
 
     assert contracts.ArtifactRef is ArtifactRef
+    assert hasattr(contracts, "CalibrationPackageParameters")
+    assert hasattr(contracts, "CalibrationPackageSummary")
     assert contracts.DiagnosticRef is DiagnosticRef
     assert contracts.Fingerprint is Fingerprint
     assert contracts.ValidationFinding is ValidationFinding
@@ -1215,6 +1217,8 @@ def test_stage_contract_package_exports_public_api():
         "ArtifactRef",
         "CANONICAL_STAGE_IDS",
         "CONTRACT_TYPE_BY_STAGE_ID",
+        "CalibrationPackageParameters",
+        "CalibrationPackageSummary",
         "DiagnosticRef",
         "Fingerprint",
         "ValidationFinding",


### PR DESCRIPTION
Fixes #926

## Summary
- Add a Stage 2 calibration package contract builder and validator.
- Write `calibration_package_contract.json` next to `calibration_package.pkl` during package build.
- Keep the pickle as the runtime and diagnostic artifact while validating that the JSON sidecar matches it.

## Testing
- `make lint`
- `uv run --no-sync towncrier check --compare-with origin/main`
- `uv run --no-sync ruff check policyengine_us_data/stage_contracts/calibration_package.py policyengine_us_data/stage_contracts/__init__.py policyengine_us_data/calibration/unified_calibration.py modal_app/remote_calibration_runner.py tests/unit/test_calibration_package_stage_contract.py tests/unit/test_remote_calibration_runner.py tests/unit/calibration/test_unified_calibration.py`
- `uv run --no-sync pytest tests/unit/test_calibration_package_stage_contract.py tests/unit/test_stage_contracts.py tests/unit/test_remote_calibration_runner.py tests/unit/calibration/test_unified_calibration.py`