### PR TITLE
Add release manifest backfill command

### DIFF
--- a/.github/workflows/backfill_release_manifest.yaml
+++ b/.github/workflows/backfill_release_manifest.yaml
@@ -1,0 +1,179 @@
+name: Backfill release manifest
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Existing policyengine-us-data HF revision/version to backfill"
+        required: true
+        type: string
+      artifacts:
+        description: "Newline-separated artifact paths in the HF revision"
+        required: true
+        default: "enhanced_cps_2024.h5"
+        type: string
+      model_package_version:
+        description: "Exact policyengine-us version used with this data release"
+        required: true
+        type: string
+      core_package_version:
+        description: "Exact policyengine-core version used with this data release"
+        required: true
+        type: string
+      model_package_git_sha:
+        description: "Optional policyengine-us git SHA"
+        required: false
+        default: ""
+        type: string
+      model_package_data_build_fingerprint:
+        description: "Optional policyengine-us data-build fingerprint"
+        required: false
+        default: ""
+        type: string
+      data_package_git_sha:
+        description: "Optional policyengine-us-data git SHA"
+        required: false
+        default: ""
+        type: string
+      upload:
+        description: "Upload the generated manifest and TRACE TRO to Hugging Face"
+        required: true
+        default: false
+        type: boolean
+      upload_revision:
+        description: "Optional HF base branch for the PR; blank targets main"
+        required: true
+        default: ""
+        type: string
+      confirm_publish:
+        description: "Required when upload=true: set to the exact version"
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: backfill-release-manifest-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - uses: astral-sh/setup-uv@v8.1.0
+
+      - name: Install package
+        run: uv sync --dev
+
+      - name: Validate publish confirmation
+        if: inputs.upload
+        env:
+          CONFIRM_PUBLISH: ${{ inputs.confirm_publish }}
+          VERSION: ${{ inputs.version }}
+          HUGGING_FACE_TOKEN: ${{ secrets.HUGGING_FACE_TOKEN }}
+        run: |
+          if [ "${CONFIRM_PUBLISH}" != "${VERSION}" ]; then
+            echo "::error::Set confirm_publish to '${VERSION}' to upload."
+            exit 1
+          fi
+          if [ -z "${HUGGING_FACE_TOKEN}" ]; then
+            echo "::error::HUGGING_FACE_TOKEN is not configured."
+            exit 1
+          fi
+
+      - name: Build release manifest
+        env:
+          VERSION: ${{ inputs.version }}
+          ARTIFACTS: ${{ inputs.artifacts }}
+          MODEL_PACKAGE_VERSION: ${{ inputs.model_package_version }}
+          CORE_PACKAGE_VERSION: ${{ inputs.core_package_version }}
+          MODEL_PACKAGE_GIT_SHA: ${{ inputs.model_package_git_sha }}
+          MODEL_PACKAGE_DATA_BUILD_FINGERPRINT: ${{ inputs.model_package_data_build_fingerprint }}
+          DATA_PACKAGE_GIT_SHA: ${{ inputs.data_package_git_sha }}
+          UPLOAD: ${{ inputs.upload }}
+          UPLOAD_REVISION: ${{ inputs.upload_revision }}
+          HUGGING_FACE_TOKEN: ${{ secrets.HUGGING_FACE_TOKEN }}
+        run: |
+          if [[ ! "${VERSION}" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+            echo "::error::Version must use x.y.z form, got '${VERSION}'."
+            exit 1
+          fi
+
+          artifact_args=()
+          artifact_count=0
+          while IFS= read -r artifact; do
+            if [ -z "${artifact}" ]; then
+              continue
+            fi
+            if [[ "${artifact}" = /* ]] ||
+              [[ "${artifact}" == *".."* ]] ||
+              [[ "${artifact}" == "release_manifest.json" ]] ||
+              [[ "${artifact}" == "trace.tro.jsonld" ]] ||
+              [[ "${artifact}" == releases/* ]] ||
+              [[ "${artifact}" == staging/* ]]; then
+              echo "::error::Unsafe artifact path '${artifact}'."
+              exit 1
+            fi
+            artifact_args+=(--artifact "${artifact}")
+            artifact_count=$((artifact_count + 1))
+          done <<< "${ARTIFACTS}"
+          if [ "${artifact_count}" -eq 0 ]; then
+            echo "::error::At least one artifact path is required."
+            exit 1
+          fi
+
+          cmd=(
+            uv run python -m policyengine_us_data.storage.backfill_release_manifest
+            --version "${VERSION}"
+            --model-package-version "${MODEL_PACKAGE_VERSION}"
+            --core-package-version "${CORE_PACKAGE_VERSION}"
+            --output "release_manifest-${VERSION}.json"
+            "${artifact_args[@]}"
+          )
+
+          if [ -n "${MODEL_PACKAGE_GIT_SHA}" ]; then
+            cmd+=(--model-package-git-sha "${MODEL_PACKAGE_GIT_SHA}")
+          fi
+          if [ -n "${MODEL_PACKAGE_DATA_BUILD_FINGERPRINT}" ]; then
+            cmd+=(
+              --model-package-data-build-fingerprint
+              "${MODEL_PACKAGE_DATA_BUILD_FINGERPRINT}"
+            )
+          fi
+          if [ -n "${DATA_PACKAGE_GIT_SHA}" ]; then
+            cmd+=(--data-package-git-sha "${DATA_PACKAGE_GIT_SHA}")
+          fi
+          if [ "${UPLOAD}" = "true" ]; then
+            cmd+=(--upload --create-pr)
+            if [ -n "${UPLOAD_REVISION}" ]; then
+              cmd+=(--upload-revision "${UPLOAD_REVISION}")
+            fi
+          fi
+
+          "${cmd[@]}"
+
+          {
+            echo "## Release manifest backfill"
+            echo ""
+            echo "- Version: \`${VERSION}\`"
+            echo "- Manifest artifact: \`release_manifest-${VERSION}.json\`"
+            echo "- Upload requested: \`${UPLOAD}\`"
+            if [ "${UPLOAD}" = "true" ]; then
+              echo "- HF base branch: \`${UPLOAD_REVISION:-main}\`"
+              echo "- HF pull request requested: \`true\`"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload generated manifest artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-manifest-${{ inputs.version }}
+          path: release_manifest-${{ inputs.version }}.json

--- a/.github/workflows/backfill_release_manifest.yaml
+++ b/.github/workflows/backfill_release_manifest.yaml
@@ -45,6 +45,14 @@ on:
         required: true
         default: ""
         type: string
+      publish_mode:
+        description: "How to publish when upload=true"
+        required: true
+        default: "pull_request"
+        type: choice
+        options:
+          - "pull_request"
+          - "direct"
       confirm_publish:
         description: "Required when upload=true: set to the exact version"
         required: false
@@ -100,6 +108,7 @@ jobs:
           DATA_PACKAGE_GIT_SHA: ${{ inputs.data_package_git_sha }}
           UPLOAD: ${{ inputs.upload }}
           UPLOAD_REVISION: ${{ inputs.upload_revision }}
+          PUBLISH_MODE: ${{ inputs.publish_mode }}
           HUGGING_FACE_TOKEN: ${{ secrets.HUGGING_FACE_TOKEN }}
         run: |
           if [[ ! "${VERSION}" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
@@ -152,7 +161,15 @@ jobs:
             cmd+=(--data-package-git-sha "${DATA_PACKAGE_GIT_SHA}")
           fi
           if [ "${UPLOAD}" = "true" ]; then
-            cmd+=(--upload --create-pr)
+            if [ "${PUBLISH_MODE}" != "pull_request" ] &&
+              [ "${PUBLISH_MODE}" != "direct" ]; then
+              echo "::error::publish_mode must be pull_request or direct."
+              exit 1
+            fi
+            cmd+=(--upload)
+            if [ "${PUBLISH_MODE}" = "pull_request" ]; then
+              cmd+=(--create-pr)
+            fi
             if [ -n "${UPLOAD_REVISION}" ]; then
               cmd+=(--upload-revision "${UPLOAD_REVISION}")
             fi
@@ -167,8 +184,8 @@ jobs:
             echo "- Manifest artifact: \`release_manifest-${VERSION}.json\`"
             echo "- Upload requested: \`${UPLOAD}\`"
             if [ "${UPLOAD}" = "true" ]; then
-              echo "- HF base branch: \`${UPLOAD_REVISION:-main}\`"
-              echo "- HF pull request requested: \`true\`"
+              echo "- Publish mode: \`${PUBLISH_MODE}\`"
+              echo "- HF branch/revision: \`${UPLOAD_REVISION:-main}\`"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/changelog.d/release-manifest-backfill.added.md
+++ b/changelog.d/release-manifest-backfill.added.md
@@ -1,0 +1,1 @@
+Added a release-manifest backfill command for building bundle-certifiable manifests from existing Hugging Face artifact metadata.

--- a/policyengine_us_data/storage/backfill_release_manifest.py
+++ b/policyengine_us_data/storage/backfill_release_manifest.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping, Sequence
+
+from huggingface_hub import HfApi
+
+from policyengine_us_data.utils.data_upload import (
+    create_release_manifest_operations_from_manifest,
+    get_repo_head_revision,
+    hf_create_commit_with_retry,
+)
+from policyengine_us_data.utils.release_manifest import (
+    build_release_manifest,
+    serialize_release_manifest,
+)
+
+
+DEFAULT_HF_REPO_NAME = "policyengine/policyengine-us-data"
+DEFAULT_HF_REPO_TYPE = "model"
+DEFAULT_MODEL_PACKAGE_NAME = "policyengine-us"
+DEFAULT_CORE_PACKAGE_NAME = "policyengine-core"
+DEFAULT_NATIONAL_DATASET = "enhanced_cps_2024"
+
+
+@dataclass(frozen=True)
+class HfArtifactMetadata:
+    path: str
+    sha256: str
+    size_bytes: int
+
+
+def _artifact_key(path_in_repo: str) -> str:
+    return str(PurePosixPath(path_in_repo).with_suffix(""))
+
+
+def _artifact_kind(path_in_repo: str) -> str:
+    suffix = PurePosixPath(path_in_repo).suffix.lower()
+    if suffix == ".h5":
+        return "microdata"
+    if suffix == ".db":
+        return "database"
+    if suffix == ".npz":
+        return "geography"
+    if suffix == ".npy":
+        return "weights"
+    return "auxiliary"
+
+
+def _require_lfs_artifact(entry: Any) -> HfArtifactMetadata:
+    lfs = getattr(entry, "lfs", None)
+    if lfs is None:
+        raise ValueError(f"{entry.path} is not an LFS artifact with checksum metadata.")
+    sha256 = getattr(lfs, "sha256", None)
+    size = getattr(lfs, "size", None) or getattr(entry, "size", None)
+    if not sha256 or size is None:
+        raise ValueError(f"{entry.path} is missing LFS sha256/size metadata.")
+    return HfArtifactMetadata(
+        path=entry.path,
+        sha256=sha256,
+        size_bytes=int(size),
+    )
+
+
+def collect_hf_artifact_metadata(
+    *,
+    version: str,
+    artifact_paths: Sequence[str],
+    hf_repo_name: str = DEFAULT_HF_REPO_NAME,
+    hf_repo_type: str = DEFAULT_HF_REPO_TYPE,
+    api: HfApi | None = None,
+    token: str | None = None,
+) -> list[HfArtifactMetadata]:
+    """Collect artifact checksums from an existing Hugging Face revision."""
+    if not artifact_paths:
+        raise ValueError("At least one artifact path is required.")
+
+    api = api or HfApi()
+    requested_paths = set(artifact_paths)
+    found: dict[str, HfArtifactMetadata] = {}
+    for entry in api.list_repo_tree(
+        repo_id=hf_repo_name,
+        repo_type=hf_repo_type,
+        revision=version,
+        recursive=True,
+        expand=True,
+        token=token,
+    ):
+        path = getattr(entry, "path", None)
+        if path not in requested_paths:
+            continue
+        found[path] = _require_lfs_artifact(entry)
+        if len(found) == len(requested_paths):
+            break
+
+    missing = sorted(requested_paths - set(found))
+    if missing:
+        raise FileNotFoundError(
+            f"Missing artifact(s) at {hf_repo_name}@{version}: " + ", ".join(missing)
+        )
+    return [found[path] for path in artifact_paths]
+
+
+def build_backfilled_release_manifest(
+    *,
+    version: str,
+    artifacts: Sequence[HfArtifactMetadata],
+    model_package_version: str,
+    core_package_version: str,
+    hf_repo_name: str = DEFAULT_HF_REPO_NAME,
+    model_package_name: str = DEFAULT_MODEL_PACKAGE_NAME,
+    model_package_git_sha: str | None = None,
+    model_package_data_build_fingerprint: str | None = None,
+    data_package_git_sha: str | None = None,
+    default_national_dataset: str | None = DEFAULT_NATIONAL_DATASET,
+) -> dict[str, Any]:
+    """Build a certifiable release manifest from already-published HF artifacts."""
+    manifest = build_release_manifest(
+        files_with_repo_paths=[],
+        version=version,
+        repo_id=hf_repo_name,
+        model_package_name=model_package_name,
+        model_package_version=model_package_version,
+        model_package_git_sha=model_package_git_sha,
+        model_package_data_build_fingerprint=model_package_data_build_fingerprint,
+        core_package_metadata={
+            "name": DEFAULT_CORE_PACKAGE_NAME,
+            "version": core_package_version,
+        },
+        data_package_git_sha=data_package_git_sha,
+        build_id=f"policyengine-us-data-{version}",
+    )
+    manifest["artifacts"] = {
+        _artifact_key(artifact.path): {
+            "kind": _artifact_kind(artifact.path),
+            "path": artifact.path,
+            "repo_id": hf_repo_name,
+            "revision": version,
+            "sha256": artifact.sha256,
+            "size_bytes": artifact.size_bytes,
+        }
+        for artifact in artifacts
+    }
+    if (
+        default_national_dataset is not None
+        and default_national_dataset in manifest["artifacts"]
+    ):
+        manifest.setdefault("default_datasets", {})["national"] = (
+            default_national_dataset
+        )
+    return manifest
+
+
+def upload_backfilled_release_manifest(
+    manifest: Mapping[str, Any],
+    *,
+    version: str,
+    hf_repo_name: str = DEFAULT_HF_REPO_NAME,
+    hf_repo_type: str = DEFAULT_HF_REPO_TYPE,
+    revision: str | None = None,
+    create_pr: bool = False,
+    token: str | None = None,
+    api: HfApi | None = None,
+) -> str:
+    """Upload a backfilled manifest to a branch/revision without moving tags."""
+    api = api or HfApi()
+    token = token or os.environ.get("HUGGING_FACE_TOKEN")
+    parent_commit = get_repo_head_revision(
+        api=api,
+        repo_id=hf_repo_name,
+        repo_type=hf_repo_type,
+        token=token,
+    )
+    commit_info = hf_create_commit_with_retry(
+        api=api,
+        operations=create_release_manifest_operations_from_manifest(
+            manifest,
+            version=version,
+        ),
+        repo_id=hf_repo_name,
+        repo_type=hf_repo_type,
+        token=token,
+        commit_message=f"Backfill release manifest for version {version}",
+        parent_commit=parent_commit,
+        revision=revision,
+        create_pr=create_pr,
+    )
+    return commit_info.oid
+
+
+def _write_manifest(path: Path, manifest: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(serialize_release_manifest(manifest))
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build a release_manifest.json from checksums on an existing "
+            "Hugging Face policyengine-us-data revision."
+        )
+    )
+    parser.add_argument("--version", required=True)
+    parser.add_argument(
+        "--artifact",
+        action="append",
+        dest="artifacts",
+        required=True,
+        help="Artifact path on Hugging Face. Repeat for multiple artifacts.",
+    )
+    parser.add_argument("--model-package-version", required=True)
+    parser.add_argument("--core-package-version", required=True)
+    parser.add_argument("--model-package-git-sha")
+    parser.add_argument("--model-package-data-build-fingerprint")
+    parser.add_argument("--data-package-git-sha")
+    parser.add_argument("--hf-repo-name", default=DEFAULT_HF_REPO_NAME)
+    parser.add_argument("--hf-repo-type", default=DEFAULT_HF_REPO_TYPE)
+    parser.add_argument(
+        "--default-national-dataset",
+        default=DEFAULT_NATIONAL_DATASET,
+        help="Artifact key to mark as default national dataset; use '' for none.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Write the generated manifest locally instead of printing JSON.",
+    )
+    parser.add_argument(
+        "--upload",
+        action="store_true",
+        help="Upload release_manifest.json and TRACE TRO to Hugging Face.",
+    )
+    parser.add_argument(
+        "--upload-revision",
+        help="Branch/revision to receive the upload. Defaults to the repo default branch.",
+    )
+    parser.add_argument(
+        "--create-pr",
+        action="store_true",
+        help="Ask Hugging Face to create a PR for the upload.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    token = os.environ.get("HUGGING_FACE_TOKEN")
+    artifacts = collect_hf_artifact_metadata(
+        version=args.version,
+        artifact_paths=args.artifacts,
+        hf_repo_name=args.hf_repo_name,
+        hf_repo_type=args.hf_repo_type,
+        token=token,
+    )
+    manifest = build_backfilled_release_manifest(
+        version=args.version,
+        artifacts=artifacts,
+        model_package_version=args.model_package_version,
+        core_package_version=args.core_package_version,
+        hf_repo_name=args.hf_repo_name,
+        model_package_git_sha=args.model_package_git_sha,
+        model_package_data_build_fingerprint=args.model_package_data_build_fingerprint,
+        data_package_git_sha=args.data_package_git_sha,
+        default_national_dataset=args.default_national_dataset or None,
+    )
+    if args.output is not None:
+        _write_manifest(args.output, manifest)
+    else:
+        print(json.dumps(manifest, indent=2, sort_keys=True))
+
+    if args.upload:
+        commit_oid = upload_backfilled_release_manifest(
+            manifest,
+            version=args.version,
+            hf_repo_name=args.hf_repo_name,
+            hf_repo_type=args.hf_repo_type,
+            revision=args.upload_revision,
+            create_pr=args.create_pr,
+            token=token,
+        )
+        print(f"Uploaded release manifest commit: {commit_oid}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/policyengine_us_data/storage/backfill_release_manifest.py
+++ b/policyengine_us_data/storage/backfill_release_manifest.py
@@ -173,6 +173,7 @@ def upload_backfilled_release_manifest(
         api=api,
         repo_id=hf_repo_name,
         repo_type=hf_repo_type,
+        revision=revision,
         token=token,
     )
     commit_info = hf_create_commit_with_retry(
@@ -180,6 +181,7 @@ def upload_backfilled_release_manifest(
         operations=create_release_manifest_operations_from_manifest(
             manifest,
             version=version,
+            include_root_paths=False,
         ),
         repo_id=hf_repo_name,
         repo_type=hf_repo_type,

--- a/policyengine_us_data/utils/data_upload.py
+++ b/policyengine_us_data/utils/data_upload.py
@@ -432,12 +432,25 @@ def create_release_manifest_commit_operations(
         data_package_git_sha=data_package_git_sha,
         existing_manifest=existing_manifest,
     )
+    operations = create_release_manifest_operations_from_manifest(
+        manifest,
+        version=version,
+    )
+    return manifest, operations
+
+
+def create_release_manifest_operations_from_manifest(
+    manifest: Mapping[str, Any],
+    *,
+    version: str,
+) -> List[CommitOperationAdd]:
+    """Create HF commit operations for an already-built release manifest."""
     manifest_payload = serialize_release_manifest(manifest)
     trace_tro_payload = serialize_trace_tro(
         build_trace_tro_from_release_manifest(manifest)
     )
 
-    operations = [
+    return [
         CommitOperationAdd(
             path_in_repo=RELEASE_MANIFEST_PATH,
             path_or_fileobj=BytesIO(manifest_payload),
@@ -455,7 +468,6 @@ def create_release_manifest_commit_operations(
             path_or_fileobj=BytesIO(trace_tro_payload),
         ),
     ]
-    return manifest, operations
 
 
 def create_release_tag(
@@ -944,6 +956,8 @@ def hf_create_commit_with_retry(
     token: str,
     commit_message: str,
     parent_commit: Optional[str] = None,
+    revision: Optional[str] = None,
+    create_pr: Optional[bool] = None,
 ):
     """
     Create HuggingFace commit with retry logic for timeout errors.
@@ -957,6 +971,8 @@ def hf_create_commit_with_retry(
         repo_type=repo_type,
         commit_message=commit_message,
         parent_commit=parent_commit,
+        revision=revision,
+        create_pr=create_pr,
     )
 
 

--- a/policyengine_us_data/utils/data_upload.py
+++ b/policyengine_us_data/utils/data_upload.py
@@ -290,11 +290,13 @@ def get_repo_head_revision(
     api: HfApi,
     repo_id: str,
     repo_type: str,
+    revision: Optional[str] = None,
     token: Optional[str] = None,
 ) -> Optional[str]:
     repo_info = api.repo_info(
         repo_id=repo_id,
         repo_type=repo_type,
+        revision=revision,
         token=token,
     )
     return getattr(repo_info, "sha", None)
@@ -443,6 +445,7 @@ def create_release_manifest_operations_from_manifest(
     manifest: Mapping[str, Any],
     *,
     version: str,
+    include_root_paths: bool = True,
 ) -> List[CommitOperationAdd]:
     """Create HF commit operations for an already-built release manifest."""
     manifest_payload = serialize_release_manifest(manifest)
@@ -450,24 +453,34 @@ def create_release_manifest_operations_from_manifest(
         build_trace_tro_from_release_manifest(manifest)
     )
 
-    return [
-        CommitOperationAdd(
-            path_in_repo=RELEASE_MANIFEST_PATH,
-            path_or_fileobj=BytesIO(manifest_payload),
-        ),
+    operations = []
+    if include_root_paths:
+        operations.append(
+            CommitOperationAdd(
+                path_in_repo=RELEASE_MANIFEST_PATH,
+                path_or_fileobj=BytesIO(manifest_payload),
+            )
+        )
+    operations.append(
         CommitOperationAdd(
             path_in_repo=f"releases/{version}/{RELEASE_MANIFEST_PATH}",
             path_or_fileobj=BytesIO(manifest_payload),
-        ),
-        CommitOperationAdd(
-            path_in_repo=TRACE_TRO_FILENAME,
-            path_or_fileobj=BytesIO(trace_tro_payload),
-        ),
+        )
+    )
+    if include_root_paths:
+        operations.append(
+            CommitOperationAdd(
+                path_in_repo=TRACE_TRO_FILENAME,
+                path_or_fileobj=BytesIO(trace_tro_payload),
+            )
+        )
+    operations.append(
         CommitOperationAdd(
             path_in_repo=f"releases/{version}/{TRACE_TRO_FILENAME}",
             path_or_fileobj=BytesIO(trace_tro_payload),
-        ),
-    ]
+        )
+    )
+    return operations
 
 
 def create_release_tag(

--- a/tests/unit/test_backfill_release_manifest.py
+++ b/tests/unit/test_backfill_release_manifest.py
@@ -124,9 +124,15 @@ def test_build_backfilled_release_manifest_records_exact_core_metadata():
 def test_upload_backfilled_release_manifest_uploads_manifest_and_trace(monkeypatch):
     api = MagicMock()
     api.create_commit.return_value = SimpleNamespace(oid="commit-sha")
+    head_calls = []
+
+    def fake_head(**kwargs):
+        head_calls.append(kwargs)
+        return "parent-sha"
+
     monkeypatch.setattr(
         "policyengine_us_data.storage.backfill_release_manifest.get_repo_head_revision",
-        lambda **kwargs: "parent-sha",
+        fake_head,
     )
 
     manifest = build_backfilled_release_manifest(
@@ -152,14 +158,21 @@ def test_upload_backfilled_release_manifest_uploads_manifest_and_trace(monkeypat
     )
 
     assert commit_sha == "commit-sha"
+    assert head_calls == [
+        {
+            "api": api,
+            "repo_id": "policyengine/policyengine-us-data",
+            "repo_type": "model",
+            "revision": "backfill-branch",
+            "token": "token",
+        }
+    ]
     call = api.create_commit.call_args.kwargs
     assert call["revision"] == "backfill-branch"
     assert call["create_pr"] is True
     assert call["parent_commit"] == "parent-sha"
     operation_paths = [operation.path_in_repo for operation in call["operations"]]
     assert operation_paths == [
-        "release_manifest.json",
         "releases/1.73.0/release_manifest.json",
-        "trace.tro.jsonld",
         "releases/1.73.0/trace.tro.jsonld",
     ]

--- a/tests/unit/test_backfill_release_manifest.py
+++ b/tests/unit/test_backfill_release_manifest.py
@@ -1,0 +1,165 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from policyengine_us_data.storage.backfill_release_manifest import (
+    HfArtifactMetadata,
+    build_backfilled_release_manifest,
+    collect_hf_artifact_metadata,
+    upload_backfilled_release_manifest,
+)
+
+
+def _repo_file(path: str, sha256: str, size: int):
+    return SimpleNamespace(
+        path=path,
+        lfs=SimpleNamespace(sha256=sha256, size=size),
+        size=size,
+    )
+
+
+def test_collect_hf_artifact_metadata_reads_lfs_checksums_in_requested_order():
+    api = MagicMock()
+    api.list_repo_tree.return_value = [
+        _repo_file("states/AL.h5", "b" * 64, 2),
+        _repo_file("enhanced_cps_2024.h5", "a" * 64, 1),
+    ]
+
+    artifacts = collect_hf_artifact_metadata(
+        version="1.73.0",
+        artifact_paths=["enhanced_cps_2024.h5", "states/AL.h5"],
+        api=api,
+    )
+
+    assert artifacts == [
+        HfArtifactMetadata(
+            path="enhanced_cps_2024.h5",
+            sha256="a" * 64,
+            size_bytes=1,
+        ),
+        HfArtifactMetadata(path="states/AL.h5", sha256="b" * 64, size_bytes=2),
+    ]
+    api.list_repo_tree.assert_called_once_with(
+        repo_id="policyengine/policyengine-us-data",
+        repo_type="model",
+        revision="1.73.0",
+        recursive=True,
+        expand=True,
+        token=None,
+    )
+
+
+def test_collect_hf_artifact_metadata_rejects_missing_paths():
+    api = MagicMock()
+    api.list_repo_tree.return_value = [
+        _repo_file("enhanced_cps_2024.h5", "a" * 64, 1),
+    ]
+
+    with pytest.raises(FileNotFoundError, match="states/AL.h5"):
+        collect_hf_artifact_metadata(
+            version="1.73.0",
+            artifact_paths=["enhanced_cps_2024.h5", "states/AL.h5"],
+            api=api,
+        )
+
+
+def test_build_backfilled_release_manifest_records_exact_core_metadata():
+    manifest = build_backfilled_release_manifest(
+        version="1.73.0",
+        artifacts=[
+            HfArtifactMetadata(
+                path="enhanced_cps_2024.h5",
+                sha256="a" * 64,
+                size_bytes=1,
+            ),
+            HfArtifactMetadata(
+                path="enhanced_cps_2024.clone_diagnostics.json",
+                sha256="b" * 64,
+                size_bytes=2,
+            ),
+        ],
+        model_package_version="1.653.3",
+        core_package_version="3.26.0",
+        model_package_data_build_fingerprint="sha256:stable",
+    )
+
+    assert manifest["data_package"] == {
+        "name": "policyengine-us-data",
+        "version": "1.73.0",
+    }
+    assert manifest["compatible_model_packages"] == [
+        {"name": "policyengine-us", "specifier": "==1.653.3"}
+    ]
+    assert manifest["compatible_core_packages"] == [
+        {"name": "policyengine-core", "specifier": "==3.26.0"}
+    ]
+    assert manifest["default_datasets"] == {"national": "enhanced_cps_2024"}
+    assert manifest["build"]["built_with_core_package"] == {
+        "name": "policyengine-core",
+        "version": "3.26.0",
+    }
+    assert manifest["build"]["built_with_model_package"]["core"] == {
+        "name": "policyengine-core",
+        "version": "3.26.0",
+    }
+    assert manifest["artifacts"]["enhanced_cps_2024"] == {
+        "kind": "microdata",
+        "path": "enhanced_cps_2024.h5",
+        "repo_id": "policyengine/policyengine-us-data",
+        "revision": "1.73.0",
+        "sha256": "a" * 64,
+        "size_bytes": 1,
+    }
+    assert manifest["artifacts"]["enhanced_cps_2024.clone_diagnostics"] == {
+        "kind": "auxiliary",
+        "path": "enhanced_cps_2024.clone_diagnostics.json",
+        "repo_id": "policyengine/policyengine-us-data",
+        "revision": "1.73.0",
+        "sha256": "b" * 64,
+        "size_bytes": 2,
+    }
+
+
+def test_upload_backfilled_release_manifest_uploads_manifest_and_trace(monkeypatch):
+    api = MagicMock()
+    api.create_commit.return_value = SimpleNamespace(oid="commit-sha")
+    monkeypatch.setattr(
+        "policyengine_us_data.storage.backfill_release_manifest.get_repo_head_revision",
+        lambda **kwargs: "parent-sha",
+    )
+
+    manifest = build_backfilled_release_manifest(
+        version="1.73.0",
+        artifacts=[
+            HfArtifactMetadata(
+                path="enhanced_cps_2024.h5",
+                sha256="a" * 64,
+                size_bytes=1,
+            )
+        ],
+        model_package_version="1.653.3",
+        core_package_version="3.26.0",
+    )
+
+    commit_sha = upload_backfilled_release_manifest(
+        manifest,
+        version="1.73.0",
+        revision="backfill-branch",
+        create_pr=True,
+        token="token",
+        api=api,
+    )
+
+    assert commit_sha == "commit-sha"
+    call = api.create_commit.call_args.kwargs
+    assert call["revision"] == "backfill-branch"
+    assert call["create_pr"] is True
+    assert call["parent_commit"] == "parent-sha"
+    operation_paths = [operation.path_in_repo for operation in call["operations"]]
+    assert operation_paths == [
+        "release_manifest.json",
+        "releases/1.73.0/release_manifest.json",
+        "trace.tro.jsonld",
+        "releases/1.73.0/trace.tro.jsonld",
+    ]


### PR DESCRIPTION
Adds a targeted backfill command for reconstructing release_manifest.json from existing Hugging Face artifact metadata when old data tags have the artifacts but no manifest.\n\nWhy:\n- policyengine-bundles can fully validate once the data release manifest carries exact model/core compatibility and artifact checksums.\n- Existing US HF tags such as 1.73.0 and 1.78.2 have the H5 artifacts but no release_manifest.json at the tag.\n\nWhat this does:\n- Collects LFS sha256/size metadata from an existing HF revision for explicit artifact paths.\n- Builds a bundle-certifiable release manifest with exact policyengine-us and policyengine-core compatibility.\n- Reuses the existing release_manifest.json + TRACE TRO commit operation code for optional upload to a branch/PR.\n- Does not move existing HF tags.\n\nLocal verification:\n- uv run python -m pytest -q tests/unit/test_backfill_release_manifest.py tests/unit/test_release_manifest.py tests/unit/test_trace_tro.py\n- uv run ruff format --check policyengine_us_data/storage/backfill_release_manifest.py policyengine_us_data/utils/data_upload.py tests/unit/test_backfill_release_manifest.py\n- uv run ruff check policyengine_us_data/storage/backfill_release_manifest.py policyengine_us_data/utils/data_upload.py tests/unit/test_backfill_release_manifest.py\n- env -u UV_FROZEN uv lock --locked\n\nRepro proof:\n- Generated /Users/maxghenis/PolicyEngine/_tmp_repro/us-backfill-1.73.0-release_manifest.json from HF metadata for policyengine-us-data 1.73.0 / policyengine-us 1.653.3 / policyengine-core 3.26.0.\n- A policyengine-bundles US validation against that generated manifest passed with validation_scope=full.