### PR TITLE
Allow additional core compatibility in release manifests

### DIFF
--- a/.github/workflows/backfill_release_manifest.yaml
+++ b/.github/workflows/backfill_release_manifest.yaml
@@ -20,6 +20,11 @@ on:
         description: "Exact policyengine-core version used with this data release"
         required: true
         type: string
+      compatible_core_package_versions:
+        description: "Optional newline-separated additional exact policyengine-core runtime versions to certify"
+        required: false
+        default: ""
+        type: string
       model_package_git_sha:
         description: "Optional policyengine-us git SHA"
         required: false
@@ -103,6 +108,7 @@ jobs:
           ARTIFACTS: ${{ inputs.artifacts }}
           MODEL_PACKAGE_VERSION: ${{ inputs.model_package_version }}
           CORE_PACKAGE_VERSION: ${{ inputs.core_package_version }}
+          COMPATIBLE_CORE_PACKAGE_VERSIONS: ${{ inputs.compatible_core_package_versions }}
           MODEL_PACKAGE_GIT_SHA: ${{ inputs.model_package_git_sha }}
           MODEL_PACKAGE_DATA_BUILD_FINGERPRINT: ${{ inputs.model_package_data_build_fingerprint }}
           DATA_PACKAGE_GIT_SHA: ${{ inputs.data_package_git_sha }}
@@ -147,6 +153,17 @@ jobs:
             --output "release_manifest-${VERSION}.json"
             "${artifact_args[@]}"
           )
+
+          while IFS= read -r core_version; do
+            if [ -z "${core_version}" ]; then
+              continue
+            fi
+            if [[ ! "${core_version}" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+              echo "::error::Compatible core version must use x.y.z form, got '${core_version}'."
+              exit 1
+            fi
+            cmd+=(--compatible-core-package-version "${core_version}")
+          done <<< "${COMPATIBLE_CORE_PACKAGE_VERSIONS}"
 
           if [ -n "${MODEL_PACKAGE_GIT_SHA}" ]; then
             cmd+=(--model-package-git-sha "${MODEL_PACKAGE_GIT_SHA}")

--- a/changelog.d/931.changed
+++ b/changelog.d/931.changed
@@ -1,0 +1,1 @@
+Allow release manifest backfills to certify additional exact policyengine-core runtime versions without changing recorded build-core metadata.

--- a/policyengine_us_data/storage/backfill_release_manifest.py
+++ b/policyengine_us_data/storage/backfill_release_manifest.py
@@ -111,6 +111,7 @@ def build_backfilled_release_manifest(
     artifacts: Sequence[HfArtifactMetadata],
     model_package_version: str,
     core_package_version: str,
+    compatible_core_package_versions: Sequence[str] | None = None,
     hf_repo_name: str = DEFAULT_HF_REPO_NAME,
     model_package_name: str = DEFAULT_MODEL_PACKAGE_NAME,
     model_package_git_sha: str | None = None,
@@ -131,6 +132,9 @@ def build_backfilled_release_manifest(
             "name": DEFAULT_CORE_PACKAGE_NAME,
             "version": core_package_version,
         },
+        additional_core_compatible_specifiers=[
+            f"=={version}" for version in compatible_core_package_versions or ()
+        ],
         data_package_git_sha=data_package_git_sha,
         build_id=f"policyengine-us-data-{version}",
     )
@@ -216,6 +220,17 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--model-package-version", required=True)
     parser.add_argument("--core-package-version", required=True)
+    parser.add_argument(
+        "--compatible-core-package-version",
+        action="append",
+        dest="compatible_core_package_versions",
+        default=[],
+        help=(
+            "Additional exact policyengine-core runtime version to certify as "
+            "compatible. Repeat for multiple versions. The build core remains "
+            "--core-package-version."
+        ),
+    )
     parser.add_argument("--model-package-git-sha")
     parser.add_argument("--model-package-data-build-fingerprint")
     parser.add_argument("--data-package-git-sha")
@@ -263,6 +278,7 @@ def main() -> int:
         artifacts=artifacts,
         model_package_version=args.model_package_version,
         core_package_version=args.core_package_version,
+        compatible_core_package_versions=args.compatible_core_package_versions,
         hf_repo_name=args.hf_repo_name,
         model_package_git_sha=args.model_package_git_sha,
         model_package_data_build_fingerprint=args.model_package_data_build_fingerprint,

--- a/policyengine_us_data/utils/release_manifest.py
+++ b/policyengine_us_data/utils/release_manifest.py
@@ -105,16 +105,26 @@ def _model_package_compatibility(
 
 def _core_package_compatibility(
     core_package_metadata: Mapping[str, Any] | None,
+    additional_compatible_specifiers: Sequence[str] | None = None,
 ) -> list[Dict[str, str]]:
+    package_name = "policyengine-core"
+    if core_package_metadata is not None:
+        package_name = core_package_metadata.get("name", package_name)
+
+    compatible_packages: list[Dict[str, str]] = []
     core_version = _core_version(core_package_metadata)
-    if not core_version:
-        return []
-    return [
-        {
-            "name": core_package_metadata.get("name", "policyengine-core"),
-            "specifier": f"=={core_version}",
-        }
-    ]
+    if core_version:
+        compatible_packages.append(
+            {
+                "name": package_name,
+                "specifier": f"=={core_version}",
+            }
+        )
+    for specifier in additional_compatible_specifiers or ():
+        candidate = {"name": package_name, "specifier": specifier}
+        if candidate not in compatible_packages:
+            compatible_packages.append(candidate)
+    return compatible_packages
 
 
 def _build_section(
@@ -168,6 +178,7 @@ def _new_manifest(
     build_id: str,
     created_at: str,
     additional_compatible_specifiers: Sequence[str] | None = None,
+    additional_core_compatible_specifiers: Sequence[str] | None = None,
     pipeline_run_id: str | None,
     data_package_git_sha: str | None,
 ) -> Dict:
@@ -182,7 +193,10 @@ def _new_manifest(
             model_package_version=model_package_version,
             additional_compatible_specifiers=additional_compatible_specifiers,
         ),
-        "compatible_core_packages": _core_package_compatibility(core_package_metadata),
+        "compatible_core_packages": _core_package_compatibility(
+            core_package_metadata,
+            additional_compatible_specifiers=additional_core_compatible_specifiers,
+        ),
         "default_datasets": {},
         "build": _build_section(
             model_package_name=model_package_name,
@@ -251,6 +265,7 @@ def _update_existing_manifest_metadata(
     build_id: str,
     created_at: str,
     additional_compatible_specifiers: Sequence[str] | None = None,
+    additional_core_compatible_specifiers: Sequence[str] | None = None,
     pipeline_run_id: str | None,
     data_package_git_sha: str | None,
 ) -> None:
@@ -278,7 +293,10 @@ def _update_existing_manifest_metadata(
     if compatible_model_packages:
         manifest["compatible_model_packages"] = compatible_model_packages
 
-    compatible_core_packages = _core_package_compatibility(core_package_metadata)
+    compatible_core_packages = _core_package_compatibility(
+        core_package_metadata,
+        additional_compatible_specifiers=additional_core_compatible_specifiers,
+    )
     if compatible_core_packages:
         manifest["compatible_core_packages"] = compatible_core_packages
 
@@ -379,6 +397,7 @@ def build_release_manifest(
     default_datasets: Optional[Mapping[str, str]] = None,
     created_at: str | None = None,
     additional_compatible_specifiers: Sequence[str] | None = None,
+    additional_core_compatible_specifiers: Sequence[str] | None = None,
     preservation_mirrors_by_artifact: Optional[
         Mapping[str, Sequence[Mapping[str, Any]]]
     ] = None,
@@ -405,6 +424,7 @@ def build_release_manifest(
             build_id=resolved_build_id,
             created_at=manifest_timestamp,
             additional_compatible_specifiers=additional_compatible_specifiers,
+            additional_core_compatible_specifiers=additional_core_compatible_specifiers,
             pipeline_run_id=pipeline_run_id,
             data_package_git_sha=data_package_git_sha,
         )
@@ -420,6 +440,7 @@ def build_release_manifest(
             build_id=resolved_build_id,
             created_at=manifest_timestamp,
             additional_compatible_specifiers=additional_compatible_specifiers,
+            additional_core_compatible_specifiers=additional_core_compatible_specifiers,
             pipeline_run_id=pipeline_run_id,
             data_package_git_sha=data_package_git_sha,
         )

--- a/tests/unit/test_backfill_release_manifest.py
+++ b/tests/unit/test_backfill_release_manifest.py
@@ -121,6 +121,31 @@ def test_build_backfilled_release_manifest_records_exact_core_metadata():
     }
 
 
+def test_build_backfilled_release_manifest_records_additional_core_compatibility():
+    manifest = build_backfilled_release_manifest(
+        version="1.73.0",
+        artifacts=[
+            HfArtifactMetadata(
+                path="enhanced_cps_2024.h5",
+                sha256="a" * 64,
+                size_bytes=1,
+            )
+        ],
+        model_package_version="1.653.3",
+        core_package_version="3.26.0",
+        compatible_core_package_versions=["3.26.1"],
+    )
+
+    assert manifest["build"]["built_with_core_package"] == {
+        "name": "policyengine-core",
+        "version": "3.26.0",
+    }
+    assert manifest["compatible_core_packages"] == [
+        {"name": "policyengine-core", "specifier": "==3.26.0"},
+        {"name": "policyengine-core", "specifier": "==3.26.1"},
+    ]
+
+
 def test_upload_backfilled_release_manifest_uploads_manifest_and_trace(monkeypatch):
     api = MagicMock()
     api.create_commit.return_value = SimpleNamespace(oid="commit-sha")


### PR DESCRIPTION
Adds an explicit path for release manifest backfills to certify additional exact policyengine-core runtime versions without changing the recorded build core. This is needed for policyengine==4.4.1 bundle certification: the US 1.78.2 artifact was backfilled with built core 3.26.0, while the live all-country install resolves core 3.26.1.\n\nLocal checks:\n- uv run pytest tests/unit/test_backfill_release_manifest.py -q\n- uv run ruff format --check policyengine_us_data/utils/release_manifest.py policyengine_us_data/storage/backfill_release_manifest.py tests/unit/test_backfill_release_manifest.py\n- uv run ruff check policyengine_us_data/utils/release_manifest.py policyengine_us_data/storage/backfill_release_manifest.py tests/unit/test_backfill_release_manifest.py