### PR TITLE
Update policyengine-us data-build dependency

### DIFF
--- a/changelog.d/policyengine-us-1.690.4.changed
+++ b/changelog.d/policyengine-us-1.690.4.changed
@@ -1,0 +1,1 @@
+Update the data-build policyengine-us dependency floor to 1.690.4.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us>=1.690.3",
+    "policyengine-us>=1.690.4",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/uv.lock
+++ b/uv.lock
@@ -2122,7 +2122,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.690.3"
+version = "1.690.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2132,9 +2132,9 @@ dependencies = [
     { name = "tables" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/af/4c69d6bf4eff9f8cdd2deee289226c450bbbf5ede482d629a52c963371a4/policyengine_us-1.690.3.tar.gz", hash = "sha256:8f3b3a57eb431220d100181f8a4aae5c6c1f94f9dcbbd68941f7b40d97df50df", size = 9473021, upload-time = "2026-05-08T15:01:46.223Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/34/f452b3c2f541d0e732b1455b63fc481a6aaaa30ec8063a4030c75f49bc4e/policyengine_us-1.690.4.tar.gz", hash = "sha256:97811fb78801ce763a1baf04fe6282a6e13af54fa4855ca571c3dd2bdb196216", size = 9473689, upload-time = "2026-05-10T08:49:04.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/f7/299f5034c69d26d0e022af90528a93f55ed5ecfd7d0cacbaefadcdbc80ef/policyengine_us-1.690.3-py3-none-any.whl", hash = "sha256:1be429d186c19b4f7e810bbd90bda2b0b106535065c4e6fa375ade3e8df3fdbf", size = 9974260, upload-time = "2026-05-08T15:01:43.089Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/50/9c090316f94c5ab1f051192e9098d293345a80f6451b92cd050ca1f6d350/policyengine_us-1.690.4-py3-none-any.whl", hash = "sha256:75bfc6c30f2cbacd5b17b7a41c742444e902d2bb3cef144b069e619ef73cbe38", size = 9975717, upload-time = "2026-05-10T08:49:00.716Z" },
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", specifier = ">=1.690.3" },
+    { name = "policyengine-us", specifier = ">=1.690.4" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },


### PR DESCRIPTION
## Summary
- Raise the data-build policyengine-us dependency floor to 1.690.4.
- Refresh uv.lock so the next us-data release is built with the latest policyengine-us data-build fingerprint.

## Testing
- uv run ruff check pyproject.toml
- uv run python - <<'PY'
from policyengine_us.build_metadata import get_data_build_metadata
print(get_data_build_metadata())
PY
- git diff --check