### PR TITLE
Update policyengine-us data-build dependency

### DIFF
--- a/changelog.d/policyengine-us-1.690.5.changed
+++ b/changelog.d/policyengine-us-1.690.5.changed
@@ -1,0 +1,1 @@
+Update the data-build policyengine-us dependency floor to 1.690.5.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us>=1.690.4",
+    "policyengine-us>=1.690.5",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/uv.lock
+++ b/uv.lock
@@ -2122,7 +2122,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.690.4"
+version = "1.690.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2132,9 +2132,9 @@ dependencies = [
     { name = "tables" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/34/f452b3c2f541d0e732b1455b63fc481a6aaaa30ec8063a4030c75f49bc4e/policyengine_us-1.690.4.tar.gz", hash = "sha256:97811fb78801ce763a1baf04fe6282a6e13af54fa4855ca571c3dd2bdb196216", size = 9473689, upload-time = "2026-05-10T08:49:04.376Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/d0/40aa53428b31306be0979ce6dc804f1b5c2e14d9088f54548009c2ac3ca1/policyengine_us-1.690.5.tar.gz", hash = "sha256:a23f03445664552915e835118a4ac4d3fb8e4c0da95c2fb7ab84a8bda8767680", size = 9475321, upload-time = "2026-05-10T13:56:08.35Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/50/9c090316f94c5ab1f051192e9098d293345a80f6451b92cd050ca1f6d350/policyengine_us-1.690.4-py3-none-any.whl", hash = "sha256:75bfc6c30f2cbacd5b17b7a41c742444e902d2bb3cef144b069e619ef73cbe38", size = 9975717, upload-time = "2026-05-10T08:49:00.716Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ee/411405d3b28709ec52f81941faeac10abe1cf59f44ca0168ad65cdc95169/policyengine_us-1.690.5-py3-none-any.whl", hash = "sha256:e228a2e990a49b63441e3fc3f2f6d856e75188ba92fed6a65a0d40563b8b2277", size = 9979078, upload-time = "2026-05-10T13:56:04.986Z" },
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", specifier = ">=1.690.4" },
+    { name = "policyengine-us", specifier = ">=1.690.5" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },


### PR DESCRIPTION
## Summary
- Bump the data-build policyengine-us dependency floor to 1.690.5.
- Refresh uv.lock so the production data build includes the merged Medicare Part B/MSP MOOP logic from PolicyEngine/policyengine-us#7972.

## Testing
- uv lock --check
- uv run towncrier check --compare-with upstream/main