### PR TITLE
Update policyengine-us data-build dependency to 1.690.6

### DIFF
--- a/changelog.d/policyengine-us-1.690.6.changed
+++ b/changelog.d/policyengine-us-1.690.6.changed
@@ -1,0 +1,1 @@
+Update the data-build dependency floor to policyengine-us 1.690.6.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us>=1.690.5",
+    "policyengine-us>=1.690.6",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/uv.lock
+++ b/uv.lock
@@ -2122,7 +2122,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.690.5"
+version = "1.690.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2132,9 +2132,9 @@ dependencies = [
     { name = "tables" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/d0/40aa53428b31306be0979ce6dc804f1b5c2e14d9088f54548009c2ac3ca1/policyengine_us-1.690.5.tar.gz", hash = "sha256:a23f03445664552915e835118a4ac4d3fb8e4c0da95c2fb7ab84a8bda8767680", size = 9475321, upload-time = "2026-05-10T13:56:08.35Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/0d/42142659cd14c5715c14d45b641ddceff0802fc70e1c890f50b897ba514c/policyengine_us-1.690.6.tar.gz", hash = "sha256:46e9dce9d6f025989da58d45257355e23456c93b85eb9b37197bd3e3c70f7d27", size = 9478904, upload-time = "2026-05-10T14:54:12.003Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/ee/411405d3b28709ec52f81941faeac10abe1cf59f44ca0168ad65cdc95169/policyengine_us-1.690.5-py3-none-any.whl", hash = "sha256:e228a2e990a49b63441e3fc3f2f6d856e75188ba92fed6a65a0d40563b8b2277", size = 9979078, upload-time = "2026-05-10T13:56:04.986Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/e9e241873abb4ce31b3261966cd9348702459633d72977d693457cb61e1d/policyengine_us-1.690.6-py3-none-any.whl", hash = "sha256:552352574d9054184799e78a6df3c4d879b2ecb33aa15475744c1506cde59602", size = 9985484, upload-time = "2026-05-10T14:54:08.398Z" },
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", specifier = ">=1.690.5" },
+    { name = "policyengine-us", specifier = ">=1.690.6" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },


### PR DESCRIPTION
## Summary
- Bump the policyengine-us data-build dependency floor to 1.690.6
- Refresh uv.lock so data builds resolve the Medicare Part B/MSP SPM fix

## Tests
- uv lock --check
- uv run towncrier check --compare-with upstream/main
- uv run python -c 'import importlib.metadata as m; print(m.version("policyengine-us")); print(m.version("policyengine-us-data"))'