### PR TITLE
Expose national GPU in data pipeline workflow

### DIFF
--- a/.github/scripts/spawn_modal_pipeline.py
+++ b/.github/scripts/spawn_modal_pipeline.py
@@ -28,7 +28,10 @@ def _append_summary(function_call_id: str, context: RunContext) -> None:
         handle.write("## Pipeline Launched\n\n")
         handle.write("| Field | Value |\n")
         handle.write("|-------|-------|\n")
-        handle.write(f"| GPU | `{os.environ['GPU']}` |\n")
+        handle.write(f"| Regional GPU | `{os.environ['GPU']}` |\n")
+        handle.write(
+            f"| National GPU | `{_env('NATIONAL_GPU', os.environ['GPU'])}` |\n"
+        )
         handle.write(
             "| Epochs | "
             f"`{os.environ['EPOCHS']}` / "
@@ -58,6 +61,7 @@ def main() -> None:
     kwargs = {
         "branch": os.environ.get("PIPELINE_BRANCH", "main"),
         "gpu": os.environ["GPU"],
+        "national_gpu": _env("NATIONAL_GPU", os.environ["GPU"]),
         "epochs": int(os.environ["EPOCHS"]),
         "national_epochs": int(os.environ["NATIONAL_EPOCHS"]),
         "num_workers": int(os.environ["NUM_WORKERS"]),

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -7,6 +7,10 @@ on:
         description: "GPU type for regional calibration"
         default: "T4"
         type: string
+      national_gpu:
+        description: "GPU type for national calibration"
+        default: "T4"
+        type: string
       epochs:
         description: "Epochs for regional calibration"
         default: "1000"
@@ -89,6 +93,7 @@ jobs:
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
           PIPELINE_BRANCH: main
           GPU: ${{ inputs.gpu || 'T4' }}
+          NATIONAL_GPU: ${{ inputs.national_gpu || 'T4' }}
           EPOCHS: ${{ inputs.epochs || '1000' }}
           NATIONAL_EPOCHS: ${{ inputs.national_epochs || '1000' }}
           NUM_WORKERS: ${{ inputs.num_workers || '50' }}

--- a/changelog.d/944.fixed
+++ b/changelog.d/944.fixed
@@ -1,0 +1,1 @@
+Expose the national calibration GPU in the publication pipeline workflow.


### PR DESCRIPTION
## Summary\n- add a workflow_dispatch input for national calibration GPU\n- pass NATIONAL_GPU through the Modal launcher to run_pipeline\n- show regional and national GPU separately in the GitHub summary\n\n## Tests\n- uv run ruff check .github/scripts/spawn_modal_pipeline.py\n- uv run ruff format --check .github/scripts/spawn_modal_pipeline.py\n- python3 -m py_compile .github/scripts/spawn_modal_pipeline.py