### PR TITLE
Build us-data with latest policyengine-us

### DIFF
--- a/changelog.d/955.changed.md
+++ b/changelog.d/955.changed.md
@@ -1,0 +1,1 @@
+Build datasets with policyengine-us 1.691.1 or later.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us>=1.690.7",
+    "policyengine-us>=1.691.1",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/uv.lock
+++ b/uv.lock
@@ -2122,7 +2122,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.690.7"
+version = "1.691.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2132,9 +2132,9 @@ dependencies = [
     { name = "tables" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/df/60548e64a5ccf5f961a45608c2c6744833daf756c1c82d1e59e5bca14850/policyengine_us-1.690.7.tar.gz", hash = "sha256:3dbb1f54824902fcd6ae64d5879f36ce6b2372a42321c838c20c430fd1507a2e", size = 9479020, upload-time = "2026-05-10T22:27:01.776Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/e4/5996e8b105ac43ed988af920473fae8fee8efa78ae9628a773cf2f54f592/policyengine_us-1.691.1.tar.gz", hash = "sha256:870b520af75640ea6bce63e4a55535349ff0c9df31d0e9de6ef74e68c12842a9", size = 9495134, upload-time = "2026-05-12T02:31:09.388Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/02/52109bae5f4767237b43bd72ce0bc4edf7925650a788053b2bc168caa5ae/policyengine_us-1.690.7-py3-none-any.whl", hash = "sha256:5a7a541efabac98fa069d6845902cf5924c81db67383234b55dcd2b8bfcfc3ca", size = 9985671, upload-time = "2026-05-10T22:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/55/df/c3a3f1402f3210d08c6ff7a0e049b4c8999dfd22c338b090ac23f5f78a03/policyengine_us-1.691.1-py3-none-any.whl", hash = "sha256:9231f360d91afc19bf052da4be9e0559946ce97c2940eac3602afa65a344efc3", size = 10019777, upload-time = "2026-05-12T02:31:05.581Z" },
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", specifier = ">=1.690.7" },
+    { name = "policyengine-us", specifier = ">=1.691.1" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },


### PR DESCRIPTION
## Summary
- raise the policyengine-us lower bound to 1.691.1
- refresh uv.lock so Modal data builds use policyengine-us 1.691.1 instead of the stale 1.690.7 lock

## Tests
- env -u UV_FROZEN uv lock --check
- env -u UV_FROZEN uv run ruff check pyproject.toml
- env -u UV_FROZEN uv run python - <<'PY'
import importlib.metadata as m
print('policyengine-us', m.version('policyengine-us'))
print('policyengine-core', m.version('policyengine-core'))
PY
- env -u UV_FROZEN uv run pytest tests/unit/test_extended_cps.py -q