### PR TITLE
Download geography prerequisites before remote calibration

### DIFF
--- a/changelog.d/modal-geo-prereqs.fixed
+++ b/changelog.d/modal-geo-prereqs.fixed
@@ -1,0 +1,1 @@
+Download generated block geography prerequisites before remote calibration package builds.

--- a/modal_app/remote_calibration_runner.py
+++ b/modal_app/remote_calibration_runner.py
@@ -62,6 +62,22 @@ def _setup_repo():
     os.chdir("/root/policyengine-us-data")
 
 
+def _ensure_geography_prerequisites() -> None:
+    """Download geography prerequisites excluded from the package wheel."""
+    from policyengine_us_data.storage.download_prerequisites import (
+        GEOGRAPHY_REPO,
+        PREREQUISITE_ARTIFACTS,
+        download_prerequisites,
+    )
+
+    geography_artifacts = tuple(
+        artifact
+        for artifact in PREREQUISITE_ARTIFACTS
+        if artifact.repo == GEOGRAPHY_REPO
+    )
+    download_prerequisites(geography_artifacts)
+
+
 def _append_hyperparams(cmd, beta, lambda_l0, lambda_l2, learning_rate, log_freq=None):
     """Append optional hyperparameter flags to a command list."""
     if beta is not None:
@@ -180,6 +196,7 @@ def _fit_weights_impl(
 ) -> dict:
     """Full pipeline: read data from pipeline volume, build matrix, fit."""
     _setup_repo()
+    _ensure_geography_prerequisites()
 
     pipeline_vol.reload()
     artifacts = artifacts_dir if artifacts_dir else f"{PIPELINE_MOUNT}/artifacts"
@@ -348,6 +365,7 @@ def _build_package_impl(
 ) -> str:
     """Read data from pipeline volume, build X matrix, save package."""
     _setup_repo()
+    _ensure_geography_prerequisites()
 
     pipeline_vol.reload()
     artifacts = f"{PIPELINE_MOUNT}/artifacts"

--- a/tests/unit/test_remote_calibration_runner.py
+++ b/tests/unit/test_remote_calibration_runner.py
@@ -88,6 +88,31 @@ def test_collect_outputs_returns_pipeline_artifact_bytes(tmp_path):
     }
 
 
+def test_ensure_geography_prerequisites_downloads_only_geography(monkeypatch):
+    remote_runner = _load_remote_calibration_runner_module()
+    from policyengine_us_data.storage import download_prerequisites as prereq_module
+
+    captured = {}
+
+    def fake_download_prerequisites(artifacts):
+        captured["artifacts"] = artifacts
+
+    monkeypatch.setattr(
+        prereq_module,
+        "download_prerequisites",
+        fake_download_prerequisites,
+    )
+
+    remote_runner._ensure_geography_prerequisites()
+
+    artifacts = captured["artifacts"]
+    assert {artifact.local_filename for artifact in artifacts} == {
+        "block_cd_distributions.csv.gz",
+        "block_crosswalk.csv.gz",
+    }
+    assert all(artifact.repo == prereq_module.GEOGRAPHY_REPO for artifact in artifacts)
+
+
 def test_fit_weights_impl_does_not_use_optimizer_checkpoint_artifacts(
     monkeypatch,
     tmp_path,
@@ -98,8 +123,14 @@ def test_fit_weights_impl_does_not_use_optimizer_checkpoint_artifacts(
     weights = tmp_path / "weights.npy"
 
     volume = SimpleNamespace(reload=Mock(), commit=Mock())
+    ensure_prereqs = Mock()
     monkeypatch.setattr(remote_runner, "pipeline_vol", volume)
     monkeypatch.setattr(remote_runner, "_setup_repo", lambda: None)
+    monkeypatch.setattr(
+        remote_runner,
+        "_ensure_geography_prerequisites",
+        ensure_prereqs,
+    )
 
     def fake_run_streaming(cmd, env=None, label=""):
         assert "--resume-from" not in cmd
@@ -117,6 +148,7 @@ def test_fit_weights_impl_does_not_use_optimizer_checkpoint_artifacts(
 
     assert result["weights"] == b"weights"
     assert "checkpoint" not in result
+    ensure_prereqs.assert_called_once()
     volume.reload.assert_called_once()
     volume.commit.assert_not_called()
 
@@ -132,9 +164,15 @@ def test_build_package_impl_sets_volume_chunk_dir_for_parallel_matrix(
     (artifacts_dir / "source_imputed_stratified_extended_cps.h5").write_bytes(b"h5")
 
     volume = SimpleNamespace(reload=Mock(), commit=Mock())
+    ensure_prereqs = Mock()
     monkeypatch.setattr(remote_runner, "PIPELINE_MOUNT", str(tmp_path))
     monkeypatch.setattr(remote_runner, "pipeline_vol", volume)
     monkeypatch.setattr(remote_runner, "_setup_repo", lambda: None)
+    monkeypatch.setattr(
+        remote_runner,
+        "_ensure_geography_prerequisites",
+        ensure_prereqs,
+    )
     monkeypatch.setattr(remote_runner, "_write_package_sidecar", lambda _: True)
     from policyengine_us_data.stage_contracts import calibration_package
 
@@ -205,5 +243,6 @@ def test_build_package_impl_sets_volume_chunk_dir_for_parallel_matrix(
     assert captured["contract_validation"]["db_path"] == (
         artifacts_dir / "policy_data.db"
     )
+    ensure_prereqs.assert_called_once()
     volume.reload.assert_called_once()
     volume.commit.assert_called_once()


### PR DESCRIPTION
## Summary
- download generated block geography prerequisites before remote calibration package and direct weight-fit jobs
- keep the download scoped to geography artifacts, not the private PUF prerequisites
- add unit coverage that the remote runner hydrates these files before building/fitting

## Tests
- uv run ruff format modal_app/remote_calibration_runner.py tests/unit/test_remote_calibration_runner.py
- uv run ruff check modal_app/remote_calibration_runner.py tests/unit/test_remote_calibration_runner.py
- uv run pytest tests/unit/test_remote_calibration_runner.py tests/unit/storage/test_download_prerequisites.py -q