### PR TITLE
Drop temporary CPS take-up anchors from H5 outputs

### DIFF
--- a/changelog.d/964.fixed
+++ b/changelog.d/964.fixed
@@ -1,0 +1,1 @@
+Remove temporary CPS take-up source anchors from persisted H5 outputs and add an enhanced-CPS-only data build path.

--- a/modal_app/data_build.py
+++ b/modal_app/data_build.py
@@ -117,6 +117,7 @@ SCRIPT_OUTPUTS = {
     # enhanced_cps.py produces both the dataset and calibration log
     "policyengine_us_data/datasets/cps/enhanced_cps.py": [
         "policyengine_us_data/storage/enhanced_cps_2024.h5",
+        "policyengine_us_data/storage/enhanced_cps_2024.clone_diagnostics.json",
         "calibration_log.csv",
     ],
     "policyengine_us_data/calibration/create_stratified_cps.py": (
@@ -317,12 +318,15 @@ def validate_and_maybe_upload_datasets(
     upload: bool,
     skip_enhanced_cps: bool,
     env: dict,
+    require_small_enhanced_cps: bool = True,
     stage_only: bool = False,
     run_id: str = "",
 ) -> None:
     validation_args = ["--validate-only"]
     if skip_enhanced_cps:
         validation_args.append("--no-require-enhanced-cps")
+    elif not require_small_enhanced_cps:
+        validation_args.append("--no-require-small-enhanced-cps")
 
     print("=== Validating built datasets ===")
     run_script(
@@ -335,6 +339,8 @@ def validate_and_maybe_upload_datasets(
         upload_args = []
         if skip_enhanced_cps:
             upload_args.append("--no-require-enhanced-cps")
+        elif not require_small_enhanced_cps:
+            upload_args.append("--no-require-small-enhanced-cps")
         if stage_only:
             upload_args.append("--stage-only")
         if run_id:
@@ -504,6 +510,7 @@ def write_dataset_build_contract(
     upload_requested: bool,
     stage_only: bool,
     skip_enhanced_cps: bool,
+    skip_stage_5: bool = False,
 ) -> StageContract:
     """Write the Stage 1 semantic handoff contract next to copied artifacts."""
     contract = build_dataset_build_output_contract(
@@ -518,6 +525,7 @@ def write_dataset_build_contract(
         upload_requested=upload_requested,
         stage_only=stage_only,
         skip_enhanced_cps=skip_enhanced_cps,
+        skip_stage_5=skip_stage_5,
     )
     write_contract(
         contract,
@@ -559,6 +567,7 @@ def build_datasets(
     clear_checkpoints: bool = False,
     skip_tests: bool = False,
     skip_enhanced_cps: bool = False,
+    skip_stage_5: bool = False,
     stage_only: bool = False,
     run_id: str = "",
 ):
@@ -572,6 +581,8 @@ def build_datasets(
         skip_tests: Skip running the test suite (useful for calibration runs).
         skip_enhanced_cps: Skip enhanced_cps.py and small_enhanced_cps.py
             (useful for calibration runs that only need source_imputed H5).
+        skip_stage_5: Skip source-imputed CPS and small enhanced CPS after
+            enhanced_cps_2024.h5 is built.
         stage_only: Upload to HF staging only, without promoting a release.
     """
     setup_gcp_credentials()
@@ -645,6 +656,12 @@ def build_datasets(
 
     if sequential:
         for script, output in SCRIPT_OUTPUTS.items():
+            if skip_stage_5 and script in (
+                "policyengine_us_data/calibration/create_source_imputed_cps.py",
+                "policyengine_us_data/datasets/cps/small_enhanced_cps.py",
+            ):
+                print(f"Skipping {script} (--skip-stage-5)")
+                continue
             if skip_enhanced_cps and script in (
                 "policyengine_us_data/datasets/cps/enhanced_cps.py",
                 "policyengine_us_data/datasets/cps/small_enhanced_cps.py",
@@ -761,33 +778,21 @@ def build_datasets(
         # GROUP 4: After Phase 4 - run in parallel
         # create_source_imputed_cps needs stratified_cps
         # small_enhanced_cps needs enhanced_cps
-        print(
-            "=== Phase 5: Building source imputed CPS "
-            "and small enhanced CPS (parallel) ==="
-        )
-        phase5_futures = []
-        with ThreadPoolExecutor(max_workers=2) as executor:
-            phase5_futures.append(
-                executor.submit(
-                    run_script_with_checkpoint,
-                    "policyengine_us_data/calibration/create_source_imputed_cps.py",
-                    SCRIPT_OUTPUTS[
-                        "policyengine_us_data/calibration/create_source_imputed_cps.py"
-                    ],
-                    branch,
-                    checkpoint_volume,
-                    env=env,
-                    log_file=log_file,
-                    checkpoint_stats=checkpoint_stats,
-                )
+        if skip_stage_5:
+            print("Skipping Phase 5 (--skip-stage-5)")
+        else:
+            print(
+                "=== Phase 5: Building source imputed CPS "
+                "and small enhanced CPS (parallel) ==="
             )
-            if not skip_enhanced_cps:
+            phase5_futures = []
+            with ThreadPoolExecutor(max_workers=2) as executor:
                 phase5_futures.append(
                     executor.submit(
                         run_script_with_checkpoint,
-                        "policyengine_us_data/datasets/cps/small_enhanced_cps.py",
+                        "policyengine_us_data/calibration/create_source_imputed_cps.py",
                         SCRIPT_OUTPUTS[
-                            "policyengine_us_data/datasets/cps/small_enhanced_cps.py"
+                            "policyengine_us_data/calibration/create_source_imputed_cps.py"
                         ],
                         branch,
                         checkpoint_volume,
@@ -796,10 +801,25 @@ def build_datasets(
                         checkpoint_stats=checkpoint_stats,
                     )
                 )
-            else:
-                print("Skipping small_enhanced_cps.py (--skip-enhanced-cps)")
-            for future in as_completed(phase5_futures):
-                future.result()
+                if not skip_enhanced_cps:
+                    phase5_futures.append(
+                        executor.submit(
+                            run_script_with_checkpoint,
+                            "policyengine_us_data/datasets/cps/small_enhanced_cps.py",
+                            SCRIPT_OUTPUTS[
+                                "policyengine_us_data/datasets/cps/small_enhanced_cps.py"
+                            ],
+                            branch,
+                            checkpoint_volume,
+                            env=env,
+                            log_file=log_file,
+                            checkpoint_stats=checkpoint_stats,
+                        )
+                    )
+                else:
+                    print("Skipping small_enhanced_cps.py (--skip-enhanced-cps)")
+                for future in as_completed(phase5_futures):
+                    future.result()
 
     # Checkpoint the build log so it survives preemption
     log_file.flush()
@@ -857,6 +877,7 @@ def build_datasets(
         upload_requested=upload,
         stage_only=stage_only,
         skip_enhanced_cps=skip_enhanced_cps,
+        skip_stage_5=skip_stage_5,
     )
     pipeline_volume.commit()
     print("Pipeline artifacts committed to shared volume")
@@ -871,6 +892,7 @@ def build_datasets(
     validate_and_maybe_upload_datasets(
         upload=upload,
         skip_enhanced_cps=skip_enhanced_cps,
+        require_small_enhanced_cps=not skip_stage_5,
         env=env,
         stage_only=stage_only,
         run_id=run_id,
@@ -890,6 +912,7 @@ def main(
     clear_checkpoints: bool = False,
     skip_tests: bool = False,
     skip_enhanced_cps: bool = False,
+    skip_stage_5: bool = False,
     stage_only: bool = False,
     run_id: str = "",
 ):
@@ -905,6 +928,7 @@ def main(
         clear_checkpoints=clear_checkpoints,
         skip_tests=skip_tests,
         skip_enhanced_cps=skip_enhanced_cps,
+        skip_stage_5=skip_stage_5,
         stage_only=stage_only,
         run_id=run_id,
     )

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -450,6 +450,16 @@ def add_rent(self, cps: h5py.File, person: DataFrame, household: DataFrame):
     cps["real_estate_taxes"][mask] = imputed_values["real_estate_taxes"]
 
 
+TEMPORARY_TAKEUP_SOURCE_ANCHORS = ("snap_reported", "ssi_reported")
+
+
+def _drop_persisted_dataset_variables(file_path, variable_names):
+    with h5py.File(file_path, "a") as dataset_file:
+        for variable_name in variable_names:
+            if variable_name in dataset_file:
+                del dataset_file[variable_name]
+
+
 @pipeline_node(
     PipelineNode(
         id="add_takeup",
@@ -636,10 +646,14 @@ def add_takeup(self):
         data["age"],
     )
 
-    for source_anchor in ("snap_reported", "ssi_reported"):
+    for source_anchor in TEMPORARY_TAKEUP_SOURCE_ANCHORS:
         data.pop(source_anchor, None)
 
     self.save_dataset(data)
+    _drop_persisted_dataset_variables(
+        self.file_path,
+        TEMPORARY_TAKEUP_SOURCE_ANCHORS,
+    )
 
 
 def add_marketplace_plan_benchmark_ratio(self):

--- a/policyengine_us_data/stage_contracts/dataset_build.py
+++ b/policyengine_us_data/stage_contracts/dataset_build.py
@@ -31,6 +31,7 @@ class _Stage1ArtifactSpec:
     required_for_stage_2: bool = False
     yearless_alias: bool = False
     skip_when_enhanced_cps_skipped: bool = False
+    skip_when_stage_5_skipped: bool = False
 
 
 _STAGE_1_ARTIFACTS: tuple[_Stage1ArtifactSpec, ...] = (
@@ -84,6 +85,7 @@ _STAGE_1_ARTIFACTS: tuple[_Stage1ArtifactSpec, ...] = (
         period=2024,
         substage_id="1d_enhanced_cps_reweighting",
         skip_when_enhanced_cps_skipped=True,
+        skip_when_stage_5_skipped=True,
     ),
     _Stage1ArtifactSpec(
         filename="stratified_extended_cps_2024.h5",
@@ -99,6 +101,7 @@ _STAGE_1_ARTIFACTS: tuple[_Stage1ArtifactSpec, ...] = (
         period=2024,
         substage_id="1f_source_imputation",
         required_for_stage_2=True,
+        skip_when_stage_5_skipped=True,
     ),
     _Stage1ArtifactSpec(
         filename="source_imputed_stratified_extended_cps.h5",
@@ -108,6 +111,7 @@ _STAGE_1_ARTIFACTS: tuple[_Stage1ArtifactSpec, ...] = (
         substage_id="1f_source_imputation",
         required_for_stage_2=True,
         yearless_alias=True,
+        skip_when_stage_5_skipped=True,
     ),
     _Stage1ArtifactSpec(
         filename="policy_data.db",
@@ -154,6 +158,7 @@ def build_dataset_build_output_contract(
     upload_requested: bool = False,
     stage_only: bool = False,
     skip_enhanced_cps: bool = False,
+    skip_stage_5: bool = False,
 ) -> StageContract:
     """Build the Stage 1 handoff contract from copied pipeline artifacts."""
 
@@ -161,12 +166,14 @@ def build_dataset_build_output_contract(
     parameters = {
         "period": 2024,
         "skip_enhanced_cps": skip_enhanced_cps,
+        "skip_stage_5": skip_stage_5,
         "stage_only": stage_only,
         "upload_requested": upload_requested,
     }
     outputs = _stage_1_outputs(
         artifacts_dir=artifacts_dir,
         skip_enhanced_cps=skip_enhanced_cps,
+        skip_stage_5=skip_stage_5,
     )
     execution = _execution_record(
         checkpoint_stats=checkpoint_stats,
@@ -193,6 +200,7 @@ def build_dataset_build_output_contract(
         substages=_stage_1_substages(
             outputs=outputs,
             skip_enhanced_cps=skip_enhanced_cps,
+            skip_stage_5=skip_stage_5,
         ),
         execution=execution,
         metadata={
@@ -207,11 +215,14 @@ def _stage_1_outputs(
     *,
     artifacts_dir: Path,
     skip_enhanced_cps: bool,
+    skip_stage_5: bool,
 ) -> tuple[ArtifactRef, ...]:
     outputs: list[ArtifactRef] = []
     missing_required: list[str] = []
     for spec in _STAGE_1_ARTIFACTS:
         if skip_enhanced_cps and spec.skip_when_enhanced_cps_skipped:
+            continue
+        if skip_stage_5 and spec.skip_when_stage_5_skipped:
             continue
         artifact_path = artifacts_dir / spec.filename
         if not artifact_path.exists():
@@ -276,6 +287,7 @@ def _stage_1_substages(
     *,
     outputs: tuple[ArtifactRef, ...],
     skip_enhanced_cps: bool,
+    skip_stage_5: bool,
 ) -> tuple[SubstageRecord, ...]:
     output_by_substage: dict[str, list[ArtifactRef]] = {
         substage_id: [] for substage_id in _SUBSTAGE_IDS
@@ -289,6 +301,8 @@ def _stage_1_substages(
     for substage_id in _SUBSTAGE_IDS:
         status = "completed"
         if substage_id == "1d_enhanced_cps_reweighting" and skip_enhanced_cps:
+            status = "skipped"
+        if substage_id == "1f_source_imputation" and skip_stage_5:
             status = "skipped"
         reuse_mode = "checkpointable"
         if substage_id in {

--- a/policyengine_us_data/storage/upload_completed_datasets.py
+++ b/policyengine_us_data/storage/upload_completed_datasets.py
@@ -53,6 +53,22 @@ REQUIRED_GROUPS = [
     "household_weight",
 ]
 
+PROHIBITED_DATASET_VARIABLES = {
+    "social_security_retirement_reported",
+    "snap_reported",
+    "ssi_reported",
+    "tanf_reported",
+    "wic_reported",
+    "free_school_meals_reported",
+    "reduced_price_school_meals_reported",
+    "spm_unit_wic_reported",
+    "spm_unit_broadband_subsidy",
+    "spm_unit_broadband_subsidy_reported",
+    "spm_unit_payroll_tax_reported",
+    "spm_unit_federal_tax_reported",
+    "spm_unit_state_tax_reported",
+}
+
 # At least one of these income groups must exist with data.
 INCOME_GROUPS = [
     "employment_income_before_lsr",
@@ -88,8 +104,9 @@ class DatasetValidationError(Exception):
 
 def _dataset_upload_specs(
     require_enhanced_cps: bool = True,
+    require_small_enhanced_cps: bool = True,
 ) -> list[tuple[Path, str, bool]]:
-    return [
+    specs = [
         (CPS_2024.file_path, CPS_2024.file_path.name, True),
         (
             STORAGE_FOLDER / "calibration" / "policy_data.db",
@@ -106,27 +123,37 @@ def _dataset_upload_specs(
             clone_diagnostics_path(EnhancedCPS_2024.file_path).name,
             require_enhanced_cps,
         ),
-        (
-            STORAGE_FOLDER / "small_enhanced_cps_2024.h5",
-            "small_enhanced_cps_2024.h5",
-            require_enhanced_cps,
-        ),
     ]
+    if require_small_enhanced_cps:
+        specs.append(
+            (
+                STORAGE_FOLDER / "small_enhanced_cps_2024.h5",
+                "small_enhanced_cps_2024.h5",
+                require_enhanced_cps,
+            )
+        )
+    return specs
 
 
-def _enhanced_dataset_files() -> list[Path]:
-    return [
+def _enhanced_dataset_files(require_small_enhanced_cps: bool = True) -> list[Path]:
+    files = [
         EnhancedCPS_2024.file_path,
         clone_diagnostics_path(EnhancedCPS_2024.file_path),
-        STORAGE_FOLDER / "small_enhanced_cps_2024.h5",
     ]
+    if require_small_enhanced_cps:
+        files.append(STORAGE_FOLDER / "small_enhanced_cps_2024.h5")
+    return files
 
 
 def _collect_existing_dataset_artifacts(
     require_enhanced_cps: bool = True,
+    require_small_enhanced_cps: bool = True,
 ) -> list[tuple[Path, str]]:
     existing_files = []
-    for file_path, repo_path, required in _dataset_upload_specs(require_enhanced_cps):
+    for file_path, repo_path, required in _dataset_upload_specs(
+        require_enhanced_cps,
+        require_small_enhanced_cps,
+    ):
         if file_path.exists():
             existing_files.append((file_path, repo_path))
             print(f"✓ Found{' (optional)' if not required else ''}: {file_path}")
@@ -143,6 +170,7 @@ def _collect_existing_dataset_artifacts(
 
 def _collect_staged_dataset_repo_paths(
     require_enhanced_cps: bool = True,
+    require_small_enhanced_cps: bool = True,
     run_id: str = "",
 ) -> list[str]:
     api = HfApi()
@@ -157,7 +185,10 @@ def _collect_staged_dataset_repo_paths(
 
     rel_paths = []
     missing_required = []
-    for _, repo_path, required in _dataset_upload_specs(require_enhanced_cps):
+    for _, repo_path, required in _dataset_upload_specs(
+        require_enhanced_cps,
+        require_small_enhanced_cps,
+    ):
         staged_path = f"{prefix}/{repo_path}"
         if staged_path in repo_files:
             rel_paths.append(repo_path)
@@ -250,6 +281,15 @@ def validate_dataset(file_path: Path) -> None:
 
     try:
         with h5py.File(file_path, "r") as f:
+            prohibited_variables = sorted(
+                PROHIBITED_DATASET_VARIABLES.intersection(f.keys())
+            )
+            if prohibited_variables:
+                errors.append(
+                    "Dataset contains temporary or retired variables: "
+                    + ", ".join(prohibited_variables)
+                )
+
             for group_name in REQUIRED_GROUPS:
                 if not _check_group_has_data(f, group_name):
                     errors.append(
@@ -410,13 +450,15 @@ def _clone_diagnostics_errors(diagnostics, *, context: str) -> list[str]:
 
 def stage_datasets(
     require_enhanced_cps: bool = True,
+    require_small_enhanced_cps: bool = True,
     version: str | None = None,
     run_id: str = "",
 ) -> list[tuple[Path, str]]:
     run_id = _resolve_run_id(run_id)
     version = version or DATA_PACKAGE_VERSION
     files_with_repo_paths = _collect_existing_dataset_artifacts(
-        require_enhanced_cps=require_enhanced_cps
+        require_enhanced_cps=require_enhanced_cps,
+        require_small_enhanced_cps=require_small_enhanced_cps,
     )
     _validate_dataset_artifacts(files_with_repo_paths)
 
@@ -433,6 +475,7 @@ def stage_datasets(
 
 def promote_datasets(
     require_enhanced_cps: bool = True,
+    require_small_enhanced_cps: bool = True,
     version: str | None = None,
     run_id: str = "",
     files_with_repo_paths: list[tuple[Path, str]] | None = None,
@@ -445,6 +488,7 @@ def promote_datasets(
         if files_with_repo_paths
         else _collect_staged_dataset_repo_paths(
             require_enhanced_cps=require_enhanced_cps,
+            require_small_enhanced_cps=require_small_enhanced_cps,
             run_id=run_id,
         )
     )
@@ -524,6 +568,7 @@ def promote_datasets(
 
 def upload_datasets(
     require_enhanced_cps: bool = True,
+    require_small_enhanced_cps: bool = True,
     *,
     stage_only: bool = False,
     promote_only: bool = False,
@@ -540,6 +585,7 @@ def upload_datasets(
     if promote_only:
         return promote_datasets(
             require_enhanced_cps=require_enhanced_cps,
+            require_small_enhanced_cps=require_small_enhanced_cps,
             version=version,
             run_id=run_id,
             cleanup_staging=cleanup_staging,
@@ -547,6 +593,7 @@ def upload_datasets(
 
     files_with_repo_paths = stage_datasets(
         require_enhanced_cps=require_enhanced_cps,
+        require_small_enhanced_cps=require_small_enhanced_cps,
         version=version,
         run_id=run_id,
     )
@@ -555,6 +602,7 @@ def upload_datasets(
 
     return promote_datasets(
         require_enhanced_cps=require_enhanced_cps,
+        require_small_enhanced_cps=require_small_enhanced_cps,
         version=version,
         run_id=run_id,
         files_with_repo_paths=files_with_repo_paths,
@@ -567,10 +615,13 @@ def validate_all_datasets():
     validate_built_datasets(require_enhanced_cps=True)
 
 
-def validate_built_datasets(require_enhanced_cps: bool = True):
+def validate_built_datasets(
+    require_enhanced_cps: bool = True,
+    require_small_enhanced_cps: bool = True,
+):
     required_files = [CPS_2024.file_path]
     if require_enhanced_cps:
-        required_files.extend(_enhanced_dataset_files())
+        required_files.extend(_enhanced_dataset_files(require_small_enhanced_cps))
 
     for file_path in required_files:
         if not file_path.exists():
@@ -587,6 +638,11 @@ if __name__ == "__main__":
         "--no-require-enhanced-cps",
         action="store_true",
         help="Treat enhanced_cps and small_enhanced_cps as optional.",
+    )
+    parser.add_argument(
+        "--no-require-small-enhanced-cps",
+        action="store_true",
+        help="Treat small_enhanced_cps as optional while still requiring enhanced_cps.",
     )
     parser.add_argument(
         "--validate-only",
@@ -615,11 +671,19 @@ if __name__ == "__main__":
         help="Override the policyengine-us-data version used for staging/promote.",
     )
     args = parser.parse_args()
+    require_enhanced_cps = not args.no_require_enhanced_cps
+    require_small_enhanced_cps = (
+        require_enhanced_cps and not args.no_require_small_enhanced_cps
+    )
     if args.validate_only:
-        validate_built_datasets(require_enhanced_cps=not args.no_require_enhanced_cps)
+        validate_built_datasets(
+            require_enhanced_cps=require_enhanced_cps,
+            require_small_enhanced_cps=require_small_enhanced_cps,
+        )
     else:
         upload_datasets(
-            require_enhanced_cps=not args.no_require_enhanced_cps,
+            require_enhanced_cps=require_enhanced_cps,
+            require_small_enhanced_cps=require_small_enhanced_cps,
             stage_only=args.stage_only,
             promote_only=args.promote_only,
             run_id=args.run_id,

--- a/tests/integration/test_cps_generation.py
+++ b/tests/integration/test_cps_generation.py
@@ -3,6 +3,134 @@ import numpy as np
 import pandas as pd
 
 
+def test_drop_persisted_dataset_variables_removes_stale_h5_keys(tmp_path):
+    from policyengine_us_data.datasets.cps.cps import (
+        _drop_persisted_dataset_variables,
+    )
+
+    file_path = tmp_path / "cps_2024.h5"
+    with h5py.File(file_path, "w") as h5_file:
+        h5_file.create_dataset("snap_reported", data=np.array([1_200.0]))
+        h5_file.create_dataset("ssi_reported", data=np.array([600.0]))
+        h5_file.create_dataset("social_security_retirement", data=np.array([8_000.0]))
+
+    _drop_persisted_dataset_variables(
+        file_path,
+        ("snap_reported", "ssi_reported"),
+    )
+
+    with h5py.File(file_path, "r") as h5_file:
+        assert "snap_reported" not in h5_file
+        assert "ssi_reported" not in h5_file
+        assert h5_file["social_security_retirement"][:].tolist() == [8_000.0]
+
+
+def test_add_takeup_removes_temporary_source_anchors_from_saved_h5(
+    monkeypatch,
+    tmp_path,
+):
+    import policyengine_us
+    import policyengine_us_data.datasets.cps.cps as cps_module
+    import policyengine_us_data.db.etl_pregnancy as etl_pregnancy
+    from policyengine_us_data.datasets.cps.cps import add_takeup
+
+    class FakeResult:
+        def __init__(self, values):
+            self.values = np.asarray(values)
+
+    class FakeMicrosimulation:
+        def __init__(self, dataset):
+            self.dataset = dataset
+
+        def calculate(self, variable_name):
+            values_by_variable = {
+                "eitc_child_count": [0],
+                "eitc": [0],
+                "state_code_str": ["CA"],
+                "wic_category_str": ["NONE", "NONE"],
+                "receives_wic": [False, False],
+                "tax_unit_child_dependents": [0],
+                "age_head": [40],
+            }
+            return FakeResult(values_by_variable[variable_name])
+
+    class FakeDataset:
+        def __init__(self, file_path):
+            self.file_path = file_path
+            self.time_period = 2024
+            self.data = {
+                "person_id": np.array([1, 2], dtype=np.int32),
+                "tax_unit_id": np.array([10], dtype=np.int32),
+                "spm_unit_id": np.array([100], dtype=np.int32),
+                "household_id": np.array([1_000], dtype=np.int32),
+                "person_tax_unit_id": np.array([10, 10], dtype=np.int32),
+                "person_household_id": np.array([1_000, 1_000], dtype=np.int32),
+                "snap_reported": np.array([1_200.0], dtype=np.float32),
+                "ssi_reported": np.array([600.0, 0.0], dtype=np.float32),
+                "reported_has_subsidized_marketplace_health_coverage_at_interview": np.array(
+                    [False, False]
+                ),
+                "has_medicaid_health_coverage_at_interview": np.array([False, False]),
+                "employment_income": np.array([20_000.0, 0.0], dtype=np.float32),
+                "age": np.array([40, 66], dtype=np.int32),
+                "is_female": np.array([True, False]),
+                "is_disabled": np.array([False, False]),
+            }
+
+        def load_dataset(self):
+            return {name: values.copy() for name, values in self.data.items()}
+
+        def save_dataset(self, data):
+            with h5py.File(self.file_path, "a") as h5_file:
+                for name, values in data.items():
+                    if name in h5_file:
+                        del h5_file[name]
+                    h5_file.create_dataset(name, data=values)
+
+    voluntary_filing_rates = {
+        children: {
+            wage: {"under_65": 0.0, "age_65_plus": 0.0}
+            for wage in ("zero", "low", "medium", "high")
+        }
+        for children in ("with_children", "no_children")
+    }
+    rates = {
+        "eitc": {0: 0.0},
+        "dc_ptc": 0.0,
+        "snap": 1.0,
+        "aca": 0.0,
+        "medicaid": {"CA": 0.0},
+        "head_start": 0.0,
+        "early_head_start": 0.0,
+        "ssi": 1.0,
+        "voluntary_filing": voluntary_filing_rates,
+        "tanf": 0.0,
+        "wic_takeup": {"NONE": 0.0},
+        "wic_nutritional_risk": {"NONE": 0.0},
+    }
+
+    monkeypatch.setattr(policyengine_us, "Microsimulation", FakeMicrosimulation)
+    monkeypatch.setattr(cps_module, "load_take_up_rate", lambda name, year: rates[name])
+    monkeypatch.setattr(
+        etl_pregnancy,
+        "get_state_pregnancy_rates",
+        lambda cdc_year, acs_year: {"CA": 0.0},
+    )
+
+    file_path = tmp_path / "cps_2024.h5"
+    with h5py.File(file_path, "w") as h5_file:
+        h5_file.create_dataset("snap_reported", data=np.array([1_200.0]))
+        h5_file.create_dataset("ssi_reported", data=np.array([600.0, 0.0]))
+
+    add_takeup(FakeDataset(file_path))
+
+    with h5py.File(file_path, "r") as h5_file:
+        assert "snap_reported" not in h5_file
+        assert "ssi_reported" not in h5_file
+        assert "takes_up_snap_if_eligible" in h5_file
+        assert "takes_up_ssi_if_eligible" in h5_file
+
+
 def test_add_tips_derives_tipped_status_from_raw_cps(monkeypatch):
     import policyengine_us_data.datasets.sipp as sipp_module
     from policyengine_us_data.datasets.cps.cps import add_tips

--- a/tests/unit/test_dataset_build_stage_contract.py
+++ b/tests/unit/test_dataset_build_stage_contract.py
@@ -31,12 +31,19 @@ def _write_artifacts(
     artifacts_dir: Path,
     *,
     include_enhanced_cps: bool = True,
+    include_stage_5: bool = True,
 ) -> None:
     artifacts_dir.mkdir(exist_ok=True)
     for filename, payload in _ARTIFACT_BYTES.items():
         if not include_enhanced_cps and filename in {
             "enhanced_cps_2024.h5",
             "small_enhanced_cps_2024.h5",
+        }:
+            continue
+        if not include_stage_5 and filename in {
+            "small_enhanced_cps_2024.h5",
+            "source_imputed_stratified_extended_cps_2024.h5",
+            "source_imputed_stratified_extended_cps.h5",
         }:
             continue
         (artifacts_dir / filename).write_bytes(payload)
@@ -47,6 +54,7 @@ def _contract(
     *,
     run_id: str = "run-a",
     skip_enhanced_cps: bool = False,
+    skip_stage_5: bool = False,
 ) -> StageContract:
     return build_dataset_build_output_contract(
         artifacts_dir=artifacts_dir,
@@ -65,6 +73,7 @@ def _contract(
         upload_requested=True,
         stage_only=False,
         skip_enhanced_cps=skip_enhanced_cps,
+        skip_stage_5=skip_stage_5,
     )
 
 
@@ -121,6 +130,22 @@ def test_dataset_build_contract_omits_enhanced_cps_when_skipped(tmp_path):
     records = {record.substage_id: record for record in contract.substages}
     assert records["1d_enhanced_cps_reweighting"].status == "skipped"
     assert records["1d_enhanced_cps_reweighting"].outputs == ()
+
+
+def test_dataset_build_contract_omits_phase_5_artifacts_when_skipped(tmp_path):
+    _write_artifacts(tmp_path, include_stage_5=False)
+
+    contract = _contract(tmp_path, skip_stage_5=True)
+
+    logical_names = {artifact.logical_name for artifact in contract.outputs}
+    assert "enhanced_cps_2024" in logical_names
+    assert "small_enhanced_cps_2024" not in logical_names
+    assert "source_imputed_stratified_extended_cps_2024" not in logical_names
+    assert "source_imputed_stratified_extended_cps" not in logical_names
+    assert contract.parameters["skip_stage_5"] is True
+    records = {record.substage_id: record for record in contract.substages}
+    assert records["1d_enhanced_cps_reweighting"].status == "completed"
+    assert records["1f_source_imputation"].status == "skipped"
 
 
 def test_dataset_build_contract_rejects_missing_required_stage_1_artifact(tmp_path):

--- a/tests/unit/test_modal_data_build.py
+++ b/tests/unit/test_modal_data_build.py
@@ -151,6 +151,45 @@ def test_validate_and_maybe_upload_datasets_stages_with_run_id(monkeypatch):
     ]
 
 
+def test_validate_and_maybe_upload_datasets_can_skip_small_enhanced_cps(
+    monkeypatch,
+):
+    data_build = _load_data_build_module()
+    calls = []
+
+    def fake_run_script(script_path, args=None, env=None, log_file=None):
+        calls.append((script_path, args or [], env))
+        return script_path
+
+    monkeypatch.setattr(data_build, "run_script", fake_run_script)
+
+    data_build.validate_and_maybe_upload_datasets(
+        upload=True,
+        skip_enhanced_cps=False,
+        require_small_enhanced_cps=False,
+        env={"TEST_ENV": "1"},
+        stage_only=True,
+        run_id="ecps-only",
+    )
+
+    assert calls == [
+        (
+            "policyengine_us_data/storage/upload_completed_datasets.py",
+            ["--validate-only", "--no-require-small-enhanced-cps"],
+            {"TEST_ENV": "1"},
+        ),
+        (
+            "policyengine_us_data/storage/upload_completed_datasets.py",
+            [
+                "--no-require-small-enhanced-cps",
+                "--stage-only",
+                "--run-id=ecps-only",
+            ],
+            {"TEST_ENV": "1"},
+        ),
+    ]
+
+
 def test_run_cps_then_puf_phase_uses_sequential_checkpointed_builds(
     monkeypatch,
 ):

--- a/tests/unit/test_upload_completed_datasets.py
+++ b/tests/unit/test_upload_completed_datasets.py
@@ -172,6 +172,35 @@ def test_validate_dataset_infers_time_period_for_flat_h5(tmp_path, monkeypatch):
     assert _TimePeriodCheckingAggregateMicrosimulation.last_dataset.time_period == 2024
 
 
+def test_validate_dataset_rejects_temporary_reported_source_variables(
+    tmp_path,
+    monkeypatch,
+):
+    file_path = tmp_path / "cps_2024.h5"
+    _write_h5(
+        file_path,
+        {
+            "person_id": np.array([101], dtype=np.int32),
+            "household_id": np.array([201], dtype=np.int32),
+            "employment_income": np.array([50_000.0], dtype=np.float32),
+            "household_weight": np.array([1.0], dtype=np.float32),
+            "snap_reported": np.array([1_200.0], dtype=np.float32),
+            "ssi_reported": np.array([600.0], dtype=np.float32),
+        },
+    )
+
+    monkeypatch.setattr(
+        "policyengine_us.Microsimulation",
+        _TimePeriodCheckingAggregateMicrosimulation,
+    )
+
+    with pytest.raises(
+        DatasetValidationError,
+        match="temporary or retired variables: snap_reported, ssi_reported",
+    ):
+        validate_dataset(file_path)
+
+
 def _prepare_release_files(tmp_path, monkeypatch):
     cps_path = tmp_path / "cps_2024.h5"
     cps_path.write_bytes(b"cps")
@@ -355,6 +384,39 @@ def test_upload_datasets_stage_only_skips_promote(tmp_path, monkeypatch):
         }
     ]
     assert promote_calls == []
+
+
+def test_upload_datasets_can_stage_enhanced_cps_without_small(
+    tmp_path,
+    monkeypatch,
+):
+    _prepare_release_files(tmp_path, monkeypatch)
+    staged_files = []
+
+    monkeypatch.setattr(upload_module, "validate_dataset", lambda file_path: None)
+    monkeypatch.setattr(upload_module, "DATA_PACKAGE_VERSION", "1.73.0")
+    monkeypatch.setattr(
+        upload_module,
+        "upload_to_staging_hf",
+        lambda files_with_paths, **kwargs: staged_files.append(
+            ([(Path(path), repo_path) for path, repo_path in files_with_paths], kwargs)
+        ),
+    )
+
+    upload_datasets(
+        require_small_enhanced_cps=False,
+        stage_only=True,
+        run_id="ecps-only",
+        version="1.73.0",
+    )
+
+    assert [repo_path for _, repo_path in staged_files[0][0]] == [
+        "cps_2024.h5",
+        "policy_data.db",
+        "enhanced_cps_2024.h5",
+        "enhanced_cps_2024.clone_diagnostics.json",
+    ]
+    assert staged_files[0][1]["run_id"] == "ecps-only"
 
 
 def test_upload_datasets_promote_only_uses_staged_artifacts(tmp_path, monkeypatch):
@@ -611,3 +673,43 @@ def test_validate_built_datasets_requires_clone_diagnostics_sidecar(
 
     with pytest.raises(FileNotFoundError, match="clone_diagnostics"):
         validate_built_datasets(require_enhanced_cps=True)
+
+
+def test_validate_built_datasets_can_skip_small_enhanced_cps(tmp_path, monkeypatch):
+    storage_folder = tmp_path / "storage"
+    cps_path = storage_folder / "cps_2024.h5"
+    enhanced_path = storage_folder / "enhanced_cps_2024.h5"
+    diagnostics_path = enhanced_path.with_suffix(".clone_diagnostics.json")
+
+    storage_folder.mkdir(parents=True)
+    for path in [cps_path, enhanced_path, diagnostics_path]:
+        path.write_text("placeholder")
+
+    monkeypatch.setattr(
+        upload_module,
+        "CPS_2024",
+        SimpleNamespace(file_path=cps_path),
+    )
+    monkeypatch.setattr(
+        upload_module,
+        "EnhancedCPS_2024",
+        SimpleNamespace(file_path=enhanced_path),
+    )
+    monkeypatch.setattr(upload_module, "STORAGE_FOLDER", storage_folder)
+    validated = []
+    monkeypatch.setattr(
+        upload_module,
+        "validate_dataset",
+        lambda file_path: validated.append(Path(file_path).name),
+    )
+
+    validate_built_datasets(
+        require_enhanced_cps=True,
+        require_small_enhanced_cps=False,
+    )
+
+    assert validated == [
+        "cps_2024.h5",
+        "enhanced_cps_2024.h5",
+        "enhanced_cps_2024.clone_diagnostics.json",
+    ]


### PR DESCRIPTION
## Summary
- delete temporary SNAP/SSI take-up source anchors from persisted CPS H5 outputs after append-style saves
- reject temporary or retired reported/source variables during dataset upload validation
- add an eCPS-only data-build path that can skip source-imputed CPS and small enhanced CPS when only enhanced_cps_2024.h5 is needed
- checkpoint enhanced_cps clone diagnostics alongside the H5 so eCPS-only runs can validate and stage the sidecar
- record skipped Phase 5 in the Stage 1 contract and exclude stale small enhanced CPS artifacts from eCPS-only upload/promote

## Where this broke
The prior production data run was [Run Pipeline 25751771946](https://github.com/PolicyEngine/policyengine-us-data/actions/runs/25751771946), for commit `d4871933` / version `1.112.3`. That GitHub job completed because it only launched the Modal pipeline, but the Modal eCPS checkpoint from that run contained the temporary source anchors `snap_reported` and `ssi_reported`.

With this PR's validator, that checkpointed H5 fails before upload:

```text
Validation failed for enhanced_cps_2024.h5:
  - Dataset contains temporary or retired variables: snap_reported, ssi_reported
```

The root cause is that `Dataset.save_dataset` appends/overwrites H5 keys but does not delete keys that were popped from the in-memory dict.

## Tests
- `uv run ruff format policyengine_us_data/datasets/cps/cps.py policyengine_us_data/storage/upload_completed_datasets.py policyengine_us_data/stage_contracts/dataset_build.py modal_app/data_build.py tests/integration/test_cps_generation.py tests/unit/test_upload_completed_datasets.py tests/unit/test_modal_data_build.py tests/unit/test_dataset_build_stage_contract.py`
- `uv run ruff check policyengine_us_data/datasets/cps/cps.py policyengine_us_data/storage/upload_completed_datasets.py policyengine_us_data/stage_contracts/dataset_build.py modal_app/data_build.py tests/integration/test_cps_generation.py tests/unit/test_upload_completed_datasets.py tests/unit/test_modal_data_build.py tests/unit/test_dataset_build_stage_contract.py`
- `uv run pytest tests/integration/test_cps_generation.py::test_add_takeup_removes_temporary_source_anchors_from_saved_h5 tests/integration/test_cps_generation.py::test_drop_persisted_dataset_variables_removes_stale_h5_keys tests/unit/test_upload_completed_datasets.py::test_validate_dataset_rejects_temporary_reported_source_variables -q`
- `uv run pytest tests/unit/test_dataset_build_stage_contract.py tests/unit/test_modal_data_build.py tests/unit/test_upload_completed_datasets.py tests/integration/test_cps_generation.py tests/unit/datasets/test_cps_takeup.py -q`
