### PR TITLE
Extract local H5 selection and cloning seams

### DIFF
--- a/changelog.d/965.added
+++ b/changelog.d/965.added
@@ -1,0 +1,1 @@
+Extract local H5 clone selection, entity reindexing, and variable cloning into dedicated build-output seams.

--- a/policyengine_us_data/build_outputs/__init__.py
+++ b/policyengine_us_data/build_outputs/__init__.py
@@ -5,6 +5,6 @@ seams rather than speculative placeholders. The current early slices support
 H5 output request construction, exact calibration geography loading,
 fingerprinting, clone-weight shape contracts, worker partitioning, source
 dataset snapshot contracts, worker input normalization, worker-bootstrap
-artifacts, worker-scoped session and validation context setup, clone selection,
-entity reindexing, and source-variable cloning.
+artifacts, worker-scoped session and validation context setup, microsimulation
+access helpers, clone selection, entity reindexing, and source-variable cloning.
 """

--- a/policyengine_us_data/build_outputs/__init__.py
+++ b/policyengine_us_data/build_outputs/__init__.py
@@ -5,5 +5,6 @@ seams rather than speculative placeholders. The current early slices support
 H5 output request construction, exact calibration geography loading,
 fingerprinting, clone-weight shape contracts, worker partitioning, source
 dataset snapshot contracts, worker input normalization, worker-bootstrap
-artifacts, and worker-scoped session and validation context setup.
+artifacts, worker-scoped session and validation context setup, clone selection,
+entity reindexing, and source-variable cloning.
 """

--- a/policyengine_us_data/build_outputs/fingerprinting.py
+++ b/policyengine_us_data/build_outputs/fingerprinting.py
@@ -11,6 +11,7 @@ from typing import Any, Literal, Mapping
 from policyengine_us_data.pipeline_metadata import pipeline_node
 
 from .geography_loader import CalibrationGeographyLoader
+from .simulation_access import calculate_variable_values
 
 FingerprintScope = Literal["regional", "national"]
 ScopeFingerprint = str
@@ -409,4 +410,9 @@ class FingerprintingService:
         from policyengine_us import Microsimulation
 
         simulation = Microsimulation(dataset=str(source_dataset_path))
-        return int(len(simulation.calculate("household_id", map_to="household").values))
+        household_ids = calculate_variable_values(
+            simulation,
+            "household_id",
+            map_to="household",
+        )
+        return int(len(household_ids))

--- a/policyengine_us_data/build_outputs/reindexing.py
+++ b/policyengine_us_data/build_outputs/reindexing.py
@@ -12,7 +12,7 @@ from numpy.typing import ArrayLike
 from policyengine_us_data.pipeline_metadata import pipeline_node
 
 from .selection import CloneSelection
-from .source_dataset import SourceDatasetSnapshot
+from .source_dataset import EntityGraph, SourceDatasetSnapshot
 
 __all__ = ["EntityReindexer", "ReindexedEntities"]
 
@@ -54,82 +54,58 @@ class EntityReindexer:
         household_source_indices = selection.source_household_indices
         n_household_clones = selection.n_selected_clones
 
-        person_counts = np.array(
-            [
-                len(graph.household_to_person_indices.get(int(household_index), ()))
-                for household_index in household_source_indices
-            ],
-            dtype=np.int64,
+        household_ids = _create_household_ids(n_household_clones)
+        person_reindexing = _build_person_reindexing(
+            graph=graph,
+            household_source_indices=household_source_indices,
+            household_ids=household_ids,
         )
-        person_source_indices = _concatenate_membership(
-            graph.household_to_person_indices,
-            household_source_indices,
+        subentity_reindexing = _build_subentity_reindexing(
+            graph=graph,
+            household_source_indices=household_source_indices,
+            person_source_indices=person_reindexing.source_indices,
+            person_household_clone_indices=(
+                person_reindexing.person_household_clone_indices
+            ),
+            n_household_clones=n_household_clones,
         )
-
-        subentity_source_indices: dict[str, np.ndarray] = {}
-        subentity_counts: dict[str, np.ndarray] = {}
-        for entity_key, membership in graph.household_to_subentity_indices.items():
-            subentity_counts[entity_key] = np.array(
-                [
-                    len(membership.get(int(household_index), ()))
-                    for household_index in household_source_indices
-                ],
-                dtype=np.int64,
-            )
-            subentity_source_indices[entity_key] = _concatenate_membership(
-                membership,
-                household_source_indices,
-            )
-
-        household_ids = np.arange(n_household_clones, dtype=np.int32)
-        person_ids = np.arange(len(person_source_indices), dtype=np.int32)
-        person_household_ids = np.repeat(household_ids, person_counts).astype(np.int32)
-        person_household_clone_indices = np.repeat(
-            np.arange(n_household_clones, dtype=np.int64),
-            person_counts,
-        )
-
-        subentity_ids: dict[str, np.ndarray] = {}
-        person_subentity_ids: dict[str, np.ndarray] = {}
-        subentity_household_clone_indices: dict[str, np.ndarray] = {}
-
-        for entity_key, entity_source_indices in subentity_source_indices.items():
-            entity_counts = subentity_counts[entity_key]
-            subentity_ids[entity_key] = np.arange(
-                len(entity_source_indices),
-                dtype=np.int32,
-            )
-            subentity_household_clone_indices[entity_key] = np.repeat(
-                np.arange(n_household_clones, dtype=np.int64),
-                entity_counts,
-            )
-            person_subentity_ids[entity_key] = _reindex_person_subentity_ids(
-                entity_key=entity_key,
-                graph_subentity_ids=graph.subentity_ids[entity_key],
-                graph_person_subentity_ids=graph.person_subentity_ids[entity_key],
-                person_source_indices=person_source_indices,
-                entity_source_indices=entity_source_indices,
-                new_entity_ids=subentity_ids[entity_key],
-                person_household_clone_indices=person_household_clone_indices,
-                entity_household_clone_indices=subentity_household_clone_indices[
-                    entity_key
-                ],
-            )
 
         return ReindexedEntities(
             household_ids=household_ids,
-            person_ids=person_ids,
-            person_household_ids=person_household_ids,
-            subentity_ids=subentity_ids,
-            person_subentity_ids=person_subentity_ids,
+            person_ids=person_reindexing.ids,
+            person_household_ids=person_reindexing.person_household_ids,
+            subentity_ids=subentity_reindexing.ids,
+            person_subentity_ids=subentity_reindexing.person_subentity_ids,
             household_source_indices=household_source_indices,
-            person_source_indices=person_source_indices,
-            subentity_source_indices=subentity_source_indices,
-            persons_per_household_clone=person_counts,
-            subentities_per_household_clone=subentity_counts,
-            person_household_clone_indices=person_household_clone_indices,
-            subentity_household_clone_indices=subentity_household_clone_indices,
+            person_source_indices=person_reindexing.source_indices,
+            subentity_source_indices=subentity_reindexing.source_indices,
+            persons_per_household_clone=person_reindexing.counts,
+            subentities_per_household_clone=subentity_reindexing.counts,
+            person_household_clone_indices=(
+                person_reindexing.person_household_clone_indices
+            ),
+            subentity_household_clone_indices=(
+                subentity_reindexing.subentity_household_clone_indices
+            ),
         )
+
+
+@dataclass(frozen=True)
+class _PersonReindexing:
+    counts: np.ndarray
+    source_indices: np.ndarray
+    ids: np.ndarray
+    person_household_ids: np.ndarray
+    person_household_clone_indices: np.ndarray
+
+
+@dataclass(frozen=True)
+class _SubentityReindexing:
+    counts: dict[str, np.ndarray]
+    source_indices: dict[str, np.ndarray]
+    ids: dict[str, np.ndarray]
+    person_subentity_ids: dict[str, np.ndarray]
+    subentity_household_clone_indices: dict[str, np.ndarray]
 
 
 @pipeline_node(
@@ -243,6 +219,141 @@ class ReindexedEntities:
             ),
         )
         _validate_reindexed_entities(self)
+
+
+def _create_household_ids(n_household_clones: int) -> np.ndarray:
+    return np.arange(n_household_clones, dtype=np.int32)
+
+
+def _build_person_reindexing(
+    *,
+    graph: EntityGraph,
+    household_source_indices: np.ndarray,
+    household_ids: np.ndarray,
+) -> _PersonReindexing:
+    person_counts = _create_person_counts(
+        graph.household_to_person_indices,
+        household_source_indices,
+    )
+    person_source_indices = _concatenate_membership(
+        graph.household_to_person_indices,
+        household_source_indices,
+    )
+    return _PersonReindexing(
+        counts=person_counts,
+        source_indices=person_source_indices,
+        ids=_create_entity_ids(len(person_source_indices)),
+        person_household_ids=_create_person_household_ids(
+            household_ids=household_ids,
+            person_counts=person_counts,
+        ),
+        person_household_clone_indices=_create_household_clone_indices(
+            n_household_clones=len(household_ids),
+            member_counts=person_counts,
+        ),
+    )
+
+
+def _build_subentity_reindexing(
+    *,
+    graph: EntityGraph,
+    household_source_indices: np.ndarray,
+    person_source_indices: np.ndarray,
+    person_household_clone_indices: np.ndarray,
+    n_household_clones: int,
+) -> _SubentityReindexing:
+    subentity_counts: dict[str, np.ndarray] = {}
+    subentity_source_indices: dict[str, np.ndarray] = {}
+    subentity_ids: dict[str, np.ndarray] = {}
+    person_subentity_ids: dict[str, np.ndarray] = {}
+    subentity_household_clone_indices: dict[str, np.ndarray] = {}
+
+    for entity_key, membership in graph.household_to_subentity_indices.items():
+        subentity_counts[entity_key] = _create_subentity_counts(
+            membership,
+            household_source_indices,
+        )
+        subentity_source_indices[entity_key] = _concatenate_membership(
+            membership,
+            household_source_indices,
+        )
+        subentity_ids[entity_key] = _create_entity_ids(
+            len(subentity_source_indices[entity_key]),
+        )
+        subentity_household_clone_indices[entity_key] = _create_household_clone_indices(
+            n_household_clones=n_household_clones,
+            member_counts=subentity_counts[entity_key],
+        )
+        person_subentity_ids[entity_key] = _reindex_person_subentity_ids(
+            entity_key=entity_key,
+            graph_subentity_ids=graph.subentity_ids[entity_key],
+            graph_person_subentity_ids=graph.person_subentity_ids[entity_key],
+            person_source_indices=person_source_indices,
+            entity_source_indices=subentity_source_indices[entity_key],
+            new_entity_ids=subentity_ids[entity_key],
+            person_household_clone_indices=person_household_clone_indices,
+            entity_household_clone_indices=subentity_household_clone_indices[
+                entity_key
+            ],
+        )
+
+    return _SubentityReindexing(
+        counts=subentity_counts,
+        source_indices=subentity_source_indices,
+        ids=subentity_ids,
+        person_subentity_ids=person_subentity_ids,
+        subentity_household_clone_indices=subentity_household_clone_indices,
+    )
+
+
+def _create_person_counts(
+    membership: Mapping[int, tuple[int, ...]],
+    household_source_indices: np.ndarray,
+) -> np.ndarray:
+    return _count_members_per_household(membership, household_source_indices)
+
+
+def _create_subentity_counts(
+    membership: Mapping[int, tuple[int, ...]],
+    household_source_indices: np.ndarray,
+) -> np.ndarray:
+    return _count_members_per_household(membership, household_source_indices)
+
+
+def _count_members_per_household(
+    membership: Mapping[int, tuple[int, ...]],
+    household_indices: np.ndarray,
+) -> np.ndarray:
+    return np.array(
+        [
+            len(membership.get(int(household_index), ()))
+            for household_index in household_indices
+        ],
+        dtype=np.int64,
+    )
+
+
+def _create_entity_ids(count: int) -> np.ndarray:
+    return np.arange(count, dtype=np.int32)
+
+
+def _create_person_household_ids(
+    *,
+    household_ids: np.ndarray,
+    person_counts: np.ndarray,
+) -> np.ndarray:
+    return np.repeat(household_ids, person_counts).astype(np.int32)
+
+
+def _create_household_clone_indices(
+    *,
+    n_household_clones: int,
+    member_counts: np.ndarray,
+) -> np.ndarray:
+    return np.repeat(
+        np.arange(n_household_clones, dtype=np.int64),
+        member_counts,
+    )
 
 
 def _concatenate_membership(

--- a/policyengine_us_data/build_outputs/reindexing.py
+++ b/policyengine_us_data/build_outputs/reindexing.py
@@ -1,0 +1,439 @@
+"""Entity reindexing seam for local H5 publication."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Mapping
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+from policyengine_us_data.pipeline_metadata import pipeline_node
+
+from .selection import CloneSelection
+from .source_dataset import SourceDatasetSnapshot
+
+__all__ = ["EntityReindexer", "ReindexedEntities"]
+
+
+@pipeline_node(
+    id="local_h5_entity_reindexer",
+    label="EntityReindexer",
+    node_type="library",
+    description="Reindex selected household, person, and subentity rows for local H5 outputs.",
+    source_file="policyengine_us_data/build_outputs/reindexing.py",
+    status="current",
+    stability="moving",
+    pathways=["local_h5"],
+    validation_commands=["uv run pytest tests/unit/build_outputs/test_reindexing.py"],
+)
+class EntityReindexer:
+    """Build sequential entity IDs and relationship arrays after clone selection."""
+
+    def reindex(
+        self,
+        *,
+        source: SourceDatasetSnapshot,
+        selection: CloneSelection,
+    ) -> "ReindexedEntities":
+        """Reindex selected source entities into one output entity graph.
+
+        Args:
+            source: Source dataset snapshot with entity graph.
+            selection: Selected clone-household rows.
+
+        Returns:
+            A `ReindexedEntities` object containing output IDs and source row
+            indices for variable cloning.
+        """
+
+        _validate_selection_for_source(source=source, selection=selection)
+
+        graph = source.entity_graph
+        household_source_indices = selection.source_household_indices
+        n_household_clones = selection.n_selected_clones
+
+        person_counts = np.array(
+            [
+                len(graph.household_to_person_indices.get(int(household_index), ()))
+                for household_index in household_source_indices
+            ],
+            dtype=np.int64,
+        )
+        person_source_indices = _concatenate_membership(
+            graph.household_to_person_indices,
+            household_source_indices,
+        )
+
+        subentity_source_indices: dict[str, np.ndarray] = {}
+        subentity_counts: dict[str, np.ndarray] = {}
+        for entity_key, membership in graph.household_to_subentity_indices.items():
+            subentity_counts[entity_key] = np.array(
+                [
+                    len(membership.get(int(household_index), ()))
+                    for household_index in household_source_indices
+                ],
+                dtype=np.int64,
+            )
+            subentity_source_indices[entity_key] = _concatenate_membership(
+                membership,
+                household_source_indices,
+            )
+
+        household_ids = np.arange(n_household_clones, dtype=np.int32)
+        person_ids = np.arange(len(person_source_indices), dtype=np.int32)
+        person_household_ids = np.repeat(household_ids, person_counts).astype(np.int32)
+        person_household_clone_indices = np.repeat(
+            np.arange(n_household_clones, dtype=np.int64),
+            person_counts,
+        )
+
+        subentity_ids: dict[str, np.ndarray] = {}
+        person_subentity_ids: dict[str, np.ndarray] = {}
+        subentity_household_clone_indices: dict[str, np.ndarray] = {}
+
+        for entity_key, entity_source_indices in subentity_source_indices.items():
+            entity_counts = subentity_counts[entity_key]
+            subentity_ids[entity_key] = np.arange(
+                len(entity_source_indices),
+                dtype=np.int32,
+            )
+            subentity_household_clone_indices[entity_key] = np.repeat(
+                np.arange(n_household_clones, dtype=np.int64),
+                entity_counts,
+            )
+            person_subentity_ids[entity_key] = _reindex_person_subentity_ids(
+                entity_key=entity_key,
+                graph_subentity_ids=graph.subentity_ids[entity_key],
+                graph_person_subentity_ids=graph.person_subentity_ids[entity_key],
+                person_source_indices=person_source_indices,
+                entity_source_indices=entity_source_indices,
+                new_entity_ids=subentity_ids[entity_key],
+                person_household_clone_indices=person_household_clone_indices,
+                entity_household_clone_indices=subentity_household_clone_indices[
+                    entity_key
+                ],
+            )
+
+        return ReindexedEntities(
+            household_ids=household_ids,
+            person_ids=person_ids,
+            person_household_ids=person_household_ids,
+            subentity_ids=subentity_ids,
+            person_subentity_ids=person_subentity_ids,
+            household_source_indices=household_source_indices,
+            person_source_indices=person_source_indices,
+            subentity_source_indices=subentity_source_indices,
+            persons_per_household_clone=person_counts,
+            subentities_per_household_clone=subentity_counts,
+            person_household_clone_indices=person_household_clone_indices,
+            subentity_household_clone_indices=subentity_household_clone_indices,
+        )
+
+
+@pipeline_node(
+    id="local_h5_reindexed_entities",
+    label="ReindexedEntities",
+    node_type="library",
+    description="Output entity IDs and source row indices after local H5 clone selection.",
+    source_file="policyengine_us_data/build_outputs/reindexing.py",
+    status="current",
+    stability="moving",
+    pathways=["local_h5"],
+    validation_commands=["uv run pytest tests/unit/build_outputs/test_reindexing.py"],
+)
+@dataclass(frozen=True)
+class ReindexedEntities:
+    """Entity IDs, relationship arrays, and source indices for one H5 output."""
+
+    household_ids: np.ndarray
+    person_ids: np.ndarray
+    person_household_ids: np.ndarray
+    subentity_ids: Mapping[str, np.ndarray]
+    person_subentity_ids: Mapping[str, np.ndarray]
+    household_source_indices: np.ndarray
+    person_source_indices: np.ndarray
+    subentity_source_indices: Mapping[str, np.ndarray]
+    persons_per_household_clone: np.ndarray
+    subentities_per_household_clone: Mapping[str, np.ndarray]
+    person_household_clone_indices: np.ndarray
+    subentity_household_clone_indices: Mapping[str, np.ndarray]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "household_ids",
+            _readonly_1d_array(self.household_ids, "household_ids"),
+        )
+        object.__setattr__(
+            self,
+            "person_ids",
+            _readonly_1d_array(self.person_ids, "person_ids"),
+        )
+        object.__setattr__(
+            self,
+            "person_household_ids",
+            _readonly_1d_array(self.person_household_ids, "person_household_ids"),
+        )
+        object.__setattr__(
+            self,
+            "subentity_ids",
+            _readonly_array_mapping(self.subentity_ids, "subentity_ids"),
+        )
+        object.__setattr__(
+            self,
+            "person_subentity_ids",
+            _readonly_array_mapping(
+                self.person_subentity_ids,
+                "person_subentity_ids",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "household_source_indices",
+            _readonly_1d_array(
+                self.household_source_indices,
+                "household_source_indices",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "person_source_indices",
+            _readonly_1d_array(self.person_source_indices, "person_source_indices"),
+        )
+        object.__setattr__(
+            self,
+            "subentity_source_indices",
+            _readonly_array_mapping(
+                self.subentity_source_indices,
+                "subentity_source_indices",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "persons_per_household_clone",
+            _readonly_1d_array(
+                self.persons_per_household_clone,
+                "persons_per_household_clone",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "subentities_per_household_clone",
+            _readonly_array_mapping(
+                self.subentities_per_household_clone,
+                "subentities_per_household_clone",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "person_household_clone_indices",
+            _readonly_1d_array(
+                self.person_household_clone_indices,
+                "person_household_clone_indices",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "subentity_household_clone_indices",
+            _readonly_array_mapping(
+                self.subentity_household_clone_indices,
+                "subentity_household_clone_indices",
+            ),
+        )
+        _validate_reindexed_entities(self)
+
+
+def _concatenate_membership(
+    membership: Mapping[int, tuple[int, ...]],
+    household_indices: np.ndarray,
+) -> np.ndarray:
+    parts = [
+        np.asarray(membership.get(int(household_index), ()), dtype=np.int64)
+        for household_index in household_indices
+    ]
+    if not parts:
+        return np.array([], dtype=np.int64)
+    return np.concatenate(parts).astype(np.int64)
+
+
+def _validate_selection_for_source(
+    *,
+    source: SourceDatasetSnapshot,
+    selection: CloneSelection,
+) -> None:
+    if selection.n_source_households != source.n_households:
+        raise ValueError(
+            "CloneSelection source household count does not match source dataset: "
+            f"{selection.n_source_households} != {source.n_households}"
+        )
+
+    household_indices = selection.source_household_indices
+    if np.any(household_indices < 0) or np.any(
+        household_indices >= source.n_households
+    ):
+        raise IndexError("CloneSelection source household indices are out of bounds")
+
+
+def _validate_reindexed_entities(reindexed: ReindexedEntities) -> None:
+    subentity_keys = set(reindexed.subentity_ids)
+    for name, keys in {
+        "person_subentity_ids": set(reindexed.person_subentity_ids),
+        "subentity_source_indices": set(reindexed.subentity_source_indices),
+        "subentities_per_household_clone": set(
+            reindexed.subentities_per_household_clone
+        ),
+        "subentity_household_clone_indices": set(
+            reindexed.subentity_household_clone_indices
+        ),
+    }.items():
+        if keys != subentity_keys:
+            raise ValueError(f"{name} keys must match subentity_ids keys")
+
+    n_households = len(reindexed.household_ids)
+    n_persons = len(reindexed.person_ids)
+    if not np.array_equal(reindexed.household_ids, np.arange(n_households)):
+        raise ValueError("household_ids must be sequential zero-based IDs")
+    if not np.array_equal(reindexed.person_ids, np.arange(n_persons)):
+        raise ValueError("person_ids must be sequential zero-based IDs")
+    if len(reindexed.household_source_indices) != n_households:
+        raise ValueError("household_source_indices length must match household_ids")
+    if len(reindexed.person_household_ids) != n_persons:
+        raise ValueError("person_household_ids length must match person_ids")
+    if len(reindexed.person_source_indices) != n_persons:
+        raise ValueError("person_source_indices length must match person_ids")
+    if len(reindexed.person_household_clone_indices) != n_persons:
+        raise ValueError("person_household_clone_indices length must match person_ids")
+    if len(reindexed.persons_per_household_clone) != n_households:
+        raise ValueError("persons_per_household_clone length must match household_ids")
+    if int(np.sum(reindexed.persons_per_household_clone)) != n_persons:
+        raise ValueError("persons_per_household_clone must sum to person count")
+    _validate_index_bounds(
+        reindexed.person_household_ids,
+        upper_bound=n_households,
+        name="person_household_ids",
+    )
+    _validate_index_bounds(
+        reindexed.person_household_clone_indices,
+        upper_bound=n_households,
+        name="person_household_clone_indices",
+    )
+
+    for entity_key, entity_ids in reindexed.subentity_ids.items():
+        n_entities = len(entity_ids)
+        if not np.array_equal(entity_ids, np.arange(n_entities)):
+            raise ValueError(f"subentity_ids[{entity_key!r}] must be sequential IDs")
+
+        if len(reindexed.subentity_source_indices[entity_key]) != n_entities:
+            raise ValueError(
+                f"subentity_source_indices[{entity_key!r}] length must match "
+                f"subentity_ids[{entity_key!r}]"
+            )
+        if len(reindexed.subentity_household_clone_indices[entity_key]) != n_entities:
+            raise ValueError(
+                f"subentity_household_clone_indices[{entity_key!r}] length must "
+                f"match subentity_ids[{entity_key!r}]"
+            )
+        entity_counts = reindexed.subentities_per_household_clone[entity_key]
+        if len(entity_counts) != n_households:
+            raise ValueError(
+                f"subentities_per_household_clone[{entity_key!r}] length must "
+                "match household_ids"
+            )
+        if int(np.sum(entity_counts)) != n_entities:
+            raise ValueError(
+                f"subentities_per_household_clone[{entity_key!r}] must sum to "
+                f"{entity_key} count"
+            )
+        if len(reindexed.person_subentity_ids[entity_key]) != n_persons:
+            raise ValueError(
+                f"person_subentity_ids[{entity_key!r}] length must match person_ids"
+            )
+        _validate_index_bounds(
+            reindexed.person_subentity_ids[entity_key],
+            upper_bound=n_entities,
+            name=f"person_subentity_ids[{entity_key!r}]",
+        )
+        _validate_index_bounds(
+            reindexed.subentity_household_clone_indices[entity_key],
+            upper_bound=n_households,
+            name=f"subentity_household_clone_indices[{entity_key!r}]",
+        )
+
+
+def _validate_index_bounds(
+    values: np.ndarray,
+    *,
+    upper_bound: int,
+    name: str,
+) -> None:
+    if len(values) == 0:
+        return
+    if np.any(values < 0) or np.any(values >= upper_bound):
+        raise ValueError(f"{name} contains out-of-bounds IDs")
+
+
+def _reindex_person_subentity_ids(
+    *,
+    entity_key: str,
+    graph_subentity_ids: np.ndarray,
+    graph_person_subentity_ids: np.ndarray,
+    person_source_indices: np.ndarray,
+    entity_source_indices: np.ndarray,
+    new_entity_ids: np.ndarray,
+    person_household_clone_indices: np.ndarray,
+    entity_household_clone_indices: np.ndarray,
+) -> np.ndarray:
+    old_entity_ids = graph_subentity_ids[entity_source_indices].astype(np.int64)
+    person_old_entity_ids = graph_person_subentity_ids[person_source_indices].astype(
+        np.int64
+    )
+
+    if len(old_entity_ids) == 0:
+        if len(person_old_entity_ids) > 0:
+            raise ValueError(
+                f"Selected persons reference {entity_key} rows, but no "
+                f"{entity_key} rows were selected"
+            )
+        return np.array([], dtype=np.int32)
+
+    offset = int(old_entity_ids.max()) + 1
+    entity_keys = entity_household_clone_indices * offset + old_entity_ids
+    sorted_order = np.argsort(entity_keys)
+    sorted_keys = entity_keys[sorted_order]
+    sorted_new_ids = new_entity_ids[sorted_order]
+
+    person_keys = person_household_clone_indices * offset + person_old_entity_ids
+    positions = np.searchsorted(sorted_keys, person_keys)
+    if len(positions) > 0:
+        valid_positions = positions < len(sorted_keys)
+        if not np.all(valid_positions) or not np.array_equal(
+            sorted_keys[positions[valid_positions]],
+            person_keys[valid_positions],
+        ):
+            raise ValueError(
+                f"Selected person rows could not be mapped to cloned {entity_key} IDs"
+            )
+    return sorted_new_ids[positions].astype(np.int32)
+
+
+def _readonly_1d_array(values: ArrayLike, name: str) -> np.ndarray:
+    array = np.asarray(values)
+    if array.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional")
+    normalized = np.array(array, copy=True)
+    normalized.setflags(write=False)
+    return normalized
+
+
+def _readonly_array_mapping(
+    values: Mapping[str, ArrayLike],
+    name: str,
+) -> Mapping[str, np.ndarray]:
+    normalized: dict[str, np.ndarray] = {}
+    for key, value in values.items():
+        if not isinstance(key, str) or not key:
+            raise ValueError(f"{name} keys must be non-empty strings")
+        normalized[key] = _readonly_1d_array(value, f"{name}[{key!r}]")
+    return MappingProxyType(normalized)

--- a/policyengine_us_data/build_outputs/selection.py
+++ b/policyengine_us_data/build_outputs/selection.py
@@ -1,0 +1,218 @@
+"""Clone-selection seam for local H5 publication."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+from policyengine_us_data.pipeline_metadata import pipeline_node
+
+from .requests import AreaFilter
+from .weights import CloneWeightMatrix
+
+__all__ = ["AreaSelector", "CloneSelection"]
+
+
+@pipeline_node(
+    id="local_h5_area_selector",
+    label="AreaSelector",
+    node_type="library",
+    description="Select active clone-household rows for one local H5 output.",
+    source_file="policyengine_us_data/build_outputs/selection.py",
+    status="current",
+    stability="moving",
+    pathways=["local_h5"],
+    validation_commands=["uv run pytest tests/unit/build_outputs/test_selection.py"],
+)
+class AreaSelector:
+    """Apply request geography filters to clone-level calibration weights."""
+
+    def select(
+        self,
+        *,
+        weights: CloneWeightMatrix,
+        geography: Any,
+        filters: tuple[AreaFilter, ...] = (),
+    ) -> "CloneSelection":
+        """Return active clone rows after applying area filters.
+
+        Args:
+            weights: Structured clone-level weights.
+            geography: Geography assignment with vectors aligned to weights.
+            filters: Geography filters from an `AreaBuildRequest`.
+
+        Returns:
+            A `CloneSelection` with only positive-weight clone rows.
+
+        Raises:
+            ValueError: If no clones remain, geography is misaligned, or selected
+                clone rows have empty block GEOIDs.
+        """
+
+        weight_matrix = np.array(weights.as_matrix(), copy=True)
+
+        for area_filter in filters:
+            field_matrix = _geography_matrix(
+                geography,
+                area_filter.geography_field,
+                weights=weights,
+            )
+            mask = _filter_mask(field_matrix, area_filter)
+            weight_matrix[~mask] = 0
+
+        active_clone_indices, source_household_indices = np.where(weight_matrix > 0)
+        if len(active_clone_indices) == 0:
+            raise ValueError(
+                "No active clones after filtering. "
+                f"filters={[item.to_dict() for item in filters]}"
+            )
+
+        block_geoids = _geography_matrix(
+            geography,
+            "block_geoid",
+            weights=weights,
+        )[active_clone_indices, source_household_indices]
+        empty_blocks = np.asarray(block_geoids, dtype=str) == ""
+        empty_count = int(np.sum(empty_blocks))
+        if empty_count > 0:
+            raise ValueError(f"{empty_count} active clones have empty block GEOIDs")
+
+        cd_geoids = _geography_matrix(
+            geography,
+            "cd_geoid",
+            weights=weights,
+        )[active_clone_indices, source_household_indices]
+
+        return CloneSelection(
+            clone_indices=active_clone_indices,
+            source_household_indices=source_household_indices,
+            weights=weight_matrix[active_clone_indices, source_household_indices],
+            block_geoids=block_geoids,
+            congressional_district_geoids=cd_geoids,
+            filters=tuple(filters),
+            n_source_households=weights.n_records,
+            n_total_clones=weights.n_clones,
+        )
+
+
+@pipeline_node(
+    id="local_h5_clone_selection",
+    label="CloneSelection",
+    node_type="library",
+    description="Selected clone-household rows for one local H5 output.",
+    source_file="policyengine_us_data/build_outputs/selection.py",
+    status="current",
+    stability="moving",
+    pathways=["local_h5"],
+    validation_commands=["uv run pytest tests/unit/build_outputs/test_selection.py"],
+)
+@dataclass(frozen=True)
+class CloneSelection:
+    """Active clone rows selected for one H5 output."""
+
+    clone_indices: np.ndarray
+    source_household_indices: np.ndarray
+    weights: np.ndarray
+    block_geoids: np.ndarray
+    congressional_district_geoids: np.ndarray
+    filters: tuple[AreaFilter, ...]
+    n_source_households: int
+    n_total_clones: int
+
+    def __post_init__(self) -> None:
+        clone_indices = _readonly_1d_array(self.clone_indices, "clone_indices")
+        source_household_indices = _readonly_1d_array(
+            self.source_household_indices,
+            "source_household_indices",
+        )
+        weights = _readonly_1d_array(self.weights, "weights")
+        block_geoids = _readonly_1d_array(self.block_geoids, "block_geoids")
+        cd_geoids = _readonly_1d_array(
+            self.congressional_district_geoids,
+            "congressional_district_geoids",
+        )
+
+        lengths = {
+            len(clone_indices),
+            len(source_household_indices),
+            len(weights),
+            len(block_geoids),
+            len(cd_geoids),
+        }
+        if len(lengths) != 1:
+            raise ValueError("CloneSelection arrays must have matching lengths")
+        if len(clone_indices) == 0:
+            raise ValueError("CloneSelection must contain at least one clone row")
+        if not np.issubdtype(clone_indices.dtype, np.integer):
+            raise TypeError("clone_indices must be integer indices")
+        if not np.issubdtype(source_household_indices.dtype, np.integer):
+            raise TypeError("source_household_indices must be integer indices")
+        if not np.issubdtype(weights.dtype, np.number):
+            raise TypeError("weights must be numeric")
+        if np.issubdtype(weights.dtype, np.complexfloating):
+            raise TypeError("weights must be real numeric values")
+
+        clone_indices = clone_indices.astype(np.int64, copy=True)
+        clone_indices.setflags(write=False)
+        source_household_indices = source_household_indices.astype(np.int64, copy=True)
+        source_household_indices.setflags(write=False)
+
+        object.__setattr__(self, "clone_indices", clone_indices)
+        object.__setattr__(
+            self,
+            "source_household_indices",
+            source_household_indices,
+        )
+        object.__setattr__(self, "weights", weights)
+        object.__setattr__(self, "block_geoids", block_geoids)
+        object.__setattr__(self, "congressional_district_geoids", cd_geoids)
+        object.__setattr__(self, "filters", tuple(self.filters))
+        object.__setattr__(self, "n_source_households", int(self.n_source_households))
+        object.__setattr__(self, "n_total_clones", int(self.n_total_clones))
+
+    @property
+    def n_selected_clones(self) -> int:
+        """Return the number of selected clone-household rows."""
+
+        return int(len(self.clone_indices))
+
+
+def _filter_mask(field_matrix: np.ndarray, area_filter: AreaFilter) -> np.ndarray:
+    if area_filter.op == "eq":
+        return field_matrix == area_filter.value
+    if area_filter.op == "in":
+        return np.isin(field_matrix, list(area_filter.value))
+    raise ValueError(f"Unsupported area filter op: {area_filter.op}")
+
+
+def _geography_matrix(
+    geography: Any,
+    field: str,
+    *,
+    weights: CloneWeightMatrix,
+) -> np.ndarray:
+    try:
+        values = getattr(geography, field)
+    except AttributeError as exc:
+        raise ValueError(f"Geography is missing required field {field!r}") from exc
+
+    vector = np.asarray(values)
+    expected_length = weights.n_clones * weights.n_records
+    if vector.size != expected_length:
+        raise ValueError(
+            f"Geography field {field!r} length {vector.size} does not equal "
+            f"n_clones * n_records={expected_length}"
+        )
+    return vector.reshape(weights.n_clones, weights.n_records)
+
+
+def _readonly_1d_array(values: ArrayLike, name: str) -> np.ndarray:
+    array = np.asarray(values)
+    if array.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional")
+    normalized = np.array(array, copy=True)
+    normalized.setflags(write=False)
+    return normalized

--- a/policyengine_us_data/build_outputs/selection.py
+++ b/policyengine_us_data/build_outputs/selection.py
@@ -206,6 +206,8 @@ def _geography_matrix(
             f"Geography field {field!r} length {vector.size} does not equal "
             f"n_clones * n_records={expected_length}"
         )
+    if field == "cd_geoid":
+        vector = vector.astype(str)
     return vector.reshape(weights.n_clones, weights.n_records)
 
 

--- a/policyengine_us_data/build_outputs/simulation_access.py
+++ b/policyengine_us_data/build_outputs/simulation_access.py
@@ -1,0 +1,135 @@
+"""Accessors for PolicyEngine microsimulation-backed build-output seams."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+__all__ = [
+    "calculate_variable_values",
+    "get_default_calculation_period",
+    "get_holder",
+    "get_holder_array",
+    "get_input_variables",
+    "get_known_periods",
+    "get_tax_benefit_variables",
+    "get_variable_definition",
+    "get_variable_entity_key",
+    "get_variable_names",
+    "get_variable_value_type",
+]
+
+
+def get_input_variables(simulation: Any) -> frozenset[str]:
+    """Return input variable names declared by a microsimulation."""
+
+    try:
+        input_variables = simulation.input_variables
+    except AttributeError as exc:
+        raise AttributeError("Simulation has no input_variables attribute") from exc
+    return frozenset(str(variable) for variable in input_variables)
+
+
+def get_tax_benefit_variables(simulation: Any) -> Any | None:
+    """Return tax-benefit variable definitions when available."""
+
+    tax_benefit_system = getattr(simulation, "tax_benefit_system", None)
+    return getattr(tax_benefit_system, "variables", None)
+
+
+def get_variable_names(simulation: Any) -> tuple[str, ...]:
+    """Return known variable names, falling back to input variables."""
+
+    variables = get_tax_benefit_variables(simulation)
+    if variables is None:
+        return tuple(sorted(get_input_variables(simulation)))
+    return tuple(str(variable) for variable in variables)
+
+
+def get_variable_definition(simulation: Any, variable: str) -> Any:
+    """Return one tax-benefit variable definition."""
+
+    variables = get_tax_benefit_variables(simulation)
+    if variables is None or variable not in variables:
+        raise KeyError(f"Variable {variable!r} metadata is not available")
+    return variables[variable]
+
+
+def get_variable_entity_key(simulation: Any, variable: str) -> str:
+    """Return the entity key for one tax-benefit variable definition."""
+
+    variable_definition = get_variable_definition(simulation, variable)
+    entity = getattr(variable_definition, "entity", None)
+    entity_key = getattr(entity, "key", None)
+    if not entity_key:
+        raise ValueError(f"Variable {variable!r} has no entity key")
+    return str(entity_key)
+
+
+def get_variable_value_type(simulation: Any, variable: str) -> object:
+    """Return the declared value type for one tax-benefit variable."""
+
+    return getattr(get_variable_definition(simulation, variable), "value_type", None)
+
+
+def get_holder(simulation: Any, variable: str) -> Any:
+    """Return one variable holder from a microsimulation."""
+
+    try:
+        holder = simulation.get_holder(variable)
+    except Exception as exc:
+        raise KeyError(f"Variable {variable!r} is not available") from exc
+    if holder is None:
+        raise KeyError(f"Variable {variable!r} is not available")
+    return holder
+
+
+def get_known_periods(simulation: Any, variable: str) -> tuple[Any, ...]:
+    """Return known holder periods for one variable."""
+
+    return tuple(get_holder(simulation, variable).get_known_periods())
+
+
+def get_holder_array(simulation: Any, variable: str, period: Any) -> Any:
+    """Return the holder array for one variable and period."""
+
+    return get_holder(simulation, variable).get_array(period)
+
+
+def get_default_calculation_period(simulation: Any) -> int:
+    """Return the default calculation period for a microsimulation."""
+
+    try:
+        return int(simulation.default_calculation_period)
+    except AttributeError as exc:
+        raise AttributeError(
+            "Simulation has no default_calculation_period attribute"
+        ) from exc
+
+
+def calculate_variable_values(
+    simulation: Any,
+    variable: str,
+    *,
+    period: Any | None = None,
+    map_to: str | None = None,
+) -> np.ndarray:
+    """Calculate one variable and return numpy-like values."""
+
+    kwargs: dict[str, Any] = {}
+    if period is not None:
+        kwargs["period"] = period
+    if map_to is not None:
+        kwargs["map_to"] = map_to
+    return _calculation_values(simulation.calculate(variable, **kwargs))
+
+
+def _calculation_values(calculation: Any) -> np.ndarray:
+    if hasattr(calculation, "__array__"):
+        return np.asarray(calculation)
+    if hasattr(calculation, "to_numpy"):
+        return calculation.to_numpy()
+    if hasattr(calculation, "values"):
+        return calculation.values
+    return np.asarray(calculation)

--- a/policyengine_us_data/build_outputs/source_dataset.py
+++ b/policyengine_us_data/build_outputs/source_dataset.py
@@ -17,6 +17,17 @@ from numpy.typing import ArrayLike
 
 from policyengine_us_data.pipeline_metadata import pipeline_node
 
+from .simulation_access import (
+    calculate_variable_values,
+    get_default_calculation_period,
+    get_holder_array,
+    get_input_variables,
+    get_known_periods,
+    get_variable_entity_key,
+    get_variable_names,
+    get_variable_value_type,
+)
+
 __all__ = [
     "EntityGraph",
     "MicrosimulationVariableProvider",
@@ -156,32 +167,28 @@ class EntityGraph:
             A validated `EntityGraph`.
         """
 
-        household_ids = _calculation_values(
-            simulation.calculate(
-                "household_id",
-                map_to="household",
-            )
+        household_ids = calculate_variable_values(
+            simulation,
+            "household_id",
+            map_to="household",
         )
-        person_household_ids = _calculation_values(
-            simulation.calculate(
-                "household_id",
-                map_to="person",
-            )
+        person_household_ids = calculate_variable_values(
+            simulation,
+            "household_id",
+            map_to="person",
         )
         subentity_ids = {}
         person_subentity_ids = {}
         for entity_key in subentities:
-            subentity_ids[entity_key] = _calculation_values(
-                simulation.calculate(
-                    f"{entity_key}_id",
-                    map_to=entity_key,
-                )
+            subentity_ids[entity_key] = calculate_variable_values(
+                simulation,
+                f"{entity_key}_id",
+                map_to=entity_key,
             )
-            person_subentity_ids[entity_key] = _calculation_values(
-                simulation.calculate(
-                    f"person_{entity_key}_id",
-                    map_to="person",
-                )
+            person_subentity_ids[entity_key] = calculate_variable_values(
+                simulation,
+                f"person_{entity_key}_id",
+                map_to="person",
             )
         return cls(
             household_ids=household_ids,
@@ -360,16 +367,6 @@ def _normalized_id(value) -> object:
     return value
 
 
-def _calculation_values(calculation) -> np.ndarray:
-    if hasattr(calculation, "__array__"):
-        return np.asarray(calculation)
-    if hasattr(calculation, "to_numpy"):
-        return calculation.to_numpy()
-    if hasattr(calculation, "values"):
-        return calculation.values
-    return np.asarray(calculation)
-
-
 @pipeline_node(
     id="local_h5_microsimulation_variable_provider",
     label="MicrosimulationVariableProvider",
@@ -407,42 +404,21 @@ class MicrosimulationVariableProvider:
     def input_variables(self) -> frozenset[str]:
         """Return the source simulation input variable inventory."""
 
-        return frozenset(str(variable) for variable in self.simulation.input_variables)
+        return get_input_variables(self.simulation)
 
     @property
     def variable_names(self) -> tuple[str, ...]:
         """Return variables declared by the source tax-benefit system."""
 
-        variables = getattr(
-            getattr(self.simulation, "tax_benefit_system", None),
-            "variables",
-            None,
-        )
-        if variables is None:
-            return tuple(sorted(self.input_variables))
-        return tuple(str(variable) for variable in variables)
+        return get_variable_names(self.simulation)
 
     def get_metadata(self, variable: str) -> SourceVariableMetadata:
         """Return entity and value metadata for one source variable."""
 
-        variables = getattr(
-            getattr(self.simulation, "tax_benefit_system", None),
-            "variables",
-            None,
-        )
-        if variables is None or variable not in variables:
-            raise KeyError(f"Variable {variable!r} metadata is not available")
-
-        variable_definition = variables[variable]
-        entity = getattr(variable_definition, "entity", None)
-        entity_key = getattr(entity, "key", None)
-        if not entity_key:
-            raise ValueError(f"Variable {variable!r} has no entity key")
-
         return SourceVariableMetadata(
             name=str(variable),
-            entity_key=str(entity_key),
-            value_type=getattr(variable_definition, "value_type", None),
+            entity_key=get_variable_entity_key(self.simulation, variable),
+            value_type=get_variable_value_type(self.simulation, variable),
         )
 
     def known_periods(self, variable: str) -> tuple[Any, ...]:
@@ -455,8 +431,7 @@ class MicrosimulationVariableProvider:
             Tuple of holder periods.
         """
 
-        holder = self._get_holder(variable)
-        return tuple(holder.get_known_periods())
+        return get_known_periods(self.simulation, variable)
 
     def get_array(self, variable: str, period: Any | None = None) -> np.ndarray:
         """Return one source variable array, loading and caching it lazily.
@@ -469,16 +444,18 @@ class MicrosimulationVariableProvider:
             A read-only numpy array copy of the holder values.
         """
 
-        holder = self._get_holder(variable)
         if period is None:
-            periods = tuple(holder.get_known_periods())
+            periods = get_known_periods(self.simulation, variable)
             if not periods:
                 raise ValueError(f"Variable {variable!r} has no known periods")
             period = periods[0]
 
         cache_key = (str(variable), str(period))
         if cache_key not in self._array_cache:
-            array = np.array(holder.get_array(period), copy=True)
+            array = np.array(
+                get_holder_array(self.simulation, variable, period),
+                copy=True,
+            )
             array.setflags(write=False)
             self._array_cache[cache_key] = array
         return self._array_cache[cache_key]
@@ -486,16 +463,7 @@ class MicrosimulationVariableProvider:
     def get_raw_array(self, variable: str, period: Any) -> Any:
         """Return one holder array without normalizing the backing object."""
 
-        return self._get_holder(variable).get_array(period)
-
-    def _get_holder(self, variable: str):
-        try:
-            holder = self.simulation.get_holder(variable)
-        except Exception as exc:
-            raise KeyError(f"Variable {variable!r} is not available") from exc
-        if holder is None:
-            raise KeyError(f"Variable {variable!r} is not available")
-        return holder
+        return get_holder_array(self.simulation, variable, period)
 
 
 @pipeline_node(
@@ -568,7 +536,7 @@ class SourceDatasetSnapshot:
         provider = MicrosimulationVariableProvider(simulation)
         return cls(
             dataset_path=Path(dataset_path),
-            time_period=int(simulation.default_calculation_period),
+            time_period=get_default_calculation_period(simulation),
             entity_graph=EntityGraph.from_simulation(simulation),
             input_variables=provider.input_variables,
             variable_provider=provider,
@@ -631,7 +599,7 @@ class PolicyEngineDatasetReader:
         provider = MicrosimulationVariableProvider(simulation)
         return SourceDatasetSnapshot(
             dataset_path=path,
-            time_period=int(simulation.default_calculation_period),
+            time_period=get_default_calculation_period(simulation),
             entity_graph=entity_graph,
             input_variables=provider.input_variables,
             variable_provider=provider,

--- a/policyengine_us_data/build_outputs/source_dataset.py
+++ b/policyengine_us_data/build_outputs/source_dataset.py
@@ -21,11 +21,21 @@ __all__ = [
     "EntityGraph",
     "MicrosimulationVariableProvider",
     "PolicyEngineDatasetReader",
+    "SourceVariableMetadata",
     "SourceDatasetSnapshot",
 ]
 
 
 DEFAULT_SUBENTITIES = ("tax_unit", "spm_unit", "family", "marital_unit")
+
+
+@dataclass(frozen=True)
+class SourceVariableMetadata:
+    """Entity and value metadata for one source variable."""
+
+    name: str
+    entity_key: str
+    value_type: object
 
 
 @dataclass(frozen=True)
@@ -399,6 +409,42 @@ class MicrosimulationVariableProvider:
 
         return frozenset(str(variable) for variable in self.simulation.input_variables)
 
+    @property
+    def variable_names(self) -> tuple[str, ...]:
+        """Return variables declared by the source tax-benefit system."""
+
+        variables = getattr(
+            getattr(self.simulation, "tax_benefit_system", None),
+            "variables",
+            None,
+        )
+        if variables is None:
+            return tuple(sorted(self.input_variables))
+        return tuple(str(variable) for variable in variables)
+
+    def get_metadata(self, variable: str) -> SourceVariableMetadata:
+        """Return entity and value metadata for one source variable."""
+
+        variables = getattr(
+            getattr(self.simulation, "tax_benefit_system", None),
+            "variables",
+            None,
+        )
+        if variables is None or variable not in variables:
+            raise KeyError(f"Variable {variable!r} metadata is not available")
+
+        variable_definition = variables[variable]
+        entity = getattr(variable_definition, "entity", None)
+        entity_key = getattr(entity, "key", None)
+        if not entity_key:
+            raise ValueError(f"Variable {variable!r} has no entity key")
+
+        return SourceVariableMetadata(
+            name=str(variable),
+            entity_key=str(entity_key),
+            value_type=getattr(variable_definition, "value_type", None),
+        )
+
     def known_periods(self, variable: str) -> tuple[Any, ...]:
         """Return periods known to the source holder for `variable`.
 
@@ -436,6 +482,11 @@ class MicrosimulationVariableProvider:
             array.setflags(write=False)
             self._array_cache[cache_key] = array
         return self._array_cache[cache_key]
+
+    def get_raw_array(self, variable: str, period: Any) -> Any:
+        """Return one holder array without normalizing the backing object."""
+
+        return self._get_holder(variable).get_array(period)
 
     def _get_holder(self, variable: str):
         try:

--- a/policyengine_us_data/build_outputs/variables.py
+++ b/policyengine_us_data/build_outputs/variables.py
@@ -1,0 +1,216 @@
+"""Variable-cloning seam for local H5 publication."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+import numpy as np
+from policyengine_core.enums import Enum
+
+from policyengine_us_data.calibration.formulaic_inputs import (
+    drop_formulaic_spm_inputs,
+)
+from policyengine_us_data.datasets.puf.variable_roles import (
+    PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES,
+)
+from policyengine_us_data.pipeline_metadata import pipeline_node
+
+from .reindexing import ReindexedEntities
+from .selection import CloneSelection
+from .source_dataset import SourceDatasetSnapshot, SourceVariableMetadata
+
+__all__ = ["VariableClonePayload", "VariableCloner", "default_variables_to_save"]
+
+GEOGRAPHY_VARIABLES = (
+    "block_geoid",
+    "tract_geoid",
+    "cbsa_code",
+    "sldu",
+    "sldl",
+    "place_fips",
+    "vtd",
+    "puma",
+    "zcta",
+)
+
+
+@pipeline_node(
+    id="local_h5_variable_cloner",
+    label="VariableCloner",
+    node_type="library",
+    description="Clone selected source variables into period-grouped local H5 payloads.",
+    source_file="policyengine_us_data/build_outputs/variables.py",
+    status="current",
+    stability="moving",
+    pathways=["local_h5"],
+    validation_commands=["uv run pytest tests/unit/build_outputs/test_variables.py"],
+)
+class VariableCloner:
+    """Clone source variable arrays using selected and reindexed entity rows.
+
+    The skip/error policy intentionally mirrors the first local H5 pipeline
+    implementation. Variables outside the local-H5 allowlist are skipped before
+    holder access. Allowed variables are skipped when they have no known periods
+    or belong to an entity that local H5s do not clone. Malformed metadata for
+    an allowed variable is not skipped; it should fail so incomplete outputs are
+    not produced silently.
+    """
+
+    def clone(
+        self,
+        *,
+        source: SourceDatasetSnapshot,
+        selection: CloneSelection,
+        reindexed: ReindexedEntities,
+        variables_to_save: set[str] | None = None,
+    ) -> "VariableClonePayload":
+        """Clone period-grouped variable arrays for one selected H5 output.
+
+        Args:
+            source: Source dataset snapshot with lazy variable provider.
+            selection: Selected clone-household rows.
+            reindexed: Output entity/source index mapping.
+            variables_to_save: Optional explicit variable allowlist. When
+                omitted, current local H5 inclusion rules are used.
+
+        Returns:
+            A period-grouped variable payload and cloned-period count.
+        """
+
+        _validate_reindexed_selection_alignment(
+            selection=selection,
+            reindexed=reindexed,
+        )
+        variable_allowlist = (
+            set(variables_to_save)
+            if variables_to_save is not None
+            else default_variables_to_save(source)
+        )
+        indices_by_entity = _source_indices_by_entity(reindexed)
+
+        data: dict[str, dict[Any, np.ndarray]] = {}
+        variables_saved = 0
+
+        for variable in _provider_variable_names(source.variable_provider):
+            if variable not in variable_allowlist:
+                continue
+
+            metadata = source.variable_provider.get_metadata(variable)
+
+            source_indices = indices_by_entity.get(metadata.entity_key)
+            if source_indices is None:
+                continue
+
+            periods = source.variable_provider.known_periods(variable)
+            if not periods:
+                continue
+
+            period_data: dict[Any, np.ndarray] = {}
+            for period in periods:
+                values = _provider_raw_array(source.variable_provider, variable, period)
+                normalized = _normalize_values(
+                    variable=variable,
+                    values=values,
+                    metadata=metadata,
+                )
+                period_data[period] = normalized[source_indices]
+                variables_saved += 1
+
+            if period_data:
+                data[variable] = period_data
+
+        return VariableClonePayload(data=data, values_saved=variables_saved)
+
+
+@pipeline_node(
+    id="local_h5_variable_clone_payload",
+    label="VariableClonePayload",
+    node_type="library",
+    description="Period-grouped cloned source variables for one local H5 output.",
+    source_file="policyengine_us_data/build_outputs/variables.py",
+    status="current",
+    stability="moving",
+    pathways=["local_h5"],
+    validation_commands=["uv run pytest tests/unit/build_outputs/test_variables.py"],
+)
+@dataclass(frozen=True)
+class VariableClonePayload:
+    """Cloned source variable arrays before H5-specific overrides."""
+
+    data: Mapping[str, Mapping[Any, np.ndarray]]
+    values_saved: int
+
+
+def default_variables_to_save(source: SourceDatasetSnapshot) -> set[str]:
+    """Return the current local H5 source-variable inclusion set."""
+
+    variables = (
+        set(source.input_variables) - PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES
+    )
+    drop_formulaic_spm_inputs(variables)
+    variables.add("county")
+    variables.add("congressional_district_geoid")
+    variables.update(GEOGRAPHY_VARIABLES)
+    return variables
+
+
+def _source_indices_by_entity(
+    reindexed: ReindexedEntities,
+) -> dict[str, np.ndarray]:
+    indices = {
+        "household": reindexed.household_source_indices,
+        "person": reindexed.person_source_indices,
+    }
+    indices.update(reindexed.subentity_source_indices)
+    return indices
+
+
+def _validate_reindexed_selection_alignment(
+    *,
+    selection: CloneSelection,
+    reindexed: ReindexedEntities,
+) -> None:
+    if len(reindexed.household_ids) != selection.n_selected_clones:
+        raise ValueError("Reindexed household count must match selected clone count")
+    if not np.array_equal(
+        reindexed.household_source_indices,
+        selection.source_household_indices,
+    ):
+        raise ValueError(
+            "Reindexed household source indices must match clone selection"
+        )
+
+
+def _provider_variable_names(provider) -> tuple[str, ...]:
+    variable_names = getattr(provider, "variable_names", None)
+    if variable_names is None:
+        return tuple(sorted(provider.input_variables))
+    return tuple(variable_names)
+
+
+def _provider_raw_array(provider, variable: str, period: Any) -> Any:
+    get_raw_array = getattr(provider, "get_raw_array", None)
+    if callable(get_raw_array):
+        return get_raw_array(variable, period)
+    return provider.get_array(variable, period)
+
+
+def _normalize_values(
+    *,
+    variable: str,
+    values: Any,
+    metadata: SourceVariableMetadata,
+) -> np.ndarray:
+    if hasattr(values, "_pa_array") or hasattr(values, "_ndarray"):
+        values = np.asarray(values)
+
+    if metadata.value_type in (Enum, str) and variable != "county_fips":
+        if hasattr(values, "decode_to_str"):
+            return values.decode_to_str().astype("S")
+        return np.asarray(values).astype("S")
+
+    if variable == "county_fips":
+        return np.asarray(values).astype("int32")
+
+    return np.asarray(values)

--- a/policyengine_us_data/calibration/publish_local_area.py
+++ b/policyengine_us_data/calibration/publish_local_area.py
@@ -23,6 +23,12 @@ from policyengine_us_data.build_outputs.fingerprinting import (
 from policyengine_us_data.build_outputs.geography_loader import (
     CalibrationGeographyLoader,
 )
+from policyengine_us_data.build_outputs.reindexing import EntityReindexer
+from policyengine_us_data.build_outputs.requests import AreaFilter
+from policyengine_us_data.build_outputs.selection import AreaSelector
+from policyengine_us_data.build_outputs.source_dataset import SourceDatasetSnapshot
+from policyengine_us_data.build_outputs.variables import VariableCloner
+from policyengine_us_data.build_outputs.weights import CloneWeightMatrix
 from policyengine_us_data.utils.huggingface import download_calibration_inputs
 from policyengine_us_data.utils.data_upload import (
     upload_local_area_file,
@@ -33,12 +39,6 @@ from policyengine_us_data.calibration.calibration_utils import (
 )
 from policyengine_us_data.calibration.block_assignment import (
     derive_geography_from_blocks,
-)
-from policyengine_us_data.calibration.formulaic_inputs import (
-    drop_formulaic_spm_inputs,
-)
-from policyengine_us_data.datasets.puf.variable_roles import (
-    PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES,
 )
 from policyengine_us_data.utils.takeup import (
     SIMPLE_TAKEUP_VARS,
@@ -228,14 +228,6 @@ def validate_or_clear_checkpoints(fingerprint: str):
     META_FILE.write_text(json.dumps({"fingerprint": fingerprint}))
 
 
-SUB_ENTITIES = [
-    "tax_unit",
-    "spm_unit",
-    "family",
-    "marital_unit",
-]
-
-
 def load_completed_states() -> set:
     if CHECKPOINT_FILE.exists():
         content = CHECKPOINT_FILE.read_text().strip()
@@ -303,6 +295,31 @@ def _build_reported_takeup_anchors(
     return reported_anchors
 
 
+def _build_legacy_area_filters(
+    *,
+    cd_subset: List[str] | None,
+    county_fips_filter: set | None,
+) -> tuple[AreaFilter, ...]:
+    filters = []
+    if cd_subset is not None:
+        filters.append(
+            AreaFilter(
+                geography_field="cd_geoid",
+                op="in",
+                value=tuple(str(item) for item in cd_subset),
+            )
+        )
+    if county_fips_filter is not None:
+        filters.append(
+            AreaFilter(
+                geography_field="county_fips",
+                op="in",
+                value=tuple(sorted(str(item) for item in county_fips_filter)),
+            )
+        )
+    return tuple(filters)
+
+
 @pipeline_node(
     PipelineNode(
         id="build_h5",
@@ -350,42 +367,24 @@ def build_h5(
         Path to the output H5 file.
     """
     import h5py
-    from collections import defaultdict
-    from policyengine_core.enums import Enum
 
     output_path = Path(output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     blocks = np.asarray(geography.block_geoid)
-    clone_cds = np.asarray(geography.cd_geoid, dtype=str)
 
     # === Load base simulation ===
     sim = Microsimulation(dataset=str(dataset_path))
-    time_period = int(sim.default_calculation_period)
-    household_ids = sim.calculate("household_id", map_to="household").values
-    n_hh = len(household_ids)
-
-    if weights.shape[0] % n_hh != 0:
-        raise ValueError(
-            f"Weight vector length {weights.shape[0]} is not divisible by n_hh={n_hh}"
-        )
-    n_clones_total = weights.shape[0] // n_hh
-
-    # === Reshape and filter weight matrix ===
-    W = weights.reshape(n_clones_total, n_hh).copy()
-    clone_cds_matrix = clone_cds.reshape(n_clones_total, n_hh)
-
-    # CD subset filtering: zero out cells whose CD isn't in subset
-    if cd_subset is not None:
-        cd_subset_set = set(cd_subset)
-        cd_mask = np.vectorize(lambda cd: cd in cd_subset_set)(clone_cds_matrix)
-        W[~cd_mask] = 0
-
-    # County FIPS filtering: zero out clones not in target counties
-    if county_fips_filter is not None:
-        fips_array = np.asarray(geography.county_fips).reshape(n_clones_total, n_hh)
-        fips_mask = np.isin(fips_array, list(county_fips_filter))
-        W[~fips_mask] = 0
+    source = SourceDatasetSnapshot.from_simulation(Path(dataset_path), sim)
+    time_period = int(source.time_period)
+    household_ids = source.household_ids
+    n_hh = source.n_households
+    weight_matrix = CloneWeightMatrix.from_vector(weights, n_records=n_hh)
+    n_clones_total = weight_matrix.n_clones
+    filters = _build_legacy_area_filters(
+        cd_subset=cd_subset,
+        county_fips_filter=county_fips_filter,
+    )
 
     label = (
         f"CD subset {cd_subset}"
@@ -396,118 +395,37 @@ def build_h5(
     print(f"Building {output_path.name} ({label}, {n_hh} households)")
     print(f"{'=' * 60}")
 
-    # === Identify active clones ===
-    active_geo, active_hh = np.where(W > 0)
-    n_clones = len(active_geo)
-    if n_clones == 0:
-        raise ValueError(
-            f"No active clones after filtering. "
-            f"cd_subset={cd_subset}, county_fips_filter={county_fips_filter}"
-        )
-    clone_weights = W[active_geo, active_hh]
-    active_blocks = blocks.reshape(n_clones_total, n_hh)[active_geo, active_hh]
-    active_clone_cds = clone_cds.reshape(n_clones_total, n_hh)[active_geo, active_hh]
-
-    empty_count = np.sum(active_blocks == "")
-    if empty_count > 0:
-        raise ValueError(f"{empty_count} active clones have empty block GEOIDs")
-
+    # === Select active clones ===
+    selection = AreaSelector().select(
+        weights=weight_matrix,
+        geography=geography,
+        filters=filters,
+    )
+    active_geo = selection.clone_indices
+    active_hh = selection.source_household_indices
+    n_clones = selection.n_selected_clones
+    clone_weights = selection.weights
+    active_blocks = selection.block_geoids
+    active_clone_cds = selection.congressional_district_geoids
     print(f"Active clones: {n_clones:,}")
     print(f"Total weight: {clone_weights.sum():,.0f}")
 
-    # === Build entity membership maps ===
-    hh_id_to_idx = {int(hid): i for i, hid in enumerate(household_ids)}
-    person_hh_ids = sim.calculate("household_id", map_to="person").values
-
-    hh_to_persons = defaultdict(list)
-    for p_idx, p_hh_id in enumerate(person_hh_ids):
-        hh_to_persons[hh_id_to_idx[int(p_hh_id)]].append(p_idx)
-
-    hh_to_entity = {}
-    entity_id_arrays = {}
-    person_entity_id_arrays = {}
-
-    for ek in SUB_ENTITIES:
-        eids = sim.calculate(f"{ek}_id", map_to=ek).values
-        peids = sim.calculate(f"person_{ek}_id", map_to="person").values
-        entity_id_arrays[ek] = eids
-        person_entity_id_arrays[ek] = peids
-        eid_to_idx = {int(eid): i for i, eid in enumerate(eids)}
-
-        mapping = defaultdict(list)
-        seen = defaultdict(set)
-        for p_idx in range(len(person_hh_ids)):
-            hh_idx = hh_id_to_idx[int(person_hh_ids[p_idx])]
-            e_idx = eid_to_idx[int(peids[p_idx])]
-            if e_idx not in seen[hh_idx]:
-                seen[hh_idx].add(e_idx)
-                mapping[hh_idx].append(e_idx)
-        for hh_idx in mapping:
-            mapping[hh_idx].sort()
-        hh_to_entity[ek] = mapping
-
-    # === Build clone index arrays ===
-    hh_clone_idx = active_hh
-
-    persons_per_clone = np.array([len(hh_to_persons.get(h, [])) for h in active_hh])
-    person_parts = [
-        np.array(hh_to_persons.get(h, []), dtype=np.int64) for h in active_hh
-    ]
-    person_clone_idx = (
-        np.concatenate(person_parts) if person_parts else np.array([], dtype=np.int64)
-    )
-
-    entity_clone_idx = {}
-    entities_per_clone = {}
-    for ek in SUB_ENTITIES:
-        epc = np.array([len(hh_to_entity[ek].get(h, [])) for h in active_hh])
-        entities_per_clone[ek] = epc
-        parts = [
-            np.array(hh_to_entity[ek].get(h, []), dtype=np.int64) for h in active_hh
-        ]
-        entity_clone_idx[ek] = (
-            np.concatenate(parts) if parts else np.array([], dtype=np.int64)
-        )
-
-    n_persons = len(person_clone_idx)
+    # === Reindex selected entities ===
+    reindexed = EntityReindexer().reindex(source=source, selection=selection)
+    person_clone_idx = reindexed.person_source_indices
+    entity_clone_idx = dict(reindexed.subentity_source_indices)
+    persons_per_clone = reindexed.persons_per_household_clone
+    entities_per_clone = dict(reindexed.subentities_per_household_clone)
+    n_persons = len(reindexed.person_ids)
     print(f"Cloned persons: {n_persons:,}")
-    for ek in SUB_ENTITIES:
+    for ek in entity_clone_idx:
         print(f"Cloned {ek}s: {len(entity_clone_idx[ek]):,}")
 
-    # === Build new entity IDs and cross-references ===
-    new_hh_ids = np.arange(n_clones, dtype=np.int32)
-    new_person_ids = np.arange(n_persons, dtype=np.int32)
-    new_person_hh_ids = np.repeat(new_hh_ids, persons_per_clone)
-
-    new_entity_ids = {}
-    new_person_entity_ids = {}
-    clone_ids_for_persons = np.repeat(
-        np.arange(n_clones, dtype=np.int64), persons_per_clone
-    )
-
-    for ek in SUB_ENTITIES:
-        n_ents = len(entity_clone_idx[ek])
-        new_entity_ids[ek] = np.arange(n_ents, dtype=np.int32)
-
-        old_eids = entity_id_arrays[ek][entity_clone_idx[ek]].astype(np.int64)
-        clone_ids_e = np.repeat(
-            np.arange(n_clones, dtype=np.int64),
-            entities_per_clone[ek],
-        )
-
-        offset = int(old_eids.max()) + 1 if len(old_eids) > 0 else 1
-        entity_keys = clone_ids_e * offset + old_eids
-
-        sorted_order = np.argsort(entity_keys)
-        sorted_keys = entity_keys[sorted_order]
-        sorted_new = new_entity_ids[ek][sorted_order]
-
-        p_old_eids = person_entity_id_arrays[ek][person_clone_idx].astype(np.int64)
-        person_keys = clone_ids_for_persons * offset + p_old_eids
-
-        positions = np.searchsorted(sorted_keys, person_keys)
-        positions = np.clip(positions, 0, len(sorted_keys) - 1)
-        new_person_entity_ids[ek] = sorted_new[positions]
+    new_hh_ids = reindexed.household_ids
+    new_person_ids = reindexed.person_ids
+    new_person_hh_ids = reindexed.person_household_ids
+    new_entity_ids = dict(reindexed.subentity_ids)
+    new_person_entity_ids = dict(reindexed.person_subentity_ids)
 
     # === Derive geography from blocks (dedup optimization) ===
     print("Deriving geography from blocks...")
@@ -516,77 +434,14 @@ def build_h5(
     unique_geo = derive_geography_from_blocks(unique_blocks)
     clone_geo = {k: v[block_inv] for k, v in unique_geo.items()}
 
-    # === Determine variables to save ===
-    vars_to_save = (
-        set(sim.input_variables) - PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES
-    )
-    drop_formulaic_spm_inputs(vars_to_save)
-    vars_to_save.add("county")
-    vars_to_save.add("congressional_district_geoid")
-    for gv in [
-        "block_geoid",
-        "tract_geoid",
-        "cbsa_code",
-        "sldu",
-        "sldl",
-        "place_fips",
-        "vtd",
-        "puma",
-        "zcta",
-    ]:
-        vars_to_save.add(gv)
-
     # === Clone variable arrays ===
-    clone_idx_map = {
-        "household": hh_clone_idx,
-        "person": person_clone_idx,
-    }
-    for ek in SUB_ENTITIES:
-        clone_idx_map[ek] = entity_clone_idx[ek]
-
-    data = {}
-    variables_saved = 0
-
-    for variable in sim.tax_benefit_system.variables:
-        if variable not in vars_to_save:
-            continue
-
-        holder = sim.get_holder(variable)
-        periods = holder.get_known_periods()
-        if not periods:
-            continue
-
-        var_def = sim.tax_benefit_system.variables.get(variable)
-        entity_key = var_def.entity.key
-        if entity_key not in clone_idx_map:
-            continue
-
-        cidx = clone_idx_map[entity_key]
-        var_data = {}
-
-        for period in periods:
-            values = holder.get_array(period)
-
-            if hasattr(values, "_pa_array") or hasattr(values, "_ndarray"):
-                values = np.asarray(values)
-
-            if var_def.value_type in (Enum, str) and variable != "county_fips":
-                if hasattr(values, "decode_to_str"):
-                    values = values.decode_to_str().astype("S")
-                else:
-                    values = np.asarray(values).astype("S")
-            elif variable == "county_fips":
-                values = np.asarray(values).astype("int32")
-            else:
-                values = np.asarray(values)
-
-            var_data[period] = values[cidx]
-            variables_saved += 1
-
-        if var_data:
-            data[variable] = var_data
-
-    print(f"Variables cloned: {variables_saved}")
+    payload = VariableCloner().clone(
+        source=source,
+        selection=selection,
+        reindexed=reindexed,
+    )
+    data = {variable: dict(periods) for variable, periods in payload.data.items()}
+    print(f"Variables cloned: {payload.values_saved}")
 
     # === Override entity IDs ===
     data["household_id"] = {time_period: new_hh_ids}
@@ -594,7 +449,7 @@ def build_h5(
     data["person_household_id"] = {
         time_period: new_person_hh_ids,
     }
-    for ek in SUB_ENTITIES:
+    for ek in new_entity_ids:
         data[f"{ek}_id"] = {
             time_period: new_entity_ids[ek],
         }

--- a/tests/support/build_outputs/source_dataset.py
+++ b/tests/support/build_outputs/source_dataset.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import numpy as np
 
 
@@ -42,11 +44,27 @@ class FakeHolder:
 class FakeSimulation:
     """Small simulation test double for lazy-provider tests."""
 
-    def __init__(self, holders):
+    def __init__(self, holders, *, variable_entities=None, value_types=None):
         self.holders = dict(holders)
         self.input_variables = frozenset(holders)
         self.default_calculation_period = 2023
         self.get_holder_calls = []
+        variable_entities = dict(variable_entities or {})
+        value_types = dict(value_types or {})
+        self.tax_benefit_system = SimpleNamespace(
+            variables={
+                variable: SimpleNamespace(
+                    entity=SimpleNamespace(
+                        key=variable_entities.get(
+                            variable,
+                            _infer_entity_key(variable),
+                        )
+                    ),
+                    value_type=value_types.get(variable, float),
+                )
+                for variable in holders
+            }
+        )
 
     def get_holder(self, variable):
         self.get_holder_calls.append(variable)
@@ -70,3 +88,12 @@ class FakeCalculation:
 
     def __init__(self, values):
         self.values = np.asarray(values)
+
+
+def _infer_entity_key(variable: str) -> str:
+    if variable.startswith("person_") or variable in {"age", "employment_income"}:
+        return "person"
+    for entity_key in ("tax_unit", "spm_unit", "family", "marital_unit"):
+        if variable == f"{entity_key}_id" or variable.startswith(f"{entity_key}_"):
+            return entity_key
+    return "household"

--- a/tests/unit/build_outputs/test_reindexing.py
+++ b/tests/unit/build_outputs/test_reindexing.py
@@ -1,0 +1,164 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from policyengine_us_data.build_outputs.reindexing import (
+    EntityReindexer,
+    ReindexedEntities,
+)
+from policyengine_us_data.build_outputs.selection import CloneSelection
+from policyengine_us_data.build_outputs.source_dataset import (
+    EntityGraph,
+    SourceDatasetSnapshot,
+)
+from tests.support.build_outputs.source_dataset import (
+    FakeSimulation,
+    make_entity_graph_arrays,
+)
+
+
+def _source_snapshot() -> SourceDatasetSnapshot:
+    return SourceDatasetSnapshot(
+        dataset_path=Path("source.h5"),
+        time_period=2024,
+        entity_graph=EntityGraph(**make_entity_graph_arrays()),
+        input_variables=frozenset(),
+        variable_provider=FakeSimulation({}),
+    )
+
+
+def _selection() -> CloneSelection:
+    return CloneSelection(
+        clone_indices=np.array([0, 1, 1]),
+        source_household_indices=np.array([1, 0, 1]),
+        weights=np.array([2.0, 3.0, 4.0]),
+        block_geoids=np.array(["block-1", "block-2", "block-3"]),
+        congressional_district_geoids=np.array(["3701", "3701", "3702"]),
+        filters=(),
+        n_source_households=2,
+        n_total_clones=2,
+    )
+
+
+def _selection_with_source_indices(indices: np.ndarray) -> CloneSelection:
+    return CloneSelection(
+        clone_indices=np.arange(len(indices)),
+        source_household_indices=indices,
+        weights=np.ones(len(indices)),
+        block_geoids=np.array([f"block-{i}" for i in range(len(indices))]),
+        congressional_district_geoids=np.array(["3701"] * len(indices)),
+        filters=(),
+        n_source_households=2,
+        n_total_clones=max(len(indices), 1),
+    )
+
+
+def test_entity_reindexer_builds_sequential_entity_ids_for_repeated_households():
+    result = EntityReindexer().reindex(
+        source=_source_snapshot(),
+        selection=_selection(),
+    )
+
+    np.testing.assert_array_equal(result.household_ids, np.array([0, 1, 2]))
+    np.testing.assert_array_equal(result.person_ids, np.array([0, 1, 2, 3]))
+    np.testing.assert_array_equal(
+        result.person_household_ids,
+        np.array([0, 1, 1, 2]),
+    )
+    np.testing.assert_array_equal(
+        result.household_source_indices,
+        np.array([1, 0, 1]),
+    )
+    np.testing.assert_array_equal(
+        result.person_source_indices,
+        np.array([2, 0, 1, 2]),
+    )
+    np.testing.assert_array_equal(
+        result.persons_per_household_clone,
+        np.array([1, 2, 1]),
+    )
+
+
+def test_entity_reindexer_reindexes_person_subentity_links_per_clone():
+    result = EntityReindexer().reindex(
+        source=_source_snapshot(),
+        selection=_selection(),
+    )
+
+    np.testing.assert_array_equal(result.subentity_ids["tax_unit"], np.array([0, 1, 2]))
+    np.testing.assert_array_equal(
+        result.subentity_source_indices["tax_unit"],
+        np.array([1, 0, 1]),
+    )
+    np.testing.assert_array_equal(
+        result.person_subentity_ids["tax_unit"],
+        np.array([0, 1, 1, 2]),
+    )
+    np.testing.assert_array_equal(
+        result.subentity_household_clone_indices["tax_unit"],
+        np.array([0, 1, 2]),
+    )
+
+
+def test_entity_reindexer_outputs_are_read_only():
+    result = EntityReindexer().reindex(
+        source=_source_snapshot(),
+        selection=_selection(),
+    )
+
+    with pytest.raises(ValueError, match="read-only"):
+        result.person_source_indices[0] = 99
+    with pytest.raises(TypeError):
+        result.subentity_source_indices["tax_unit"] = np.array([])
+
+
+def test_entity_reindexer_rejects_source_household_count_mismatch():
+    selection = _selection_with_source_indices(np.array([0]))
+    object.__setattr__(selection, "n_source_households", 99)
+
+    with pytest.raises(ValueError, match="source household count"):
+        EntityReindexer().reindex(source=_source_snapshot(), selection=selection)
+
+
+def test_entity_reindexer_rejects_out_of_bounds_source_indices():
+    selection = _selection_with_source_indices(np.array([2]))
+
+    with pytest.raises(IndexError, match="out of bounds"):
+        EntityReindexer().reindex(source=_source_snapshot(), selection=selection)
+
+
+def test_reindexed_entities_rejects_inconsistent_subentity_keys():
+    with pytest.raises(ValueError, match="person_subentity_ids keys"):
+        ReindexedEntities(
+            household_ids=np.array([0]),
+            person_ids=np.array([0]),
+            person_household_ids=np.array([0]),
+            subentity_ids={"tax_unit": np.array([0])},
+            person_subentity_ids={"spm_unit": np.array([0])},
+            household_source_indices=np.array([0]),
+            person_source_indices=np.array([0]),
+            subentity_source_indices={"tax_unit": np.array([0])},
+            persons_per_household_clone=np.array([1]),
+            subentities_per_household_clone={"tax_unit": np.array([1])},
+            person_household_clone_indices=np.array([0]),
+            subentity_household_clone_indices={"tax_unit": np.array([0])},
+        )
+
+
+def test_reindexed_entities_rejects_inconsistent_person_counts():
+    with pytest.raises(ValueError, match="persons_per_household_clone"):
+        ReindexedEntities(
+            household_ids=np.array([0]),
+            person_ids=np.array([0, 1]),
+            person_household_ids=np.array([0, 0]),
+            subentity_ids={"tax_unit": np.array([0])},
+            person_subentity_ids={"tax_unit": np.array([0, 0])},
+            household_source_indices=np.array([0]),
+            person_source_indices=np.array([0, 1]),
+            subentity_source_indices={"tax_unit": np.array([0])},
+            persons_per_household_clone=np.array([1]),
+            subentities_per_household_clone={"tax_unit": np.array([1])},
+            person_household_clone_indices=np.array([0, 0]),
+            subentity_household_clone_indices={"tax_unit": np.array([0])},
+        )

--- a/tests/unit/build_outputs/test_selection.py
+++ b/tests/unit/build_outputs/test_selection.py
@@ -61,6 +61,27 @@ def test_area_selector_applies_cd_and_county_filters_as_conjunction():
     np.testing.assert_array_equal(selection.block_geoids, np.array(["block-4"]))
 
 
+def test_area_selector_preserves_legacy_numeric_cd_geoid_filtering():
+    weights = CloneWeightMatrix.from_vector(
+        np.array([1.0, 1.0, 1.0, 1.0]),
+        n_records=2,
+    )
+    filters = (AreaFilter(geography_field="cd_geoid", op="in", value=("3702",)),)
+
+    selection = AreaSelector().select(
+        weights=weights,
+        geography=_geography(cd_geoid=np.array([3701, 3702, 3701, 3702])),
+        filters=filters,
+    )
+
+    np.testing.assert_array_equal(selection.clone_indices, np.array([0, 1]))
+    np.testing.assert_array_equal(selection.source_household_indices, np.array([1, 1]))
+    np.testing.assert_array_equal(
+        selection.congressional_district_geoids,
+        np.array(["3702", "3702"]),
+    )
+
+
 def test_area_selector_rejects_zero_active_clones():
     weights = CloneWeightMatrix.from_vector(
         np.array([1.0, 1.0, 1.0, 1.0]),

--- a/tests/unit/build_outputs/test_selection.py
+++ b/tests/unit/build_outputs/test_selection.py
@@ -1,0 +1,114 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from policyengine_us_data.build_outputs.requests import AreaFilter
+from policyengine_us_data.build_outputs.selection import AreaSelector, CloneSelection
+from policyengine_us_data.build_outputs.weights import CloneWeightMatrix
+
+
+def _geography(**overrides):
+    values = {
+        "block_geoid": np.array(["block-1", "block-2", "block-3", "block-4"]),
+        "cd_geoid": np.array(["3701", "3702", "3701", "3702"]),
+        "county_fips": np.array(["37183", "37183", "06037", "06037"]),
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_area_selector_returns_positive_weight_clone_rows():
+    weights = CloneWeightMatrix.from_vector(
+        np.array([1.0, 0.0, 2.0, 3.0]),
+        n_records=2,
+    )
+
+    selection = AreaSelector().select(weights=weights, geography=_geography())
+
+    np.testing.assert_array_equal(selection.clone_indices, np.array([0, 1, 1]))
+    np.testing.assert_array_equal(
+        selection.source_household_indices,
+        np.array([0, 0, 1]),
+    )
+    np.testing.assert_array_equal(selection.weights, np.array([1.0, 2.0, 3.0]))
+    np.testing.assert_array_equal(
+        selection.block_geoids,
+        np.array(["block-1", "block-3", "block-4"]),
+    )
+    assert selection.n_source_households == 2
+    assert selection.n_total_clones == 2
+
+
+def test_area_selector_applies_cd_and_county_filters_as_conjunction():
+    weights = CloneWeightMatrix.from_vector(
+        np.array([1.0, 1.0, 1.0, 1.0]),
+        n_records=2,
+    )
+    filters = (
+        AreaFilter(geography_field="cd_geoid", op="in", value=("3702",)),
+        AreaFilter(geography_field="county_fips", op="in", value=("06037",)),
+    )
+
+    selection = AreaSelector().select(
+        weights=weights,
+        geography=_geography(),
+        filters=filters,
+    )
+
+    np.testing.assert_array_equal(selection.clone_indices, np.array([1]))
+    np.testing.assert_array_equal(selection.source_household_indices, np.array([1]))
+    np.testing.assert_array_equal(selection.block_geoids, np.array(["block-4"]))
+
+
+def test_area_selector_rejects_zero_active_clones():
+    weights = CloneWeightMatrix.from_vector(
+        np.array([1.0, 1.0, 1.0, 1.0]),
+        n_records=2,
+    )
+    filters = (AreaFilter(geography_field="cd_geoid", op="in", value=("9999",)),)
+
+    with pytest.raises(ValueError, match="No active clones"):
+        AreaSelector().select(weights=weights, geography=_geography(), filters=filters)
+
+
+def test_area_selector_rejects_empty_active_block_geoids():
+    weights = CloneWeightMatrix.from_vector(
+        np.array([1.0, 0.0, 0.0, 0.0]),
+        n_records=2,
+    )
+
+    with pytest.raises(ValueError, match="empty block GEOIDs"):
+        AreaSelector().select(
+            weights=weights,
+            geography=_geography(block_geoid=np.array(["", "b", "c", "d"])),
+        )
+
+
+def test_area_selector_rejects_misaligned_geography_vectors():
+    weights = CloneWeightMatrix.from_vector(
+        np.array([1.0, 0.0, 0.0, 0.0]),
+        n_records=2,
+    )
+
+    with pytest.raises(ValueError, match="length 1"):
+        AreaSelector().select(
+            weights=weights,
+            geography=_geography(cd_geoid=np.array(["3701"])),
+        )
+
+
+def test_clone_selection_is_read_only():
+    selection = CloneSelection(
+        clone_indices=np.array([0]),
+        source_household_indices=np.array([0]),
+        weights=np.array([1.0]),
+        block_geoids=np.array(["block-1"]),
+        congressional_district_geoids=np.array(["3701"]),
+        filters=(),
+        n_source_households=1,
+        n_total_clones=1,
+    )
+
+    with pytest.raises(ValueError, match="read-only"):
+        selection.clone_indices[0] = 99

--- a/tests/unit/build_outputs/test_simulation_access.py
+++ b/tests/unit/build_outputs/test_simulation_access.py
@@ -1,0 +1,103 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from policyengine_us_data.build_outputs.simulation_access import (
+    calculate_variable_values,
+    get_default_calculation_period,
+    get_holder,
+    get_holder_array,
+    get_input_variables,
+    get_known_periods,
+    get_tax_benefit_variables,
+    get_variable_definition,
+    get_variable_entity_key,
+    get_variable_names,
+    get_variable_value_type,
+)
+from tests.support.build_outputs.source_dataset import FakeHolder, FakeSimulation
+
+
+def test_simulation_access_reads_variable_inventory_and_metadata():
+    simulation = FakeSimulation(
+        {"rent": FakeHolder({2023: np.array([1, 2])})},
+        variable_entities={"rent": "household"},
+        value_types={"rent": float},
+    )
+
+    assert get_input_variables(simulation) == frozenset({"rent"})
+    assert get_variable_names(simulation) == ("rent",)
+    assert (
+        get_variable_definition(simulation, "rent")
+        is (simulation.tax_benefit_system.variables["rent"])
+    )
+    assert get_variable_entity_key(simulation, "rent") == "household"
+    assert get_variable_value_type(simulation, "rent") is float
+
+
+def test_simulation_access_variable_names_falls_back_to_input_variables():
+    simulation = FakeSimulation(
+        {
+            "household_id": FakeHolder({2023: np.array([1, 2])}),
+            "age": FakeHolder({2023: np.array([40, 12, 8])}),
+        }
+    )
+    simulation.tax_benefit_system = None
+
+    assert get_tax_benefit_variables(simulation) is None
+    assert get_variable_names(simulation) == ("age", "household_id")
+
+
+def test_simulation_access_rejects_missing_variable_metadata():
+    simulation = FakeSimulation({})
+
+    with pytest.raises(KeyError, match="missing"):
+        get_variable_definition(simulation, "missing")
+
+
+def test_simulation_access_rejects_variable_metadata_without_entity_key():
+    simulation = FakeSimulation({"rent": FakeHolder({2023: np.array([1, 2])})})
+    simulation.tax_benefit_system.variables["rent"] = SimpleNamespace(
+        entity=SimpleNamespace(key=None),
+        value_type=float,
+    )
+
+    with pytest.raises(ValueError, match="entity key"):
+        get_variable_entity_key(simulation, "rent")
+
+
+def test_simulation_access_reads_holder_periods_and_arrays():
+    holder = FakeHolder({2023: np.array([40, 12, 8])})
+    simulation = FakeSimulation({"age": holder})
+
+    assert get_holder(simulation, "age") is holder
+    assert get_known_periods(simulation, "age") == (2023,)
+    np.testing.assert_array_equal(
+        get_holder_array(simulation, "age", 2023),
+        np.array([40, 12, 8]),
+    )
+    assert simulation.get_holder_calls == ["age", "age", "age"]
+
+
+def test_simulation_access_rejects_missing_holders():
+    simulation = FakeSimulation({})
+
+    with pytest.raises(KeyError, match="missing"):
+        get_holder(simulation, "missing")
+
+
+def test_simulation_access_reads_default_period_and_calculation_values():
+    simulation = FakeSimulation(
+        {"household_id": FakeHolder({2023: np.array([10, 20])})}
+    )
+
+    assert get_default_calculation_period(simulation) == 2023
+    np.testing.assert_array_equal(
+        calculate_variable_values(
+            simulation,
+            "household_id",
+            map_to="household",
+        ),
+        np.array([10, 20]),
+    )

--- a/tests/unit/build_outputs/test_source_dataset.py
+++ b/tests/unit/build_outputs/test_source_dataset.py
@@ -136,7 +136,7 @@ def test_variable_provider_loads_and_caches_requested_array():
 
     assert np.array_equal(first, np.array([40, 12, 8]))
     assert first is second
-    assert simulation.get_holder_calls == ["age", "age"]
+    assert simulation.get_holder_calls == ["age"]
     assert holder.get_array_calls == [2023]
     with pytest.raises(ValueError, match="read-only"):
         first[0] = 99

--- a/tests/unit/build_outputs/test_source_dataset.py
+++ b/tests/unit/build_outputs/test_source_dataset.py
@@ -153,6 +153,23 @@ def test_variable_provider_uses_first_known_period_when_period_is_omitted():
     assert holder.get_array_calls == [2023]
 
 
+def test_variable_provider_exposes_variable_metadata():
+    provider = MicrosimulationVariableProvider(
+        FakeSimulation(
+            {"rent": FakeHolder({2023: np.array([1, 2])})},
+            variable_entities={"rent": "household"},
+            value_types={"rent": float},
+        )
+    )
+
+    metadata = provider.get_metadata("rent")
+
+    assert provider.variable_names == ("rent",)
+    assert metadata.name == "rent"
+    assert metadata.entity_key == "household"
+    assert metadata.value_type is float
+
+
 def test_variable_provider_rejects_missing_variables():
     provider = MicrosimulationVariableProvider(FakeSimulation({}))
 

--- a/tests/unit/build_outputs/test_variables.py
+++ b/tests/unit/build_outputs/test_variables.py
@@ -1,0 +1,170 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from policyengine_us_data.build_outputs.reindexing import (
+    EntityReindexer,
+    ReindexedEntities,
+)
+from policyengine_us_data.build_outputs.selection import CloneSelection
+from policyengine_us_data.build_outputs.source_dataset import (
+    EntityGraph,
+    MicrosimulationVariableProvider,
+    SourceDatasetSnapshot,
+)
+from policyengine_us_data.build_outputs.variables import (
+    VariableCloner,
+    default_variables_to_save,
+)
+from tests.support.build_outputs.source_dataset import (
+    FakeHolder,
+    FakeSimulation,
+    make_entity_graph_arrays,
+)
+
+
+def _selection() -> CloneSelection:
+    return CloneSelection(
+        clone_indices=np.array([0, 1]),
+        source_household_indices=np.array([1, 0]),
+        weights=np.array([2.0, 3.0]),
+        block_geoids=np.array(["block-1", "block-2"]),
+        congressional_district_geoids=np.array(["3701", "3702"]),
+        filters=(),
+        n_source_households=2,
+        n_total_clones=2,
+    )
+
+
+def _source_snapshot() -> SourceDatasetSnapshot:
+    simulation = FakeSimulation(
+        {
+            "rent": FakeHolder({2024: np.array([100, 200])}),
+            "age": FakeHolder({2024: np.array([10, 20, 30])}),
+            "taxable_income": FakeHolder({2024: np.array([1_000, 2_000])}),
+            "person_name": FakeHolder({2024: np.array(["a", "b", "c"])}),
+            "county_fips": FakeHolder({2024: np.array(["37183", "06037"])}),
+            "unsupported": FakeHolder({2024: np.array([1, 2])}),
+            "no_period": FakeHolder({}),
+        },
+        variable_entities={
+            "rent": "household",
+            "age": "person",
+            "taxable_income": "tax_unit",
+            "person_name": "person",
+            "county_fips": "household",
+            "unsupported": "unsupported_entity",
+            "no_period": "household",
+        },
+        value_types={
+            "person_name": str,
+            "county_fips": str,
+        },
+    )
+    return SourceDatasetSnapshot(
+        dataset_path=Path("source.h5"),
+        time_period=2024,
+        entity_graph=EntityGraph(**make_entity_graph_arrays()),
+        input_variables=frozenset(simulation.holders),
+        variable_provider=MicrosimulationVariableProvider(simulation),
+    )
+
+
+def test_variable_cloner_clones_by_reindexed_entity_source_indices():
+    source = _source_snapshot()
+    selection = _selection()
+    reindexed = EntityReindexer().reindex(source=source, selection=selection)
+
+    payload = VariableCloner().clone(
+        source=source,
+        selection=selection,
+        reindexed=reindexed,
+        variables_to_save={
+            "rent",
+            "age",
+            "taxable_income",
+            "person_name",
+            "county_fips",
+            "unsupported",
+            "no_period",
+        },
+    )
+
+    np.testing.assert_array_equal(payload.data["rent"][2024], np.array([200, 100]))
+    np.testing.assert_array_equal(payload.data["age"][2024], np.array([30, 10, 20]))
+    np.testing.assert_array_equal(
+        payload.data["taxable_income"][2024],
+        np.array([2_000, 1_000]),
+    )
+    np.testing.assert_array_equal(
+        payload.data["person_name"][2024],
+        np.array([b"c", b"a", b"b"]),
+    )
+    np.testing.assert_array_equal(
+        payload.data["county_fips"][2024],
+        np.array([6037, 37183], dtype=np.int32),
+    )
+    assert "unsupported" not in payload.data
+    assert "no_period" not in payload.data
+    assert payload.values_saved == 5
+
+
+def test_variable_cloner_inherits_legacy_skip_and_metadata_error_policy():
+    source = _source_snapshot()
+    selection = _selection()
+    reindexed = EntityReindexer().reindex(source=source, selection=selection)
+    source.variable_provider.simulation.tax_benefit_system.variables[
+        "rent"
+    ].entity.key = ""
+
+    with pytest.raises(ValueError, match="no entity key"):
+        VariableCloner().clone(
+            source=source,
+            selection=selection,
+            reindexed=reindexed,
+            variables_to_save={
+                "rent",
+                "unsupported",
+                "no_period",
+            },
+        )
+
+
+def test_variable_cloner_rejects_reindexed_selection_mismatch():
+    source = _source_snapshot()
+    selection = _selection()
+    reindexed = EntityReindexer().reindex(source=source, selection=selection)
+    mismatched = ReindexedEntities(
+        household_ids=reindexed.household_ids,
+        person_ids=reindexed.person_ids,
+        person_household_ids=reindexed.person_household_ids,
+        subentity_ids=reindexed.subentity_ids,
+        person_subentity_ids=reindexed.person_subentity_ids,
+        household_source_indices=np.array([0, 1]),
+        person_source_indices=reindexed.person_source_indices,
+        subentity_source_indices=reindexed.subentity_source_indices,
+        persons_per_household_clone=reindexed.persons_per_household_clone,
+        subentities_per_household_clone=reindexed.subentities_per_household_clone,
+        person_household_clone_indices=reindexed.person_household_clone_indices,
+        subentity_household_clone_indices=reindexed.subentity_household_clone_indices,
+    )
+
+    with pytest.raises(ValueError, match="source indices"):
+        VariableCloner().clone(
+            source=source,
+            selection=selection,
+            reindexed=mismatched,
+            variables_to_save={"rent"},
+        )
+
+
+def test_default_variables_to_save_keeps_current_local_h5_overrides():
+    source = _source_snapshot()
+
+    variables = default_variables_to_save(source)
+
+    assert "county" in variables
+    assert "congressional_district_geoid" in variables
+    assert "block_geoid" in variables
+    assert "rent" in variables


### PR DESCRIPTION
Fixes #965

## Summary
- Extract local H5 clone selection, entity reindexing, and variable cloning into dedicated build-output seams.
- Keep `build_h5(...)` as the transitional facade while preserving current output layout and legacy congressional-district filtering compatibility.
- Leave US augmentation, H5 writing ownership, and `LocalAreaDatasetBuilder` for PR 7.

## Tests
- `uv run --no-sync pytest tests/unit/build_outputs/test_selection.py tests/unit/build_outputs/test_reindexing.py tests/unit/build_outputs/test_variables.py tests/unit/build_outputs/test_source_dataset.py tests/unit/test_modal_worker_script.py -q`
- `uv run --no-sync --with pyyaml python scripts/run_quality_guards.py`
- `uv run --no-sync --with pyyaml --with pytest pytest tests/unit/test_pipeline_docs_extractor.py tests/unit/test_pipeline_doc_guards.py -q`
- `make lint`
