### PR TITLE
Add published dataset contract checks

### DIFF
--- a/changelog.d/published-ecps-contract.changed
+++ b/changelog.d/published-ecps-contract.changed
@@ -1,0 +1,1 @@
+Add configurable publication-time H5 leaf-input and microsimulation aggregate contract checks.

--- a/policyengine_us_data/storage/upload_completed_datasets.py
+++ b/policyengine_us_data/storage/upload_completed_datasets.py
@@ -1,5 +1,6 @@
 import json
 import math
+from dataclasses import dataclass
 from pathlib import Path
 
 import h5py
@@ -48,10 +49,43 @@ MIN_FILE_SIZES = {
     "cps_2024.h5": 50 * 1024 * 1024,  # 50 MB
 }
 
-# H5 groups that must exist and contain data.
-REQUIRED_GROUPS = [
-    "household_weight",
-]
+
+@dataclass(frozen=True)
+class H5SumCheck:
+    variable: str
+    label: str
+    min_value: float | None = None
+    max_value: float | None = None
+
+
+@dataclass(frozen=True)
+class MicrosimulationAggregateCheck:
+    variable: str
+    label: str
+    statistic: str
+    min_value: float | None = None
+    max_value: float | None = None
+    map_to: str | None = None
+    filter_variable: str | None = None
+    filter_map_to: str | None = None
+    filter_min_value: float | None = None
+
+
+# H5 groups that must exist and contain data in every validated dataset.
+REQUIRED_GROUPS = ("household_weight",)
+
+# Extra file-specific leaf inputs that should survive publication. These are
+# not formula outputs; they are source or imputed inputs used by model formulas.
+REQUIRED_VARIABLES_BY_FILENAME = {
+    "enhanced_cps_2024.h5": (
+        "social_security_retirement",
+        "takes_up_snap_if_eligible",
+        "takes_up_ssi_if_eligible",
+        "takes_up_tanf_if_eligible",
+        "would_claim_wic",
+        "is_wic_at_nutritional_risk",
+    ),
+}
 
 PROHIBITED_DATASET_VARIABLES = {
     "social_security_retirement_reported",
@@ -75,10 +109,74 @@ INCOME_GROUPS = [
     "employment_income",
 ]
 
-# Aggregate thresholds for sanity checks (year 2024).
+# Aggregate thresholds for broad sanity checks (year 2024).
 MIN_EMPLOYMENT_INCOME_SUM = 5e12  # $5 trillion
 MIN_HOUSEHOLD_WEIGHT_SUM = 100e6  # 100 million
 MAX_HOUSEHOLD_WEIGHT_SUM = 200e6  # 200 million
+
+H5_SUM_CHECKS_BY_FILENAME = {
+    "enhanced_cps_2024.h5": (
+        H5SumCheck(
+            variable="household_weight",
+            label="household_weight raw sum",
+            min_value=MIN_HOUSEHOLD_WEIGHT_SUM,
+            max_value=MAX_HOUSEHOLD_WEIGHT_SUM,
+        ),
+    ),
+    "cps_2024.h5": (
+        H5SumCheck(
+            variable="household_weight",
+            label="household_weight raw sum",
+            min_value=MIN_HOUSEHOLD_WEIGHT_SUM,
+            max_value=MAX_HOUSEHOLD_WEIGHT_SUM,
+        ),
+    ),
+}
+
+MICROSIMULATION_AGGREGATE_CHECKS_BY_FILENAME = {
+    "enhanced_cps_2024.h5": (
+        MicrosimulationAggregateCheck(
+            variable="employment_income",
+            label="employment_income sum",
+            statistic="sum",
+            min_value=MIN_EMPLOYMENT_INCOME_SUM,
+        ),
+        MicrosimulationAggregateCheck(
+            variable="social_security_retirement",
+            label="social_security_retirement sum",
+            statistic="sum",
+            min_value=8e11,
+            max_value=1.6e12,
+        ),
+        MicrosimulationAggregateCheck(
+            variable="person_in_poverty",
+            label="SPM poverty rate",
+            statistic="mean",
+            min_value=0.08,
+            max_value=0.35,
+            map_to="person",
+        ),
+        MicrosimulationAggregateCheck(
+            variable="person_in_poverty",
+            label="senior SPM poverty rate",
+            statistic="mean",
+            min_value=0.05,
+            max_value=0.35,
+            map_to="person",
+            filter_variable="age",
+            filter_map_to="person",
+            filter_min_value=65,
+        ),
+    ),
+    "cps_2024.h5": (
+        MicrosimulationAggregateCheck(
+            variable="employment_income",
+            label="employment_income sum",
+            statistic="sum",
+            min_value=MIN_EMPLOYMENT_INCOME_SUM,
+        ),
+    ),
+}
 
 CLONE_DIAGNOSTICS_FILENAME = "enhanced_cps_2024.clone_diagnostics.json"
 CLONE_DIAGNOSTICS_METRICS = {
@@ -264,21 +362,6 @@ def validate_dataset(file_path: Path) -> None:
             f"This likely indicates corrupted/incomplete data."
         )
 
-    # 2. H5 structure check - verify critical groups exist with data
-    def _check_group_has_data(f, name):
-        """Return True if the H5 group/dataset has non-empty data."""
-        if name not in f:
-            return False
-        group = f[name]
-        if isinstance(group, h5py.Group):
-            if len(group.keys()) == 0:
-                return False
-            first_key = list(group.keys())[0]
-            return len(group[first_key][:]) > 0
-        elif isinstance(group, h5py.Dataset):
-            return group.size > 0
-        return False
-
     try:
         with h5py.File(file_path, "r") as f:
             prohibited_variables = sorted(
@@ -290,11 +373,26 @@ def validate_dataset(file_path: Path) -> None:
                     + ", ".join(prohibited_variables)
                 )
 
-            for group_name in REQUIRED_GROUPS:
+            required_groups = (
+                *REQUIRED_GROUPS,
+                *REQUIRED_VARIABLES_BY_FILENAME.get(filename, ()),
+            )
+            for group_name in required_groups:
                 if not _check_group_has_data(f, group_name):
                     errors.append(
                         f"Required group '{group_name}' missing or empty in H5 file."
                     )
+
+            for check in H5_SUM_CHECKS_BY_FILENAME.get(filename, ()):
+                if not _check_group_has_data(f, check.variable):
+                    continue
+                _validate_range(
+                    errors,
+                    label=check.label,
+                    value=_h5_sum(f, check.variable),
+                    min_value=check.min_value,
+                    max_value=check.max_value,
+                )
 
             # At least one income group must have data
             has_income = any(_check_group_has_data(f, g) for g in INCOME_GROUPS)
@@ -329,27 +427,12 @@ def validate_dataset(file_path: Path) -> None:
         sim = Microsimulation(
             dataset=load_dataset_for_validation(file_path, Dataset.from_file)
         )
-        year = 2024
-
-        emp_income = sim.calculate("employment_income", year).sum()
-        if emp_income < MIN_EMPLOYMENT_INCOME_SUM:
-            errors.append(
-                f"employment_income sum = ${emp_income:,.0f}, "
-                f"expected > ${MIN_EMPLOYMENT_INCOME_SUM:,.0f}. "
-                f"Data may have dropped employment income."
-            )
-
-        hh_weight = sim.calculate("household_weight", year).values.sum()
-        if hh_weight < MIN_HOUSEHOLD_WEIGHT_SUM:
-            errors.append(
-                f"household_weight sum = {hh_weight:,.0f}, "
-                f"expected > {MIN_HOUSEHOLD_WEIGHT_SUM:,.0f}."
-            )
-        if hh_weight > MAX_HOUSEHOLD_WEIGHT_SUM:
-            errors.append(
-                f"household_weight sum = {hh_weight:,.0f}, "
-                f"expected < {MAX_HOUSEHOLD_WEIGHT_SUM:,.0f}."
-            )
+        aggregate_results = _run_microsimulation_aggregate_checks(
+            sim,
+            filename=filename,
+            period=2024,
+            errors=errors,
+        )
     except Exception as e:
         errors.append(f"Microsimulation validation failed: {e}")
 
@@ -370,8 +453,105 @@ def validate_dataset(file_path: Path) -> None:
             else ""
         )
     )
-    print(f"    employment_income sum: ${emp_income:,.0f}")
-    print(f"    Household weight sum: {hh_weight:,.0f}")
+    for label, value in aggregate_results:
+        print(f"    {label}: {_format_validation_value(value)}")
+
+
+def _check_group_has_data(f, name):
+    """Return True if the H5 group/dataset has non-empty data."""
+    if name not in f:
+        return False
+    group = f[name]
+    if isinstance(group, h5py.Group):
+        if len(group.keys()) == 0:
+            return False
+        first_key = list(group.keys())[0]
+        return len(group[first_key][:]) > 0
+    elif isinstance(group, h5py.Dataset):
+        return group.size > 0
+    return False
+
+
+def _h5_sum(f, name: str) -> float:
+    group = f[name]
+    if isinstance(group, h5py.Group):
+        first_key = list(group.keys())[0]
+        return float(group[first_key][:].sum())
+    return float(group[:].sum())
+
+
+def _format_validation_value(value: float) -> str:
+    if abs(value) >= 1e6:
+        return f"{value:,.0f}"
+    return f"{value:.4f}"
+
+
+def _validate_range(
+    errors: list[str],
+    *,
+    label: str,
+    value: float,
+    min_value: float | None,
+    max_value: float | None,
+) -> None:
+    if min_value is not None and value < min_value:
+        errors.append(
+            f"{label} = {_format_validation_value(value)}, "
+            f"expected >= {_format_validation_value(min_value)}."
+        )
+    if max_value is not None and value > max_value:
+        errors.append(
+            f"{label} = {_format_validation_value(value)}, "
+            f"expected <= {_format_validation_value(max_value)}."
+        )
+
+
+def _calculate_for_check(sim, variable: str, period: int, map_to: str | None):
+    kwargs = {"period": period}
+    if map_to is not None:
+        kwargs["map_to"] = map_to
+    return sim.calculate(variable, **kwargs)
+
+
+def _run_microsimulation_aggregate_checks(
+    sim,
+    *,
+    filename: str,
+    period: int,
+    errors: list[str],
+) -> list[tuple[str, float]]:
+    results = []
+    for check in MICROSIMULATION_AGGREGATE_CHECKS_BY_FILENAME.get(filename, ()):
+        values = _calculate_for_check(
+            sim,
+            check.variable,
+            period,
+            check.map_to,
+        )
+        if check.filter_variable is not None:
+            filter_values = _calculate_for_check(
+                sim,
+                check.filter_variable,
+                period,
+                check.filter_map_to,
+            )
+            if check.filter_min_value is not None:
+                values = values[filter_values >= check.filter_min_value]
+        if check.statistic == "sum":
+            result = float(values.sum())
+        elif check.statistic == "mean":
+            result = float(values.mean())
+        else:
+            raise ValueError(f"Unsupported aggregate statistic: {check.statistic}")
+        _validate_range(
+            errors,
+            label=check.label,
+            value=result,
+            min_value=check.min_value,
+            max_value=check.max_value,
+        )
+        results.append((check.label, result))
+    return results
 
 
 def validate_clone_diagnostics(file_path: Path) -> None:

--- a/tests/unit/test_upload_completed_datasets.py
+++ b/tests/unit/test_upload_completed_datasets.py
@@ -51,9 +51,20 @@ class _AggregateResult:
     def sum(self):
         return float(self.values.sum())
 
+    def mean(self):
+        return float(self.values.mean())
+
+    def __ge__(self, other):
+        return self.values >= other
+
+    def __getitem__(self, key):
+        return _AggregateResult(self.values[key])
+
 
 class _TimePeriodCheckingAggregateMicrosimulation:
     last_dataset = None
+    calls = []
+    overrides = {}
 
     def __init__(self, dataset=None):
         _TimePeriodCheckingAggregateMicrosimulation.last_dataset = dataset
@@ -62,7 +73,14 @@ class _TimePeriodCheckingAggregateMicrosimulation:
                 "Expected a period (eg. '2017', '2017-01', '2017-01-01', ...); got: 'None'."
             )
 
-    def calculate(self, variable_name, period=None):
+    def calculate(self, variable_name, period=None, map_to=None):
+        _TimePeriodCheckingAggregateMicrosimulation.calls.append(
+            (variable_name, period, map_to)
+        )
+        if variable_name in _TimePeriodCheckingAggregateMicrosimulation.overrides:
+            return _AggregateResult(
+                _TimePeriodCheckingAggregateMicrosimulation.overrides[variable_name]
+            )
         if variable_name == "employment_income":
             return _AggregateResult([6e12])
         if variable_name == "household_weight":
@@ -73,9 +91,15 @@ class _TimePeriodCheckingAggregateMicrosimulation:
 def _fake_tax_benefit_system():
     variable_entities = {
         "person_id": "person",
+        "spm_unit_id": "spm_unit",
         "household_id": "household",
         "employment_income": "person",
         "household_weight": "household",
+        "takes_up_snap_if_eligible": "spm_unit",
+        "takes_up_ssi_if_eligible": "person",
+        "takes_up_tanf_if_eligible": "spm_unit",
+        "would_claim_wic": "person",
+        "is_wic_at_nutritional_risk": "person",
     }
     return SimpleNamespace(
         variables={
@@ -91,9 +115,34 @@ def _write_h5(path, datasets: dict[str, np.ndarray]) -> None:
             h5_file.create_dataset(name, data=values)
 
 
+def _minimal_enhanced_cps_contract_datasets(**overrides):
+    datasets = {
+        "person_id": np.array([101, 102, 103], dtype=np.int32),
+        "spm_unit_id": np.array([201, 202], dtype=np.int32),
+        "household_id": np.array([301, 302], dtype=np.int32),
+        "employment_income": np.array([50_000.0, 60_000.0, 0.0], dtype=np.float32),
+        "household_weight": np.array([1.0, 1.0], dtype=np.float32),
+    }
+    for key, value in overrides.items():
+        if value is None:
+            datasets.pop(key, None)
+        else:
+            datasets[key] = value
+    return datasets
+
+
 @pytest.fixture(autouse=True)
 def patch_contract_validation(monkeypatch):
     monkeypatch.setitem(upload_module.MIN_FILE_SIZES, "cps_2024.h5", 0)
+    monkeypatch.setitem(upload_module.MIN_FILE_SIZES, "enhanced_cps_2024.h5", 0)
+    monkeypatch.setattr(upload_module, "H5_SUM_CHECKS_BY_FILENAME", {})
+    monkeypatch.setattr(
+        upload_module,
+        "MICROSIMULATION_AGGREGATE_CHECKS_BY_FILENAME",
+        {},
+    )
+    _TimePeriodCheckingAggregateMicrosimulation.calls = []
+    _TimePeriodCheckingAggregateMicrosimulation.overrides = {}
     monkeypatch.setattr(
         _dv_mod,
         "assert_locked_policyengine_us_version",
@@ -199,6 +248,85 @@ def test_validate_dataset_rejects_temporary_reported_source_variables(
         match="temporary or retired variables: snap_reported, ssi_reported",
     ):
         validate_dataset(file_path)
+
+
+def test_validate_enhanced_cps_rejects_missing_critical_leaf_inputs(
+    tmp_path,
+    monkeypatch,
+):
+    file_path = tmp_path / "enhanced_cps_2024.h5"
+    _write_h5(
+        file_path,
+        _minimal_enhanced_cps_contract_datasets(),
+    )
+    monkeypatch.setattr(
+        upload_module,
+        "REQUIRED_VARIABLES_BY_FILENAME",
+        {"enhanced_cps_2024.h5": ("required_leaf_input",)},
+    )
+
+    monkeypatch.setattr(
+        "policyengine_us.Microsimulation",
+        _TimePeriodCheckingAggregateMicrosimulation,
+    )
+
+    with pytest.raises(
+        DatasetValidationError,
+        match="Required group 'required_leaf_input' missing or empty",
+    ):
+        validate_dataset(file_path)
+
+
+def test_validate_dataset_rejects_configured_implausible_mapped_aggregate(
+    tmp_path,
+    monkeypatch,
+):
+    file_path = tmp_path / "enhanced_cps_2024.h5"
+    _write_h5(file_path, _minimal_enhanced_cps_contract_datasets())
+    _TimePeriodCheckingAggregateMicrosimulation.overrides = {
+        "generic_population_share": [0, 1, 1, 0, 1],
+        "generic_age": [30, 67, 66, 12, 78],
+    }
+    monkeypatch.setattr(
+        upload_module,
+        "REQUIRED_VARIABLES_BY_FILENAME",
+        {},
+    )
+    monkeypatch.setattr(
+        upload_module,
+        "MICROSIMULATION_AGGREGATE_CHECKS_BY_FILENAME",
+        {
+            "enhanced_cps_2024.h5": (
+                upload_module.MicrosimulationAggregateCheck(
+                    variable="generic_population_share",
+                    label="generic senior share",
+                    statistic="mean",
+                    max_value=0.5,
+                    map_to="person",
+                    filter_variable="generic_age",
+                    filter_map_to="person",
+                    filter_min_value=65,
+                ),
+            )
+        },
+    )
+
+    monkeypatch.setattr(
+        "policyengine_us.Microsimulation",
+        _TimePeriodCheckingAggregateMicrosimulation,
+    )
+
+    with pytest.raises(
+        DatasetValidationError,
+        match="generic senior share",
+    ):
+        validate_dataset(file_path)
+
+    assert (
+        "generic_population_share",
+        2024,
+        "person",
+    ) in _TimePeriodCheckingAggregateMicrosimulation.calls
 
 
 def _prepare_release_files(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Add config-driven publication-time H5 checks for required leaf inputs by dataset artifact.
- Add config-driven raw H5 sum and microsimulation aggregate plausibility checks.
- Cover the validator generically so future required leaves or aggregate checks can be added without one-off test logic.

## Validation
- uv run ruff format --check policyengine_us_data/storage/upload_completed_datasets.py tests/unit/test_upload_completed_datasets.py
- uv run ruff check policyengine_us_data/storage/upload_completed_datasets.py tests/unit/test_upload_completed_datasets.py
- uv run pytest tests/unit/test_upload_completed_datasets.py -q