### PR TITLE
Extract local H5 builder seams

### DIFF
--- a/changelog.d/969.changed
+++ b/changelog.d/969.changed
@@ -1,0 +1,1 @@
+Extracted local H5 build-output seams and split US payload postprocessors for focused unit testing.

--- a/docs/engineering/skills/README.md
+++ b/docs/engineering/skills/README.md
@@ -20,3 +20,7 @@ Current skills:
   pipeline status and durable error records.
 - `testing.md`: test layout, fixture scope, helper placement, and quality guard
   expectations.
+
+Stage-specific AI-facing engineering guides live under `docs/engineering/stages/`.
+Use them alongside these cross-cutting skills when modifying a stage-specific
+pipeline path.

--- a/docs/engineering/stages/build_outputs.md
+++ b/docs/engineering/stages/build_outputs.md
@@ -1,0 +1,171 @@
+# Build Outputs Stage AI Guide
+
+This guide is for AI agents and maintainers modifying Stage 4
+(`4_build_outputs`) code. Stage 4 turns calibrated and staged pipeline artifacts
+into publishable outputs, including local-area H5 files, national H5 files,
+diagnostics, and release-staging artifacts.
+
+The active local H5 seams live under `policyengine_us_data/build_outputs/`.
+Treat this package as the place for reusable Stage 4 library boundaries. Keep
+Modal orchestration, worker entrypoints, and release promotion behavior outside
+these library seams unless a stage plan explicitly says otherwise.
+
+## Local H5 Build Path
+
+The transitional runtime entrypoint is still
+`policyengine_us_data.calibration.publish_local_area.build_h5()`. It should stay
+as a facade while Stage 4 is being migrated. New implementation logic should
+move behind narrower build-output library seams instead of growing this facade.
+
+The current in-memory local H5 path is:
+
+1. `AreaSelector` selects active clone-household rows from clone weights and
+   geography filters.
+2. `EntityReindexer` creates output household, person, and subentity IDs.
+3. `VariableCloner` copies allowed source variables into a period-grouped
+   payload.
+4. `LocalAreaDatasetBuilder` applies payload postprocessors in declared order.
+5. `H5Writer` writes the final `H5Payload` and verifies summary counts.
+
+When adding behavior to this path, decide whether it is a selection, reindexing,
+source-variable cloning, postprocessing, or writing concern. Do not place
+country-specific payload mutation in `build_h5()` when it can be represented as
+a postprocessor.
+
+## Payload Postprocessors
+
+Payload postprocessors are ordered, country- or product-specific transformations
+that consume an `H5Payload` and return either another `H5Payload` or a structured
+result object exposing a `.payload` attribute.
+
+Use a postprocessor when the operation:
+
+- Mutates or adds payload variables after generic source-variable cloning.
+- Depends on country-specific business rules.
+- Needs focused unit tests independent of the full H5 builder.
+- Should run after some other payload construction step.
+
+Do not use a postprocessor for:
+
+- Selecting active clones. Use `AreaSelector`.
+- Reindexing entities. Use `EntityReindexer`.
+- Copying source variables unchanged. Use `VariableCloner`.
+- Writing H5 files. Use `H5Writer`.
+- Modal orchestration, volume setup, or publication promotion.
+
+## Postprocessor Spec Contract
+
+Every postprocessor should expose a stable `spec`:
+
+```python
+spec = PayloadPostProcessorSpec(
+    key="stable_unique_key",
+    requires=("upstream_key",),
+)
+```
+
+The `key` is a durable identifier for the processing step. Prefer short,
+stage-specific names such as `us_entity`, `us_geography`, or `us_takeup`.
+Do not use display names, class names, or generated values as the key when the
+processor is part of a stable runtime path.
+
+The `requires` tuple lists postprocessor keys that must already have run. This
+declares ordering explicitly. It is not a substitute for validating the concrete
+payload fields the postprocessor consumes.
+
+`LocalAreaDatasetBuilder` validates the configured postprocessor sequence before
+building:
+
+- Duplicate `spec.key` values are rejected.
+- A postprocessor whose `requires` keys have not appeared earlier is rejected.
+- Processors without an explicit `spec` receive a fallback key based on class
+  name. This fallback is for tests or transitional code only; production
+  postprocessors should define stable keys.
+
+If a processor consumes fields written by an earlier processor, define both the
+dependency and a payload validation. The dependency catches bad builder
+configuration early; payload validation catches direct processor use and
+malformed payloads.
+
+## Current US Postprocessors
+
+The production US postprocessor sequence is defined by
+`default_us_postprocessors()`:
+
+1. `USEntityPostProcessor`
+   - Key: `us_entity`
+   - Dependencies: none
+   - Adds output entity IDs and `household_weight`.
+
+2. `USGeographyPostProcessor`
+   - Key: `us_geography`
+   - Dependencies: none
+   - Derives geography from selected block GEOIDs and writes geography
+     variables such as `state_fips`, `county_fips`, `zip_code`, and
+     `congressional_district_geoid`.
+
+3. `USTakeupPostProcessor`
+   - Key: `us_takeup`
+   - Dependencies: `us_entity`, `us_geography`
+   - Applies take-up draws and writes take-up variables.
+   - Validates that required reindexed subentities exist.
+   - Validates that `state_fips` exists in the payload.
+   - Validates that `person_tax_unit_id` and `tax_unit_id` exist when reported
+     ACA anchors are present.
+
+Keep this ordering unless you also update specs, structural validations, and
+unit tests.
+
+## Adding A Postprocessor
+
+When adding a postprocessor:
+
+1. Define a result dataclass if callers need metadata beyond the payload.
+2. Define a stable `PayloadPostProcessorSpec`.
+3. Add direct payload precondition checks for every field the processor consumes.
+4. Preserve the incoming payload's `time_period`, `entity_lengths`, and
+   `variable_entities` unless intentionally changing them.
+5. When adding variables with non-obvious entity lengths, update
+   `variable_entities` so `H5Payload` can validate their shapes.
+6. Add the postprocessor to the production factory only if it belongs in the
+   runtime path.
+7. Add unit tests for the processor in `tests/unit/build_outputs/`.
+8. Add or update a builder-order test if the processor has dependencies.
+
+Prefer dependency injection for expensive or external behavior. For example,
+`USTakeupPostProcessor` accepts a `takeup_applier` so unit tests can verify the
+contract without loading rates or running the full pipeline.
+
+## Testing Expectations
+
+Unit tests should cover each new postprocessor directly. At minimum, test:
+
+- The variables it writes.
+- The payload fields it consumes.
+- Its declared `spec.key` and `spec.requires` ordering.
+- Failure for missing required payload fields.
+- Failure for wrong-length generated arrays when the output entity is known.
+
+Builder tests should cover:
+
+- Missing dependency rejection.
+- Duplicate postprocessor key rejection.
+- Result recording through `PayloadPostProcessorRun`.
+
+Integration tests should only be added when the behavior crosses module or
+runtime boundaries that unit tests cannot represent. Do not add a second
+integration test that proves the same seam.
+
+## Documentation Expectations
+
+When Stage 4 behavior changes, update the durable documentation surface:
+
+- Add or update `@pipeline_node` metadata for new stable library seams.
+- Update `docs/pipeline_map.yaml` when the stage graph or durable artifacts
+  change.
+- Keep generated docs out of manual PR edits unless the repository workflow
+  specifically requires them.
+
+Do not put PR-specific rationale in docstrings. Put durable behavior in source
+docs and put review or migration rationale in PR descriptions, issues, or stage
+planning docs.

--- a/docs/pipeline_map.yaml
+++ b/docs/pipeline_map.yaml
@@ -1167,10 +1167,6 @@ stages:
     label: Modal Worker Container
     node_type: external
     description: 16GB RAM, 1 CPU each, 8-hour timeout
-  - id: spm_recalc
-    label: SPM Threshold Recalculation
-    node_type: process
-    description: Local median rents, family composition, tenure type
   - id: takeup_apply
     label: Takeup Re-application
     node_type: process
@@ -1235,9 +1231,6 @@ stages:
     target: geo_derive
     edge_type: data_flow
   - source: geo_derive
-    target: spm_recalc
-    edge_type: data_flow
-  - source: spm_recalc
     target: takeup_apply
     edge_type: data_flow
   - source: modal_coord

--- a/policyengine_us_data/build_outputs/__init__.py
+++ b/policyengine_us_data/build_outputs/__init__.py
@@ -6,5 +6,7 @@ H5 output request construction, exact calibration geography loading,
 fingerprinting, clone-weight shape contracts, worker partitioning, source
 dataset snapshot contracts, worker input normalization, worker-bootstrap
 artifacts, worker-scoped session and validation context setup, microsimulation
-access helpers, clone selection, entity reindexing, and source-variable cloning.
+access helpers, clone selection, entity reindexing, source-variable cloning,
+validated H5 payload contracts, ordered output postprocessing, one-area payload
+building, and H5 writing.
 """

--- a/policyengine_us_data/build_outputs/builder.py
+++ b/policyengine_us_data/build_outputs/builder.py
@@ -1,0 +1,250 @@
+"""One-area local H5 build orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Protocol, TypeAlias
+
+import numpy as np
+
+from policyengine_us_data.pipeline_metadata import pipeline_node
+
+from .payload import H5Payload, PayloadBuildContext
+from .reindexing import EntityReindexer, ReindexedEntities
+from .requests import AreaBuildRequest
+from .selection import AreaSelector, CloneSelection
+from .source_dataset import SourceDatasetSnapshot
+from .variables import VariableCloner
+from .weights import CloneWeightMatrix
+
+__all__ = [
+    "LocalAreaBuildResult",
+    "LocalAreaDatasetBuilder",
+    "PayloadPostProcessor",
+    "PayloadPostProcessorRun",
+    "PayloadPostProcessorResult",
+]
+
+
+class PayloadPostProcessorResult(Protocol):
+    """Result contract for a payload postprocessor."""
+
+    payload: H5Payload
+
+
+PostProcessorReturn: TypeAlias = H5Payload | PayloadPostProcessorResult
+
+
+class PayloadPostProcessor(Protocol):
+    """Country- or product-specific processor for an H5 payload."""
+
+    def apply(
+        self,
+        *,
+        payload: H5Payload,
+        context: PayloadBuildContext,
+    ) -> PostProcessorReturn:
+        """Return a processed `H5Payload` or structured result with `.payload`."""
+
+
+@dataclass(frozen=True)
+class PayloadPostProcessorRun:
+    """Result metadata for one payload postprocessor invocation."""
+
+    name: str
+    postprocessor_type: type
+    result: PostProcessorReturn
+
+
+@pipeline_node(
+    id="local_h5_build_result",
+    label="LocalAreaBuildResult",
+    node_type="library",
+    description="In-memory local H5 payload and diagnostics for one area.",
+    source_file="policyengine_us_data/build_outputs/builder.py",
+    status="current",
+    stability="moving",
+    pathways=["local_h5"],
+    validation_commands=["uv run pytest tests/unit/build_outputs/test_builder.py"],
+)
+@dataclass(frozen=True)
+class LocalAreaBuildResult:
+    """In-memory output from building one local H5 area."""
+
+    payload: H5Payload
+    selection: CloneSelection
+    reindexed: ReindexedEntities
+    variables_saved: int
+    summary: Mapping[str, int | float | str]
+    postprocessor_runs: tuple[PayloadPostProcessorRun, ...] = ()
+
+    @property
+    def data(self) -> Mapping[str, Mapping[Any, np.ndarray]]:
+        """Payload data retained for transitional callers."""
+
+        return self.payload.data
+
+    @property
+    def time_period(self) -> int:
+        """Payload time period retained for transitional callers."""
+
+        return self.payload.time_period
+
+    def postprocessor_result(self, postprocessor: type | str) -> Any | None:
+        """Return the result for one configured postprocessor."""
+
+        key = (
+            postprocessor if isinstance(postprocessor, str) else postprocessor.__name__
+        )
+        for run in self.postprocessor_runs:
+            if run.name == key:
+                return run.result
+            if not isinstance(postprocessor, str) and issubclass(
+                run.postprocessor_type,
+                postprocessor,
+            ):
+                return run.result
+        return None
+
+    def postprocessor_results(self, postprocessor: type | str) -> tuple[Any, ...]:
+        """Return every result for a configured postprocessor type or name."""
+
+        key = (
+            postprocessor if isinstance(postprocessor, str) else postprocessor.__name__
+        )
+        return tuple(
+            run.result
+            for run in self.postprocessor_runs
+            if run.name == key
+            or (
+                not isinstance(postprocessor, str)
+                and issubclass(run.postprocessor_type, postprocessor)
+            )
+        )
+
+
+@pipeline_node(
+    id="local_h5_dataset_builder",
+    label="LocalAreaDatasetBuilder",
+    node_type="library",
+    description="Build the in-memory payload for one local-area or national H5 output.",
+    source_file="policyengine_us_data/build_outputs/builder.py",
+    status="current",
+    stability="moving",
+    pathways=["local_h5"],
+    validation_commands=["uv run pytest tests/unit/build_outputs/test_builder.py"],
+)
+@dataclass(frozen=True)
+class LocalAreaDatasetBuilder:
+    """Coordinate clone selection, reindexing, variable cloning, and postprocessing."""
+
+    selector: AreaSelector = field(default_factory=AreaSelector)
+    reindexer: EntityReindexer = field(default_factory=EntityReindexer)
+    variable_cloner: VariableCloner = field(default_factory=VariableCloner)
+    postprocessors: tuple[PayloadPostProcessor, ...] = ()
+
+    def build(
+        self,
+        *,
+        source: SourceDatasetSnapshot,
+        simulation: Any,
+        weights: CloneWeightMatrix,
+        geography: Any,
+        request: AreaBuildRequest,
+        takeup_filter: tuple[str, ...] | None = None,
+    ) -> LocalAreaBuildResult:
+        """Build one local H5 payload without writing it to disk."""
+
+        selection = self.selector.select(
+            weights=weights,
+            geography=geography,
+            filters=request.filters,
+        )
+        reindexed = self.reindexer.reindex(source=source, selection=selection)
+        payload = self.variable_cloner.clone(
+            source=source,
+            selection=selection,
+            reindexed=reindexed,
+        )
+        h5_payload = H5Payload(
+            data=payload.data,
+            time_period=int(source.time_period),
+            entity_lengths=_entity_lengths(reindexed),
+        )
+        context = PayloadBuildContext(
+            source=source,
+            simulation=simulation,
+            selection=selection,
+            reindexed=reindexed,
+            geography=geography,
+            time_period=int(source.time_period),
+            takeup_filter=takeup_filter,
+        )
+        postprocessor_runs: list[PayloadPostProcessorRun] = []
+        for postprocessor in self.postprocessors:
+            result = postprocessor.apply(payload=h5_payload, context=context)
+            postprocessor_runs.append(
+                PayloadPostProcessorRun(
+                    name=type(postprocessor).__name__,
+                    postprocessor_type=type(postprocessor),
+                    result=result,
+                )
+            )
+            h5_payload = _payload_from_postprocessor_result(result)
+
+        return LocalAreaBuildResult(
+            payload=h5_payload,
+            selection=selection,
+            reindexed=reindexed,
+            variables_saved=payload.values_saved,
+            summary=_build_summary(
+                request=request,
+                selection=selection,
+                reindexed=reindexed,
+                variables_saved=payload.values_saved,
+            ),
+            postprocessor_runs=tuple(postprocessor_runs),
+        )
+
+
+def _build_summary(
+    *,
+    request: AreaBuildRequest,
+    selection: CloneSelection,
+    reindexed: ReindexedEntities,
+    variables_saved: int,
+) -> dict[str, int | float | str]:
+    summary: dict[str, int | float | str] = {
+        "area_type": request.area_type,
+        "area_id": request.area_id,
+        "display_name": request.display_name,
+        "active_clones": selection.n_selected_clones,
+        "total_weight": float(np.sum(selection.weights)),
+        "persons": int(len(reindexed.person_ids)),
+        "variables_saved": int(variables_saved),
+    }
+    for entity_key, entity_source_indices in reindexed.subentity_source_indices.items():
+        summary[f"{entity_key}s"] = int(len(entity_source_indices))
+    return summary
+
+
+def _entity_lengths(reindexed: ReindexedEntities) -> dict[str, int]:
+    lengths = {
+        "household": int(len(reindexed.household_ids)),
+        "person": int(len(reindexed.person_ids)),
+    }
+    for entity_key, entity_ids in reindexed.subentity_ids.items():
+        lengths[entity_key] = int(len(entity_ids))
+    return lengths
+
+
+def _payload_from_postprocessor_result(result: PostProcessorReturn) -> H5Payload:
+    if isinstance(result, H5Payload):
+        return result
+    payload = getattr(result, "payload", None)
+    if isinstance(payload, H5Payload):
+        return payload
+    raise TypeError(
+        "Payload postprocessors must return H5Payload or an object exposing "
+        "an H5Payload `.payload` attribute"
+    )

--- a/policyengine_us_data/build_outputs/builder.py
+++ b/policyengine_us_data/build_outputs/builder.py
@@ -22,6 +22,7 @@ __all__ = [
     "LocalAreaDatasetBuilder",
     "PayloadPostProcessor",
     "PayloadPostProcessorRun",
+    "PayloadPostProcessorSpec",
     "PayloadPostProcessorResult",
 ]
 
@@ -38,6 +39,8 @@ PostProcessorReturn: TypeAlias = H5Payload | PayloadPostProcessorResult
 class PayloadPostProcessor(Protocol):
     """Country- or product-specific processor for an H5 payload."""
 
+    spec: PayloadPostProcessorSpec
+
     def apply(
         self,
         *,
@@ -48,9 +51,18 @@ class PayloadPostProcessor(Protocol):
 
 
 @dataclass(frozen=True)
+class PayloadPostProcessorSpec:
+    """Stable identity and ordering requirements for a payload postprocessor."""
+
+    key: str
+    requires: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class PayloadPostProcessorRun:
     """Result metadata for one payload postprocessor invocation."""
 
+    key: str
     name: str
     postprocessor_type: type
     result: PostProcessorReturn
@@ -97,7 +109,7 @@ class LocalAreaBuildResult:
             postprocessor if isinstance(postprocessor, str) else postprocessor.__name__
         )
         for run in self.postprocessor_runs:
-            if run.name == key:
+            if run.key == key or run.name == key:
                 return run.result
             if not isinstance(postprocessor, str) and issubclass(
                 run.postprocessor_type,
@@ -115,7 +127,8 @@ class LocalAreaBuildResult:
         return tuple(
             run.result
             for run in self.postprocessor_runs
-            if run.name == key
+            if run.key == key
+            or run.name == key
             or (
                 not isinstance(postprocessor, str)
                 and issubclass(run.postprocessor_type, postprocessor)
@@ -142,6 +155,9 @@ class LocalAreaDatasetBuilder:
     reindexer: EntityReindexer = field(default_factory=EntityReindexer)
     variable_cloner: VariableCloner = field(default_factory=VariableCloner)
     postprocessors: tuple[PayloadPostProcessor, ...] = ()
+
+    def __post_init__(self) -> None:
+        _validate_postprocessor_order(self.postprocessors)
 
     def build(
         self,
@@ -185,6 +201,7 @@ class LocalAreaDatasetBuilder:
             result = postprocessor.apply(payload=h5_payload, context=context)
             postprocessor_runs.append(
                 PayloadPostProcessorRun(
+                    key=_postprocessor_spec(postprocessor).key,
                     name=type(postprocessor).__name__,
                     postprocessor_type=type(postprocessor),
                     result=result,
@@ -248,3 +265,31 @@ def _payload_from_postprocessor_result(result: PostProcessorReturn) -> H5Payload
         "Payload postprocessors must return H5Payload or an object exposing "
         "an H5Payload `.payload` attribute"
     )
+
+
+def _validate_postprocessor_order(
+    postprocessors: tuple[PayloadPostProcessor, ...],
+) -> None:
+    seen: set[str] = set()
+    for postprocessor in postprocessors:
+        spec = _postprocessor_spec(postprocessor)
+        if spec.key in seen:
+            raise ValueError(f"Duplicate payload postprocessor key: {spec.key}")
+        missing = tuple(
+            requirement for requirement in spec.requires if requirement not in seen
+        )
+        if missing:
+            raise ValueError(
+                f"{type(postprocessor).__name__} requires postprocessor(s) "
+                f"to run first: {', '.join(missing)}"
+            )
+        seen.add(spec.key)
+
+
+def _postprocessor_spec(
+    postprocessor: PayloadPostProcessor,
+) -> PayloadPostProcessorSpec:
+    spec = getattr(postprocessor, "spec", None)
+    if isinstance(spec, PayloadPostProcessorSpec):
+        return spec
+    return PayloadPostProcessorSpec(key=type(postprocessor).__name__)

--- a/policyengine_us_data/build_outputs/payload.py
+++ b/policyengine_us_data/build_outputs/payload.py
@@ -1,0 +1,172 @@
+"""In-memory H5 payload contracts for local-area publication outputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+import numpy as np
+
+from policyengine_us_data.pipeline_metadata import pipeline_node
+
+from .reindexing import ReindexedEntities
+from .selection import CloneSelection
+from .source_dataset import SourceDatasetSnapshot
+
+__all__ = ["H5Payload", "PayloadBuildContext"]
+
+PeriodData = Mapping[Any, np.ndarray]
+PayloadData = Mapping[str, PeriodData]
+
+HOUSEHOLD_LENGTH_VARIABLES = frozenset(
+    (
+        "household_id",
+        "household_weight",
+        "state_fips",
+        "county",
+        "county_fips",
+        "block_geoid",
+        "tract_geoid",
+        "cbsa_code",
+        "sldu",
+        "sldl",
+        "place_fips",
+        "vtd",
+        "puma",
+        "zcta",
+        "zip_code",
+        "congressional_district_geoid",
+    )
+)
+
+
+@pipeline_node(
+    id="local_h5_payload",
+    label="H5Payload",
+    node_type="library",
+    description="Validated in-memory period-grouped payload for one local H5 output.",
+    source_file="policyengine_us_data/build_outputs/payload.py",
+    status="current",
+    stability="moving",
+    pathways=["local_h5"],
+    validation_commands=["uv run pytest tests/unit/build_outputs/test_payload.py"],
+)
+@dataclass(frozen=True)
+class H5Payload:
+    """Period-grouped arrays ready to write to a local-area H5 file.
+
+    `entity_lengths` records the row count expected for each entity in this
+    payload. Shape validation intentionally covers the stable structural
+    variables first; formula variables that do not encode their entity in the
+    variable name are left to existing source-variable and runtime checks.
+    """
+
+    data: PayloadData
+    time_period: int
+    entity_lengths: Mapping[str, int] = field(default_factory=dict)
+    variable_entities: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        normalized_data = _normalize_payload_data(self.data)
+        normalized_entity_lengths = {
+            str(entity): int(length) for entity, length in self.entity_lengths.items()
+        }
+        object.__setattr__(self, "data", normalized_data)
+        object.__setattr__(
+            self,
+            "entity_lengths",
+            normalized_entity_lengths,
+        )
+        object.__setattr__(
+            self,
+            "variable_entities",
+            {
+                str(variable): str(entity)
+                for variable, entity in self.variable_entities.items()
+            },
+        )
+        self.validate_shapes()
+
+    def validate_shapes(self) -> None:
+        """Raise when structural payload arrays do not match entity lengths."""
+
+        for variable, periods in self.data.items():
+            if not periods:
+                raise ValueError(f"{variable} must contain at least one period")
+            explicit_entity = self.variable_entities.get(variable)
+            expected_entity = _infer_entity(
+                variable,
+                self.entity_lengths,
+                self.variable_entities,
+            )
+            for period, values in periods.items():
+                array = np.asarray(values)
+                if array.ndim == 0:
+                    raise ValueError(f"{variable}[{period}] must be array-like")
+                if expected_entity is None:
+                    continue
+                expected_length = self.entity_lengths.get(expected_entity)
+                if expected_length is None:
+                    if explicit_entity is not None:
+                        raise ValueError(
+                            f"{variable} maps to unknown entity {expected_entity!r}"
+                        )
+                    continue
+                if len(array) != expected_length:
+                    raise ValueError(
+                        f"{variable}[{period}] length {len(array)} does not match "
+                        f"{expected_entity} length {expected_length}"
+                    )
+
+
+@pipeline_node(
+    id="local_h5_payload_build_context",
+    label="PayloadBuildContext",
+    node_type="library",
+    description="Context passed to payload postprocessors during one H5 build.",
+    source_file="policyengine_us_data/build_outputs/payload.py",
+    status="current",
+    stability="moving",
+    pathways=["local_h5"],
+    validation_commands=["uv run pytest tests/unit/build_outputs/test_payload.py"],
+)
+@dataclass(frozen=True)
+class PayloadBuildContext:
+    """Context available to country-specific local H5 payload postprocessors."""
+
+    source: SourceDatasetSnapshot
+    simulation: Any
+    selection: CloneSelection
+    reindexed: ReindexedEntities
+    geography: Any
+    time_period: int
+    takeup_filter: tuple[str, ...] | None = None
+
+
+def _normalize_payload_data(data: PayloadData) -> dict[str, dict[Any, np.ndarray]]:
+    return {
+        str(variable): {
+            period: np.asarray(values) for period, values in periods.items()
+        }
+        for variable, periods in data.items()
+    }
+
+
+def _infer_entity(
+    variable: str,
+    entity_lengths: Mapping[str, int],
+    variable_entities: Mapping[str, str],
+) -> str | None:
+    if variable in variable_entities:
+        return variable_entities[variable]
+    if variable in HOUSEHOLD_LENGTH_VARIABLES:
+        return "household"
+    if variable in ("person_id", "person_household_id"):
+        return "person"
+    if variable.startswith("person_") and variable.endswith("_id"):
+        return "person"
+    if variable.endswith("_id"):
+        entity = variable.removesuffix("_id")
+        if entity in entity_lengths:
+            return entity
+    return None

--- a/policyengine_us_data/build_outputs/us_augmentations.py
+++ b/policyengine_us_data/build_outputs/us_augmentations.py
@@ -18,6 +18,7 @@ from policyengine_us_data.utils.takeup import (
     reported_subsidized_marketplace_by_tax_unit,
 )
 
+from .builder import PayloadPostProcessorSpec
 from .payload import H5Payload, PayloadBuildContext
 from .selection import CloneSelection
 from .simulation_access import calculate_variable_values
@@ -25,6 +26,9 @@ from .variables import GEOGRAPHY_VARIABLES
 
 __all__ = [
     "TAKEUP_VARIABLE_ENTITIES",
+    "US_ENTITY_POSTPROCESSOR_KEY",
+    "US_GEOGRAPHY_POSTPROCESSOR_KEY",
+    "US_TAKEUP_POSTPROCESSOR_KEY",
     "USEntityPostProcessor",
     "USEntityPostProcessorResult",
     "USGeographyPostProcessor",
@@ -42,6 +46,9 @@ TAKEUP_VARIABLE_ENTITIES = {
     str(spec["variable"]): str(spec["entity"]) for spec in SIMPLE_TAKEUP_VARS
 }
 REQUIRED_TAKEUP_SUBENTITIES = ("tax_unit", "spm_unit")
+US_ENTITY_POSTPROCESSOR_KEY = "us_entity"
+US_GEOGRAPHY_POSTPROCESSOR_KEY = "us_geography"
+US_TAKEUP_POSTPROCESSOR_KEY = "us_takeup"
 
 
 @pipeline_node(
@@ -141,6 +148,8 @@ class USTakeupPostProcessorResult:
 class USEntityPostProcessor:
     """Apply US entity IDs and calibrated household weights."""
 
+    spec = PayloadPostProcessorSpec(key=US_ENTITY_POSTPROCESSOR_KEY)
+
     def apply(
         self,
         *,
@@ -191,6 +200,8 @@ class USEntityPostProcessor:
 @dataclass(frozen=True)
 class USGeographyPostProcessor:
     """Apply block-derived US geography overrides."""
+
+    spec = PayloadPostProcessorSpec(key=US_GEOGRAPHY_POSTPROCESSOR_KEY)
 
     geography_deriver: GeographyDeriver = derive_geography_from_blocks
     _string_geography_variables: tuple[str, ...] = field(
@@ -295,6 +306,10 @@ class USGeographyPostProcessor:
 class USTakeupPostProcessor:
     """Apply US take-up draws after entity and geography postprocessing."""
 
+    spec = PayloadPostProcessorSpec(
+        key=US_TAKEUP_POSTPROCESSOR_KEY,
+        requires=(US_ENTITY_POSTPROCESSOR_KEY, US_GEOGRAPHY_POSTPROCESSOR_KEY),
+    )
     takeup_applier: TakeupApplier = apply_block_takeup_to_arrays
     sum_person_values_to_tax_units: Callable[
         [np.ndarray, np.ndarray, np.ndarray],
@@ -312,6 +327,7 @@ class USTakeupPostProcessor:
         self._validate_required_subentities(context)
         output = _copy_payload(payload.data)
         time_period = context.time_period
+        self._validate_required_payload_fields(output, time_period)
         results = self._build_takeup_results(output, context)
         takeup_variables = tuple(str(variable) for variable in results)
         self._validate_takeup_variables(takeup_variables)
@@ -348,6 +364,32 @@ class USTakeupPostProcessor:
             raise ValueError(
                 f"US take-up requires reindexed subentities: {', '.join(missing)}"
             )
+
+    def _validate_required_payload_fields(
+        self,
+        data: PayloadData,
+        time_period: int,
+    ) -> None:
+        _required_period_array(
+            data,
+            "state_fips",
+            time_period,
+            "US take-up requires state_fips from USGeographyPostProcessor",
+        )
+        if _has_period_array(
+            data,
+            "reported_has_subsidized_marketplace_health_coverage_at_interview",
+            time_period,
+        ):
+            for variable in ("person_tax_unit_id", "tax_unit_id"):
+                _required_period_array(
+                    data,
+                    variable,
+                    time_period,
+                    "US take-up reported ACA anchors require "
+                    "person_tax_unit_id and tax_unit_id from "
+                    "USEntityPostProcessor",
+                )
 
     def _build_takeup_results(
         self,
@@ -479,6 +521,14 @@ def _required_period_array(
     if variable not in data or time_period not in data[variable]:
         raise ValueError(message)
     return np.asarray(data[variable][time_period])
+
+
+def _has_period_array(
+    data: Mapping[str, Mapping[Any, np.ndarray]],
+    variable: str,
+    time_period: int,
+) -> bool:
+    return variable in data and time_period in data[variable]
 
 
 def _build_reported_takeup_anchors(

--- a/policyengine_us_data/build_outputs/us_augmentations.py
+++ b/policyengine_us_data/build_outputs/us_augmentations.py
@@ -1,0 +1,510 @@
+"""US-specific payload postprocessors for local H5 outputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Mapping
+
+import numpy as np
+
+from policyengine_us_data.calibration.block_assignment import (
+    derive_geography_from_blocks,
+)
+from policyengine_us_data.pipeline_metadata import pipeline_node
+from policyengine_us_data.utils.takeup import (
+    SIMPLE_TAKEUP_VARS,
+    _sum_person_values_to_tax_units,
+    apply_block_takeup_to_arrays,
+    reported_subsidized_marketplace_by_tax_unit,
+)
+
+from .payload import H5Payload, PayloadBuildContext
+from .selection import CloneSelection
+from .simulation_access import calculate_variable_values
+from .variables import GEOGRAPHY_VARIABLES
+
+__all__ = [
+    "TAKEUP_VARIABLE_ENTITIES",
+    "USEntityPostProcessor",
+    "USEntityPostProcessorResult",
+    "USGeographyPostProcessor",
+    "USGeographyPostProcessorResult",
+    "USTakeupPostProcessor",
+    "USTakeupPostProcessorResult",
+    "default_us_postprocessors",
+]
+
+PeriodData = dict[Any, np.ndarray]
+PayloadData = dict[str, PeriodData]
+GeographyDeriver = Callable[[np.ndarray], Mapping[str, np.ndarray]]
+TakeupApplier = Callable[..., Mapping[str, np.ndarray]]
+TAKEUP_VARIABLE_ENTITIES = {
+    str(spec["variable"]): str(spec["entity"]) for spec in SIMPLE_TAKEUP_VARS
+}
+REQUIRED_TAKEUP_SUBENTITIES = ("tax_unit", "spm_unit")
+
+
+@pipeline_node(
+    id="local_h5_us_entity_postprocessor_result",
+    label="USEntityPostProcessorResult",
+    node_type="library",
+    description="US entity ID and household-weight local H5 payload data.",
+    source_file="policyengine_us_data/build_outputs/us_augmentations.py",
+    status="current",
+    stability="moving",
+    pathways=["local_h5"],
+    validation_commands=[
+        "uv run pytest tests/unit/build_outputs/test_us_augmentations.py"
+    ],
+)
+@dataclass(frozen=True)
+class USEntityPostProcessorResult:
+    """Payload after US entity ID and household-weight fields are applied."""
+
+    payload: H5Payload
+
+    @property
+    def data(self) -> PayloadData:
+        """Augmented payload data retained for transitional callers."""
+
+        return self.payload.data
+
+
+@pipeline_node(
+    id="local_h5_us_geography_postprocessor_result",
+    label="USGeographyPostProcessorResult",
+    node_type="library",
+    description="US geography local H5 payload data and block-derived geography.",
+    source_file="policyengine_us_data/build_outputs/us_augmentations.py",
+    status="current",
+    stability="moving",
+    pathways=["local_h5"],
+    validation_commands=[
+        "uv run pytest tests/unit/build_outputs/test_us_augmentations.py"
+    ],
+)
+@dataclass(frozen=True)
+class USGeographyPostProcessorResult:
+    """Payload after US geography fields are applied."""
+
+    payload: H5Payload
+    clone_geography: Mapping[str, np.ndarray]
+
+    @property
+    def data(self) -> PayloadData:
+        """Augmented payload data retained for transitional callers."""
+
+        return self.payload.data
+
+
+@pipeline_node(
+    id="local_h5_us_takeup_postprocessor_result",
+    label="USTakeupPostProcessorResult",
+    node_type="library",
+    description="US take-up local H5 payload data and generated take-up variables.",
+    source_file="policyengine_us_data/build_outputs/us_augmentations.py",
+    status="current",
+    stability="moving",
+    pathways=["local_h5"],
+    validation_commands=[
+        "uv run pytest tests/unit/build_outputs/test_us_augmentations.py"
+    ],
+)
+@dataclass(frozen=True)
+class USTakeupPostProcessorResult:
+    """Payload after US take-up fields are applied."""
+
+    payload: H5Payload
+    takeup_variables: tuple[str, ...] = ()
+
+    @property
+    def data(self) -> PayloadData:
+        """Augmented payload data retained for transitional callers."""
+
+        return self.payload.data
+
+
+@pipeline_node(
+    id="local_h5_us_entity_postprocessor",
+    label="USEntityPostProcessor",
+    node_type="library",
+    description="Apply US entity ID and household-weight fields to local H5 payloads.",
+    source_file="policyengine_us_data/build_outputs/us_augmentations.py",
+    status="current",
+    stability="moving",
+    pathways=["local_h5"],
+    validation_commands=[
+        "uv run pytest tests/unit/build_outputs/test_us_augmentations.py"
+    ],
+)
+@dataclass(frozen=True)
+class USEntityPostProcessor:
+    """Apply US entity IDs and calibrated household weights."""
+
+    def apply(
+        self,
+        *,
+        payload: H5Payload,
+        context: PayloadBuildContext,
+    ) -> USEntityPostProcessorResult:
+        """Return a payload with structural ID and weight overrides applied."""
+
+        output = _copy_payload(payload.data)
+        time_period = context.time_period
+        reindexed = context.reindexed
+        output["household_id"] = {time_period: reindexed.household_ids}
+        output["person_id"] = {time_period: reindexed.person_ids}
+        output["person_household_id"] = {
+            time_period: reindexed.person_household_ids,
+        }
+        for entity_key, entity_ids in reindexed.subentity_ids.items():
+            output[f"{entity_key}_id"] = {time_period: entity_ids}
+            output[f"person_{entity_key}_id"] = {
+                time_period: reindexed.person_subentity_ids[entity_key],
+            }
+        output["household_weight"] = {
+            time_period: context.selection.weights.astype(np.float32),
+        }
+        return USEntityPostProcessorResult(
+            payload=H5Payload(
+                data=output,
+                time_period=payload.time_period,
+                entity_lengths=payload.entity_lengths,
+                variable_entities=payload.variable_entities,
+            ),
+        )
+
+
+@pipeline_node(
+    id="local_h5_us_geography_postprocessor",
+    label="USGeographyPostProcessor",
+    node_type="library",
+    description="Apply US geography fields to local H5 payloads.",
+    source_file="policyengine_us_data/build_outputs/us_augmentations.py",
+    status="current",
+    stability="moving",
+    pathways=["local_h5"],
+    validation_commands=[
+        "uv run pytest tests/unit/build_outputs/test_us_augmentations.py"
+    ],
+)
+@dataclass(frozen=True)
+class USGeographyPostProcessor:
+    """Apply block-derived US geography overrides."""
+
+    geography_deriver: GeographyDeriver = derive_geography_from_blocks
+    _string_geography_variables: tuple[str, ...] = field(
+        default=GEOGRAPHY_VARIABLES,
+        init=False,
+        repr=False,
+    )
+
+    def apply(
+        self,
+        *,
+        payload: H5Payload,
+        context: PayloadBuildContext,
+    ) -> USGeographyPostProcessorResult:
+        """Return a payload with block-derived geography fields applied."""
+
+        output = _copy_payload(payload.data)
+        clone_geography = self._derive_clone_geography(context.selection)
+        self._apply_geography_overrides(output, clone_geography, context)
+        return USGeographyPostProcessorResult(
+            payload=H5Payload(
+                data=output,
+                time_period=payload.time_period,
+                entity_lengths=payload.entity_lengths,
+                variable_entities=payload.variable_entities,
+            ),
+            clone_geography=clone_geography,
+        )
+
+    def _derive_clone_geography(
+        self,
+        selection: CloneSelection,
+    ) -> Mapping[str, np.ndarray]:
+        unique_blocks, block_inverse = np.unique(
+            selection.block_geoids,
+            return_inverse=True,
+        )
+        unique_geography = self.geography_deriver(unique_blocks)
+        return {
+            key: np.asarray(values)[block_inverse]
+            for key, values in unique_geography.items()
+        }
+
+    def _apply_geography_overrides(
+        self,
+        data: PayloadData,
+        clone_geography: Mapping[str, np.ndarray],
+        context: PayloadBuildContext,
+    ) -> None:
+        time_period = context.time_period
+        data["state_fips"] = {
+            time_period: np.asarray(clone_geography["state_fips"]).astype(np.int32),
+        }
+        data["county"] = {
+            time_period: np.asarray(clone_geography["county_index"]).astype(np.int32),
+        }
+        data["county_fips"] = {
+            time_period: np.asarray(clone_geography["county_fips"]).astype(np.int32),
+        }
+        for variable in self._string_geography_variables:
+            if variable in clone_geography:
+                data[variable] = {
+                    time_period: np.asarray(clone_geography[variable]).astype("S"),
+                }
+        self._apply_los_angeles_zip_patch(data, clone_geography, time_period)
+        data["congressional_district_geoid"] = {
+            time_period: np.asarray(
+                [int(cd) for cd in context.selection.congressional_district_geoids],
+                dtype=np.int32,
+            ),
+        }
+
+    def _apply_los_angeles_zip_patch(
+        self,
+        data: PayloadData,
+        clone_geography: Mapping[str, np.ndarray],
+        time_period: int,
+    ) -> None:
+        county_fips = np.asarray(clone_geography["county_fips"]).astype(str)
+        los_angeles_mask = county_fips == "06037"
+        if not los_angeles_mask.any():
+            return
+        zip_codes = np.full(len(los_angeles_mask), "00000")
+        zip_codes[los_angeles_mask] = "90001"
+        data["zip_code"] = {time_period: zip_codes.astype("S")}
+
+
+@pipeline_node(
+    id="local_h5_us_takeup_postprocessor",
+    label="USTakeupPostProcessor",
+    node_type="library",
+    description="Apply US take-up fields to local H5 payloads.",
+    source_file="policyengine_us_data/build_outputs/us_augmentations.py",
+    status="current",
+    stability="moving",
+    pathways=["local_h5"],
+    validation_commands=[
+        "uv run pytest tests/unit/build_outputs/test_us_augmentations.py"
+    ],
+)
+@dataclass(frozen=True)
+class USTakeupPostProcessor:
+    """Apply US take-up draws after entity and geography postprocessing."""
+
+    takeup_applier: TakeupApplier = apply_block_takeup_to_arrays
+    sum_person_values_to_tax_units: Callable[
+        [np.ndarray, np.ndarray, np.ndarray],
+        np.ndarray,
+    ] = _sum_person_values_to_tax_units
+
+    def apply(
+        self,
+        *,
+        payload: H5Payload,
+        context: PayloadBuildContext,
+    ) -> USTakeupPostProcessorResult:
+        """Return a payload with take-up variables applied."""
+
+        self._validate_required_subentities(context)
+        output = _copy_payload(payload.data)
+        time_period = context.time_period
+        results = self._build_takeup_results(output, context)
+        takeup_variables = tuple(str(variable) for variable in results)
+        self._validate_takeup_variables(takeup_variables)
+        for variable, values in results.items():
+            output[str(variable)] = {time_period: np.asarray(values)}
+        variable_entities = {
+            **payload.variable_entities,
+            **{
+                variable: TAKEUP_VARIABLE_ENTITIES[variable]
+                for variable in takeup_variables
+            },
+        }
+        return USTakeupPostProcessorResult(
+            payload=H5Payload(
+                data=output,
+                time_period=payload.time_period,
+                entity_lengths=payload.entity_lengths,
+                variable_entities=variable_entities,
+            ),
+            takeup_variables=takeup_variables,
+        )
+
+    def _validate_required_subentities(self, context: PayloadBuildContext) -> None:
+        reindexed = context.reindexed
+        missing = [
+            entity_key
+            for entity_key in REQUIRED_TAKEUP_SUBENTITIES
+            if entity_key not in reindexed.subentity_ids
+            or entity_key not in reindexed.person_subentity_ids
+            or entity_key not in reindexed.subentity_source_indices
+            or entity_key not in reindexed.subentity_household_clone_indices
+        ]
+        if missing:
+            raise ValueError(
+                f"US take-up requires reindexed subentities: {', '.join(missing)}"
+            )
+
+    def _build_takeup_results(
+        self,
+        data: PayloadData,
+        context: PayloadBuildContext,
+    ) -> Mapping[str, np.ndarray]:
+        reindexed = context.reindexed
+        selection = context.selection
+        time_period = context.time_period
+        subentity_source_indices = reindexed.subentity_source_indices
+        subentity_ids = reindexed.subentity_ids
+        person_subentity_ids = reindexed.person_subentity_ids
+        state_fips = _required_period_array(
+            data,
+            "state_fips",
+            time_period,
+            "US take-up requires state_fips from USGeographyPostProcessor",
+        )
+
+        entity_hh_indices = {
+            "person": reindexed.person_household_clone_indices.astype(np.int64),
+            "tax_unit": reindexed.subentity_household_clone_indices["tax_unit"].astype(
+                np.int64
+            ),
+            "spm_unit": reindexed.subentity_household_clone_indices["spm_unit"].astype(
+                np.int64
+            ),
+        }
+        entity_counts = {
+            "person": len(reindexed.person_ids),
+            "tax_unit": len(subentity_source_indices["tax_unit"]),
+            "spm_unit": len(subentity_source_indices["spm_unit"]),
+        }
+        reported_anchors = _build_reported_takeup_anchors(data, time_period)
+        voluntary_filing_inputs = self._build_voluntary_filing_inputs(
+            context=context,
+            tax_unit_source_indices=subentity_source_indices["tax_unit"],
+            new_tax_unit_ids=subentity_ids["tax_unit"],
+            new_person_tax_unit_ids=person_subentity_ids["tax_unit"],
+        )
+        return self.takeup_applier(
+            hh_blocks=selection.block_geoids,
+            hh_state_fips=np.asarray(state_fips).astype(np.int32),
+            hh_ids=context.source.household_ids[
+                selection.source_household_indices
+            ].astype(np.int64),
+            hh_clone_indices=selection.clone_indices.astype(np.int64),
+            entity_hh_indices=entity_hh_indices,
+            entity_counts=entity_counts,
+            time_period=time_period,
+            takeup_filter=(
+                list(context.takeup_filter)
+                if context.takeup_filter is not None
+                else None
+            ),
+            reported_anchors=reported_anchors,
+            voluntary_filing_inputs=voluntary_filing_inputs,
+        )
+
+    def _validate_takeup_variables(self, takeup_variables: tuple[str, ...]) -> None:
+        unknown_variables = [
+            variable
+            for variable in takeup_variables
+            if variable not in TAKEUP_VARIABLE_ENTITIES
+        ]
+        if unknown_variables:
+            raise ValueError(
+                "Unknown take-up variable(s) returned by takeup applier: "
+                f"{', '.join(unknown_variables)}"
+            )
+
+    def _build_voluntary_filing_inputs(
+        self,
+        *,
+        context: PayloadBuildContext,
+        tax_unit_source_indices: np.ndarray,
+        new_tax_unit_ids: np.ndarray,
+        new_person_tax_unit_ids: np.ndarray,
+    ) -> dict[str, np.ndarray]:
+        time_period = context.time_period
+        return {
+            "tax_unit_child_dependents": calculate_variable_values(
+                context.simulation,
+                "tax_unit_child_dependents",
+                period=time_period,
+                map_to="tax_unit",
+            )[tax_unit_source_indices],
+            "tax_unit_wage_income": self.sum_person_values_to_tax_units(
+                calculate_variable_values(
+                    context.simulation,
+                    "employment_income",
+                    period=time_period,
+                    map_to="person",
+                )[context.reindexed.person_source_indices],
+                new_person_tax_unit_ids,
+                new_tax_unit_ids,
+            ),
+            "age_head": calculate_variable_values(
+                context.simulation,
+                "age_head",
+                period=time_period,
+                map_to="tax_unit",
+            )[tax_unit_source_indices],
+        }
+
+
+def default_us_postprocessors() -> tuple[
+    USEntityPostProcessor | USGeographyPostProcessor | USTakeupPostProcessor, ...
+]:
+    """Return production US postprocessors in their required order."""
+
+    return (
+        USEntityPostProcessor(),
+        USGeographyPostProcessor(),
+        USTakeupPostProcessor(),
+    )
+
+
+def _copy_payload(data: Mapping[str, Mapping[Any, np.ndarray]]) -> PayloadData:
+    return {variable: dict(periods) for variable, periods in data.items()}
+
+
+def _required_period_array(
+    data: Mapping[str, Mapping[Any, np.ndarray]],
+    variable: str,
+    time_period: int,
+    message: str,
+) -> np.ndarray:
+    if variable not in data or time_period not in data[variable]:
+        raise ValueError(message)
+    return np.asarray(data[variable][time_period])
+
+
+def _build_reported_takeup_anchors(
+    data: Mapping[str, Mapping[Any, np.ndarray]],
+    time_period: int,
+) -> dict[str, np.ndarray]:
+    reported_anchors = {}
+    if (
+        "reported_has_subsidized_marketplace_health_coverage_at_interview" in data
+        and time_period
+        in data["reported_has_subsidized_marketplace_health_coverage_at_interview"]
+    ):
+        reported_anchors["takes_up_aca_if_eligible"] = (
+            reported_subsidized_marketplace_by_tax_unit(
+                data["person_tax_unit_id"][time_period],
+                data["tax_unit_id"][time_period],
+                data[
+                    "reported_has_subsidized_marketplace_health_coverage_at_interview"
+                ][time_period],
+            )
+        )
+    if (
+        "has_medicaid_health_coverage_at_interview" in data
+        and time_period in data["has_medicaid_health_coverage_at_interview"]
+    ):
+        reported_anchors["takes_up_medicaid_if_eligible"] = data[
+            "has_medicaid_health_coverage_at_interview"
+        ][time_period].astype(bool)
+    return reported_anchors

--- a/policyengine_us_data/build_outputs/writer.py
+++ b/policyengine_us_data/build_outputs/writer.py
@@ -1,0 +1,100 @@
+"""H5 writing boundary for local-area publication outputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+from policyengine_us_data.pipeline_metadata import pipeline_node
+
+from .payload import H5Payload
+
+__all__ = ["H5WriteResult", "H5Writer"]
+
+
+@pipeline_node(
+    id="local_h5_write_result",
+    label="H5WriteResult",
+    node_type="library",
+    description="Post-write verification summary for one local H5 file.",
+    source_file="policyengine_us_data/build_outputs/writer.py",
+    status="current",
+    stability="moving",
+    pathways=["local_h5"],
+    validation_commands=["uv run pytest tests/unit/build_outputs/test_writer.py"],
+)
+@dataclass(frozen=True)
+class H5WriteResult:
+    """Summary of one H5 write and lightweight verification pass."""
+
+    path: Path
+    households: int | None
+    persons: int | None
+    household_weight_sum: float | None
+    person_weight_sum: float | None
+
+
+@pipeline_node(
+    id="local_h5_writer",
+    label="H5Writer",
+    node_type="library",
+    description="Write one period-grouped local H5 payload to disk.",
+    source_file="policyengine_us_data/build_outputs/writer.py",
+    status="current",
+    stability="moving",
+    pathways=["local_h5"],
+    validation_commands=["uv run pytest tests/unit/build_outputs/test_writer.py"],
+)
+@dataclass(frozen=True)
+class H5Writer:
+    """Write period-grouped local H5 payloads and verify key output counts."""
+
+    def write(
+        self,
+        *,
+        payload: H5Payload,
+        output_path: Path,
+    ) -> H5WriteResult:
+        """Write `payload` to `output_path` and return a verification summary."""
+
+        payload.validate_shapes()
+        path = Path(output_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with h5py.File(str(path), "w") as file:
+            for variable, periods in payload.data.items():
+                group = file.create_group(variable)
+                for period, values in periods.items():
+                    group.create_dataset(str(period), data=values)
+        return self.verify(path=path, time_period=payload.time_period)
+
+    def verify(self, *, path: Path, time_period: int) -> H5WriteResult:
+        """Read key output variables from a written H5 file."""
+
+        tp = str(time_period)
+        with h5py.File(str(path), "r") as file:
+            households = _length_if_present(file, "household_id", tp)
+            persons = _length_if_present(file, "person_id", tp)
+            household_weight_sum = _sum_if_present(file, "household_weight", tp)
+            person_weight_sum = _sum_if_present(file, "person_weight", tp)
+        return H5WriteResult(
+            path=Path(path),
+            households=households,
+            persons=persons,
+            household_weight_sum=household_weight_sum,
+            person_weight_sum=person_weight_sum,
+        )
+
+
+def _length_if_present(file: h5py.File, variable: str, period: str) -> int | None:
+    if variable not in file or period not in file[variable]:
+        return None
+    return int(len(file[variable][period][:]))
+
+
+def _sum_if_present(file: h5py.File, variable: str, period: str) -> float | None:
+    if variable not in file or period not in file[variable]:
+        return None
+    return float(np.sum(file[variable][period][:]))

--- a/policyengine_us_data/calibration/publish_local_area.py
+++ b/policyengine_us_data/calibration/publish_local_area.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from policyengine_us import Microsimulation
+from policyengine_us_data.build_outputs.builder import LocalAreaDatasetBuilder
 from policyengine_us_data.build_outputs.fingerprinting import (
     FingerprintingService,
     PublishingInputBundle,
@@ -23,12 +24,14 @@ from policyengine_us_data.build_outputs.fingerprinting import (
 from policyengine_us_data.build_outputs.geography_loader import (
     CalibrationGeographyLoader,
 )
-from policyengine_us_data.build_outputs.reindexing import EntityReindexer
-from policyengine_us_data.build_outputs.requests import AreaFilter
-from policyengine_us_data.build_outputs.selection import AreaSelector
+from policyengine_us_data.build_outputs.requests import AreaBuildRequest, AreaFilter
 from policyengine_us_data.build_outputs.source_dataset import SourceDatasetSnapshot
-from policyengine_us_data.build_outputs.variables import VariableCloner
+from policyengine_us_data.build_outputs.us_augmentations import (
+    USTakeupPostProcessor,
+    default_us_postprocessors,
+)
 from policyengine_us_data.build_outputs.weights import CloneWeightMatrix
+from policyengine_us_data.build_outputs.writer import H5Writer
 from policyengine_us_data.utils.huggingface import download_calibration_inputs
 from policyengine_us_data.utils.data_upload import (
     upload_local_area_file,
@@ -37,14 +40,8 @@ from policyengine_us_data.utils.data_upload import (
 from policyengine_us_data.calibration.calibration_utils import (
     STATE_CODES,
 )
-from policyengine_us_data.calibration.block_assignment import (
-    derive_geography_from_blocks,
-)
 from policyengine_us_data.utils.takeup import (
     SIMPLE_TAKEUP_VARS,
-    _sum_person_values_to_tax_units,
-    apply_block_takeup_to_arrays,
-    reported_subsidized_marketplace_by_tax_unit,
 )
 from policyengine_us_data.pipeline_metadata import pipeline_node
 from policyengine_us_data.pipeline_schema import PipelineNode
@@ -267,34 +264,6 @@ def record_completed_city(city_name: str):
         f.write(f"{city_name}\n")
 
 
-def _build_reported_takeup_anchors(
-    data: dict, time_period: int
-) -> dict[str, np.ndarray]:
-    reported_anchors = {}
-    if (
-        "reported_has_subsidized_marketplace_health_coverage_at_interview" in data
-        and time_period
-        in data["reported_has_subsidized_marketplace_health_coverage_at_interview"]
-    ):
-        reported_anchors["takes_up_aca_if_eligible"] = (
-            reported_subsidized_marketplace_by_tax_unit(
-                data["person_tax_unit_id"][time_period],
-                data["tax_unit_id"][time_period],
-                data[
-                    "reported_has_subsidized_marketplace_health_coverage_at_interview"
-                ][time_period],
-            )
-        )
-    if (
-        "has_medicaid_health_coverage_at_interview" in data
-        and time_period in data["has_medicaid_health_coverage_at_interview"]
-    ):
-        reported_anchors["takes_up_medicaid_if_eligible"] = data[
-            "has_medicaid_health_coverage_at_interview"
-        ][time_period].astype(bool)
-    return reported_anchors
-
-
 def _build_legacy_area_filters(
     *,
     cd_subset: List[str] | None,
@@ -320,12 +289,26 @@ def _build_legacy_area_filters(
     return tuple(filters)
 
 
+def _build_legacy_area_request(
+    *,
+    output_path: Path,
+    filters: tuple[AreaFilter, ...],
+) -> AreaBuildRequest:
+    return AreaBuildRequest(
+        area_type="custom",
+        area_id=Path(output_path).stem,
+        display_name=Path(output_path).name,
+        output_relative_path=Path(output_path).name,
+        filters=filters,
+    )
+
+
 @pipeline_node(
     PipelineNode(
         id="build_h5",
         label="Build Local Area H5",
         node_type="library",
-        description="Expand calibrated clone weights into local-area H5 datasets with geography, SPM, and takeup updates.",
+        description="Expand calibrated clone weights into local-area H5 datasets with geography and takeup updates.",
         details="This is the main bundled H5 construction routine and remains a critical transitional waypoint.",
         source_file="policyengine_us_data/calibration/publish_local_area.py",
         status="transitional",
@@ -366,18 +349,12 @@ def build_h5(
     Returns:
         Path to the output H5 file.
     """
-    import h5py
-
     output_path = Path(output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-
-    blocks = np.asarray(geography.block_geoid)
 
     # === Load base simulation ===
     sim = Microsimulation(dataset=str(dataset_path))
     source = SourceDatasetSnapshot.from_simulation(Path(dataset_path), sim)
-    time_period = int(source.time_period)
-    household_ids = source.household_ids
     n_hh = source.n_households
     weight_matrix = CloneWeightMatrix.from_vector(weights, n_records=n_hh)
     n_clones_total = weight_matrix.n_clones
@@ -385,6 +362,7 @@ def build_h5(
         cd_subset=cd_subset,
         county_fips_filter=county_fips_filter,
     )
+    request = _build_legacy_area_request(output_path=output_path, filters=filters)
 
     label = (
         f"CD subset {cd_subset}"
@@ -395,206 +373,53 @@ def build_h5(
     print(f"Building {output_path.name} ({label}, {n_hh} households)")
     print(f"{'=' * 60}")
 
-    # === Select active clones ===
-    selection = AreaSelector().select(
+    result = LocalAreaDatasetBuilder(
+        postprocessors=default_us_postprocessors(),
+    ).build(
+        source=source,
+        simulation=sim,
         weights=weight_matrix,
         geography=geography,
-        filters=filters,
+        request=request,
+        takeup_filter=tuple(takeup_filter) if takeup_filter is not None else None,
     )
-    active_geo = selection.clone_indices
-    active_hh = selection.source_household_indices
-    n_clones = selection.n_selected_clones
-    clone_weights = selection.weights
-    active_blocks = selection.block_geoids
-    active_clone_cds = selection.congressional_district_geoids
-    print(f"Active clones: {n_clones:,}")
-    print(f"Total weight: {clone_weights.sum():,.0f}")
 
-    # === Reindex selected entities ===
-    reindexed = EntityReindexer().reindex(source=source, selection=selection)
-    person_clone_idx = reindexed.person_source_indices
-    entity_clone_idx = dict(reindexed.subentity_source_indices)
-    persons_per_clone = reindexed.persons_per_household_clone
-    entities_per_clone = dict(reindexed.subentities_per_household_clone)
-    n_persons = len(reindexed.person_ids)
-    print(f"Cloned persons: {n_persons:,}")
-    for ek in entity_clone_idx:
-        print(f"Cloned {ek}s: {len(entity_clone_idx[ek]):,}")
+    print(f"Active clones: {result.selection.n_selected_clones:,}")
+    print(f"Total weight: {result.summary['total_weight']:,.0f}")
+    print(f"Cloned persons: {len(result.reindexed.person_ids):,}")
+    for entity_key, indices in result.reindexed.subentity_source_indices.items():
+        print(f"Cloned {entity_key}s: {len(indices):,}")
+    print(f"Variables cloned: {result.variables_saved}")
 
-    new_hh_ids = reindexed.household_ids
-    new_person_ids = reindexed.person_ids
-    new_person_hh_ids = reindexed.person_household_ids
-    new_entity_ids = dict(reindexed.subentity_ids)
-    new_person_entity_ids = dict(reindexed.person_subentity_ids)
-
-    # === Derive geography from blocks (dedup optimization) ===
-    print("Deriving geography from blocks...")
-    unique_blocks, block_inv = np.unique(active_blocks, return_inverse=True)
-    print(f"  {n_clones:,} blocks -> {len(unique_blocks):,} unique")
-    unique_geo = derive_geography_from_blocks(unique_blocks)
-    clone_geo = {k: v[block_inv] for k, v in unique_geo.items()}
-
-    # === Clone variable arrays ===
-    payload = VariableCloner().clone(
-        source=source,
-        selection=selection,
-        reindexed=reindexed,
+    unique_blocks = np.unique(result.selection.block_geoids)
+    print("Derived geography from blocks.")
+    print(
+        f"  {result.selection.n_selected_clones:,} blocks -> "
+        f"{len(unique_blocks):,} unique"
     )
-    data = {variable: dict(periods) for variable, periods in payload.data.items()}
-    print(f"Variables cloned: {payload.values_saved}")
+    takeup = result.postprocessor_result(USTakeupPostProcessor)
+    if takeup is not None and takeup.takeup_variables:
+        print("Applied calibration takeup draws.")
+        print(f"Takeup variables: {', '.join(takeup.takeup_variables)}")
 
-    # === Override entity IDs ===
-    data["household_id"] = {time_period: new_hh_ids}
-    data["person_id"] = {time_period: new_person_ids}
-    data["person_household_id"] = {
-        time_period: new_person_hh_ids,
-    }
-    for ek in new_entity_ids:
-        data[f"{ek}_id"] = {
-            time_period: new_entity_ids[ek],
-        }
-        data[f"person_{ek}_id"] = {
-            time_period: new_person_entity_ids[ek],
-        }
-
-    # === Override weights ===
-    # Only write household_weight; sub-entity weights (tax_unit_weight,
-    # spm_unit_weight, person_weight, etc.) are formula variables in
-    # policyengine-us that derive from household_weight at runtime.
-    data["household_weight"] = {
-        time_period: clone_weights.astype(np.float32),
-    }
-
-    # === Override geography ===
-    data["state_fips"] = {
-        time_period: clone_geo["state_fips"].astype(np.int32),
-    }
-    data["county"] = {
-        time_period: clone_geo["county_index"].astype(np.int32),
-    }
-    data["county_fips"] = {
-        time_period: clone_geo["county_fips"].astype(np.int32),
-    }
-    for gv in [
-        "block_geoid",
-        "tract_geoid",
-        "cbsa_code",
-        "sldu",
-        "sldl",
-        "place_fips",
-        "vtd",
-        "puma",
-        "zcta",
-    ]:
-        if gv in clone_geo:
-            data[gv] = {
-                time_period: clone_geo[gv].astype("S"),
-            }
-
-    # === Set zip_code for LA County clones (ACA rating area fix) ===
-    # Default to synthetic "00000" (not "UNKNOWN") so three_digit_zip_code.py's
-    # `zip_code.astype(int) // 100` doesn't crash on non-LA households. "00000"
-    # → three_digit "000" which doesn't match any real LA rating area, so non-LA
-    # households correctly fall through to slcsp_rating_area_default. Without
-    # this numeric default, aca_ptc computation crashes whenever the dataset
-    # has any in_la households (which is always, via the LA County clones).
-    la_mask = clone_geo["county_fips"].astype(str) == "06037"
-    if la_mask.any():
-        zip_codes = np.full(len(la_mask), "00000")
-        zip_codes[la_mask] = "90001"
-        data["zip_code"] = {time_period: zip_codes.astype("S")}
-
-    # === Congressional district GEOID ===
-    clone_cd_geoids = np.array([int(cd) for cd in active_clone_cds], dtype=np.int32)
-    data["congressional_district_geoid"] = {
-        time_period: clone_cd_geoids,
-    }
-
-    # === Apply calibration takeup draws ===
-    if blocks is not None:
-        print("Applying calibration takeup draws...")
-        entity_hh_indices = {
-            "person": np.repeat(
-                np.arange(n_clones, dtype=np.int64),
-                persons_per_clone,
-            ).astype(np.int64),
-            "tax_unit": np.repeat(
-                np.arange(n_clones, dtype=np.int64),
-                entities_per_clone["tax_unit"],
-            ).astype(np.int64),
-            "spm_unit": np.repeat(
-                np.arange(n_clones, dtype=np.int64),
-                entities_per_clone["spm_unit"],
-            ).astype(np.int64),
-        }
-        entity_counts = {
-            "person": n_persons,
-            "tax_unit": len(entity_clone_idx["tax_unit"]),
-            "spm_unit": len(entity_clone_idx["spm_unit"]),
-        }
-        hh_state_fips = clone_geo["state_fips"].astype(np.int32)
-        original_hh_ids = household_ids[active_hh].astype(np.int64)
-        reported_anchors = _build_reported_takeup_anchors(data, time_period)
-        voluntary_filing_inputs = {
-            "tax_unit_child_dependents": sim.calculate(
-                "tax_unit_child_dependents",
-                time_period,
-                map_to="tax_unit",
-            ).values[entity_clone_idx["tax_unit"]],
-            "tax_unit_wage_income": _sum_person_values_to_tax_units(
-                sim.calculate(
-                    "employment_income",
-                    time_period,
-                    map_to="person",
-                ).values[person_clone_idx],
-                new_person_entity_ids["tax_unit"],
-                new_entity_ids["tax_unit"],
-            ),
-            "age_head": sim.calculate(
-                "age_head",
-                time_period,
-                map_to="tax_unit",
-            ).values[entity_clone_idx["tax_unit"]],
-        }
-
-        takeup_results = apply_block_takeup_to_arrays(
-            hh_blocks=active_blocks,
-            hh_state_fips=hh_state_fips,
-            hh_ids=original_hh_ids,
-            hh_clone_indices=active_geo.astype(np.int64),
-            entity_hh_indices=entity_hh_indices,
-            entity_counts=entity_counts,
-            time_period=time_period,
-            takeup_filter=takeup_filter,
-            reported_anchors=reported_anchors,
-            voluntary_filing_inputs=voluntary_filing_inputs,
-        )
-        for var_name, bools in takeup_results.items():
-            data[var_name] = {time_period: bools}
-
-    # === Write H5 ===
-    with h5py.File(str(output_path), "w") as f:
-        for variable, periods in data.items():
-            grp = f.create_group(variable)
-            for period, values in periods.items():
-                grp.create_dataset(str(period), data=values)
+    write_result = H5Writer().write(
+        payload=result.payload,
+        output_path=output_path,
+    )
 
     print(f"\nH5 saved to {output_path}")
-
-    with h5py.File(str(output_path), "r") as f:
-        tp = str(time_period)
-        if "household_id" in f and tp in f["household_id"]:
-            n = len(f["household_id"][tp][:])
-            print(f"Verified: {n:,} households in output")
-        if "person_id" in f and tp in f["person_id"]:
-            n = len(f["person_id"][tp][:])
-            print(f"Verified: {n:,} persons in output")
-        if "household_weight" in f and tp in f["household_weight"]:
-            hw = f["household_weight"][tp][:]
-            print(f"Total population (HH weights): {hw.sum():,.0f}")
-        if "person_weight" in f and tp in f["person_weight"]:
-            pw = f["person_weight"][tp][:]
-            print(f"Total population (person weights): {pw.sum():,.0f}")
+    if write_result.households is not None:
+        print(f"Verified: {write_result.households:,} households in output")
+    if write_result.persons is not None:
+        print(f"Verified: {write_result.persons:,} persons in output")
+    if write_result.household_weight_sum is not None:
+        print(
+            f"Total population (HH weights): {write_result.household_weight_sum:,.0f}"
+        )
+    if write_result.person_weight_sum is not None:
+        print(
+            f"Total population (person weights): {write_result.person_weight_sum:,.0f}"
+        )
 
     return output_path
 

--- a/tests/unit/build_outputs/test_builder.py
+++ b/tests/unit/build_outputs/test_builder.py
@@ -1,0 +1,205 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+
+from policyengine_us_data.build_outputs.builder import (
+    LocalAreaBuildResult,
+    LocalAreaDatasetBuilder,
+    PayloadPostProcessorRun,
+)
+from policyengine_us_data.build_outputs.payload import H5Payload
+from policyengine_us_data.build_outputs.reindexing import ReindexedEntities
+from policyengine_us_data.build_outputs.requests import AreaBuildRequest, AreaFilter
+from policyengine_us_data.build_outputs.selection import CloneSelection
+from policyengine_us_data.build_outputs.source_dataset import (
+    EntityGraph,
+    SourceDatasetSnapshot,
+)
+from policyengine_us_data.build_outputs.variables import VariableClonePayload
+from policyengine_us_data.build_outputs.weights import CloneWeightMatrix
+from tests.support.build_outputs.source_dataset import make_entity_graph_arrays
+
+
+def _selection() -> CloneSelection:
+    return CloneSelection(
+        clone_indices=np.array([0]),
+        source_household_indices=np.array([1]),
+        weights=np.array([2.0]),
+        block_geoids=np.array(["block-1"]),
+        congressional_district_geoids=np.array(["3701"]),
+        filters=(),
+        n_source_households=2,
+        n_total_clones=1,
+    )
+
+
+def _reindexed() -> ReindexedEntities:
+    return ReindexedEntities(
+        household_ids=np.array([0]),
+        person_ids=np.array([0]),
+        person_household_ids=np.array([0]),
+        subentity_ids={"tax_unit": np.array([0])},
+        person_subentity_ids={"tax_unit": np.array([0])},
+        household_source_indices=np.array([1]),
+        person_source_indices=np.array([2]),
+        subentity_source_indices={"tax_unit": np.array([1])},
+        persons_per_household_clone=np.array([1]),
+        subentities_per_household_clone={"tax_unit": np.array([1])},
+        person_household_clone_indices=np.array([0]),
+        subentity_household_clone_indices={"tax_unit": np.array([0])},
+    )
+
+
+def _source() -> SourceDatasetSnapshot:
+    return SourceDatasetSnapshot(
+        dataset_path=Path("source.h5"),
+        time_period=2024,
+        entity_graph=EntityGraph(**make_entity_graph_arrays()),
+        input_variables=frozenset(),
+        variable_provider=SimpleNamespace(),
+    )
+
+
+class _Selector:
+    def __init__(self, calls, selection):
+        self.calls = calls
+        self.selection = selection
+
+    def select(self, **kwargs):
+        self.calls.append(("select", kwargs))
+        return self.selection
+
+
+class _Reindexer:
+    def __init__(self, calls, reindexed):
+        self.calls = calls
+        self.reindexed = reindexed
+
+    def reindex(self, **kwargs):
+        self.calls.append(("reindex", kwargs))
+        return self.reindexed
+
+
+class _VariableCloner:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def clone(self, **kwargs):
+        self.calls.append(("clone", kwargs))
+        return VariableClonePayload(
+            data={"rent": {2024: np.array([200])}},
+            values_saved=1,
+        )
+
+
+class _AugmentationService:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def apply(self, **kwargs):
+        self.calls.append(("augment", kwargs))
+        payload = kwargs["payload"]
+        return SimpleNamespace(
+            payload=H5Payload(
+                data={
+                    **payload.data,
+                    "household_id": {2024: np.array([0])},
+                },
+                time_period=payload.time_period,
+                entity_lengths=payload.entity_lengths,
+            ),
+        )
+
+
+def test_local_area_dataset_builder_orchestrates_one_area_build_in_memory():
+    calls = []
+    source = _source()
+    selection = _selection()
+    reindexed = _reindexed()
+    weights = CloneWeightMatrix.from_vector(np.array([1.0, 2.0]), n_records=2)
+    request = AreaBuildRequest(
+        area_type="district",
+        area_id="NC-01",
+        display_name="NC-01",
+        output_relative_path="districts/NC-01.h5",
+        filters=(AreaFilter(geography_field="cd_geoid", op="in", value=("3701",)),),
+    )
+
+    result = LocalAreaDatasetBuilder(
+        selector=_Selector(calls, selection),
+        reindexer=_Reindexer(calls, reindexed),
+        variable_cloner=_VariableCloner(calls),
+        postprocessors=(_AugmentationService(calls),),
+    ).build(
+        source=source,
+        simulation=SimpleNamespace(),
+        weights=weights,
+        geography=SimpleNamespace(),
+        request=request,
+        takeup_filter=("takes_up_snap",),
+    )
+
+    assert [name for name, _ in calls] == ["select", "reindex", "clone", "augment"]
+    assert calls[0][1]["filters"] == request.filters
+    assert calls[1][1] == {"source": source, "selection": selection}
+    assert calls[2][1] == {
+        "source": source,
+        "selection": selection,
+        "reindexed": reindexed,
+    }
+    assert isinstance(calls[3][1]["payload"], H5Payload)
+    assert calls[3][1]["context"].takeup_filter == ("takes_up_snap",)
+    np.testing.assert_array_equal(result.data["household_id"][2024], np.array([0]))
+    assert result.payload.entity_lengths == {"household": 1, "person": 1, "tax_unit": 1}
+    assert result.variables_saved == 1
+    assert result.summary["area_id"] == "NC-01"
+    assert result.summary["active_clones"] == 1
+    assert result.summary["tax_units"] == 1
+    assert len(result.postprocessor_runs) == 1
+    assert (
+        result.postprocessor_result(_AugmentationService)
+        is result.postprocessor_runs[0].result
+    )
+    assert result.postprocessor_results(_AugmentationService) == (
+        result.postprocessor_runs[0].result,
+    )
+
+
+def test_local_area_build_result_retains_duplicate_postprocessor_runs():
+    class _PostProcessor:
+        pass
+
+    first = SimpleNamespace(payload=_payload("first"), label="first")
+    second = SimpleNamespace(payload=_payload("second"), label="second")
+
+    result = LocalAreaBuildResult(
+        payload=_payload("final"),
+        selection=_selection(),
+        reindexed=_reindexed(),
+        variables_saved=0,
+        summary={},
+        postprocessor_runs=(
+            PayloadPostProcessorRun(
+                name="_PostProcessor",
+                postprocessor_type=_PostProcessor,
+                result=first,
+            ),
+            PayloadPostProcessorRun(
+                name="_PostProcessor",
+                postprocessor_type=_PostProcessor,
+                result=second,
+            ),
+        ),
+    )
+
+    assert result.postprocessor_result(_PostProcessor) is first
+    assert result.postprocessor_results(_PostProcessor) == (first, second)
+
+
+def _payload(label: str) -> H5Payload:
+    return H5Payload(
+        data={label: {2024: np.array([1])}},
+        time_period=2024,
+        entity_lengths={"household": 1},
+    )

--- a/tests/unit/build_outputs/test_builder.py
+++ b/tests/unit/build_outputs/test_builder.py
@@ -2,11 +2,13 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 
 from policyengine_us_data.build_outputs.builder import (
     LocalAreaBuildResult,
     LocalAreaDatasetBuilder,
     PayloadPostProcessorRun,
+    PayloadPostProcessorSpec,
 )
 from policyengine_us_data.build_outputs.payload import H5Payload
 from policyengine_us_data.build_outputs.reindexing import ReindexedEntities
@@ -181,11 +183,13 @@ def test_local_area_build_result_retains_duplicate_postprocessor_runs():
         summary={},
         postprocessor_runs=(
             PayloadPostProcessorRun(
+                key="first",
                 name="_PostProcessor",
                 postprocessor_type=_PostProcessor,
                 result=first,
             ),
             PayloadPostProcessorRun(
+                key="second",
                 name="_PostProcessor",
                 postprocessor_type=_PostProcessor,
                 result=second,
@@ -194,7 +198,34 @@ def test_local_area_build_result_retains_duplicate_postprocessor_runs():
     )
 
     assert result.postprocessor_result(_PostProcessor) is first
+    assert result.postprocessor_result("second") is second
     assert result.postprocessor_results(_PostProcessor) == (first, second)
+
+
+def test_local_area_dataset_builder_rejects_missing_postprocessor_dependency():
+    class _DependentPostProcessor:
+        spec = PayloadPostProcessorSpec(
+            key="dependent",
+            requires=("upstream",),
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="_DependentPostProcessor requires postprocessor\\(s\\) "
+        "to run first: upstream",
+    ):
+        LocalAreaDatasetBuilder(postprocessors=(_DependentPostProcessor(),))
+
+
+def test_local_area_dataset_builder_rejects_duplicate_postprocessor_keys():
+    class _PostProcessor:
+        spec = PayloadPostProcessorSpec(key="duplicate")
+
+    with pytest.raises(
+        ValueError,
+        match="Duplicate payload postprocessor key: duplicate",
+    ):
+        LocalAreaDatasetBuilder(postprocessors=(_PostProcessor(), _PostProcessor()))
 
 
 def _payload(label: str) -> H5Payload:

--- a/tests/unit/build_outputs/test_payload.py
+++ b/tests/unit/build_outputs/test_payload.py
@@ -1,0 +1,71 @@
+import numpy as np
+import pytest
+
+from policyengine_us_data.build_outputs.payload import H5Payload
+
+
+def test_h5_payload_accepts_structural_variables_matching_entity_lengths():
+    payload = H5Payload(
+        data={
+            "household_id": {2024: np.array([0, 1])},
+            "person_id": {2024: np.array([0, 1, 2])},
+            "person_tax_unit_id": {2024: np.array([0, 1, 1])},
+            "tax_unit_id": {2024: np.array([0, 1])},
+            "rent": {2024: np.array([100, 200])},
+        },
+        time_period=2024,
+        entity_lengths={
+            "household": 2,
+            "person": 3,
+            "tax_unit": 2,
+        },
+    )
+
+    assert payload.time_period == 2024
+    assert payload.entity_lengths["household"] == 2
+
+
+def test_h5_payload_rejects_structural_variable_length_mismatch():
+    with pytest.raises(
+        ValueError,
+        match="household_id\\[2024\\] length 1 does not match household length 2",
+    ):
+        H5Payload(
+            data={"household_id": {2024: np.array([0])}},
+            time_period=2024,
+            entity_lengths={"household": 2},
+        )
+
+
+def test_h5_payload_rejects_explicit_variable_entity_length_mismatch():
+    with pytest.raises(
+        ValueError,
+        match="takes_up_snap_if_eligible\\[2024\\] length 1 "
+        "does not match spm_unit length 2",
+    ):
+        H5Payload(
+            data={"takes_up_snap_if_eligible": {2024: np.array([True])}},
+            time_period=2024,
+            entity_lengths={"spm_unit": 2},
+            variable_entities={"takes_up_snap_if_eligible": "spm_unit"},
+        )
+
+
+def test_h5_payload_rejects_unknown_explicit_variable_entity():
+    with pytest.raises(
+        ValueError,
+        match="takes_up_snap_if_eligible maps to unknown entity 'spm_unit'",
+    ):
+        H5Payload(
+            data={"takes_up_snap_if_eligible": {2024: np.array([True])}},
+            time_period=2024,
+            variable_entities={"takes_up_snap_if_eligible": "spm_unit"},
+        )
+
+
+def test_h5_payload_rejects_scalar_values():
+    with pytest.raises(ValueError, match="rent\\[2024\\] must be array-like"):
+        H5Payload(
+            data={"rent": {2024: np.array(1)}},
+            time_period=2024,
+        )

--- a/tests/unit/build_outputs/test_us_augmentations.py
+++ b/tests/unit/build_outputs/test_us_augmentations.py
@@ -13,6 +13,9 @@ from policyengine_us_data.build_outputs.source_dataset import (
     SourceDatasetSnapshot,
 )
 from policyengine_us_data.build_outputs.us_augmentations import (
+    US_ENTITY_POSTPROCESSOR_KEY,
+    US_GEOGRAPHY_POSTPROCESSOR_KEY,
+    US_TAKEUP_POSTPROCESSOR_KEY,
     USEntityPostProcessor,
     USGeographyPostProcessor,
     USTakeupPostProcessor,
@@ -127,11 +130,22 @@ def _geography_payload(context=None) -> H5Payload:
 
 
 def test_default_us_postprocessors_are_in_runtime_order():
-    assert tuple(type(processor) for processor in default_us_postprocessors()) == (
+    postprocessors = default_us_postprocessors()
+
+    assert tuple(type(processor) for processor in postprocessors) == (
         USEntityPostProcessor,
         USGeographyPostProcessor,
         USTakeupPostProcessor,
     )
+    assert tuple(processor.spec.key for processor in postprocessors) == (
+        US_ENTITY_POSTPROCESSOR_KEY,
+        US_GEOGRAPHY_POSTPROCESSOR_KEY,
+        US_TAKEUP_POSTPROCESSOR_KEY,
+    )
+    seen = set()
+    for processor in postprocessors:
+        assert set(processor.spec.requires) <= seen
+        seen.add(processor.spec.key)
 
 
 def test_build_reported_takeup_anchors_skips_missing_period():
@@ -352,6 +366,27 @@ def test_us_takeup_postprocessor_requires_geography_first():
     ):
         USTakeupPostProcessor(takeup_applier=lambda **kwargs: {}).apply(
             payload=_entity_payload(),
+            context=_context(),
+        )
+
+
+def test_us_takeup_postprocessor_requires_entity_ids_for_reported_aca_anchor():
+    payload = _base_payload(
+        {
+            "state_fips": {2024: np.array([6, 37], dtype=np.int32)},
+            "reported_has_subsidized_marketplace_health_coverage_at_interview": {
+                2024: np.array([True, False, False])
+            },
+        }
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="US take-up reported ACA anchors require person_tax_unit_id "
+        "and tax_unit_id from USEntityPostProcessor",
+    ):
+        USTakeupPostProcessor(takeup_applier=lambda **kwargs: {}).apply(
+            payload=payload,
             context=_context(),
         )
 

--- a/tests/unit/build_outputs/test_us_augmentations.py
+++ b/tests/unit/build_outputs/test_us_augmentations.py
@@ -1,0 +1,374 @@
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from policyengine_us_data.build_outputs.payload import H5Payload, PayloadBuildContext
+from policyengine_us_data.build_outputs.reindexing import EntityReindexer
+from policyengine_us_data.build_outputs.selection import CloneSelection
+from policyengine_us_data.build_outputs.source_dataset import (
+    EntityGraph,
+    SourceDatasetSnapshot,
+)
+from policyengine_us_data.build_outputs.us_augmentations import (
+    USEntityPostProcessor,
+    USGeographyPostProcessor,
+    USTakeupPostProcessor,
+    _build_reported_takeup_anchors,
+    default_us_postprocessors,
+)
+from tests.support.build_outputs.source_dataset import make_entity_graph_arrays
+
+
+class _Calculation:
+    def __init__(self, values):
+        self.values = np.asarray(values)
+
+
+class _Simulation:
+    def calculate(self, variable, period=None, map_to=None):
+        values = {
+            ("tax_unit_child_dependents", "tax_unit"): np.array([1, 2]),
+            ("employment_income", "person"): np.array([10, 20, 30]),
+            ("age_head", "tax_unit"): np.array([40, 50]),
+        }[(variable, map_to)]
+        return _Calculation(values)
+
+
+def _source_snapshot() -> SourceDatasetSnapshot:
+    return SourceDatasetSnapshot(
+        dataset_path=Path("source.h5"),
+        time_period=2024,
+        entity_graph=EntityGraph(**make_entity_graph_arrays()),
+        input_variables=frozenset(),
+        variable_provider=SimpleNamespace(),
+    )
+
+
+def _selection() -> CloneSelection:
+    return CloneSelection(
+        clone_indices=np.array([0, 1]),
+        source_household_indices=np.array([1, 0]),
+        weights=np.array([2.0, 3.0]),
+        block_geoids=np.array(["block-la", "block-nc"]),
+        congressional_district_geoids=np.array(["6037", "3701"]),
+        filters=(),
+        n_source_households=2,
+        n_total_clones=2,
+    )
+
+
+def _context(*, takeup_filter=("takes_up_snap_if_eligible",)) -> PayloadBuildContext:
+    source = _source_snapshot()
+    selection = _selection()
+    reindexed = EntityReindexer().reindex(source=source, selection=selection)
+    return PayloadBuildContext(
+        source=source,
+        simulation=_Simulation(),
+        selection=selection,
+        reindexed=reindexed,
+        geography=SimpleNamespace(),
+        time_period=2024,
+        takeup_filter=takeup_filter,
+    )
+
+
+def _base_payload(data=None) -> H5Payload:
+    return H5Payload(
+        data=data or {},
+        time_period=2024,
+        entity_lengths={
+            "household": 2,
+            "person": 3,
+            "tax_unit": 2,
+            "spm_unit": 2,
+            "family": 2,
+            "marital_unit": 2,
+        },
+    )
+
+
+def _geography_deriver(blocks):
+    assert tuple(blocks) == ("block-la", "block-nc")
+    return {
+        "block_geoid": np.asarray(blocks),
+        "state_fips": np.array([6, 37]),
+        "county_index": np.array([100, 200]),
+        "county_fips": np.array(["06037", "37183"]),
+        "tract_geoid": np.array(["06037000100", "37183000100"]),
+    }
+
+
+def _entity_payload(context=None) -> H5Payload:
+    context = context or _context()
+    return (
+        USEntityPostProcessor()
+        .apply(
+            payload=_base_payload(),
+            context=context,
+        )
+        .payload
+    )
+
+
+def _geography_payload(context=None) -> H5Payload:
+    context = context or _context()
+    payload = _entity_payload(context)
+    return (
+        USGeographyPostProcessor(geography_deriver=_geography_deriver)
+        .apply(
+            payload=payload,
+            context=context,
+        )
+        .payload
+    )
+
+
+def test_default_us_postprocessors_are_in_runtime_order():
+    assert tuple(type(processor) for processor in default_us_postprocessors()) == (
+        USEntityPostProcessor,
+        USGeographyPostProcessor,
+        USTakeupPostProcessor,
+    )
+
+
+def test_build_reported_takeup_anchors_skips_missing_period():
+    data = {
+        "person_tax_unit_id": {2024: np.array([1, 2], dtype=np.int64)},
+        "tax_unit_id": {2024: np.array([1, 2], dtype=np.int64)},
+        "reported_has_subsidized_marketplace_health_coverage_at_interview": {
+            2023: np.array([True, False])
+        },
+        "has_medicaid_health_coverage_at_interview": {2023: np.array([True, False])},
+    }
+
+    assert _build_reported_takeup_anchors(data, 2024) == {}
+
+
+def test_build_reported_takeup_anchors_uses_present_period():
+    data = {
+        "person_tax_unit_id": {2024: np.array([1, 1, 2], dtype=np.int64)},
+        "tax_unit_id": {2024: np.array([1, 2], dtype=np.int64)},
+        "reported_has_subsidized_marketplace_health_coverage_at_interview": {
+            2024: np.array([True, False, False])
+        },
+        "has_medicaid_health_coverage_at_interview": {
+            2024: np.array([False, True, False])
+        },
+    }
+
+    anchors = _build_reported_takeup_anchors(data, 2024)
+
+    np.testing.assert_array_equal(
+        anchors["takes_up_aca_if_eligible"],
+        np.array([True, False]),
+    )
+    np.testing.assert_array_equal(
+        anchors["takes_up_medicaid_if_eligible"],
+        np.array([False, True, False]),
+    )
+
+
+def test_build_reported_takeup_anchors_uses_subsidized_marketplace_only():
+    data = {
+        "person_tax_unit_id": {2024: np.array([1, 1, 2], dtype=np.int64)},
+        "tax_unit_id": {2024: np.array([1, 2], dtype=np.int64)},
+        "has_marketplace_health_coverage_at_interview": {
+            2024: np.array([True, False, True])
+        },
+        "reported_has_subsidized_marketplace_health_coverage_at_interview": {
+            2024: np.array([False, False, True])
+        },
+    }
+
+    anchors = _build_reported_takeup_anchors(data, 2024)
+
+    np.testing.assert_array_equal(
+        anchors["takes_up_aca_if_eligible"],
+        np.array([False, True]),
+    )
+
+
+def test_us_entity_postprocessor_applies_entity_ids_and_weights():
+    context = _context()
+
+    result = USEntityPostProcessor().apply(
+        payload=_base_payload({"rent": {2024: np.array([200, 100])}}),
+        context=context,
+    )
+
+    np.testing.assert_array_equal(result.data["rent"][2024], np.array([200, 100]))
+    np.testing.assert_array_equal(result.data["household_id"][2024], np.array([0, 1]))
+    np.testing.assert_array_equal(
+        result.data["person_household_id"][2024],
+        np.array([0, 1, 1]),
+    )
+    np.testing.assert_array_equal(
+        result.data["tax_unit_id"][2024],
+        np.array([0, 1]),
+    )
+    np.testing.assert_array_equal(
+        result.data["person_tax_unit_id"][2024],
+        np.array([0, 1, 1]),
+    )
+    np.testing.assert_array_equal(
+        result.data["household_weight"][2024],
+        np.array([2.0, 3.0], dtype=np.float32),
+    )
+
+
+def test_us_geography_postprocessor_applies_geography_and_la_zip_overrides():
+    result = USGeographyPostProcessor(geography_deriver=_geography_deriver).apply(
+        payload=_base_payload({"rent": {2024: np.array([200, 100])}}),
+        context=_context(takeup_filter=None),
+    )
+
+    np.testing.assert_array_equal(result.data["rent"][2024], np.array([200, 100]))
+    np.testing.assert_array_equal(
+        result.clone_geography["state_fips"],
+        np.array([6, 37]),
+    )
+    np.testing.assert_array_equal(
+        result.data["state_fips"][2024],
+        np.array([6, 37], dtype=np.int32),
+    )
+    np.testing.assert_array_equal(
+        result.data["county_fips"][2024],
+        np.array([6037, 37183], dtype=np.int32),
+    )
+    np.testing.assert_array_equal(
+        result.data["zip_code"][2024],
+        np.array([b"90001", b"00000"]),
+    )
+    np.testing.assert_array_equal(
+        result.data["congressional_district_geoid"][2024],
+        np.array([6037, 3701], dtype=np.int32),
+    )
+
+
+def test_us_takeup_postprocessor_passes_takeup_contract_inputs():
+    seen = {}
+
+    def fake_takeup(**kwargs):
+        seen.update(kwargs)
+        return {"takes_up_snap_if_eligible": np.array([True, False])}
+
+    def fake_sum_person_values(person_values, person_tax_unit_ids, tax_unit_ids):
+        np.testing.assert_array_equal(person_values, np.array([30, 10, 20]))
+        np.testing.assert_array_equal(person_tax_unit_ids, np.array([0, 1, 1]))
+        np.testing.assert_array_equal(tax_unit_ids, np.array([0, 1]))
+        return np.array([30, 30])
+
+    result = USTakeupPostProcessor(
+        takeup_applier=fake_takeup,
+        sum_person_values_to_tax_units=fake_sum_person_values,
+    ).apply(
+        payload=_geography_payload(),
+        context=_context(),
+    )
+
+    assert result.takeup_variables == ("takes_up_snap_if_eligible",)
+    np.testing.assert_array_equal(
+        result.data["takes_up_snap_if_eligible"][2024],
+        np.array([True, False]),
+    )
+    np.testing.assert_array_equal(seen["hh_blocks"], np.array(["block-la", "block-nc"]))
+    np.testing.assert_array_equal(
+        seen["hh_state_fips"],
+        np.array([6, 37], dtype=np.int32),
+    )
+    np.testing.assert_array_equal(seen["hh_ids"], np.array([20, 10]))
+    np.testing.assert_array_equal(seen["hh_clone_indices"], np.array([0, 1]))
+    np.testing.assert_array_equal(
+        seen["entity_hh_indices"]["person"], np.array([0, 1, 1])
+    )
+    assert seen["entity_counts"] == {"person": 3, "tax_unit": 2, "spm_unit": 2}
+    assert seen["takeup_filter"] == ["takes_up_snap_if_eligible"]
+    np.testing.assert_array_equal(
+        seen["voluntary_filing_inputs"]["tax_unit_child_dependents"],
+        np.array([2, 1]),
+    )
+    np.testing.assert_array_equal(
+        seen["voluntary_filing_inputs"]["tax_unit_wage_income"],
+        np.array([30, 30]),
+    )
+    np.testing.assert_array_equal(
+        seen["voluntary_filing_inputs"]["age_head"],
+        np.array([50, 40]),
+    )
+
+
+def test_us_takeup_postprocessor_rejects_wrong_length_takeup_results():
+    service = USTakeupPostProcessor(
+        takeup_applier=lambda **kwargs: {"takes_up_snap_if_eligible": np.array([True])},
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="takes_up_snap_if_eligible\\[2024\\] length 1 "
+        "does not match spm_unit length 2",
+    ):
+        service.apply(
+            payload=_geography_payload(),
+            context=_context(),
+        )
+
+
+def test_us_takeup_postprocessor_rejects_missing_required_subentities():
+    context = _context()
+    reindexed = context.reindexed
+    regional_only_reindexed = replace(
+        reindexed,
+        subentity_ids={"tax_unit": reindexed.subentity_ids["tax_unit"]},
+        person_subentity_ids={"tax_unit": reindexed.person_subentity_ids["tax_unit"]},
+        subentity_source_indices={
+            "tax_unit": reindexed.subentity_source_indices["tax_unit"]
+        },
+        subentities_per_household_clone={
+            "tax_unit": reindexed.subentities_per_household_clone["tax_unit"]
+        },
+        subentity_household_clone_indices={
+            "tax_unit": reindexed.subentity_household_clone_indices["tax_unit"]
+        },
+    )
+    context = replace(context, reindexed=regional_only_reindexed)
+
+    with pytest.raises(
+        ValueError,
+        match="US take-up requires reindexed subentities: spm_unit",
+    ):
+        USTakeupPostProcessor(takeup_applier=lambda **kwargs: {}).apply(
+            payload=_base_payload(),
+            context=context,
+        )
+
+
+def test_us_takeup_postprocessor_requires_geography_first():
+    with pytest.raises(
+        ValueError,
+        match="US take-up requires state_fips from USGeographyPostProcessor",
+    ):
+        USTakeupPostProcessor(takeup_applier=lambda **kwargs: {}).apply(
+            payload=_entity_payload(),
+            context=_context(),
+        )
+
+
+def test_us_takeup_postprocessor_rejects_unknown_takeup_results():
+    service = USTakeupPostProcessor(
+        takeup_applier=lambda **kwargs: {
+            "takes_up_new_program": np.array([True, False])
+        },
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Unknown take-up variable\\(s\\) returned by takeup applier: "
+        "takes_up_new_program",
+    ):
+        service.apply(
+            payload=_geography_payload(),
+            context=_context(),
+        )

--- a/tests/unit/build_outputs/test_writer.py
+++ b/tests/unit/build_outputs/test_writer.py
@@ -1,0 +1,51 @@
+import h5py
+import numpy as np
+
+from policyengine_us_data.build_outputs.payload import H5Payload
+from policyengine_us_data.build_outputs.writer import H5Writer
+
+
+def test_h5_writer_writes_period_grouped_payload_and_verifies_counts(tmp_path):
+    output_path = tmp_path / "nested" / "output.h5"
+    data = {
+        "household_id": {2024: np.array([0, 1], dtype=np.int32)},
+        "person_id": {2024: np.array([0, 1, 2], dtype=np.int32)},
+        "household_weight": {2024: np.array([2.5, 3.0], dtype=np.float32)},
+        "block_geoid": {2024: np.array([b"block-1", b"block-2"])},
+    }
+
+    result = H5Writer().write(
+        payload=H5Payload(
+            data=data,
+            time_period=2024,
+            entity_lengths={"household": 2, "person": 3},
+        ),
+        output_path=output_path,
+    )
+
+    assert result.path == output_path
+    assert result.households == 2
+    assert result.persons == 3
+    assert result.household_weight_sum == 5.5
+    assert result.person_weight_sum is None
+
+    with h5py.File(output_path, "r") as file:
+        np.testing.assert_array_equal(
+            file["block_geoid"]["2024"][:],
+            np.array([b"block-1", b"block-2"]),
+        )
+
+
+def test_h5_writer_verify_handles_missing_summary_variables(tmp_path):
+    output_path = tmp_path / "output.h5"
+    H5Writer().write(
+        payload=H5Payload(data={"rent": {2024: np.array([100])}}, time_period=2024),
+        output_path=output_path,
+    )
+
+    result = H5Writer().verify(path=output_path, time_period=2024)
+
+    assert result.households is None
+    assert result.persons is None
+    assert result.household_weight_sum is None
+    assert result.person_weight_sum is None

--- a/tests/unit/calibration/test_publish_local_area.py
+++ b/tests/unit/calibration/test_publish_local_area.py
@@ -1,68 +1,13 @@
 import numpy as np
 from types import SimpleNamespace
 
+import policyengine_us_data.calibration.publish_local_area as publish_local_area
+from policyengine_us_data.build_outputs.payload import H5Payload
 from policyengine_us_data.calibration.publish_local_area import (
-    _build_reported_takeup_anchors,
+    build_h5,
     compute_input_fingerprint,
     load_calibration_geography,
 )
-
-
-def test_build_reported_takeup_anchors_skips_missing_period():
-    data = {
-        "person_tax_unit_id": {2024: np.array([1, 2], dtype=np.int64)},
-        "tax_unit_id": {2024: np.array([1, 2], dtype=np.int64)},
-        "reported_has_subsidized_marketplace_health_coverage_at_interview": {
-            2023: np.array([True, False])
-        },
-        "has_medicaid_health_coverage_at_interview": {2023: np.array([True, False])},
-    }
-
-    assert _build_reported_takeup_anchors(data, 2024) == {}
-
-
-def test_build_reported_takeup_anchors_uses_present_period():
-    data = {
-        "person_tax_unit_id": {2024: np.array([1, 1, 2], dtype=np.int64)},
-        "tax_unit_id": {2024: np.array([1, 2], dtype=np.int64)},
-        "reported_has_subsidized_marketplace_health_coverage_at_interview": {
-            2024: np.array([True, False, False])
-        },
-        "has_medicaid_health_coverage_at_interview": {
-            2024: np.array([False, True, False])
-        },
-    }
-
-    anchors = _build_reported_takeup_anchors(data, 2024)
-
-    np.testing.assert_array_equal(
-        anchors["takes_up_aca_if_eligible"],
-        np.array([True, False]),
-    )
-    np.testing.assert_array_equal(
-        anchors["takes_up_medicaid_if_eligible"],
-        np.array([False, True, False]),
-    )
-
-
-def test_build_reported_takeup_anchors_uses_subsidized_marketplace_only():
-    data = {
-        "person_tax_unit_id": {2024: np.array([1, 1, 2], dtype=np.int64)},
-        "tax_unit_id": {2024: np.array([1, 2], dtype=np.int64)},
-        "has_marketplace_health_coverage_at_interview": {
-            2024: np.array([True, False, True])
-        },
-        "reported_has_subsidized_marketplace_health_coverage_at_interview": {
-            2024: np.array([False, False, True])
-        },
-    }
-
-    anchors = _build_reported_takeup_anchors(data, 2024)
-
-    np.testing.assert_array_equal(
-        anchors["takes_up_aca_if_eligible"],
-        np.array([False, True]),
-    )
 
 
 def test_compute_input_fingerprint_uses_loader_canonical_geography_identity(
@@ -188,3 +133,102 @@ def test_load_calibration_geography_passes_calibration_package_path_to_loader(
     assert result == "geography"
     assert seen["resolve"]["calibration_package_path"] == package_path
     assert seen["load"]["calibration_package_path"] == package_path
+
+
+def test_build_h5_facade_delegates_to_builder_and_writer(tmp_path, monkeypatch):
+    output_path = tmp_path / "NC-01.h5"
+    source = SimpleNamespace(n_households=2, time_period=2024)
+    seen = {}
+
+    class FakeBuilder:
+        def __init__(self, **kwargs):
+            seen["builder_init"] = kwargs
+
+        def build(self, **kwargs):
+            seen["build"] = kwargs
+            payload = H5Payload(
+                data={"household_id": {2024: np.array([0])}},
+                time_period=2024,
+                entity_lengths={"household": 1},
+            )
+            return FakeBuildResult(payload)
+
+    class FakeBuildResult:
+        def __init__(self, payload):
+            self.payload = payload
+            self.data = payload.data
+            self.time_period = payload.time_period
+            self.selection = SimpleNamespace(
+                n_selected_clones=1,
+                block_geoids=np.array(["block-1"]),
+            )
+            self.reindexed = SimpleNamespace(
+                person_ids=np.array([0]),
+                subentity_source_indices={"tax_unit": np.array([0])},
+            )
+            self.variables_saved = 1
+            self.summary = {"total_weight": 2.0}
+
+        def postprocessor_result(self, postprocessor):
+            return SimpleNamespace(takeup_variables=("takes_up_snap",))
+
+    class FakeWriter:
+        def write(self, **kwargs):
+            seen["write"] = kwargs
+            return SimpleNamespace(
+                households=1,
+                persons=1,
+                household_weight_sum=2.0,
+                person_weight_sum=None,
+            )
+
+    monkeypatch.setattr(
+        publish_local_area,
+        "Microsimulation",
+        lambda dataset: SimpleNamespace(dataset=dataset),
+    )
+    monkeypatch.setattr(
+        publish_local_area.SourceDatasetSnapshot,
+        "from_simulation",
+        classmethod(lambda cls, dataset_path, simulation: source),
+    )
+    monkeypatch.setattr(
+        publish_local_area,
+        "LocalAreaDatasetBuilder",
+        FakeBuilder,
+    )
+    monkeypatch.setattr(publish_local_area, "H5Writer", lambda: FakeWriter())
+
+    result = build_h5(
+        weights=np.array([1.0, 2.0, 3.0, 4.0]),
+        geography=SimpleNamespace(),
+        dataset_path=tmp_path / "source.h5",
+        output_path=output_path,
+        cd_subset=["3701"],
+        county_fips_filter={"37183"},
+        takeup_filter=["takes_up_snap"],
+    )
+
+    assert result == output_path
+    assert [
+        type(postprocessor).__name__
+        for postprocessor in seen["builder_init"]["postprocessors"]
+    ] == [
+        "USEntityPostProcessor",
+        "USGeographyPostProcessor",
+        "USTakeupPostProcessor",
+    ]
+    assert seen["build"]["source"] is source
+    assert seen["build"]["takeup_filter"] == ("takes_up_snap",)
+    request = seen["build"]["request"]
+    assert request.area_id == "NC-01"
+    assert [area_filter.geography_field for area_filter in request.filters] == [
+        "cd_geoid",
+        "county_fips",
+    ]
+    assert seen["write"]["output_path"] == output_path
+    assert seen["write"]["payload"].time_period == 2024
+    np.testing.assert_array_equal(
+        seen["write"]["payload"].data["household_id"][2024],
+        np.array([0]),
+    )


### PR DESCRIPTION
Fixes #969

## Summary

- Extract local H5 build-output seams for payload construction and writing.
- Split US-specific local H5 payload postprocessing into entity/weight, geography, and take-up processors.
- Add stable postprocessor keys, dependency validation, and focused unit tests.
- Keep `publish_local_area.build_h5()` as the transitional runtime facade.

## Testing

- `make lint`
- `uv run --no-sync pytest tests/unit/build_outputs -q`
- `ruff check policyengine_us_data/build_outputs tests/unit/build_outputs`
- `ruff format --check policyengine_us_data/build_outputs tests/unit/build_outputs`
- `uv run --no-sync --with pyyaml python scripts/run_quality_guards.py`

## Notes

- Local collection of `tests/unit/calibration/test_publish_local_area.py` remains blocked in this environment by missing `scipy`; CI/full dependency setup should cover it.
