### PR TITLE
Fail closed on computed dataset exports

### DIFF
--- a/changelog.d/974.fixed
+++ b/changelog.d/974.fixed
@@ -1,0 +1,1 @@
+Fail closed when generated datasets export variables computed by policyengine-us.

--- a/docs/pipeline_map.yaml
+++ b/docs/pipeline_map.yaml
@@ -474,9 +474,9 @@ stages:
     target: mortgage_convert
     edge_type: data_flow
   - source: mortgage_convert
-    target: formula_drop
+    target: computed_export_contract
     edge_type: data_flow
-  - source: formula_drop
+  - source: computed_export_contract
     target: out_ext
     edge_type: produces_artifact
   - source: util_qrf_s2

--- a/policyengine_us_data/datasets/cps/extended_cps.py
+++ b/policyengine_us_data/datasets/cps/extended_cps.py
@@ -30,6 +30,9 @@ from policyengine_us_data.utils.mortgage_interest import (
     impute_tax_unit_mortgage_balance_hints,
 )
 from policyengine_us_data.utils.policyengine import has_policyengine_us_variables
+from policyengine_us_data.utils.dataset_validation import (
+    assert_no_computed_policyengine_us_variables_exported,
+)
 from policyengine_us_data.utils.retirement_limits import (
     get_retirement_limits,
     get_se_pension_limits,
@@ -643,6 +646,34 @@ _SS_SUBCOMPONENT_VARS = {
     "social_security_survivors",
 }
 
+_PUF_COMPUTED_INTERMEDIATES_AFTER_CLONE = {
+    "cdcc_relevant_expenses",
+    "pre_tax_contributions",
+    "self_employed_health_insurance_ald",
+    "self_employed_pension_contribution_ald",
+}
+
+_STAGE2_COMPUTED_PREDICTORS = {
+    "is_male",
+    "is_tax_unit_dependent",
+    "is_tax_unit_head",
+    "is_tax_unit_spouse",
+    "tax_unit_count_dependents",
+    "tax_unit_is_joint",
+}
+
+_STAGE2_COMPUTED_OUTPUTS_TO_DROP = {
+    "employment_income_last_year",
+}
+
+_COMPUTED_AGGREGATE_INPUT_RENAMES = {
+    "employment_income": "employment_income_before_lsr",
+    "long_term_capital_gains": "long_term_capital_gains_before_response",
+    "self_employment_income": "self_employment_income_before_lsr",
+    "sstb_self_employment_income": "sstb_self_employment_income_before_lsr",
+    "weekly_hours_worked": "weekly_hours_worked_before_lsr",
+}
+
 
 def _apply_post_processing(predictions, X_test, time_period, data):
     """Apply retirement constraints and SS reconciliation."""
@@ -822,6 +853,7 @@ class ExtendedCPS(Dataset):
             puf_dataset=self.puf,
             dataset_path=str(self.cps.file_path),
         )
+        new_data = self._drop_puf_computed_intermediates(new_data)
 
         # Stage 2a: donor-impute CPS feature variables for PUF clones.
         logger.info("Stage-2a: rematching CPS features for PUF clones")
@@ -852,6 +884,7 @@ class ExtendedCPS(Dataset):
             time_period=self.time_period,
             dataset_path=str(self.cps.file_path),
         )
+        new_data = self._finalize_stage2_computed_variables(new_data)
 
         new_data = self._impute_aotc_eligibility_inputs(new_data, self.time_period)
         new_data = self._impute_llc_eligibility_inputs(new_data, self.time_period)
@@ -874,7 +907,10 @@ class ExtendedCPS(Dataset):
                 self.time_period,
                 had_positive_mortgage_input,
             )
-        new_data = self._drop_formula_variables(new_data)
+        new_data = self._assert_no_computed_variables_exported(
+            new_data,
+            self.time_period,
+        )
         self.save_dataset(new_data)
 
     @classmethod
@@ -1121,6 +1157,60 @@ class ExtendedCPS(Dataset):
                 data[input_var] = data.pop(formula_var)
         return data
 
+    @classmethod
+    def _drop_puf_computed_intermediates(cls, data):
+        """Drop PUF outputs that are construction-only in Extended CPS."""
+
+        dropped = sorted(set(data) & _PUF_COMPUTED_INTERMEDIATES_AFTER_CLONE)
+        if dropped:
+            logger.info(
+                "Dropping %d PUF computed intermediates after clone stage: %s",
+                len(dropped),
+                dropped,
+            )
+            for variable in dropped:
+                del data[variable]
+        return data
+
+    @classmethod
+    def _finalize_stage2_computed_variables(cls, data):
+        """Remove or rename computed variables after their final stage-2 use."""
+
+        for source, target in _COMPUTED_AGGREGATE_INPUT_RENAMES.items():
+            if source not in data:
+                continue
+            if target not in data:
+                logger.info(
+                    "Renaming %s -> %s after stage-2 predictor use",
+                    source,
+                    target,
+                )
+                data[target] = data.pop(source)
+            else:
+                logger.info(
+                    "Dropping %s after stage-2 predictor use; %s already exists",
+                    source,
+                    target,
+                )
+                del data[source]
+
+        if "social_security" in data and _SS_SUBCOMPONENT_VARS <= set(data):
+            logger.info("Dropping social_security after reconciling leaf subcomponents")
+            del data["social_security"]
+
+        dropped = sorted(
+            set(data) & (_STAGE2_COMPUTED_PREDICTORS | _STAGE2_COMPUTED_OUTPUTS_TO_DROP)
+        )
+        if dropped:
+            logger.info(
+                "Dropping %d stage-2 computed variables after final use: %s",
+                len(dropped),
+                dropped,
+            )
+            for variable in dropped:
+                del data[variable]
+        return data
+
     @staticmethod
     def _has_positive_mortgage_input(data, time_period):
         values = data.get("deductible_mortgage_interest", {}).get(time_period)
@@ -1146,30 +1236,9 @@ class ExtendedCPS(Dataset):
             "Structural mortgage conversion lost positive mortgage inputs."
         )
 
-    # Variables with formulas/adds that must still be stored.
-    # Includes IDs needed before formulas run and tax-unit-level
-    # QRF-imputed vars that can't be renamed to person-level leaves
-    # due to entity shape mismatch.
-    _KEEP_FORMULA_VARS = {
-        "person_id",
-        "weeks_worked",
-        "self_employed_pension_contribution_ald",
-        "self_employed_health_insurance_ald",
-    }
-
-    @classmethod
-    def _keep_formula_vars(cls):
-        keep = set(cls._KEEP_FORMULA_VARS)
-        if not _supports_structural_mortgage_inputs():
-            keep.add("interest_deduction")
-        return keep
-
     # QRF imputes formula-level variables (e.g. taxable_pension_income)
-    # but we must store them under leaf input names so
-    # _drop_formula_variables doesn't discard them. The engine then
+    # but we must store them under leaf input names. The engine then
     # recomputes the formula var from its adds.
-    # NOTE: only same-entity renames here; cross-entity vars
-    # (tax_unit -> person) go in _KEEP_FORMULA_VARS instead.
     _IMPUTED_TO_INPUT = {
         "taxable_pension_income": "taxable_private_pension_income",
         "tax_exempt_pension_income": "tax_exempt_private_pension_income",
@@ -1178,75 +1247,33 @@ class ExtendedCPS(Dataset):
     @classmethod
     @pipeline_node(
         PipelineNode(
-            id="formula_drop",
-            label="Drop Formula Variables",
+            id="computed_export_contract",
+            label="Validate Leaf-Input Export",
             node_type="process",
             description=(
-                "Removes variables computed by policyengine-us formulas, "
-                "while preserving selected imputed inputs under canonical "
-                "leaf variable names."
+                "Fails the build if the final export still contains "
+                "variables computed by policyengine-us formulas, adds, or "
+                "subtracts."
             ),
             status="transitional",
             stability="moving",
             pathways=["data_build"],
             artifacts_in=["extended_cps_stage2"],
-            artifacts_out=["formula_pruned_extended_cps"],
+            artifacts_out=["validated_extended_cps"],
             pydoc=True,
         )
     )
-    def _drop_formula_variables(cls, data):
-        """Remove variables that are computed by policyengine-us.
+    def _assert_no_computed_variables_exported(cls, data, time_period):
+        """Assert that final exported variables are leaf inputs."""
 
-        Variables with formulas, ``adds``, or ``subtracts`` are
-        recomputed by the simulation engine, so storing them wastes
-        space and can mislead validation.
-
-        Aggregate variables whose ``adds`` include a behavioral-
-        response input (e.g. ``employment_income_before_lsr``) are
-        renamed to that input before dropping so the raw data is
-        preserved under the correct input-variable name.
-        """
         from policyengine_us import CountryTaxBenefitSystem
-        from policyengine_us_data.datasets.puf.variable_roles import (
-            PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES,
+
+        assert_no_computed_policyengine_us_variables_exported(
+            variable_names=data.keys(),
+            time_period=time_period,
+            tax_benefit_system=CountryTaxBenefitSystem(),
+            dataset_name=cls.name,
         )
-
-        tbs = CountryTaxBenefitSystem()
-
-        _RESPONSE_SUFFIXES = ("_before_lsr", "_before_response")
-        for name, var in tbs.variables.items():
-            if name not in data:
-                continue
-            for add_var in getattr(var, "adds", None) or []:
-                if any(add_var.endswith(s) for s in _RESPONSE_SUFFIXES):
-                    if add_var not in data:
-                        logger.info(
-                            "Renaming %s -> %s before drop",
-                            name,
-                            add_var,
-                        )
-                        data[add_var] = data.pop(name)
-                    break
-
-        calculated_vars = {
-            name
-            for name, var in tbs.variables.items()
-            if (hasattr(var, "formulas") and len(var.formulas) > 0)
-            or getattr(var, "adds", None)
-            or getattr(var, "subtracts", None)
-        }
-        drop_vars = (
-            calculated_vars | PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES
-        ) - cls._keep_formula_vars()
-        dropped = sorted(set(data.keys()) & drop_vars)
-        if dropped:
-            logger.info(
-                "Dropping %d calculated/source-output variables: %s",
-                len(dropped),
-                dropped,
-            )
-            for var in dropped:
-                del data[var]
         return data
 
 

--- a/policyengine_us_data/utils/dataset_validation.py
+++ b/policyengine_us_data/utils/dataset_validation.py
@@ -22,6 +22,10 @@ ENTITY_ID_VARIABLES = {
     "household": "household_id",
 }
 
+# policyengine-us defines a fallback formula for person_id, but persisted
+# datasets need stable person IDs for entity links and downstream joins.
+STRUCTURAL_COMPUTED_EXPORT_VARIABLES = frozenset({"person_id"})
+
 AUXILIARY_ENTITY_PREFIXES = {
     "person_": "person",
     "tax_unit_": "tax_unit",
@@ -47,6 +51,83 @@ def _format_items(items: list[str], max_display: int = 5) -> str:
     displayed = items[:max_display]
     suffix = "" if len(items) <= max_display else ", ..."
     return ", ".join(displayed) + suffix
+
+
+def _year_from_period(value) -> int | None:
+    match = re.match(r"\d{4}", str(value))
+    if match is None:
+        return None
+    return int(match.group(0))
+
+
+def _has_formula_for_period(variable, time_period) -> bool:
+    formulas = getattr(variable, "formulas", None) or {}
+    if not formulas:
+        return False
+
+    period_year = _year_from_period(time_period)
+    if period_year is None:
+        return True
+
+    for formula_start in formulas:
+        formula_year = _year_from_period(formula_start)
+        if formula_year is None or formula_year <= period_year:
+            return True
+    return False
+
+
+def _is_computed_for_period(variable, time_period) -> bool:
+    return (
+        _has_formula_for_period(variable, time_period)
+        or bool(getattr(variable, "adds", None))
+        or bool(getattr(variable, "subtracts", None))
+    )
+
+
+def computed_policyengine_us_variables_for_period(
+    variable_names,
+    time_period,
+    tax_benefit_system,
+) -> set[str]:
+    """Return exported variables computed by policyengine-us in a period."""
+
+    computed = set()
+    for variable_name in variable_names:
+        if variable_name in STRUCTURAL_COMPUTED_EXPORT_VARIABLES:
+            continue
+        variable = tax_benefit_system.variables.get(variable_name)
+        if variable is None:
+            continue
+        if _is_computed_for_period(variable, time_period):
+            computed.add(variable_name)
+    return computed
+
+
+def assert_no_computed_policyengine_us_variables_exported(
+    variable_names,
+    time_period,
+    tax_benefit_system,
+    *,
+    dataset_name: str = "dataset",
+) -> None:
+    """Fail if a dataset exports values policyengine-us should compute."""
+
+    computed_exports = sorted(
+        computed_policyengine_us_variables_for_period(
+            variable_names=variable_names,
+            time_period=time_period,
+            tax_benefit_system=tax_benefit_system,
+        )
+    )
+    if not computed_exports:
+        return
+
+    raise DatasetContractError(
+        f"{dataset_name} exports policyengine-us computed variables for "
+        f"{time_period}: {_format_items(computed_exports, max_display=10)}. "
+        "Drop construction-only intermediates after their final use, or export "
+        "the underlying leaf input instead."
+    )
 
 
 def _dataset_length(obj) -> int | None:
@@ -191,6 +272,15 @@ def validate_dataset_contract(
     )
 
     dataset_lengths = _dataset_lengths(file_path)
+    time_period = _infer_time_period_from_file(file_path)
+    if time_period is not None:
+        assert_no_computed_policyengine_us_variables_exported(
+            variable_names=dataset_lengths.keys(),
+            time_period=time_period,
+            tax_benefit_system=tax_benefit_system,
+            dataset_name=file_path.name,
+        )
+
     missing_entity_ids = [
         id_variable
         for entity_key, id_variable in ENTITY_ID_VARIABLES.items()

--- a/tests/unit/test_dataset_validation.py
+++ b/tests/unit/test_dataset_validation.py
@@ -61,6 +61,15 @@ def _fake_tax_benefit_system():
     )
 
 
+def _fake_variable(entity_key, *, formulas=None, adds=None, subtracts=None):
+    return SimpleNamespace(
+        entity=SimpleNamespace(key=entity_key),
+        formulas=formulas or {},
+        adds=adds,
+        subtracts=subtracts,
+    )
+
+
 @pytest.fixture(autouse=True)
 def reset_fake_microsim():
     _FakeMicrosimulation.last_dataset = None
@@ -192,6 +201,71 @@ def test_validate_dataset_contract_infers_time_period_for_flat_h5(
     )
 
     assert _TimePeriodCheckingMicrosimulation.last_dataset.time_period == 2024
+
+
+def test_validate_dataset_contract_rejects_computed_policyengine_variables(
+    tmp_path, monkeypatch
+):
+    file_path = tmp_path / "enhanced_cps_2024.h5"
+    _write_test_h5(
+        file_path,
+        {
+            "person_id": np.array([101, 102], dtype=np.int32),
+            "household_id": np.array([501], dtype=np.int32),
+            "computed_income": np.array([10_000.0, 20_000.0], dtype=np.float32),
+            "household_weight": np.array([1.5], dtype=np.float32),
+        },
+    )
+    monkeypatch.setattr(
+        "policyengine_us_data.utils.dataset_validation.assert_locked_policyengine_us_version",
+        lambda: PolicyEngineUSBuildInfo(version="1.587.0"),
+    )
+    tbs = _fake_tax_benefit_system()
+    tbs.variables["person_id"] = _fake_variable(
+        "person",
+        formulas={"0001-01-01": object()},
+    )
+    tbs.variables["computed_income"] = _fake_variable(
+        "person",
+        adds=["computed_income_before_response"],
+    )
+
+    with pytest.raises(DatasetContractError, match="computed_income"):
+        validate_dataset_contract(
+            file_path,
+            tax_benefit_system=tbs,
+            microsimulation_cls=_FakeMicrosimulation,
+            dataset_loader=lambda path: path,
+        )
+
+
+def test_validate_dataset_contract_allows_future_period_formulas(tmp_path, monkeypatch):
+    file_path = tmp_path / "enhanced_cps_2024.h5"
+    _write_test_h5(
+        file_path,
+        {
+            "person_id": np.array([101, 102], dtype=np.int32),
+            "household_id": np.array([501], dtype=np.int32),
+            "future_formula_input": np.array([52, 40], dtype=np.int32),
+            "household_weight": np.array([1.5], dtype=np.float32),
+        },
+    )
+    monkeypatch.setattr(
+        "policyengine_us_data.utils.dataset_validation.assert_locked_policyengine_us_version",
+        lambda: PolicyEngineUSBuildInfo(version="1.587.0"),
+    )
+    tbs = _fake_tax_benefit_system()
+    tbs.variables["future_formula_input"] = _fake_variable(
+        "person",
+        formulas={"2025-01-01": object()},
+    )
+
+    validate_dataset_contract(
+        file_path,
+        tax_benefit_system=tbs,
+        microsimulation_cls=_FakeMicrosimulation,
+        dataset_loader=lambda path: path,
+    )
 
 
 def test_validate_dataset_contract_rejects_ambiguous_auxiliary_variables(

--- a/tests/unit/test_extended_cps.py
+++ b/tests/unit/test_extended_cps.py
@@ -34,14 +34,12 @@ from policyengine_us_data.datasets.cps.extended_cps import (
 from policyengine_us_data.datasets.cps.tipped_occupation import (
     derive_treasury_tipped_occupation_code,
 )
-from policyengine_us_data.datasets.puf.variable_roles import (
-    PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES,
-)
 from policyengine_us_data.datasets.org import ORG_IMPUTED_VARIABLES
 from policyengine_us_data.utils.aotc import (
     get_american_opportunity_credit_amount_scale,
     qualifying_expenses_from_american_opportunity_credit,
 )
+from policyengine_us_data.utils.dataset_validation import DatasetContractError
 
 
 class TestVariableListConsistency:
@@ -156,25 +154,75 @@ class TestVariableListConsistency:
 
     def test_spm_threshold_is_formula_output_not_qrf_imputed(self):
         assert "spm_unit_spm_threshold" not in set(CPS_ONLY_IMPUTED_VARIABLES)
-        assert "spm_unit_spm_threshold" not in ExtendedCPS._keep_formula_vars()
-        assert "spm_unit_geographic_adjustment" not in ExtendedCPS._keep_formula_vars()
-        assert "person_in_poverty" not in ExtendedCPS._keep_formula_vars()
+        data = {
+            "spm_unit_spm_threshold": {2024: np.array([20_000.0])},
+            "spm_unit_geographic_adjustment": {2024: np.array([1.0])},
+            "person_in_poverty": {2024: np.array([False])},
+        }
+
+        with pytest.raises(
+            DatasetContractError,
+            match="spm_unit_geographic_adjustment",
+        ):
+            ExtendedCPS._assert_no_computed_variables_exported(data, 2024)
 
     def test_weeks_worked_is_preserved_for_future_year_formulas(self):
-        assert "weeks_worked" in ExtendedCPS._keep_formula_vars()
+        data = {"weeks_worked": {2024: np.array([52])}}
 
-    def test_reported_calculated_tax_outputs_dropped_before_export(self):
+        ExtendedCPS._assert_no_computed_variables_exported(data, 2024)
+        with pytest.raises(DatasetContractError, match="weeks_worked"):
+            ExtendedCPS._assert_no_computed_variables_exported(data, 2025)
+
+    def test_final_export_contract_allows_leaf_ss_retirement_input(self):
+        data = {"social_security_retirement": {2024: np.array([12_000.0])}}
+
+        ExtendedCPS._assert_no_computed_variables_exported(data, 2024)
+
+    def test_final_export_contract_rejects_computed_ss_total(self):
+        data = {"social_security": {2024: np.array([12_000.0])}}
+
+        with pytest.raises(DatasetContractError, match="social_security"):
+            ExtendedCPS._assert_no_computed_variables_exported(data, 2024)
+
+    def test_drop_puf_computed_intermediates_after_clone(self):
         data = {
-            var: {2024: np.array([1.0])}
-            for var in PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES
+            "cdcc_relevant_expenses": {2024: np.array([1_000.0])},
+            "pre_tax_contributions": {2024: np.array([500.0])},
+            "self_employed_health_insurance_ald": {2024: np.array([2_000.0])},
+            "self_employed_pension_contribution_ald": {2024: np.array([3_000.0])},
+            "employment_income": {2024: np.array([50_000.0])},
         }
-        data["person_id"] = {2024: np.array([1])}
 
-        result = ExtendedCPS._drop_formula_variables(data)
+        result = ExtendedCPS._drop_puf_computed_intermediates(data)
 
-        assert "person_id" in result
-        for var in PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES:
-            assert var not in result
+        assert "employment_income" in result
+        assert "cdcc_relevant_expenses" not in result
+        assert "pre_tax_contributions" not in result
+        assert "self_employed_health_insurance_ald" not in result
+        assert "self_employed_pension_contribution_ald" not in result
+
+    def test_finalize_stage2_computed_variables_renames_and_drops(self):
+        data = {
+            "employment_income": {2024: np.array([50_000.0])},
+            "weekly_hours_worked": {2024: np.array([40.0])},
+            "social_security": {2024: np.array([12_000.0])},
+            "social_security_retirement": {2024: np.array([12_000.0])},
+            "social_security_disability": {2024: np.array([0.0])},
+            "social_security_dependents": {2024: np.array([0.0])},
+            "social_security_survivors": {2024: np.array([0.0])},
+            "tax_unit_is_joint": {2024: np.array([True])},
+            "employment_income_last_year": {2024: np.array([45_000.0])},
+        }
+
+        result = ExtendedCPS._finalize_stage2_computed_variables(data)
+
+        assert "employment_income" not in result
+        assert "employment_income_before_lsr" in result
+        assert "weekly_hours_worked" not in result
+        assert "weekly_hours_worked_before_lsr" in result
+        assert "social_security" not in result
+        assert "tax_unit_is_joint" not in result
+        assert "employment_income_last_year" not in result
 
 
 class TestStructuralMortgageValidation:


### PR DESCRIPTION
## Summary

- Replace final Extended CPS formula-variable pruning with a fail-closed export contract.
- Drop or rename computed construction variables at their final stage boundary, including Social Security totals after subcomponents reconcile.
- Extend built-dataset validation so upload checks reject `policyengine-us` computed variables in exported H5s.

## Root Cause

The old `_drop_formula_variables` step silently removed any exported variable that `policyengine-us` classified as computed. That hid cross-repo contract breaks when a data-backed variable later gained a formula, `adds`, or `subtracts` definition upstream.

This PR changes that behavior: us-data now drops only explicitly classified construction variables, then fails the build if computed model variables still reach the final export surface.

## Validation

- `uv run ruff format policyengine_us_data/datasets/cps/extended_cps.py policyengine_us_data/utils/dataset_validation.py tests/unit/test_extended_cps.py tests/unit/test_dataset_validation.py`
- `uv run ruff check policyengine_us_data/datasets/cps/extended_cps.py policyengine_us_data/utils/dataset_validation.py tests/unit/test_extended_cps.py tests/unit/test_dataset_validation.py`
- `uv run pytest tests/unit/test_extended_cps.py tests/unit/test_dataset_validation.py tests/unit/calibration/test_calibration_puf_impute.py -q`
- `uv run pytest tests/integration/test_cps_generation.py tests/unit/test_upload_completed_datasets.py -q`

## Related Discussions

- https://github.com/PolicyEngine/policyengine-us-data/discussions/968
- https://github.com/PolicyEngine/policyengine-us-data/discussions/975
