### PR TITLE
Shorten publication run identifiers

### DIFF
--- a/.github/scripts/resolve_run_context.py
+++ b/.github/scripts/resolve_run_context.py
@@ -46,7 +46,6 @@ def _github_actions_run_id(env: Mapping[str, str]) -> str:
     return build_run_id(
         github_run_id=env.get("GITHUB_RUN_ID", ""),
         github_run_attempt=env.get("GITHUB_RUN_ATTEMPT", "1"),
-        github_sha=env.get("GITHUB_SHA", ""),
     )
 
 

--- a/.github/workflows/local_area_promote.yaml
+++ b/.github/workflows/local_area_promote.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       run_id:
-        description: 'Run ID to promote (e.g. usdata-gha123456-a1-abcdef12)'
+        description: 'Run ID to promote (e.g. usdata-gha123456-a1)'
         required: true
         type: string
 
@@ -22,7 +22,7 @@ jobs:
       MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
       MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
       MODAL_ENVIRONMENT: main
-      US_DATA_MODAL_APP_PREFIX: policyengine-us-data-pub
+      US_DATA_MODAL_APP_PREFIX: us-data
       US_DATA_RUN_ID: ${{ github.event.inputs.run_id }}
 
     steps:

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MODAL_ENVIRONMENT: main
-      US_DATA_MODAL_APP_PREFIX: policyengine-us-data-pub
+      US_DATA_MODAL_APP_PREFIX: us-data
       US_DATA_RUN_ID: ${{ inputs.run_id || '' }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -20,7 +20,7 @@ jobs:
       github_run_url: ${{ steps.run-context.outputs.github_run_url }}
     env:
       MODAL_ENVIRONMENT: main
-      US_DATA_MODAL_APP_PREFIX: policyengine-us-data-pub
+      US_DATA_MODAL_APP_PREFIX: us-data
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/changelog.d/981.changed.md
+++ b/changelog.d/981.changed.md
@@ -1,0 +1,1 @@
+Shortened publication run IDs and default Modal app names while preserving candidate-scoped staging identity.

--- a/modal_app/pipeline.py
+++ b/modal_app/pipeline.py
@@ -827,6 +827,28 @@ def _write_validation_diagnostics(
 # ── Orchestrator ─────────────────────────────────────────────────
 
 
+def _new_run_metadata(
+    *,
+    run_id: str,
+    branch: str,
+    sha: str,
+    candidate_version: str,
+    release_version: str,
+    run_context: RunContext,
+) -> RunMetadata:
+    return RunMetadata(
+        run_id=run_id,
+        branch=branch,
+        sha=sha,
+        version=candidate_version,
+        candidate_version=candidate_version,
+        release_version=release_version,
+        start_time=datetime.now(timezone.utc).isoformat(),
+        status="running",
+        **_metadata_run_fields(run_context),
+    )
+
+
 @app.function(
     image=image,
     cpu=2,
@@ -1021,18 +1043,13 @@ def run_pipeline(
             )
         _apply_run_context_env(current_run_context)
         run_id = current_run_context.run_id
-        meta = RunMetadata(
+        meta = _new_run_metadata(
             run_id=run_id,
             branch=branch,
             sha=sha,
-            version=candidate_version,
             candidate_version=candidate_version,
             release_version=release_version,
-            base_release_version=current_run_context.base_release_version,
-            release_bump=current_run_context.release_bump,
-            start_time=datetime.now(timezone.utc).isoformat(),
-            status="running",
-            **_metadata_run_fields(current_run_context),
+            run_context=current_run_context,
         )
 
     # Create run directory

--- a/policyengine_us_data/utils/run_context.py
+++ b/policyengine_us_data/utils/run_context.py
@@ -25,7 +25,7 @@ RELEASE_BUMP_ENV = "US_DATA_RELEASE_BUMP"
 DATA_PACKAGE_VERSION_ENV = "US_DATA_PACKAGE_VERSION"
 MODAL_APP_NAME_ENV = "US_DATA_MODAL_APP_NAME"
 MODAL_ENVIRONMENT_ENV = "US_DATA_MODAL_ENVIRONMENT"
-DEFAULT_MODAL_APP_PREFIX = "policyengine-us-data-pub"
+DEFAULT_MODAL_APP_PREFIX = "us-data"
 DEFAULT_MODAL_ENVIRONMENT = "main"
 DEFAULT_MAX_RESOURCE_NAME_LENGTH = 64
 VALID_RELEASE_BUMPS = frozenset({"major", "minor", "patch"})
@@ -109,14 +109,12 @@ def build_run_id(
     *,
     github_run_id: str,
     github_run_attempt: str,
-    github_sha: str,
 ) -> str:
     """Build a deterministic run ID from GitHub Actions identity."""
     if not github_run_id:
         raise ValueError("github_run_id is required")
     attempt = github_run_attempt or "1"
-    sha = (github_sha or "unknown")[:8]
-    return sanitize_run_id(f"usdata-gha{github_run_id}-a{attempt}-{sha}")
+    return sanitize_run_id(f"usdata-gha{github_run_id}-a{attempt}")
 
 
 def build_modal_resource_name(
@@ -132,6 +130,37 @@ def build_modal_resource_name(
     )
 
 
+def candidate_run_segment(
+    run_id: str,
+    candidate_version: str = "",
+    *,
+    version: str = "",
+) -> str:
+    """Return the shared candidate/run segment for staging and app names."""
+    resolved_run_id = sanitize_run_id(run_id)
+    resolved_candidate_version = candidate_version or version
+    if not resolved_candidate_version:
+        return resolved_run_id
+    return sanitize_staging_version(
+        f"{sanitize_staging_version(resolved_candidate_version)}-{resolved_run_id}"
+    )
+
+
+def build_modal_app_name(
+    run_id: str,
+    candidate_version: str = "",
+    *,
+    prefix: str = DEFAULT_MODAL_APP_PREFIX,
+    max_length: int = DEFAULT_MAX_RESOURCE_NAME_LENGTH,
+) -> str:
+    """Build a safe Modal app name from candidate scope and run ID."""
+    return build_modal_resource_name(
+        candidate_run_segment(run_id, candidate_version),
+        prefix=prefix,
+        max_length=max_length,
+    )
+
+
 def staging_prefix(
     run_id: str = "",
     candidate_version: str = "",
@@ -140,14 +169,9 @@ def staging_prefix(
 ) -> str:
     if not run_id:
         return "staging"
-    resolved_run_id = sanitize_run_id(run_id)
-    resolved_candidate_version = candidate_version or version
-    if not resolved_candidate_version:
-        return f"staging/{resolved_run_id}"
-    staging_scope = sanitize_staging_version(
-        f"{sanitize_staging_version(resolved_candidate_version)}-{resolved_run_id}"
+    return (
+        f"staging/{candidate_run_segment(run_id, candidate_version, version=version)}"
     )
-    return f"staging/{staging_scope}"
 
 
 def github_run_url(env: Mapping[str, str]) -> str:
@@ -368,8 +392,9 @@ class RunContext:
             or env.get(MODAL_APP_NAME_ENV, "")
             or env.get("MODAL_APP_NAME", "")
             or (
-                build_modal_resource_name(
+                build_modal_app_name(
                     resolved_run_id,
+                    candidate_version=resolved_candidate_version,
                     prefix=modal_app_prefix,
                 )
                 if resolved_run_id

--- a/tests/unit/calibration/test_chunked_matrix_modal.py
+++ b/tests/unit/calibration/test_chunked_matrix_modal.py
@@ -70,13 +70,13 @@ def test_lookup_worker_function_uses_run_context_env(monkeypatch) -> None:
             return object()
 
     monkeypatch.setitem(sys.modules, "modal", SimpleNamespace(Function=_FakeFunction))
-    monkeypatch.setenv("US_DATA_MODAL_APP_NAME", "policyengine-us-data-pub-run")
+    monkeypatch.setenv("US_DATA_MODAL_APP_NAME", "us-data-run")
     monkeypatch.setenv("US_DATA_MODAL_ENVIRONMENT", "main")
 
     _lookup_worker_function()
 
     assert captured == {
-        "app_name": "policyengine-us-data-pub-run",
+        "app_name": "us-data-run",
         "function_name": "build_matrix_chunk_worker",
         "kwargs": {"environment_name": "main"},
     }

--- a/tests/unit/calibration/test_compare_calibration_runs.py
+++ b/tests/unit/calibration/test_compare_calibration_runs.py
@@ -15,25 +15,25 @@ from policyengine_us_data.calibration.compare_calibration_runs import (
 
 
 def test_run_comparison_paths_are_run_scoped():
-    paths = RunComparisonPaths("usdata-gha123-a1-abcdef12", version="1.73.0")
+    paths = RunComparisonPaths("usdata-gha123-a1", version="1.73.0")
 
     assert (
         paths.regional_diagnostics
         == "hf://policyengine/policyengine-us-data/calibration/runs/"
-        "usdata-gha123-a1-abcdef12/diagnostics/unified_diagnostics.csv"
+        "usdata-gha123-a1/diagnostics/unified_diagnostics.csv"
     )
     assert (
         paths.national_diagnostics
         == "hf://policyengine/policyengine-us-data/calibration/runs/"
-        "usdata-gha123-a1-abcdef12/diagnostics/national_unified_diagnostics.csv"
+        "usdata-gha123-a1/diagnostics/national_unified_diagnostics.csv"
     )
     assert (
         paths.candidate_h5 == "hf://policyengine/policyengine-us-data/staging/"
-        "1.73.0-usdata-gha123-a1-abcdef12/national/US.h5"
+        "1.73.0-usdata-gha123-a1/national/US.h5"
     )
     assert (
         paths.legacy_h5 == "hf://policyengine/policyengine-us-data/staging/"
-        "1.73.0-usdata-gha123-a1-abcdef12/enhanced_cps_2024.h5"
+        "1.73.0-usdata-gha123-a1/enhanced_cps_2024.h5"
     )
 
 

--- a/tests/unit/test_modal_local_area.py
+++ b/tests/unit/test_modal_local_area.py
@@ -51,13 +51,13 @@ def test_promote_scripts_can_defer_staging_cleanup_for_pipeline_promotion():
 
     regional_script = local_area._build_promote_publish_script(
         version="1.73.0",
-        run_id="usdata-gha123-a1-abcdef12",
+        run_id="usdata-gha123-a1",
         rel_paths=["states/AL.h5"],
         cleanup_staging=False,
     )
     national_script = local_area._build_promote_national_publish_script(
         version="1.73.0",
-        run_id="usdata-gha123-a1-abcdef12",
+        run_id="usdata-gha123-a1",
         rel_paths=["national/US.h5"],
         cleanup_staging=False,
     )
@@ -72,7 +72,7 @@ def test_promote_publish_falls_back_to_package_version_for_new_run_ids(
     monkeypatch, tmp_path
 ):
     local_area = load_local_area_module()
-    run_id = "usdata-gha123-a1-abcdef12"
+    run_id = "usdata-gha123-a1"
     run_dir = tmp_path / run_id
     run_dir.mkdir()
     (run_dir / "manifest.json").write_text(
@@ -107,7 +107,7 @@ def test_promote_national_publish_falls_back_to_package_version_for_new_run_ids(
     monkeypatch,
 ):
     local_area = load_local_area_module()
-    run_id = "usdata-gha123-a1-abcdef12"
+    run_id = "usdata-gha123-a1"
     captured = {}
 
     monkeypatch.setattr(local_area, "setup_gcp_credentials", lambda: None)

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -13,6 +13,7 @@ from modal_app.pipeline import (  # noqa: E402
     NATIONAL_FIT_LAMBDA_L0,
     _build_diagnostics_upload_script,
     _calibration_package_parameters,
+    _new_run_metadata,
     _pipeline_error_summary,
     _run_required_promotion_subprocess,
 )
@@ -21,6 +22,7 @@ from modal_app.step_manifests.store import (  # noqa: E402
     read_run_meta,
     write_run_meta,
 )
+from policyengine_us_data.utils.run_context import RunContext  # noqa: E402
 from policyengine_us_data.utils.step_manifest import ArtifactReference  # noqa: E402
 
 
@@ -100,6 +102,37 @@ def test_pipeline_error_summary_falls_back_to_bounded_traceback(monkeypatch):
     assert summary.startswith("\n[truncated older error text; omitted ")
     assert summary.endswith("newest <redacted:API_TOKEN>")
     assert "old traceback" not in summary
+
+
+def test_new_run_metadata_accepts_release_context_fields_once():
+    context = RunContext.from_mapping(
+        {
+            "run_id": "run-123",
+            "candidate_version": "1.73.0-minor",
+            "release_version": "",
+            "base_release_version": "1.73.0",
+            "release_bump": "minor",
+            "modal_app_name": "us-data-1-73-0-minor-run-123",
+            "modal_environment": "main",
+            "hf_staging_prefix": "staging/1.73.0-minor-run-123",
+        }
+    )
+
+    meta = _new_run_metadata(
+        run_id=context.run_id,
+        branch="main",
+        sha="abc123",
+        candidate_version=context.candidate_version,
+        release_version=context.release_version,
+        run_context=context,
+    )
+
+    assert meta.base_release_version == "1.73.0"
+    assert meta.release_bump == "minor"
+    assert meta.modal_app_name == "us-data-1-73-0-minor-run-123"
+    assert meta.hf_staging_prefix == "staging/1.73.0-minor-run-123"
+    assert meta.run_context["base_release_version"] == "1.73.0"
+    assert meta.run_context["release_bump"] == "minor"
 
 
 class TestRunMetadata:

--- a/tests/unit/test_release_manifest.py
+++ b/tests/unit/test_release_manifest.py
@@ -211,17 +211,17 @@ def test_build_release_manifest_records_run_context(tmp_path):
         version="1.73.0",
         repo_id="policyengine/policyengine-us-data",
         run_context={
-            "run_id": "usdata-gha123-a1-abcdef12",
-            "modal_app_name": "policyengine-us-data-pub-usdata-gha123-a1-abcdef12",
-            "hf_staging_prefix": "staging/1.73.0-usdata-gha123-a1-abcdef12",
+            "run_id": "usdata-gha123-a1",
+            "modal_app_name": "us-data-1-73-0-usdata-gha123-a1",
+            "hf_staging_prefix": "staging/1.73.0-usdata-gha123-a1",
         },
         created_at="2026-04-10T12:00:00Z",
     )
 
     assert manifest["build"]["metadata"]["run_context"] == {
-        "run_id": "usdata-gha123-a1-abcdef12",
-        "modal_app_name": "policyengine-us-data-pub-usdata-gha123-a1-abcdef12",
-        "hf_staging_prefix": "staging/1.73.0-usdata-gha123-a1-abcdef12",
+        "run_id": "usdata-gha123-a1",
+        "modal_app_name": "us-data-1-73-0-usdata-gha123-a1",
+        "hf_staging_prefix": "staging/1.73.0-usdata-gha123-a1",
     }
 
 
@@ -244,9 +244,9 @@ def test_build_release_manifest_validates_against_bundle_contract(tmp_path):
         version="1.73.0",
         repo_id="policyengine/policyengine-us-data",
         run_context={
-            "run_id": "usdata-gha123-a1-abcdef12",
-            "modal_app_name": "policyengine-us-data-pub-usdata-gha123-a1-abcdef12",
-            "hf_staging_prefix": "staging/1.73.0-usdata-gha123-a1-abcdef12",
+            "run_id": "usdata-gha123-a1",
+            "modal_app_name": "us-data-1-73-0-usdata-gha123-a1",
+            "hf_staging_prefix": "staging/1.73.0-usdata-gha123-a1",
         },
         model_package_version=EXPECTED_MODEL_PACKAGE_VERSION,
         model_package_git_sha="deadbeef",

--- a/tests/unit/test_remote_calibration_runner.py
+++ b/tests/unit/test_remote_calibration_runner.py
@@ -200,7 +200,7 @@ def test_build_package_impl_sets_volume_chunk_dir_for_parallel_matrix(
         workers=1,
         n_clones=10,
         run_id="bench-run",
-        modal_app_name="policyengine-us-data-pub-bench-run",
+        modal_app_name="us-data-bench-run",
         modal_environment="main",
         pipeline_volume_name="pipeline-artifacts-bench-run",
         chunked_matrix=True,
@@ -220,11 +220,8 @@ def test_build_package_impl_sets_volume_chunk_dir_for_parallel_matrix(
     assert captured["cmd"][chunk_dir_idx] == str(artifacts_dir / "matrix_build")
     assert captured["env"]["POLICYENGINE_US_DATA_RUN_ID"] == "bench-run"
     assert captured["env"]["US_DATA_RUN_ID"] == "bench-run"
-    assert (
-        captured["env"]["US_DATA_MODAL_APP_NAME"]
-        == "policyengine-us-data-pub-bench-run"
-    )
-    assert captured["env"]["MODAL_APP_NAME"] == "policyengine-us-data-pub-bench-run"
+    assert captured["env"]["US_DATA_MODAL_APP_NAME"] == "us-data-bench-run"
+    assert captured["env"]["MODAL_APP_NAME"] == "us-data-bench-run"
     assert captured["env"]["US_DATA_MODAL_ENVIRONMENT"] == "main"
     assert captured["env"]["MODAL_ENVIRONMENT"] == "main"
     assert (

--- a/tests/unit/test_run_context.py
+++ b/tests/unit/test_run_context.py
@@ -2,8 +2,10 @@ from policyengine_us_data.utils.run_context import (
     PublicationVersions,
     RunContext,
     build_candidate_scope,
+    build_modal_app_name,
     build_modal_resource_name,
     build_run_id,
+    candidate_run_segment,
     release_version_from_bump,
     resolve_run_id,
     sanitize_run_id,
@@ -17,9 +19,8 @@ def test_run_id_from_github_identity() -> None:
         build_run_id(
             github_run_id="123456789",
             github_run_attempt="2",
-            github_sha="abcdef123456",
         )
-        == "usdata-gha123456789-a2-abcdef12"
+        == "usdata-gha123456789-a2"
     )
 
 
@@ -28,6 +29,9 @@ def test_run_id_sanitizes_for_modal_and_hf_paths() -> None:
 
 
 def test_staging_prefix_scopes_by_sanitized_version_and_run_id() -> None:
+    assert candidate_run_segment("Run ID", version="1.73.0rc1+build.5") == (
+        "1.73.0rc1+build.5-run-id"
+    )
     assert staging_prefix("Run ID", version="1.73.0rc1+build.5") == (
         "staging/1.73.0rc1+build.5-run-id"
     )
@@ -38,10 +42,20 @@ def test_staging_prefix_scopes_by_sanitized_version_and_run_id() -> None:
 def test_modal_resource_name_uses_safe_prefix_and_truncates() -> None:
     run_id = "usdata-gha123456789-a1-" + ("a" * 80)
 
-    name = build_modal_resource_name(run_id, prefix="policyengine-us-data-pub")
+    name = build_modal_resource_name(run_id, prefix="us-data")
 
-    assert name.startswith("policyengine-us-data-pub-usdata-gha123456789-a1")
+    assert name.startswith("us-data-usdata-gha123456789-a1")
     assert len(name) <= 64
+
+
+def test_modal_app_name_scopes_by_candidate_version_and_run_id() -> None:
+    assert (
+        build_modal_app_name(
+            "Run ID",
+            candidate_version="1.73.0-minor",
+        )
+        == "us-data-1-73-0-minor-run-id"
+    )
 
 
 def test_candidate_scope_uses_base_release_and_bump() -> None:
@@ -80,7 +94,6 @@ def test_run_context_from_env_records_cross_system_identity() -> None:
     run_id = build_run_id(
         github_run_id="123456789",
         github_run_attempt="1",
-        github_sha="abcdef123456",
     )
     env = {
         "GITHUB_SERVER_URL": "https://github.com",
@@ -102,9 +115,11 @@ def test_run_context_from_env_records_cross_system_identity() -> None:
     context = RunContext.from_env(env=env)
 
     assert context.run_id == run_id
-    assert context.modal_app_name == (
-        "policyengine-us-data-pub-usdata-gha123456789-a1-abcdef12"
+    assert context.modal_app_name == build_modal_app_name(
+        run_id,
+        candidate_version="1.73.0rc1",
     )
+    assert context.modal_app_name == "us-data-1-73-0rc1-usdata-gha123456789-a1"
     assert context.modal_environment == "main"
     assert context.candidate_version == "1.73.0rc1"
     assert context.release_version == "1.73.0"
@@ -128,7 +143,7 @@ def test_run_context_export_env_includes_modal_and_hf_values() -> None:
             "US_DATA_CANDIDATE_VERSION": "1.73.0rc1",
             "US_DATA_RELEASE_VERSION": "1.73.0",
         },
-        modal_app_name="policyengine-us-data-pub-run-123",
+        modal_app_name="us-data-run-123",
         modal_environment="main",
     )
 
@@ -138,7 +153,7 @@ def test_run_context_export_env_includes_modal_and_hf_values() -> None:
     assert exported["US_DATA_CANDIDATE_VERSION"] == "1.73.0rc1"
     assert exported["US_DATA_RELEASE_VERSION"] == "1.73.0"
     assert exported["US_DATA_PACKAGE_VERSION"] == "1.73.0rc1"
-    assert exported["MODAL_APP_NAME"] == "policyengine-us-data-pub-run-123"
+    assert exported["MODAL_APP_NAME"] == "us-data-run-123"
     assert exported["MODAL_ENVIRONMENT"] == "main"
     assert exported["US_DATA_HF_STAGING_PREFIX"] == "staging/1.73.0rc1-run-123"
 
@@ -150,7 +165,7 @@ def test_run_context_builds_candidate_scope_without_release_version() -> None:
             "US_DATA_BASE_RELEASE_VERSION": "1.73.0",
             "US_DATA_RELEASE_BUMP": "minor",
         },
-        modal_app_name="policyengine-us-data-pub-run-123",
+        modal_app_name="us-data-run-123",
         modal_environment="main",
     )
 

--- a/tests/unit/version_manifest/test_version_manifest.py
+++ b/tests/unit/version_manifest/test_version_manifest.py
@@ -167,11 +167,11 @@ class TestVersionManifestSerialization:
                 bucket="policyengine-us-data",
                 generations=sample_generations,
             ),
-            run_id="usdata-gha123-a1-abc12345",
+            run_id="usdata-gha123-a1",
             diagnostics_path=("calibration/runs/1.73.0_abc12345_20260310/diagnostics/"),
         )
         data = manifest.to_dict()
-        assert data["run_id"] == "usdata-gha123-a1-abc12345"
+        assert data["run_id"] == "usdata-gha123-a1"
         assert "diagnostics/" in data["diagnostics_path"]
 
     def test_run_id_roundtrip(self, sample_generations, sample_hf_info):
@@ -183,11 +183,11 @@ class TestVersionManifestSerialization:
                 bucket="policyengine-us-data",
                 generations=sample_generations,
             ),
-            run_id="usdata-gha123-a1-abc12345",
+            run_id="usdata-gha123-a1",
             diagnostics_path="calibration/runs/x/diag/",
         )
         roundtripped = VersionManifest.from_dict(manifest.to_dict())
-        assert roundtripped.run_id == "usdata-gha123-a1-abc12345"
+        assert roundtripped.run_id == "usdata-gha123-a1"
         assert roundtripped.diagnostics_path == ("calibration/runs/x/diag/")
 
 
@@ -323,13 +323,13 @@ class TestBuildManifest:
             "1.72.3",
             ["file.h5"],
             hf_info=sample_hf_info,
-            run_id="usdata-gha123-a1-abcdef12",
+            run_id="usdata-gha123-a1",
         )
 
         assert result.hf is not None
         assert result.hf.commit == "abc123def456"
         assert result.hf.repo == ("policyengine/policyengine-us-data")
-        assert result.run_id == "usdata-gha123-a1-abcdef12"
+        assert result.run_id == "usdata-gha123-a1"
         assert result.policyengine_us == sample_policyengine_us_info
 
     @patch(f"{_MOD}.get_policyengine_us_build_info")


### PR DESCRIPTION
Fixes #981

## Summary
- Drop the source SHA from generated publication run IDs.
- Use `us-data` as the default Modal app prefix and scope app names by candidate version plus run ID.
- Fix new-run metadata construction so release context fields are only passed once.

## Expected naming
- Run ID: `usdata-gha25865360265-a1`
- Modal app: `us-data-1-115-2-patch-usdata-gha25865360265-a1`
- HF staging: `staging/1.115.2-patch-usdata-gha25865360265-a1`

## Testing
- `make lint`
- `ruff check .github/scripts/resolve_run_context.py modal_app/pipeline.py policyengine_us_data/utils/run_context.py tests/unit/test_pipeline.py tests/unit/test_run_context.py tests/unit/test_release_manifest.py tests/unit/test_modal_local_area.py tests/unit/version_manifest/test_version_manifest.py tests/unit/calibration/test_compare_calibration_runs.py tests/unit/test_remote_calibration_runner.py tests/unit/calibration/test_chunked_matrix_modal.py`
- `ruff format .github/scripts/resolve_run_context.py modal_app/pipeline.py policyengine_us_data/utils/run_context.py tests/unit/test_pipeline.py tests/unit/test_run_context.py tests/unit/test_release_manifest.py tests/unit/test_modal_local_area.py tests/unit/version_manifest/test_version_manifest.py tests/unit/calibration/test_compare_calibration_runs.py tests/unit/test_remote_calibration_runner.py tests/unit/calibration/test_chunked_matrix_modal.py --check`
- `uv run --no-sync --with pyyaml python scripts/run_quality_guards.py`
- Focused pytest batch: 124 passed, 1 skipped; one unrelated rollback test failed because the temporary no-sync env lacked installed `policyengine-us`
- Targeted version-manifest run ID tests passed separately