### PR TITLE
Snapshot publication candidate changelog fragments

### DIFF
--- a/.github/bump_version.py
+++ b/.github/bump_version.py
@@ -2,6 +2,8 @@
 
 import json
 import re
+import os
+import shutil
 import sys
 from pathlib import Path
 
@@ -18,6 +20,8 @@ from policyengine_us_data.utils.run_context import (  # noqa: E402
 VERSION_RE = re.compile(r'^version\s*=\s*"([^"]+)"', re.MULTILINE)
 SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:rc(\d+))?$")
 PUBLICATION_SCOPE_PATH = Path(".github/publication_scope.json")
+PUBLICATION_CANDIDATES_DIR = Path(".github/publication_candidates")
+CHANGELOG_KEEP_FILE = ".gitkeep"
 
 
 def get_current_version(pyproject_path: Path) -> str:
@@ -33,9 +37,7 @@ def get_current_version(pyproject_path: Path) -> str:
 
 
 def infer_bump(changelog_dir: Path) -> str:
-    fragments = [
-        f for f in changelog_dir.iterdir() if f.is_file() and f.name != ".gitkeep"
-    ]
+    fragments = changelog_fragments(changelog_dir)
     if not fragments:
         print("No changelog fragments found", file=sys.stderr)
         sys.exit(1)
@@ -62,13 +64,56 @@ def bump_version(version: str, bump: str) -> str:
 
 
 def write_publication_scope(path: Path, payload: dict[str, str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
     print(f"  Updated {path}")
+
+
+def changelog_fragments(changelog_dir: Path) -> list[Path]:
+    return sorted(
+        f
+        for f in changelog_dir.iterdir()
+        if f.is_file() and f.name != CHANGELOG_KEEP_FILE
+    )
+
+
+def snapshot_changelog_fragments(
+    *,
+    run_id: str,
+    changelog_dir: Path,
+    publication_candidates_dir: Path,
+) -> Path:
+    fragments = changelog_fragments(changelog_dir)
+    if not run_id:
+        print(
+            "US_DATA_RUN_ID is required to snapshot changelog fragments",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if not fragments:
+        print("No changelog fragments found", file=sys.stderr)
+        sys.exit(1)
+
+    snapshot_dir = publication_candidates_dir / run_id / "changelog.d"
+    if snapshot_dir.exists() and changelog_fragments(snapshot_dir):
+        print(
+            f"Candidate changelog snapshot already exists: {snapshot_dir}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    snapshot_dir.mkdir(parents=True, exist_ok=True)
+    for fragment in fragments:
+        destination = snapshot_dir / fragment.name
+        shutil.copy2(fragment, destination)
+        fragment.unlink()
+        print(f"  Snapshotted {fragment} -> {destination}")
+    return snapshot_dir
 
 
 def main():
     pyproject = _REPO_ROOT / "pyproject.toml"
     changelog_dir = _REPO_ROOT / "changelog.d"
+    run_id = os.environ.get("US_DATA_RUN_ID", "")
 
     current = get_current_version(pyproject)
     bump = infer_bump(changelog_dir)
@@ -80,14 +125,25 @@ def main():
     print(f"Release bump: {bump}")
     print(f"Would release as at build time: {would_release_as}")
 
+    snapshot_changelog_fragments(
+        run_id=run_id,
+        changelog_dir=changelog_dir,
+        publication_candidates_dir=_REPO_ROOT / PUBLICATION_CANDIDATES_DIR,
+    )
+    payload = {
+        "run_id": run_id,
+        "base_release_version": current,
+        "release_bump": bump,
+        "candidate_scope": candidate_scope,
+        "would_release_as_at_build_time": would_release_as,
+    }
     write_publication_scope(
         _REPO_ROOT / PUBLICATION_SCOPE_PATH,
-        {
-            "base_release_version": current,
-            "release_bump": bump,
-            "candidate_scope": candidate_scope,
-            "would_release_as_at_build_time": would_release_as,
-        },
+        payload,
+    )
+    write_publication_scope(
+        _REPO_ROOT / PUBLICATION_CANDIDATES_DIR / run_id / PUBLICATION_SCOPE_PATH.name,
+        payload,
     )
 
 

--- a/.github/scripts/resolve_run_context.py
+++ b/.github/scripts/resolve_run_context.py
@@ -57,7 +57,19 @@ def _pyproject_version() -> str:
         return tomllib.load(file)["project"]["version"]
 
 
-def _publication_scope() -> dict[str, str]:
+def _publication_scope(env: Mapping[str, str] | None = None) -> dict[str, str]:
+    env = env or os.environ
+    run_id = env.get(RUN_ID_ENV, "")
+    if run_id:
+        candidate_path = (
+            _REPO_ROOT
+            / ".github"
+            / "publication_candidates"
+            / run_id
+            / "publication_scope.json"
+        )
+        if candidate_path.exists():
+            return json.loads(candidate_path.read_text())
     path = _REPO_ROOT / ".github" / "publication_scope.json"
     if not path.exists():
         return {}
@@ -65,7 +77,7 @@ def _publication_scope() -> dict[str, str]:
 
 
 def _base_release_version(env: Mapping[str, str]) -> str:
-    scope = _publication_scope()
+    scope = _publication_scope(env)
     value = (
         env.get(BASE_RELEASE_VERSION_ENV)
         or env.get("BASE_RELEASE_VERSION", "")
@@ -77,7 +89,7 @@ def _base_release_version(env: Mapping[str, str]) -> str:
 
 
 def _release_bump(env: Mapping[str, str]) -> str:
-    scope = _publication_scope()
+    scope = _publication_scope(env)
     value = (
         env.get(RELEASE_BUMP_ENV)
         or env.get("RELEASE_BUMP", "")
@@ -94,7 +106,7 @@ def _candidate_version(
     base_release_version: str = "",
     release_bump: str = "",
 ) -> str:
-    scope = _publication_scope()
+    scope = _publication_scope(env)
     version = (
         env.get(CANDIDATE_SCOPE_ENV)
         or env.get(CANDIDATE_VERSION_ENV)

--- a/.github/scripts/restore_publication_changelog.py
+++ b/.github/scripts/restore_publication_changelog.py
@@ -1,0 +1,93 @@
+"""Restore candidate-scoped changelog fragments for final promotion."""
+
+from __future__ import annotations
+
+import filecmp
+import os
+import shutil
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROOT_CHANGELOG_DIR = REPO_ROOT / "changelog.d"
+PUBLICATION_CANDIDATES_DIR = REPO_ROOT / ".github" / "publication_candidates"
+CHANGELOG_KEEP_FILE = ".gitkeep"
+
+
+def _fragments(path: Path) -> list[Path]:
+    if not path.exists():
+        return []
+    return sorted(
+        item
+        for item in path.iterdir()
+        if item.is_file() and item.name != CHANGELOG_KEEP_FILE
+    )
+
+
+def _validate_root_fragments_match_snapshot(
+    *,
+    root_fragments: list[Path],
+    snapshot_fragments: list[Path],
+) -> None:
+    snapshot_by_name = {fragment.name: fragment for fragment in snapshot_fragments}
+    root_by_name = {fragment.name: fragment for fragment in root_fragments}
+    extra = sorted(set(root_by_name).difference(snapshot_by_name))
+    missing = sorted(set(snapshot_by_name).difference(root_by_name))
+    changed = sorted(
+        name
+        for name in set(root_by_name).intersection(snapshot_by_name)
+        if not filecmp.cmp(root_by_name[name], snapshot_by_name[name], shallow=False)
+    )
+    if extra or missing or changed:
+        details = []
+        if extra:
+            details.append(f"extra root fragments: {', '.join(extra)}")
+        if missing:
+            details.append(f"missing root fragments: {', '.join(missing)}")
+        if changed:
+            details.append(f"changed root fragments: {', '.join(changed)}")
+        raise RuntimeError(
+            "Root changelog fragments do not match the candidate snapshot; "
+            + "; ".join(details)
+        )
+
+
+def restore_candidate_changelog(run_id: str) -> Path:
+    if not run_id:
+        raise RuntimeError("US_DATA_RUN_ID is required to restore changelog fragments.")
+
+    snapshot_dir = PUBLICATION_CANDIDATES_DIR / run_id / "changelog.d"
+    snapshot_fragments = _fragments(snapshot_dir)
+    if not snapshot_fragments:
+        raise RuntimeError(
+            f"No candidate changelog fragments found for run {run_id}: {snapshot_dir}"
+        )
+
+    ROOT_CHANGELOG_DIR.mkdir(parents=True, exist_ok=True)
+    root_fragments = _fragments(ROOT_CHANGELOG_DIR)
+    if root_fragments:
+        _validate_root_fragments_match_snapshot(
+            root_fragments=root_fragments,
+            snapshot_fragments=snapshot_fragments,
+        )
+
+    for fragment in snapshot_fragments:
+        destination = ROOT_CHANGELOG_DIR / fragment.name
+        shutil.copy2(fragment, destination)
+        print(f"Restored {destination} from {fragment}")
+
+    return snapshot_dir
+
+
+def main() -> None:
+    try:
+        snapshot_dir = restore_candidate_changelog(os.environ.get("US_DATA_RUN_ID", ""))
+    except Exception as exc:
+        print(str(exc), file=sys.stderr)
+        sys.exit(1)
+    print(f"Restored candidate changelog fragments from {snapshot_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/local_area_promote.yaml
+++ b/.github/workflows/local_area_promote.yaml
@@ -46,8 +46,8 @@ jobs:
 
       - uses: astral-sh/setup-uv@v8.1.0
 
-      - name: Install Modal CLI
-        run: pip install modal
+      - name: Install promotion CLI deps
+        run: pip install modal towncrier
 
       - name: Resolve run context
         id: run-context
@@ -58,13 +58,15 @@ jobs:
 
       - name: Finalize package version
         run: |
+          python .github/scripts/restore_publication_changelog.py
           python .github/scripts/finalize_package_version.py
+          towncrier build --yes --version "$US_DATA_RELEASE_VERSION"
           uv lock
 
       - name: Commit final package version
         uses: EndBug/add-and-commit@v10
         with:
-          add: "pyproject.toml uv.lock"
+          add: "pyproject.toml uv.lock CHANGELOG.md changelog.d"
           message: Finalize package version
 
       - name: Build final wheel

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -62,7 +62,7 @@ jobs:
           folder: docs/_build/html
           clean: true
 
-  # ── Publication candidate scope + changelog on ordinary pushes ──
+  # ── Publication candidate scope + changelog snapshot on ordinary pushes ──
   versioning:
     name: Versioning
     runs-on: ubuntu-latest
@@ -87,11 +87,11 @@ jobs:
         with:
           python-version: "3.14"
       - uses: astral-sh/setup-uv@v8.1.0
-      - run: pip install towncrier
-      - name: Bump version and build changelog
+      - name: Snapshot candidate changelog fragments
+        env:
+          US_DATA_RUN_ID: ${{ needs.run-context.outputs.run_id }}
         run: |
           python .github/bump_version.py
-          towncrier build --yes --version "$(python .github/scripts/fetch_publication_scope.py would_release_as_at_build_time)"
       - name: Generate pipeline documentation artifacts
         run: uv run --no-sync --with pyyaml python scripts/extract_pipeline_docs.py
       - name: Update lockfile

--- a/changelog.d/983.changed.md
+++ b/changelog.d/983.changed.md
@@ -1,0 +1,1 @@
+Snapshot publication candidate changelog fragments for final release promotion.

--- a/tests/unit/test_publication_scripts.py
+++ b/tests/unit/test_publication_scripts.py
@@ -91,6 +91,7 @@ def test_bump_version_script_runs_from_github_directory_without_installed_packag
     (changelog_dir / "123.added").write_text("Added a thing.\n")
     env = os.environ.copy()
     env.pop("PYTHONPATH", None)
+    env["US_DATA_RUN_ID"] = "run-123"
 
     result = subprocess.run(
         [sys.executable, str(script_dir / "bump_version.py")],
@@ -105,9 +106,22 @@ def test_bump_version_script_runs_from_github_directory_without_installed_packag
     assert json.loads((script_dir / "publication_scope.json").read_text()) == {
         "base_release_version": "1.73.0",
         "candidate_scope": "1.73.0-minor",
+        "run_id": "run-123",
         "release_bump": "minor",
         "would_release_as_at_build_time": "1.74.0",
     }
+    candidate_dir = script_dir / "publication_candidates" / "run-123"
+    assert json.loads((candidate_dir / "publication_scope.json").read_text()) == {
+        "base_release_version": "1.73.0",
+        "candidate_scope": "1.73.0-minor",
+        "run_id": "run-123",
+        "release_bump": "minor",
+        "would_release_as_at_build_time": "1.74.0",
+    }
+    assert (candidate_dir / "changelog.d" / "123.added").read_text() == (
+        "Added a thing.\n"
+    )
+    assert not (changelog_dir / "123.added").exists()
 
 
 def test_fetch_publication_scope_prints_requested_field(
@@ -189,6 +203,59 @@ def test_fetch_release_version_exits_on_unsupported_version(
     assert "Unsupported version format: 1.74" in capsys.readouterr().err
 
 
+def test_restore_publication_changelog_restores_candidate_snapshot(
+    tmp_path,
+    monkeypatch,
+):
+    module = _load_script(
+        ".github/scripts/restore_publication_changelog.py",
+        "restore_publication_changelog_script_test",
+    )
+    root_changelog = tmp_path / "changelog.d"
+    snapshot = (
+        tmp_path / ".github" / "publication_candidates" / "run-123" / "changelog.d"
+    )
+    snapshot.mkdir(parents=True)
+    (snapshot / "123.changed.md").write_text("Changed a thing.\n")
+    monkeypatch.setattr(module, "ROOT_CHANGELOG_DIR", root_changelog)
+    monkeypatch.setattr(
+        module,
+        "PUBLICATION_CANDIDATES_DIR",
+        tmp_path / ".github" / "publication_candidates",
+    )
+
+    module.restore_candidate_changelog("run-123")
+
+    assert (root_changelog / "123.changed.md").read_text() == "Changed a thing.\n"
+
+
+def test_restore_publication_changelog_rejects_unrelated_root_fragments(
+    tmp_path,
+    monkeypatch,
+):
+    module = _load_script(
+        ".github/scripts/restore_publication_changelog.py",
+        "restore_publication_changelog_conflict_script_test",
+    )
+    root_changelog = tmp_path / "changelog.d"
+    root_changelog.mkdir()
+    (root_changelog / "999.fixed.md").write_text("Unrelated fix.\n")
+    snapshot = (
+        tmp_path / ".github" / "publication_candidates" / "run-123" / "changelog.d"
+    )
+    snapshot.mkdir(parents=True)
+    (snapshot / "123.changed.md").write_text("Changed a thing.\n")
+    monkeypatch.setattr(module, "ROOT_CHANGELOG_DIR", root_changelog)
+    monkeypatch.setattr(
+        module,
+        "PUBLICATION_CANDIDATES_DIR",
+        tmp_path / ".github" / "publication_candidates",
+    )
+
+    with pytest.raises(RuntimeError, match="do not match"):
+        module.restore_candidate_changelog("run-123")
+
+
 def test_finalize_package_version_rewrites_current_rc_to_stable(
     tmp_path,
     monkeypatch,
@@ -259,6 +326,53 @@ def test_resolve_run_context_uses_publication_scope(
         == "1.75.0-minor"
     )
     assert module._release_version({}) == ""
+
+
+def test_resolve_run_context_prefers_run_scoped_publication_scope(
+    tmp_path,
+    monkeypatch,
+):
+    module = _load_script(
+        ".github/scripts/resolve_run_context.py",
+        "resolve_run_context_scoped_script_test",
+    )
+    _write_pyproject(tmp_path, "1.75.0")
+    scope_dir = tmp_path / ".github"
+    scoped_dir = scope_dir / "publication_candidates" / "run-123"
+    scoped_dir.mkdir(parents=True)
+    scope_dir.mkdir(exist_ok=True)
+    (scope_dir / "publication_scope.json").write_text(
+        json.dumps(
+            {
+                "base_release_version": "1.75.0",
+                "release_bump": "minor",
+                "candidate_scope": "1.75.0-minor",
+                "would_release_as_at_build_time": "1.76.0",
+            }
+        )
+    )
+    (scoped_dir / "publication_scope.json").write_text(
+        json.dumps(
+            {
+                "base_release_version": "1.75.0",
+                "release_bump": "patch",
+                "candidate_scope": "1.75.0-patch",
+                "would_release_as_at_build_time": "1.75.1",
+            }
+        )
+    )
+    monkeypatch.setattr(module, "_REPO_ROOT", tmp_path)
+    env = {"US_DATA_RUN_ID": "run-123"}
+
+    assert module._release_bump(env) == "patch"
+    assert (
+        module._candidate_version(
+            env,
+            base_release_version="1.75.0",
+            release_bump="patch",
+        )
+        == "1.75.0-patch"
+    )
 
 
 def test_resolve_run_context_builds_candidate_scope_from_env(


### PR DESCRIPTION
Fixes #983

## Summary
- Snapshot candidate changelog fragments under `.github/publication_candidates/{run_id}/changelog.d/` during push versioning instead of rendering `CHANGELOG.md` for candidate commits.
- Store run-scoped `publication_scope.json` alongside the candidate snapshot and make run context resolution prefer that run-scoped scope during promotion.
- Restore the candidate changelog snapshot during promotion, then build `CHANGELOG.md` only when finalizing the release version.

## Testing
- `uv run --no-sync --with pytest python -m pytest tests/unit/test_publication_scripts.py -q`
- `uv run --no-sync --with pyyaml python scripts/run_quality_guards.py`
- `ruff check .github/bump_version.py .github/scripts/resolve_run_context.py .github/scripts/restore_publication_changelog.py tests/unit/test_publication_scripts.py`
- `make lint`