### PR TITLE
Bump PolicyEngine US for data builds

### DIFF
--- a/changelog.d/pe-us-8298.changed.md
+++ b/changelog.d/pe-us-8298.changed.md
@@ -1,0 +1,1 @@
+Use PolicyEngine US 1.691.10 for data builds, including fixes to SNAP disability, TANF non-cash assets, capital-gains flags, and related vectorized calculations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us>=1.691.3",
+    "policyengine-us @ git+https://github.com/PolicyEngine/policyengine-us@4fd79e6608bc2dac3a7fde0be37191cb4870bd85",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/uv.lock
+++ b/uv.lock
@@ -2122,8 +2122,8 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.691.3"
-source = { registry = "https://pypi.org/simple" }
+version = "1.691.10"
+source = { git = "https://github.com/PolicyEngine/policyengine-us?rev=4fd79e6608bc2dac3a7fde0be37191cb4870bd85#4fd79e6608bc2dac3a7fde0be37191cb4870bd85" }
 dependencies = [
     { name = "microdf-python" },
     { name = "pandas" },
@@ -2131,10 +2131,6 @@ dependencies = [
     { name = "spm-calculator" },
     { name = "tables" },
     { name = "tqdm" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/04/5e74890db670d7eb736f8fcb6070e6866950ba2e1d79e1d74f0dc5cfc58c/policyengine_us-1.691.3.tar.gz", hash = "sha256:3475c0e71ebe3396cfa2d138c62eeaa22a912c301d941418238109cf51a89e86", size = 9493068, upload-time = "2026-05-12T16:54:08.94Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/03/e21c872664f90dcc99f1fcf29d1da71409c50cf8a7798ff0596ad10d9400/policyengine_us-1.691.3-py3-none-any.whl", hash = "sha256:c5d37aa4442f23d48bd5d587a02876c89d83c6135809f12988cc39bd3a47e8b2", size = 10008634, upload-time = "2026-05-12T16:54:05.956Z" },
 ]
 
 [[package]]
@@ -2204,7 +2200,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", specifier = ">=1.691.3" },
+    { name = "policyengine-us", git = "https://github.com/PolicyEngine/policyengine-us?rev=4fd79e6608bc2dac3a7fde0be37191cb4870bd85" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },


### PR DESCRIPTION
## Summary
- require PolicyEngine US 1.691.10 for data builds
- resolve PolicyEngine US from exact upstream commit `4fd79e6608bc2dac3a7fde0be37191cb4870bd85` while PyPI publication is blocked
- add a changelog note for the dependency bump

## Why
PolicyEngine US PR #8298 fixed vectorized calculations that affect SNAP disability eligibility, Medicaid medically needy categories, TANF non-cash asset tests, and capital-gains flags. The latest PyPI release remains `1.691.3`; PE-US `1.691.10` built but failed to upload because the PyPI project hit the 10 GB storage limit. I filed PolicyEngine/policyengine-us#8316 for that release blocker.

On the current `enhanced_cps_2024.h5`, comparing PE-US `1.691.3` to upstream `1.691.10` for 2024 shows the old vectorization bug was material before any recalibration:
- `is_usda_disabled` weighted mean: 1.000 -> 0.126
- `has_qdiv_or_ltcg` weighted mean: 1.000 -> 0.182
- SNAP total: $109.4B -> $101.0B (-7.7%)
- SNAP eligible SPM units: 36.7M -> 34.0M (-7.3%)

That means the ECPS should be regenerated/recalibrated against the fixed model, not only rescored downstream.

## Tests
- `uv sync --extra calibration`
- `uv run pytest tests/unit/test_import.py tests/unit/test_enhanced_cps.py -q`
- `uv lock --check`