### PR TITLE
Keep PolicyEngine US fresh for data builds

### DIFF
--- a/.github/scripts/check_policyengine_us_dependency.py
+++ b/.github/scripts/check_policyengine_us_dependency.py
@@ -1,0 +1,196 @@
+"""Check whether the locked PolicyEngine US dependency is current."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from itertools import zip_longest
+from pathlib import Path
+import re
+import sys
+import tomllib
+from urllib.error import URLError
+from urllib.request import urlopen
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPI_JSON_TIMEOUT_SECONDS = 20
+POLICYENGINE_US = "policyengine-us"
+STALE_LOCK_PREFIX = "uv.lock has policyengine-us "
+
+
+def _annotation(level: str, message: str) -> str:
+    escaped = message.replace("%", "%25").replace("\n", "%0A").replace("\r", "%0D")
+    return f"::{level} title=PolicyEngine US dependency::{escaped}"
+
+
+def _version_key(version: str) -> tuple[int, ...]:
+    release = version.split("+", 1)[0].split("-", 1)[0]
+    if not re.fullmatch(r"\d+(?:\.\d+)*", release):
+        raise ValueError(f"Unsupported version format: {version}")
+    return tuple(int(part) for part in release.split("."))
+
+
+def _compare_versions(left: str, right: str) -> int:
+    for left_part, right_part in zip_longest(
+        _version_key(left), _version_key(right), fillvalue=0
+    ):
+        if left_part < right_part:
+            return -1
+        if left_part > right_part:
+            return 1
+    return 0
+
+
+def _locked_policyengine_us(root: Path) -> tuple[str, dict[str, object]]:
+    with (root / "uv.lock").open("rb") as file:
+        lock = tomllib.load(file)
+
+    for package in lock.get("package", []):
+        if package.get("name") == POLICYENGINE_US:
+            version = package.get("version")
+            if not isinstance(version, str):
+                raise ValueError("uv.lock entry for policyengine-us has no version")
+            source = package.get("source", {})
+            return version, source if isinstance(source, dict) else {}
+
+    raise ValueError("uv.lock does not contain policyengine-us")
+
+
+def _project_policyengine_us_dependency(root: Path) -> str:
+    with (root / "pyproject.toml").open("rb") as file:
+        pyproject = tomllib.load(file)
+
+    dependencies = pyproject.get("project", {}).get("dependencies", [])
+    for dependency in dependencies:
+        if isinstance(dependency, str) and dependency.startswith(POLICYENGINE_US):
+            return dependency
+
+    raise ValueError("pyproject.toml does not declare policyengine-us")
+
+
+def _latest_pypi_version() -> str:
+    with urlopen(
+        f"https://pypi.org/pypi/{POLICYENGINE_US}/json",
+        timeout=PYPI_JSON_TIMEOUT_SECONDS,
+    ) as response:
+        payload = json.load(response)
+
+    version = payload.get("info", {}).get("version")
+    if not isinstance(version, str) or not version:
+        raise ValueError("PyPI response does not include info.version")
+    return version
+
+
+def check_dependency(root: Path, latest_version: str | None = None) -> list[str]:
+    locked_version, source = _locked_policyengine_us(root)
+    project_dependency = _project_policyengine_us_dependency(root)
+
+    violations: list[str] = []
+    if (
+        latest_version is not None
+        and _compare_versions(locked_version, latest_version) < 0
+    ):
+        violations.append(
+            f"{STALE_LOCK_PREFIX}{locked_version}, but PyPI latest is "
+            f"{latest_version}. Update pyproject.toml and run 'uv lock', or "
+            "explicitly document why the older model is required."
+        )
+
+    expected_dependency = f"{POLICYENGINE_US}=={locked_version}"
+    if project_dependency != expected_dependency:
+        violations.append(
+            f"pyproject.toml must pin {expected_dependency} to match uv.lock; "
+            f"found {project_dependency!r}."
+        )
+
+    if "git" in source:
+        violations.append(
+            "uv.lock resolves policyengine-us from a Git ref. Prefer an exact "
+            f"PyPI release pin once policyengine-us {locked_version} is published."
+        )
+
+    if "@" in project_dependency and "git+" in project_dependency:
+        violations.append(
+            "pyproject.toml pins policyengine-us to a Git ref. Prefer an exact "
+            "PyPI release pin for production data builds."
+        )
+
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mode",
+        choices=("warn", "fail"),
+        default="warn",
+        help="Whether stale dependency findings should fail the command.",
+    )
+    parser.add_argument(
+        "--allow-stale",
+        action="store_true",
+        help="Report stale dependency findings but exit successfully.",
+    )
+    args = parser.parse_args()
+    allow_stale = args.allow_stale or os.environ.get(
+        "POLICYENGINE_US_ALLOW_STALE", ""
+    ).lower() in {"1", "true", "yes"}
+
+    latest_version = None
+    try:
+        latest_version = _latest_pypi_version()
+    except (OSError, URLError, ValueError) as exc:
+        message = (
+            "Unable to fetch the latest policyengine-us version from PyPI; "
+            f"continuing with local dependency checks only: {exc}"
+        )
+        print(_annotation("warning", message))
+
+    try:
+        violations = check_dependency(REPO_ROOT, latest_version=latest_version)
+    except (OSError, ValueError) as exc:
+        message = f"Unable to check policyengine-us freshness: {exc}"
+        if args.mode == "fail":
+            print(_annotation("error", message), file=sys.stderr)
+            return 1
+        print(_annotation("warning", message))
+        return 0
+
+    if not violations:
+        locked_version, _source = _locked_policyengine_us(REPO_ROOT)
+        print(f"policyengine-us dependency is current at {locked_version}.")
+        return 0
+
+    has_blocking_violation = False
+    allowed_stale_version = False
+    for violation in violations:
+        stale_version_violation = violation.startswith(STALE_LOCK_PREFIX)
+        allowed_by_override = allow_stale and stale_version_violation
+        level = "warning" if args.mode == "warn" or allowed_by_override else "error"
+        print(_annotation(level, violation))
+        if args.mode == "fail" and not allowed_by_override:
+            has_blocking_violation = True
+        if allowed_by_override:
+            allowed_stale_version = True
+
+    if allowed_stale_version:
+        print(
+            _annotation(
+                "warning",
+                "POLICYENGINE_US_ALLOW_STALE is set; continuing despite "
+                "policyengine-us lagging the latest PyPI release.",
+            )
+        )
+
+    if has_blocking_violation:
+        return 1
+    if allowed_stale_version:
+        return 0
+
+    return 1 if args.mode == "fail" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/local_area_publish.yaml
+++ b/.github/workflows/local_area_publish.yaml
@@ -22,6 +22,11 @@ on:
         required: false
         default: false
         type: boolean
+      allow_stale_policyengine_us:
+        description: 'Allow production build when policyengine-us lags the latest PyPI release'
+        required: false
+        default: false
+        type: boolean
 
 # Trigger strategy:
 # 1. Automatic: Code changes to calibration/ pushed to main
@@ -49,6 +54,11 @@ jobs:
 
       - name: Install Modal CLI
         run: pip install modal
+
+      - name: Require current PolicyEngine US dependency
+        env:
+          POLICYENGINE_US_ALLOW_STALE: ${{ inputs.allow_stale_policyengine_us }}
+        run: python .github/scripts/check_policyengine_us_dependency.py --mode fail
 
       - name: Run local area build and stage on Modal
         run: |

--- a/.github/workflows/long_run_projection.yaml
+++ b/.github/workflows/long_run_projection.yaml
@@ -108,6 +108,11 @@ on:
         required: false
         default: ""
         type: string
+      allow_stale_policyengine_us:
+        description: "Allow production build when policyengine-us lags the latest PyPI release"
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: long-run-projection-${{ github.run_id }}-${{ github.run_attempt }}
@@ -138,6 +143,11 @@ jobs:
           checked_out_sha="$(git rev-parse HEAD)"
           echo "CHECKED_OUT_SHA=${checked_out_sha}" >> "$GITHUB_ENV"
           GITHUB_SHA="${checked_out_sha}" python .github/scripts/resolve_run_context.py
+
+      - name: Require current PolicyEngine US dependency
+        env:
+          POLICYENGINE_US_ALLOW_STALE: ${{ inputs.allow_stale_policyengine_us }}
+        run: python .github/scripts/check_policyengine_us_dependency.py --mode fail
 
       - name: Install dependencies
         run: uv sync --dev

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -67,6 +67,10 @@ on:
         description: "Number of Modal workers for parallel matrix build"
         default: "50"
         type: string
+      allow_stale_policyengine_us:
+        description: "Allow production build when policyengine-us lags the latest PyPI release"
+        default: false
+        type: boolean
 
 concurrency:
   group: pipeline-${{ github.run_id }}-${{ github.run_attempt }}
@@ -98,6 +102,11 @@ jobs:
           BASE_RELEASE_VERSION: ${{ inputs.base_release_version || '' }}
           RELEASE_BUMP: ${{ inputs.release_bump || '' }}
         run: python .github/scripts/resolve_run_context.py
+
+      - name: Require current PolicyEngine US dependency
+        env:
+          POLICYENGINE_US_ALLOW_STALE: ${{ inputs.allow_stale_policyengine_us }}
+        run: python .github/scripts/check_policyengine_us_dependency.py --mode fail
 
       - name: Deploy and launch pipeline on Modal
         env:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -35,6 +35,18 @@ jobs:
             exit 1
           }
 
+  policyengine-us-freshness:
+    name: PolicyEngine US freshness
+    runs-on: ubuntu-latest
+    needs: check-fork
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+      - name: Warn if policyengine-us is stale
+        run: python .github/scripts/check_policyengine_us_dependency.py --mode warn
+
   lint:
     runs-on: ubuntu-latest
     needs: check-fork

--- a/changelog.d/pe-us-1-691-11-freshness.changed.md
+++ b/changelog.d/pe-us-1-691-11-freshness.changed.md
@@ -1,0 +1,1 @@
+Use the released PolicyEngine US 1.691.11 model for data builds and warn when the locked model lags PyPI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us @ git+https://github.com/PolicyEngine/policyengine-us@4fd79e6608bc2dac3a7fde0be37191cb4870bd85",
+    "policyengine-us==1.691.11",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/tests/unit/test_publication_scripts.py
+++ b/tests/unit/test_publication_scripts.py
@@ -39,6 +39,40 @@ def _write_pyproject(root: Path, version: str, name: str = "policyengine-us-data
     )
 
 
+def _write_pyproject_with_policyengine_us(root: Path, dependency: str):
+    (root / "pyproject.toml").write_text(
+        "\n".join(
+            [
+                "[project]",
+                'name = "policyengine-us-data"',
+                'version = "1.115.2"',
+                "dependencies = [",
+                f'    "{dependency}",',
+                "]",
+                "",
+            ]
+        )
+    )
+
+
+def _write_uv_lock_for_policyengine_us(
+    root: Path,
+    version: str,
+    source: str = '{ registry = "https://pypi.org/simple" }',
+):
+    (root / "uv.lock").write_text(
+        "\n".join(
+            [
+                "[[package]]",
+                'name = "policyengine-us"',
+                f'version = "{version}"',
+                f"source = {source}",
+                "",
+            ]
+        )
+    )
+
+
 def test_bump_version_computes_candidate_scope_without_mutating_pyproject(
     tmp_path,
 ):
@@ -201,6 +235,117 @@ def test_fetch_release_version_exits_on_unsupported_version(
         module.main()
 
     assert "Unsupported version format: 1.74" in capsys.readouterr().err
+
+
+def test_policyengine_us_dependency_check_passes_when_locked_to_latest(tmp_path):
+    module = _load_script(
+        ".github/scripts/check_policyengine_us_dependency.py",
+        "check_policyengine_us_dependency_current_test",
+    )
+    _write_pyproject_with_policyengine_us(tmp_path, "policyengine-us==1.691.11")
+    _write_uv_lock_for_policyengine_us(tmp_path, "1.691.11")
+
+    assert module.check_dependency(tmp_path, latest_version="1.691.11") == []
+
+
+def test_policyengine_us_dependency_check_flags_stale_lock(tmp_path):
+    module = _load_script(
+        ".github/scripts/check_policyengine_us_dependency.py",
+        "check_policyengine_us_dependency_stale_test",
+    )
+    _write_pyproject_with_policyengine_us(tmp_path, "policyengine-us==1.691.10")
+    _write_uv_lock_for_policyengine_us(tmp_path, "1.691.10")
+
+    violations = module.check_dependency(tmp_path, latest_version="1.691.11")
+
+    assert any("1.691.10" in violation for violation in violations)
+    assert any("1.691.11" in violation for violation in violations)
+
+
+def test_policyengine_us_dependency_check_flags_git_refs(tmp_path):
+    module = _load_script(
+        ".github/scripts/check_policyengine_us_dependency.py",
+        "check_policyengine_us_dependency_git_test",
+    )
+    _write_pyproject_with_policyengine_us(
+        tmp_path,
+        "policyengine-us @ git+https://github.com/PolicyEngine/policyengine-us@abc",
+    )
+    _write_uv_lock_for_policyengine_us(
+        tmp_path,
+        "1.691.11",
+        source='{ git = "https://github.com/PolicyEngine/policyengine-us?rev=abc#abc" }',
+    )
+
+    violations = module.check_dependency(tmp_path, latest_version="1.691.11")
+
+    assert any("Git ref" in violation for violation in violations)
+
+
+def test_policyengine_us_dependency_check_flags_non_exact_pyproject_pin(tmp_path):
+    module = _load_script(
+        ".github/scripts/check_policyengine_us_dependency.py",
+        "check_policyengine_us_dependency_pyproject_test",
+    )
+    _write_pyproject_with_policyengine_us(tmp_path, "policyengine-us>=1.691.11")
+    _write_uv_lock_for_policyengine_us(tmp_path, "1.691.11")
+
+    violations = module.check_dependency(tmp_path, latest_version="1.691.11")
+
+    assert any(
+        "must pin policyengine-us==1.691.11" in violation for violation in violations
+    )
+
+
+def test_policyengine_us_dependency_check_allow_stale_exits_successfully(
+    tmp_path,
+    monkeypatch,
+):
+    module = _load_script(
+        ".github/scripts/check_policyengine_us_dependency.py",
+        "check_policyengine_us_dependency_allow_stale_test",
+    )
+    _write_pyproject_with_policyengine_us(tmp_path, "policyengine-us==1.691.10")
+    _write_uv_lock_for_policyengine_us(tmp_path, "1.691.10")
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(module, "_latest_pypi_version", lambda: "1.691.11")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["check_policyengine_us_dependency.py", "--mode", "fail"],
+    )
+    monkeypatch.setenv("POLICYENGINE_US_ALLOW_STALE", "true")
+
+    assert module.main() == 0
+
+
+def test_policyengine_us_dependency_check_allow_stale_keeps_local_errors_fatal(
+    tmp_path,
+    monkeypatch,
+):
+    module = _load_script(
+        ".github/scripts/check_policyengine_us_dependency.py",
+        "check_policyengine_us_dependency_allow_stale_local_error_test",
+    )
+    _write_pyproject_with_policyengine_us(
+        tmp_path,
+        "policyengine-us @ git+https://github.com/PolicyEngine/policyengine-us@abc",
+    )
+    _write_uv_lock_for_policyengine_us(
+        tmp_path,
+        "1.691.10",
+        source='{ git = "https://github.com/PolicyEngine/policyengine-us?rev=abc#abc" }',
+    )
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(module, "_latest_pypi_version", lambda: "1.691.11")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["check_policyengine_us_dependency.py", "--mode", "fail"],
+    )
+    monkeypatch.setenv("POLICYENGINE_US_ALLOW_STALE", "true")
+
+    assert module.main() == 1
 
 
 def test_restore_publication_changelog_restores_candidate_snapshot(

--- a/uv.lock
+++ b/uv.lock
@@ -2122,8 +2122,8 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.691.10"
-source = { git = "https://github.com/PolicyEngine/policyengine-us?rev=4fd79e6608bc2dac3a7fde0be37191cb4870bd85#4fd79e6608bc2dac3a7fde0be37191cb4870bd85" }
+version = "1.691.11"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
     { name = "pandas" },
@@ -2131,6 +2131,10 @@ dependencies = [
     { name = "spm-calculator" },
     { name = "tables" },
     { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/71/97a646a5351cd203ccd7ed364e20e36bf940722354d52c3f9f3bf4fc4f54/policyengine_us-1.691.11.tar.gz", hash = "sha256:cd60e6e373725a2ccd231b584006de0517c334c554344b4361a238fa18887cbb", size = 9507822, upload-time = "2026-05-16T12:01:17.62Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/54/f7a058157dc0e5532ff2fead4169cdf9679141ba2ef98af9173cb652b406/policyengine_us-1.691.11-py3-none-any.whl", hash = "sha256:dc3e110ae7a166e2483d00ea759ab9abb00a0fa4f56bc73b0e601ade2d78c3b6", size = 10022959, upload-time = "2026-05-16T12:01:13.823Z" },
 ]
 
 [[package]]
@@ -2200,7 +2204,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", git = "https://github.com/PolicyEngine/policyengine-us?rev=4fd79e6608bc2dac3a7fde0be37191cb4870bd85" },
+    { name = "policyengine-us", specifier = "==1.691.11" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },


### PR DESCRIPTION
## Summary
- replace the temporary PolicyEngine US git dependency with the released exact PyPI pin policyengine-us==1.691.11
- add a CI freshness checker that warns on PRs when the locked PolicyEngine US version lags PyPI or uses a git/non-exact pin
- require the freshness checker before production pipeline and long-run projection builds, with an explicit allow_stale_policyengine_us override only for deliberate PyPI-lag cases

## CRFB relevance
This prevents production H5 builds from silently using a stale PolicyEngine US runtime. It also moves data builds onto the released model containing the 2026 payroll cap and capital-gains election fixes from PolicyEngine/policyengine-us#8326. PolicyEngine US 1.691.12 is still publishing after PolicyEngine/policyengine-us#7959; if that lands before this merges, I will bump this PR once more.

## Tests
- env -u UV_FROZEN uv run python .github/scripts/check_policyengine_us_dependency.py --mode fail
- env -u UV_FROZEN uv run pytest tests/unit/test_publication_scripts.py -q
- env -u UV_FROZEN uv run --no-sync --with pyyaml python scripts/run_quality_guards.py
- env -u UV_FROZEN uv lock --locked
- git diff --check