### PR TITLE
Update PolicyEngine US to 1.691.12

### DIFF
--- a/changelog.d/pe-us-1-691-12.changed.md
+++ b/changelog.d/pe-us-1-691-12.changed.md
@@ -1,0 +1,1 @@
+Use PolicyEngine US 1.691.12 for data builds.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us==1.691.11",
+    "policyengine-us==1.691.12",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/uv.lock
+++ b/uv.lock
@@ -2122,7 +2122,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.691.11"
+version = "1.691.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2132,9 +2132,9 @@ dependencies = [
     { name = "tables" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/71/97a646a5351cd203ccd7ed364e20e36bf940722354d52c3f9f3bf4fc4f54/policyengine_us-1.691.11.tar.gz", hash = "sha256:cd60e6e373725a2ccd231b584006de0517c334c554344b4361a238fa18887cbb", size = 9507822, upload-time = "2026-05-16T12:01:17.62Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/23/c8eb34c1c0c0e8150fba8467f1f8463f606a68c5b28fd31ad637cecd886d/policyengine_us-1.691.12.tar.gz", hash = "sha256:435fa2a8c7085f13a7d9d2ce903670f9d40ee7538a2db28a2dfae038d2bfa91a", size = 9507768, upload-time = "2026-05-16T16:54:37.905Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/54/f7a058157dc0e5532ff2fead4169cdf9679141ba2ef98af9173cb652b406/policyengine_us-1.691.11-py3-none-any.whl", hash = "sha256:dc3e110ae7a166e2483d00ea759ab9abb00a0fa4f56bc73b0e601ade2d78c3b6", size = 10022959, upload-time = "2026-05-16T12:01:13.823Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6f/b605fc1d8e06e377ae50870dc44a28cfe6562f0032e36dd53a5ef49472db/policyengine_us-1.691.12-py3-none-any.whl", hash = "sha256:ef43482bd8c6cc16f8f1d4050423f5dc1d045af15931f5d1b089715a31c839d2", size = 10022960, upload-time = "2026-05-16T16:54:35.255Z" },
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", specifier = "==1.691.11" },
+    { name = "policyengine-us", specifier = "==1.691.12" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },


### PR DESCRIPTION
## Summary
- bump the exact PolicyEngine US data-build pin to the newly published policyengine-us==1.691.12
- refresh uv.lock
- add a changelog fragment

## Why
PolicyEngine US 1.691.12 includes the CRFB non-refundable Social Security credit fix from PolicyEngine/policyengine-us#7959. This keeps policyengine-us-data current with the freshness guard merged in #990.

## Tests
- env -u UV_FROZEN uv run python .github/scripts/check_policyengine_us_dependency.py --mode fail
- env -u UV_FROZEN uv run pytest tests/unit/test_publication_scripts.py -q
- env -u UV_FROZEN uv run --no-sync --with pyyaml python scripts/run_quality_guards.py
- env -u UV_FROZEN uv lock --locked
- git diff --check