### PR TITLE
Update PolicyEngine US to 1.691.13

### DIFF
--- a/changelog.d/992.changed
+++ b/changelog.d/992.changed
@@ -1,0 +1,1 @@
+Update the PolicyEngine US dependency to 1.691.13 for production data builds.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us @ git+https://github.com/PolicyEngine/policyengine-us@4588f756668f12cac43e847a73e6a1f38b0b296d",
+    "policyengine-us==1.691.13",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/uv.lock
+++ b/uv.lock
@@ -2122,8 +2122,8 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.691.11"
-source = { git = "https://github.com/PolicyEngine/policyengine-us?rev=4588f756668f12cac43e847a73e6a1f38b0b296d#4588f756668f12cac43e847a73e6a1f38b0b296d" }
+version = "1.691.13"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
     { name = "pandas" },
@@ -2131,6 +2131,10 @@ dependencies = [
     { name = "spm-calculator" },
     { name = "tables" },
     { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/c7/0fd113bec6b2b3894232d0d3a5826f626a5ac6c1c74a0e853cf7dfd1eacf/policyengine_us-1.691.13.tar.gz", hash = "sha256:189b66166b19ce5aa8f890f79af80e03f6851cae24cc30d7ac3f477bd1b55033", size = 9509661, upload-time = "2026-05-17T04:16:45.57Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/56/c13e3e0d91e72124fc3839f5d9fff241028efba96fa3edefb227e7275800/policyengine_us-1.691.13-py3-none-any.whl", hash = "sha256:621cc2c98e6f53d69a43b87cceb3c13beff831c6b438e2c15795205765032c41", size = 10026946, upload-time = "2026-05-17T04:16:42.835Z" },
 ]
 
 [[package]]
@@ -2200,7 +2204,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", git = "https://github.com/PolicyEngine/policyengine-us?rev=4588f756668f12cac43e847a73e6a1f38b0b296d" },
+    { name = "policyengine-us", specifier = "==1.691.13" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },


### PR DESCRIPTION
## Summary
- pin policyengine-us to the published 1.691.13 PyPI release
- refresh uv.lock off the temporary git dependency

## Tests
- uv run python .github/scripts/check_policyengine_us_dependency.py