### PR TITLE
Populate housing assistance receipt and take-up from CPS SPM input

### DIFF
--- a/changelog.d/spm-housing-assistance-input.changed.md
+++ b/changelog.d/spm-housing-assistance-input.changed.md
@@ -1,0 +1,1 @@
+Populate housing assistance receipt from the CPS ASEC SPM housing subsidy field instead of exporting the capped SPM formula variable.

--- a/changelog.d/spm-housing-assistance-input.changed.md
+++ b/changelog.d/spm-housing-assistance-input.changed.md
@@ -1,1 +1,1 @@
-Populate housing assistance receipt from the CPS ASEC SPM housing subsidy field instead of exporting the capped SPM formula variable.
+Populate housing assistance receipt from the CPS ASEC SPM housing subsidy field instead of exporting the capped SPM formula variable, and use it as the anchor for housing assistance take-up.

--- a/docs/generated/pipeline_map.json
+++ b/docs/generated/pipeline_map.json
@@ -3946,7 +3946,7 @@
           "node_type": "external"
         },
         {
-          "description": "9 takeup variables - block-level seeded draws",
+          "description": "10 takeup variables - block-level seeded draws",
           "id": "takeup_apply",
           "label": "Takeup Re-application",
           "node_type": "process"

--- a/docs/pipeline_map.yaml
+++ b/docs/pipeline_map.yaml
@@ -1170,7 +1170,7 @@ stages:
   - id: takeup_apply
     label: Takeup Re-application
     node_type: process
-    description: 9 takeup variables - block-level seeded draws
+    description: 10 takeup variables - block-level seeded draws
   - id: out_states
     label: states/*.h5
     node_type: artifact

--- a/policyengine_us_data/build_outputs/us_augmentations.py
+++ b/policyengine_us_data/build_outputs/us_augmentations.py
@@ -557,4 +557,11 @@ def _build_reported_takeup_anchors(
         reported_anchors["takes_up_medicaid_if_eligible"] = data[
             "has_medicaid_health_coverage_at_interview"
         ][time_period].astype(bool)
+    if (
+        "receives_housing_assistance" in data
+        and time_period in data["receives_housing_assistance"]
+    ):
+        reported_anchors["takes_up_housing_assistance_if_eligible"] = data[
+            "receives_housing_assistance"
+        ][time_period].astype(bool)
     return reported_anchors

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -441,9 +441,7 @@ def add_rent(self, cps: h5py.File, person: DataFrame, household: DataFrame):
     # full precision (and do not deterministically floor toward zero).
     cps["rent"] = np.zeros(len(cps["age"]), dtype=float)
     cps["rent"][mask] = imputed_values["rent"]
-    # Assume zero housing assistance since
     cps["pre_subsidy_rent"] = cps["rent"]
-    cps["housing_assistance"] = np.zeros_like(cps["spm_unit_capped_housing_subsidy"])
     cps["real_estate_taxes"] = np.zeros(len(cps["age"]), dtype=float)
     cps["real_estate_taxes"][mask] = imputed_values["real_estate_taxes"]
 
@@ -1423,7 +1421,6 @@ def add_personal_income_variables(cps: h5py.File, person: DataFrame, year: int):
 def add_spm_variables(self, cps: h5py.File, spm_unit: DataFrame) -> None:
     SPM_RENAMES = dict(
         snap_reported="SPM_SNAPSUB",
-        spm_unit_capped_housing_subsidy="SPM_CAPHOUSESUB",
         spm_unit_energy_subsidy="SPM_ENGVAL",
         spm_unit_capped_work_childcare_expenses="SPM_CAPWKCCXPNS",
         spm_unit_pre_subsidy_childcare_expenses="SPM_CHILDCAREXPNS",
@@ -1432,6 +1429,9 @@ def add_spm_variables(self, cps: h5py.File, spm_unit: DataFrame) -> None:
     for openfisca_variable, asec_variable in SPM_RENAMES.items():
         if asec_variable in spm_unit.columns:
             cps[openfisca_variable] = spm_unit[asec_variable]
+
+    if "SPM_CAPHOUSESUB" in spm_unit.columns:
+        cps["receives_housing_assistance"] = spm_unit.SPM_CAPHOUSESUB > 0
 
     if "SPM_TENMORTSTATUS" in spm_unit.columns:
         tenure_map = {

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -27,6 +27,7 @@ from policyengine_us_data.parameters import load_take_up_rate
 from policyengine_us_data.datasets.cps.takeup import (
     align_reported_ssi_disability,
     prioritize_reported_recipients,
+    very_low_income_renter_mask,
 )
 from policyengine_us_data.datasets.org import (
     ORG_BOOL_VARIABLES,
@@ -489,6 +490,7 @@ def add_takeup(self):
     head_start_rate = load_take_up_rate("head_start", self.time_period)
     early_head_start_rate = load_take_up_rate("early_head_start", self.time_period)
     ssi_rate = load_take_up_rate("ssi", self.time_period)
+    housing_assistance_rate = load_take_up_rate("housing_assistance", self.time_period)
     voluntary_filing_rates = load_take_up_rate("voluntary_filing", self.time_period)
 
     # EITC: varies by number of children
@@ -566,6 +568,27 @@ def add_takeup(self):
     tanf_rate = load_take_up_rate("tanf", self.time_period)
     rng = seeded_rng("takes_up_tanf_if_eligible")
     data["takes_up_tanf_if_eligible"] = rng.random(n_spm_units) < tanf_rate
+
+    # Housing assistance: prioritize SPM-reported recipients, then fill the
+    # remaining draw pool up to the national receipt rate.
+    rng = seeded_rng("takes_up_housing_assistance_if_eligible")
+    reported_housing_assistance = np.asarray(
+        data.get(
+            "receives_housing_assistance",
+            np.zeros(n_spm_units, dtype=bool),
+        ),
+        dtype=bool,
+    )
+    very_low_income_renter = very_low_income_renter_mask(
+        baseline.calculate("hud_income_level").values,
+        baseline.calculate("spm_unit_tenure_type").values,
+    )
+    data["takes_up_housing_assistance_if_eligible"] = prioritize_reported_recipients(
+        reported_housing_assistance,
+        housing_assistance_rate,
+        rng.random(n_spm_units),
+        eligible_mask=very_low_income_renter,
+    )
 
     # WIC: resolve draws to bools using category-specific rates
     wic_categories = baseline.calculate("wic_category_str").values

--- a/policyengine_us_data/datasets/cps/extended_cps.py
+++ b/policyengine_us_data/datasets/cps/extended_cps.py
@@ -174,7 +174,7 @@ CPS_ONLY_IMPUTED_VARIABLES = [
     "strike_benefits",
     "receives_wic",
     # SPM variables
-    "spm_unit_capped_housing_subsidy",
+    "receives_housing_assistance",
     "spm_unit_energy_subsidy",
     "spm_unit_pre_subsidy_childcare_expenses",
     # Medical expenses

--- a/policyengine_us_data/datasets/cps/takeup.py
+++ b/policyengine_us_data/datasets/cps/takeup.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+VERY_LOW_INCOME_LEVELS = {"ESPECIALLY_LOW", "VERY_LOW"}
+
 
 def _validate_same_shape(*arrays: np.ndarray) -> None:
     shapes = {np.asarray(array).shape for array in arrays}
@@ -7,21 +9,53 @@ def _validate_same_shape(*arrays: np.ndarray) -> None:
         raise ValueError("All arrays must have the same shape")
 
 
+def _enum_names(values: np.ndarray) -> np.ndarray:
+    return np.asarray(
+        [
+            getattr(value, "name", str(value))
+            for value in np.asarray(values, dtype=object)
+        ]
+    )
+
+
+def very_low_income_renter_mask(
+    income_level: np.ndarray,
+    tenure_type: np.ndarray,
+) -> np.ndarray:
+    income_level = _enum_names(income_level)
+    tenure_type = _enum_names(tenure_type)
+    _validate_same_shape(income_level, tenure_type)
+    return np.isin(income_level, list(VERY_LOW_INCOME_LEVELS)) & (
+        tenure_type == "RENTER"
+    )
+
+
 def prioritize_reported_recipients(
-    reported_receipt: np.ndarray, target_rate: float, draws: np.ndarray
+    reported_receipt: np.ndarray,
+    target_rate: float,
+    draws: np.ndarray,
+    eligible_mask: np.ndarray | None = None,
 ) -> np.ndarray:
     reported_receipt = np.asarray(reported_receipt, dtype=bool)
     draws = np.asarray(draws)
     _validate_same_shape(reported_receipt, draws)
+    if eligible_mask is None:
+        eligible_mask = np.ones(reported_receipt.shape, dtype=bool)
+    else:
+        eligible_mask = np.asarray(eligible_mask, dtype=bool)
+        _validate_same_shape(reported_receipt, eligible_mask)
 
-    n_entities = reported_receipt.size
+    eligible_mask = eligible_mask | reported_receipt
     n_reporters = reported_receipt.sum()
-    n_non_reporters = (~reported_receipt).sum()
+    n_non_reporters = (eligible_mask & ~reported_receipt).sum()
+    n_entities = eligible_mask.sum()
     target_takeup_count = int(target_rate * n_entities)
     remaining_needed = max(0, target_takeup_count - n_reporters)
     non_reporter_rate = remaining_needed / n_non_reporters if n_non_reporters > 0 else 0
 
-    return reported_receipt | ((~reported_receipt) & (draws < non_reporter_rate))
+    return reported_receipt | (
+        eligible_mask & (~reported_receipt) & (draws < non_reporter_rate)
+    )
 
 
 def align_reported_ssi_disability(

--- a/policyengine_us_data/parameters/take_up/housing_assistance.yaml
+++ b/policyengine_us_data/parameters/take_up/housing_assistance.yaml
@@ -1,0 +1,12 @@
+description: Share of very low-income renter households receiving housing assistance.
+metadata:
+  label: Housing assistance receipt rate
+  unit: /1
+  period: year
+  reference:
+    - title: HUD Worst Case Housing Needs 2025 Report to Congress
+      href: https://www.huduser.gov/portal/publications/Worst-Case-Housing-Needs-2025-Report-to-Congress.html
+    - title: Harvard Joint Center for Housing Studies summary of HUD Worst Case Housing Needs 2025
+      href: https://www.jchs.harvard.edu/blog/worst-case-housing-needs-renters-ticked-down-remain-high
+values:
+  2023-01-01: 0.28

--- a/policyengine_us_data/storage/upload_completed_datasets.py
+++ b/policyengine_us_data/storage/upload_completed_datasets.py
@@ -85,6 +85,7 @@ REQUIRED_VARIABLES_BY_FILENAME = {
         "takes_up_snap_if_eligible",
         "takes_up_ssi_if_eligible",
         "takes_up_tanf_if_eligible",
+        "takes_up_housing_assistance_if_eligible",
         "would_claim_wic",
         "is_wic_at_nutritional_risk",
     ),

--- a/policyengine_us_data/utils/soi.py
+++ b/policyengine_us_data/utils/soi.py
@@ -6,7 +6,7 @@ from policyengine_us_data.storage import CALIBRATION_FOLDER
 SOI_UPRATING_MAP = {
     "adjusted_gross_income": "adjusted_gross_income",
     "count": "population",
-    "employment_income": "employment_income",
+    "employment_income": "employment_income_before_lsr",
     "business_net_profits": "total_self_employment_income",
     "capital_gains_gross": "long_term_capital_gains",
     "ordinary_dividends": "non_qualified_dividend_income",
@@ -35,6 +35,12 @@ SOI_UPRATING_MAP = {
     "unemployment_compensation": "unemployment_compensation",
 }
 
+DEFAULT_SOI_UPRATING_VARIABLES = (
+    "employment_income_before_lsr",
+    "irs_employment_income",
+    "employment_income",
+)
+
 NATIONAL_SOI_AGGREGATE_FILTER = {
     "Filing status": "All",
     "AGI lower bound": -np.inf,
@@ -42,6 +48,19 @@ NATIONAL_SOI_AGGREGATE_FILTER = {
     "Taxable only": False,
     "Full population": True,
 }
+
+
+def get_soi_uprating_variable(variable: str, uprating: pd.DataFrame) -> str:
+    pe_name = SOI_UPRATING_MAP.get(variable)
+    if pe_name in uprating.index:
+        return pe_name
+    for default_variable in DEFAULT_SOI_UPRATING_VARIABLES:
+        if default_variable in uprating.index:
+            return default_variable
+    raise KeyError(
+        f"No PolicyEngine uprating row for SOI variable {variable!r}, "
+        f"and none of {DEFAULT_SOI_UPRATING_VARIABLES} are available."
+    )
 
 
 def pe_to_soi(pe_dataset, year):
@@ -258,17 +277,11 @@ def get_soi(year: int) -> pd.DataFrame:
         target_year_for_uprating = min(
             max(int(year), earliest_uprating_year), latest_uprating_year
         )
-        pe_name = SOI_UPRATING_MAP.get(variable)
-        if pe_name in uprating.index:
-            uprating_factors[variable] = (
-                uprating.loc[pe_name, target_year_for_uprating]
-                / uprating.loc[pe_name, source_year_for_uprating]
-            )
-        else:
-            uprating_factors[variable] = (
-                uprating.loc["employment_income", target_year_for_uprating]
-                / (uprating.loc["employment_income", source_year_for_uprating])
-            )
+        pe_name = get_soi_uprating_variable(variable, uprating)
+        uprating_factors[variable] = (
+            uprating.loc[pe_name, target_year_for_uprating]
+            / uprating.loc[pe_name, source_year_for_uprating]
+        )
 
     for variable, uprating_factor in uprating_factors.items():
         soi.loc[soi.Variable == variable, "Value"] *= uprating_factor

--- a/policyengine_us_data/utils/takeup.py
+++ b/policyengine_us_data/utils/takeup.py
@@ -72,6 +72,12 @@ SIMPLE_TAKEUP_VARS = [
         "rate_key": "tanf",
         "target": "tanf",
     },
+    {
+        "variable": "takes_up_housing_assistance_if_eligible",
+        "entity": "spm_unit",
+        "rate_key": "housing_assistance",
+        "target": None,
+    },
 ]
 
 TAKEUP_AFFECTED_TARGETS: Dict[str, dict] = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us==1.691.13",
+    "policyengine-us==1.692.1",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/tests/integration/support/tiny_stage_3.py
+++ b/tests/integration/support/tiny_stage_3.py
@@ -46,7 +46,7 @@ STAGE_3_GROUP_VARIABLES = tuple(
             *GROUP_LEVEL_VARIABLES,
             "tax_unit_count_dependents",
             "tax_unit_is_joint",
-            "spm_unit_capped_housing_subsidy",
+            "receives_housing_assistance",
             "household_is_puf_clone",
         )
     )
@@ -238,11 +238,7 @@ def _extended_group_arrays(
     return {
         "tax_unit_count_dependents": tax_unit_count_dependents,
         "tax_unit_is_joint": arrays["filing_status"] == b"JOINT",
-        "spm_unit_capped_housing_subsidy": np.where(
-            arrays["tenure_type"] == b"RENTED",
-            1_200,
-            0,
-        ).astype(np.float32),
+        "receives_housing_assistance": arrays["tenure_type"] == b"RENTED",
         "household_is_puf_clone": np.concatenate(
             [
                 np.zeros(cps_household_count, dtype=np.bool_),

--- a/tests/integration/test_cps_generation.py
+++ b/tests/integration/test_cps_generation.py
@@ -49,6 +49,8 @@ def test_add_takeup_removes_temporary_source_anchors_from_saved_h5(
                 "state_code_str": ["CA"],
                 "wic_category_str": ["NONE", "NONE"],
                 "receives_wic": [False, False],
+                "hud_income_level": ["VERY_LOW"],
+                "spm_unit_tenure_type": ["RENTER"],
                 "tax_unit_child_dependents": [0],
                 "age_head": [40],
             }
@@ -67,6 +69,7 @@ def test_add_takeup_removes_temporary_source_anchors_from_saved_h5(
                 "person_household_id": np.array([1_000, 1_000], dtype=np.int32),
                 "snap_reported": np.array([1_200.0], dtype=np.float32),
                 "ssi_reported": np.array([600.0, 0.0], dtype=np.float32),
+                "receives_housing_assistance": np.array([True]),
                 "reported_has_subsidized_marketplace_health_coverage_at_interview": np.array(
                     [False, False]
                 ),
@@ -103,6 +106,7 @@ def test_add_takeup_removes_temporary_source_anchors_from_saved_h5(
         "head_start": 0.0,
         "early_head_start": 0.0,
         "ssi": 1.0,
+        "housing_assistance": 0.0,
         "voluntary_filing": voluntary_filing_rates,
         "tanf": 0.0,
         "wic_takeup": {"NONE": 0.0},
@@ -129,6 +133,7 @@ def test_add_takeup_removes_temporary_source_anchors_from_saved_h5(
         assert "ssi_reported" not in h5_file
         assert "takes_up_snap_if_eligible" in h5_file
         assert "takes_up_ssi_if_eligible" in h5_file
+        assert h5_file["takes_up_housing_assistance_if_eligible"][:].tolist() == [True]
 
 
 def test_add_tips_derives_tipped_status_from_raw_cps(monkeypatch):

--- a/tests/integration/test_cps_generation.py
+++ b/tests/integration/test_cps_generation.py
@@ -339,7 +339,7 @@ def test_add_rent_requests_person_level_frames(monkeypatch, tmp_path):
     cps = {
         "age": np.array([40, 12, 70], dtype=np.int32),
         "is_household_head": np.array([True, False, True], dtype=bool),
-        "spm_unit_capped_housing_subsidy": np.zeros(3, dtype=np.float32),
+        "spm_unit_id": np.array([1, 2, 3], dtype=np.int32),
     }
     person = pd.DataFrame({"P_SEQ": [1, 2, 1]})
     household = pd.DataFrame({"H_TENURE": [2, 1]})
@@ -383,7 +383,9 @@ def test_add_spm_variables_keeps_spm_output_aggregates_out_of_dataset():
     assert "spm_unit_total_income_reported" not in cps
     assert "spm_unit_net_income_reported" not in cps
     assert cps["snap_reported"].tolist() == [1_200]
-    assert cps["spm_unit_capped_housing_subsidy"].tolist() == [3_000]
+    assert "spm_unit_capped_housing_subsidy" not in cps
+    assert "housing_assistance" not in cps
+    assert cps["receives_housing_assistance"].tolist() == [True]
     assert cps["spm_unit_energy_subsidy"].tolist() == [500]
     assert cps["spm_unit_tenure_type"].tolist() == [b"RENTER"]
     for variable in (

--- a/tests/unit/build_outputs/test_us_augmentations.py
+++ b/tests/unit/build_outputs/test_us_augmentations.py
@@ -171,6 +171,9 @@ def test_build_reported_takeup_anchors_uses_present_period():
         "has_medicaid_health_coverage_at_interview": {
             2024: np.array([False, True, False])
         },
+        "receives_housing_assistance": {
+            2024: np.array([True, False]),
+        },
     }
 
     anchors = _build_reported_takeup_anchors(data, 2024)
@@ -182,6 +185,10 @@ def test_build_reported_takeup_anchors_uses_present_period():
     np.testing.assert_array_equal(
         anchors["takes_up_medicaid_if_eligible"],
         np.array([False, True, False]),
+    )
+    np.testing.assert_array_equal(
+        anchors["takes_up_housing_assistance_if_eligible"],
+        np.array([True, False]),
     )
 
 

--- a/tests/unit/calibration/test_unified_calibration.py
+++ b/tests/unit/calibration/test_unified_calibration.py
@@ -638,7 +638,7 @@ class TestSimpleTakeupConfig:
             )
 
     def test_expected_count(self):
-        assert len(SIMPLE_TAKEUP_VARS) == 9
+        assert len(SIMPLE_TAKEUP_VARS) == 10
 
 
 class TestTakeupAffectedTargets:

--- a/tests/unit/datasets/test_cps_file_handles.py
+++ b/tests/unit/datasets/test_cps_file_handles.py
@@ -479,7 +479,7 @@ def test_add_rent_replaces_existing_hdf_using_read_only_hdfstore(tmp_path, monke
     dataset = FakeDataset()
     cps = {
         "age": np.array([40], dtype=np.int32),
-        "spm_unit_capped_housing_subsidy": np.array([0.0]),
+        "spm_unit_id": np.array([1], dtype=np.int32),
         # add_id_variables populates this upstream of add_rent in the real
         # pipeline; see the policyengine-core#482 workaround override below.
         "is_household_head": np.array([True]),

--- a/tests/unit/datasets/test_cps_takeup.py
+++ b/tests/unit/datasets/test_cps_takeup.py
@@ -4,6 +4,7 @@ import pytest
 from policyengine_us_data.datasets.cps.takeup import (
     align_reported_ssi_disability,
     prioritize_reported_recipients,
+    very_low_income_renter_mask,
 )
 
 
@@ -28,6 +29,59 @@ def test_prioritize_reported_recipients_caps_non_reporters_at_zero():
     np.testing.assert_array_equal(
         result,
         np.array([True, False, True, True]),
+    )
+
+
+def test_prioritize_reported_recipients_limits_draws_to_eligible_pool():
+    reported = np.array([False, True, False, False])
+    draws = np.array([0.1, 0.9, 0.1, 0.1])
+    eligible = np.array([False, False, True, False])
+
+    result = prioritize_reported_recipients(
+        reported,
+        1.0,
+        draws,
+        eligible_mask=eligible,
+    )
+
+    np.testing.assert_array_equal(
+        result,
+        np.array([False, True, True, False]),
+    )
+
+
+def test_very_low_income_renter_mask_accepts_enum_like_values():
+    class EnumLike:
+        def __init__(self, name):
+            self.name = name
+
+        def __str__(self):
+            return f"EnumLike.{self.name}"
+
+    result = very_low_income_renter_mask(
+        np.array(
+            [
+                EnumLike("VERY_LOW"),
+                EnumLike("ESPECIALLY_LOW"),
+                EnumLike("LOW"),
+                "VERY_LOW",
+            ],
+            dtype=object,
+        ),
+        np.array(
+            [
+                EnumLike("RENTER"),
+                EnumLike("OWNER_WITH_MORTGAGE"),
+                EnumLike("RENTER"),
+                "RENTER",
+            ],
+            dtype=object,
+        ),
+    )
+
+    np.testing.assert_array_equal(
+        result,
+        np.array([True, False, False, True]),
     )
 
 

--- a/tests/unit/test_extended_cps.py
+++ b/tests/unit/test_extended_cps.py
@@ -169,6 +169,9 @@ class TestVariableListConsistency:
     def test_spm_resource_aggregates_are_not_qrf_imputed(self):
         assert "spm_unit_total_income_reported" not in set(CPS_ONLY_IMPUTED_VARIABLES)
         assert "spm_unit_net_income_reported" not in set(CPS_ONLY_IMPUTED_VARIABLES)
+        assert "spm_unit_capped_housing_subsidy" not in set(CPS_ONLY_IMPUTED_VARIABLES)
+        assert "housing_assistance" not in set(CPS_ONLY_IMPUTED_VARIABLES)
+        assert "receives_housing_assistance" in set(CPS_ONLY_IMPUTED_VARIABLES)
 
     def test_weeks_worked_is_preserved_for_future_year_formulas(self):
         data = {"weeks_worked": {2024: np.array([52])}}
@@ -181,6 +184,12 @@ class TestVariableListConsistency:
         data = {"social_security_retirement": {2024: np.array([12_000.0])}}
 
         ExtendedCPS._assert_no_computed_variables_exported(data, 2024)
+
+    def test_final_export_contract_rejects_housing_assistance_formula_output(self):
+        data = {"housing_assistance": {2024: np.array([3_000.0])}}
+
+        with pytest.raises(DatasetContractError, match="housing_assistance"):
+            ExtendedCPS._assert_no_computed_variables_exported(data, 2024)
 
     def test_final_export_contract_rejects_computed_ss_total(self):
         data = {"social_security": {2024: np.array([12_000.0])}}

--- a/tests/unit/test_policyengine_us_dependency_contract.py
+++ b/tests/unit/test_policyengine_us_dependency_contract.py
@@ -1,0 +1,11 @@
+from policyengine_us import CountryTaxBenefitSystem
+
+
+def test_policyengine_us_defines_housing_assistance_takeup_input():
+    tax_benefit_system = CountryTaxBenefitSystem()
+    variable = tax_benefit_system.variables["takes_up_housing_assistance_if_eligible"]
+
+    assert variable.entity.key == "spm_unit"
+    assert not getattr(variable, "formulas", None)
+    assert not getattr(variable, "adds", None)
+    assert not getattr(variable, "subtracts", None)

--- a/tests/unit/test_soi_utils.py
+++ b/tests/unit/test_soi_utils.py
@@ -199,6 +199,63 @@ def test_get_soi_uses_best_available_year_per_variable(monkeypatch):
     assert np.isclose(taxable_interest_value, 266.6666666667)
 
 
+def test_get_soi_uses_current_employment_income_uprating_without_legacy_row(
+    monkeypatch,
+):
+    soi_module = load_soi_module()
+    fake_soi = pd.DataFrame(
+        [
+            {
+                "Year": 2023,
+                "Variable": "employment_income",
+                "Value": 100.0,
+            },
+            {
+                "Year": 2023,
+                "Variable": "income_tax_after_credits",
+                "Value": 200.0,
+            },
+        ]
+    )
+    for column, default in {
+        "SOI table": "Table 1.4",
+        "XLSX column": "A",
+        "XLSX row": 9,
+        "Filing status": "All",
+        "AGI lower bound": float("-inf"),
+        "AGI upper bound": float("inf"),
+        "Count": False,
+        "Taxable only": False,
+        "Full population": True,
+    }.items():
+        fake_soi[column] = default
+
+    uprating = pd.DataFrame(
+        {
+            2023: [2.0],
+            2024: [3.0],
+        },
+        index=["employment_income_before_lsr"],
+    )
+
+    monkeypatch.setattr(soi_module, "load_tracked_soi_targets", lambda: fake_soi.copy())
+    monkeypatch.setattr(
+        soi_module,
+        "create_policyengine_uprating_factors_table",
+        lambda: uprating,
+    )
+
+    soi = soi_module.get_soi(2024)
+
+    employment_income = soi.loc[soi["Variable"] == "employment_income", "Value"].iat[0]
+    income_tax_after_credits = soi.loc[
+        soi["Variable"] == "income_tax_after_credits", "Value"
+    ].iat[0]
+
+    assert np.isclose(employment_income, 150.0)
+    assert np.isclose(income_tax_after_credits, 300.0)
+
+
 def test_get_tracked_soi_row_selects_requested_best_year(monkeypatch):
     soi_module = load_soi_module()
     fake_soi = pd.DataFrame(

--- a/tests/unit/test_upload_completed_datasets.py
+++ b/tests/unit/test_upload_completed_datasets.py
@@ -97,6 +97,7 @@ def _fake_tax_benefit_system():
         "takes_up_snap_if_eligible": "spm_unit",
         "takes_up_ssi_if_eligible": "person",
         "takes_up_tanf_if_eligible": "spm_unit",
+        "takes_up_housing_assistance_if_eligible": "spm_unit",
         "would_claim_wic": "person",
         "is_wic_at_nutritional_risk": "person",
     }

--- a/uv.lock
+++ b/uv.lock
@@ -2122,7 +2122,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.691.13"
+version = "1.692.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2132,9 +2132,9 @@ dependencies = [
     { name = "tables" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/c7/0fd113bec6b2b3894232d0d3a5826f626a5ac6c1c74a0e853cf7dfd1eacf/policyengine_us-1.691.13.tar.gz", hash = "sha256:189b66166b19ce5aa8f890f79af80e03f6851cae24cc30d7ac3f477bd1b55033", size = 9509661, upload-time = "2026-05-17T04:16:45.57Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/a4/658b7ea245bbe4e83a43fb829daab31c81945248507a83ce0be0fbe9ceb1/policyengine_us-1.692.1.tar.gz", hash = "sha256:c6003b9ad73912939a3f301f13266d0cd455aed56c49ffdf973c2b1412e453e2", size = 9608606, upload-time = "2026-05-17T16:33:24.632Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/56/c13e3e0d91e72124fc3839f5d9fff241028efba96fa3edefb227e7275800/policyengine_us-1.691.13-py3-none-any.whl", hash = "sha256:621cc2c98e6f53d69a43b87cceb3c13beff831c6b438e2c15795205765032c41", size = 10026946, upload-time = "2026-05-17T04:16:42.835Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8c/532345840672715b955dc4e36da2ef84ffd5bb457fd18798c33bebdb5a01/policyengine_us-1.692.1-py3-none-any.whl", hash = "sha256:5bbe020699e369d1d78de05ee971ef6cc3f6047e4b0f3563efddad0498987a9b", size = 10136338, upload-time = "2026-05-17T16:33:21.792Z" },
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", specifier = "==1.691.13" },
+    { name = "policyengine-us", specifier = "==1.692.1" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },


### PR DESCRIPTION
## Summary
- Keep CPS SPM housing subsidy as a receipt anchor instead of exporting formula outputs
- Add housing assistance take-up calibrated to the 2023 HUD Worst Case Housing Needs very-low-income renter receipt rate
- Anchor reported CPS recipients, draw remaining recipients from very-low-income renter SPM units, and require policyengine-us 1.692.1 for the take-up input

## Tests
- uv run pytest tests/unit/test_policyengine_us_dependency_contract.py tests/integration/test_cps_generation.py::test_add_takeup_removes_temporary_source_anchors_from_saved_h5 tests/unit/build_outputs/test_us_augmentations.py::test_build_reported_takeup_anchors_uses_present_period tests/unit/calibration/test_unified_calibration.py::TestSimpleTakeupConfig tests/unit/datasets/test_cps_takeup.py tests/unit/test_upload_completed_datasets.py -q
- uv run ruff format --check policyengine_us_data/datasets/cps/cps.py policyengine_us_data/datasets/cps/takeup.py policyengine_us_data/build_outputs/us_augmentations.py policyengine_us_data/storage/upload_completed_datasets.py policyengine_us_data/utils/takeup.py tests/integration/test_cps_generation.py tests/unit/build_outputs/test_us_augmentations.py tests/unit/calibration/test_unified_calibration.py tests/unit/datasets/test_cps_takeup.py tests/unit/test_upload_completed_datasets.py tests/unit/test_policyengine_us_dependency_contract.py
- uv run ruff check policyengine_us_data/datasets/cps/cps.py policyengine_us_data/datasets/cps/takeup.py policyengine_us_data/build_outputs/us_augmentations.py policyengine_us_data/storage/upload_completed_datasets.py policyengine_us_data/utils/takeup.py tests/integration/test_cps_generation.py tests/unit/build_outputs/test_us_augmentations.py tests/unit/calibration/test_unified_calibration.py tests/unit/datasets/test_cps_takeup.py tests/unit/test_upload_completed_datasets.py tests/unit/test_policyengine_us_dependency_contract.py