### PR TITLE
Add nonfiler income calibration targets

### DIFF
--- a/changelog.d/994.added.md
+++ b/changelog.d/994.added.md
@@ -1,0 +1,1 @@
+Added nonfiler-inclusive income calibration targets.

--- a/policyengine_us_data/calibration/unified_matrix_builder.py
+++ b/policyengine_us_data/calibration/unified_matrix_builder.py
@@ -36,6 +36,9 @@ from policyengine_us_data.calibration.calibration_utils import (
 )
 from policyengine_us_data.pipeline_metadata import pipeline_node
 from policyengine_us_data.pipeline_schema import PipelineNode
+from policyengine_us_data.utils.target_variables import (
+    target_variable_components,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -854,6 +857,50 @@ def _evaluate_constraints_standalone(
     return np.array([hh_mask.get(hid, False) for hid in household_ids])
 
 
+def _target_expression_entity_from_map(
+    target_variable: str,
+    variable_entity_map: dict,
+) -> str:
+    entities = set()
+    missing = []
+    for component in target_variable_components(target_variable):
+        if component not in variable_entity_map:
+            missing.append(component)
+        else:
+            entities.add(variable_entity_map[component])
+    if missing:
+        raise ValueError(
+            f"Target expression {target_variable!r} includes variables "
+            f"with unknown entities: {missing}"
+        )
+    if len(entities) != 1:
+        raise ValueError(
+            "Additive target expressions must use variables with one "
+            f"entity; got {target_variable!r} with entities {entities}"
+        )
+    return entities.pop()
+
+
+def _sum_target_expression_values(
+    values_by_variable: dict,
+    target_variable: str,
+) -> np.ndarray | None:
+    result = None
+    for component in target_variable_components(target_variable):
+        values = values_by_variable.get(component)
+        if values is None:
+            return None
+        result = values if result is None else result + values
+    return result
+
+
+def _target_variables_for_calculation(target_variables) -> set[str]:
+    variables = set()
+    for variable in target_variables:
+        variables.update(target_variable_components(str(variable)))
+    return variables
+
+
 def _calculate_target_values_standalone(
     target_variable: str,
     non_geo_constraints: list,
@@ -875,7 +922,14 @@ def _calculate_target_values_standalone(
     (picklable, unlike ``tax_benefit_system``).
     """
     is_count = target_variable.endswith("_count")
-    target_entity = variable_entity_map.get(target_variable, "household")
+    is_expression = len(target_variable_components(target_variable)) > 1
+    if is_expression:
+        target_entity = _target_expression_entity_from_map(
+            target_variable,
+            variable_entity_map,
+        )
+    else:
+        target_entity = variable_entity_map.get(target_variable, "household")
 
     if reform_id > 0:
         mask = _evaluate_constraints_standalone(
@@ -898,7 +952,11 @@ def _calculate_target_values_standalone(
             household_ids,
             n_households,
         )
-        vals = hh_vars.get(target_variable)
+        vals = (
+            _sum_target_expression_values(hh_vars, target_variable)
+            if is_expression
+            else hh_vars.get(target_variable)
+        )
         if vals is None:
             return np.zeros(n_households, dtype=np.float32)
         return (vals * mask).astype(np.float32)
@@ -922,7 +980,11 @@ def _calculate_target_values_standalone(
         return hh_mask.astype(np.float32)
 
     if not is_count:
-        entity_values = target_entity_vars.get(target_variable)
+        entity_values = (
+            _sum_target_expression_values(target_entity_vars, target_variable)
+            if is_expression
+            else target_entity_vars.get(target_variable)
+        )
         entity_hh_idx = entity_hh_idx_map.get(target_entity)
         person_to_entity_idx = person_to_entity_idx_map.get(target_entity)
         if (
@@ -2601,7 +2663,10 @@ class UnifiedMatrixBuilder:
                 )
             )
 
-        unique_variables = set(targets_df["variable"].values)
+        target_variables = [
+            str(targets_df.iloc[i]["variable"]) for i in range(n_targets)
+        ]
+        unique_variables = _target_variables_for_calculation(target_variables)
         reform_variables = {
             str(row["variable"])
             for _, row in targets_df.iterrows()
@@ -2610,6 +2675,16 @@ class UnifiedMatrixBuilder:
         variable_entity_map: Dict[str, str] = {}
         for var in unique_variables:
             if var in sim.tax_benefit_system.variables:
+                variable_entity_map[var] = sim.tax_benefit_system.variables[
+                    var
+                ].entity.key
+        for var in target_variables:
+            if len(target_variable_components(var)) > 1:
+                variable_entity_map[var] = _target_expression_entity_from_map(
+                    var,
+                    variable_entity_map,
+                )
+            elif var in sim.tax_benefit_system.variables:
                 variable_entity_map[var] = sim.tax_benefit_system.variables[
                     var
                 ].entity.key
@@ -3315,7 +3390,10 @@ class UnifiedMatrixBuilder:
                 )
             )
 
-        unique_variables = set(targets_df["variable"].values)
+        target_variables = [
+            str(targets_df.iloc[i]["variable"]) for i in range(n_targets)
+        ]
+        unique_variables = _target_variables_for_calculation(target_variables)
         reform_variables = {
             str(row["variable"])
             for _, row in targets_df.iterrows()
@@ -3327,9 +3405,6 @@ class UnifiedMatrixBuilder:
                 unique_constraint_vars.add(constraint["variable"])
 
         base_entity_maps = build_household_entity_maps(sim)
-        target_variables = [
-            str(targets_df.iloc[i]["variable"]) for i in range(n_targets)
-        ]
 
         if chunk_dir is None:
             chunk_root = Path(tempfile.mkdtemp(prefix="matrix_chunks_"))

--- a/policyengine_us_data/db/etl_irs_soi.py
+++ b/policyengine_us_data/db/etl_irs_soi.py
@@ -70,6 +70,7 @@ GEOGRAPHY_FILE_TARGET_SPECS = [
         name="qualified_business_income_deduction",
         breakdown=None,
     ),
+    dict(code="00200", name="irs_employment_income", breakdown=None),
     dict(code="00900", name="total_self_employment_income", breakdown=None),
     dict(
         code="01000",

--- a/policyengine_us_data/db/etl_national_targets.py
+++ b/policyengine_us_data/db/etl_national_targets.py
@@ -9,6 +9,7 @@ from policyengine_us_data.db.create_database_tables import (
     StratumConstraint,
     Target,
 )
+from policyengine_us_data.db.create_field_valid_values import FieldValidValues
 from policyengine_us_data.storage.calibration_targets.soi_metadata import (
     RETIREMENT_CONTRIBUTION_TARGETS,
 )
@@ -25,6 +26,114 @@ from policyengine_us_data.utils.db import (
     etl_argparser,
     get_geographic_strata,
 )
+from policyengine_us_data.utils.target_variables import (
+    target_variable_components,
+)
+
+BEA_NIPA_WAGES_AND_SALARIES_2024 = 12_387_929_000_000
+BEA_NIPA_PROPRIETORS_INCOME_2024 = 2_023_080_000_000
+BEA_NIPA_PERSONAL_INTEREST_INCOME_2024 = 1_926_644_000_000
+BEA_NIPA_PERSONAL_DIVIDEND_INCOME_2024 = 2_218_700_000_000
+
+NIPA_PROPRIETORS_INCOME_VARIABLE = (
+    "total_self_employment_income+farm_operations_income+partnership_s_corp_income"
+)
+NIPA_PERSONAL_INTEREST_INCOME_VARIABLE = "interest_income"
+TAXABLE_INTEREST_AND_ORDINARY_DIVIDENDS_VARIABLE = (
+    "taxable_interest_income+dividend_income"
+)
+
+CBO_INCOME_BY_SOURCE_TARGETS = [
+    {
+        "variable": "irs_employment_income",
+        "parameter": "employment_income",
+        "notes": (
+            "CBO detailed AGI-by-source employment income; restricted to "
+            "tax filers because this is an AGI tax-return concept"
+        ),
+    },
+    {
+        "variable": "self_employment_income",
+        "parameter": "self_employment_income",
+        "notes": (
+            "CBO detailed AGI-by-source self-employment income; restricted "
+            "to tax filers because this is an AGI tax-return concept"
+        ),
+    },
+    {
+        "variable": "taxable_pension_income",
+        "parameter": "taxable_pension_income",
+        "notes": (
+            "CBO detailed AGI-by-source taxable pension income; restricted "
+            "to tax filers because this is an AGI tax-return concept"
+        ),
+    },
+    {
+        "variable": "taxable_social_security",
+        "parameter": "taxable_social_security",
+        "notes": (
+            "CBO detailed AGI-by-source taxable Social Security; restricted "
+            "to tax filers because this is an AGI tax-return concept"
+        ),
+    },
+    {
+        "variable": "qualified_dividend_income",
+        "parameter": "qualified_dividend_income",
+        "notes": (
+            "CBO detailed AGI-by-source qualified dividends; restricted to "
+            "tax filers because this is an AGI tax-return concept"
+        ),
+    },
+    {
+        "variable": "loss_limited_net_capital_gains",
+        "parameter": "net_capital_gain",
+        "notes": (
+            "CBO detailed AGI-by-source net capital gains; restricted to "
+            "tax filers because this is an AGI tax-return concept"
+        ),
+    },
+    {
+        "variable": TAXABLE_INTEREST_AND_ORDINARY_DIVIDENDS_VARIABLE,
+        "parameter": "taxable_interest_and_ordinary_dividends",
+        "notes": (
+            "CBO detailed AGI-by-source taxable interest plus ordinary "
+            "dividends; restricted to tax filers because this is an AGI "
+            "tax-return concept"
+        ),
+    },
+]
+
+
+def _register_target_variable(session: Session, variable: str) -> None:
+    from policyengine_us.system import system
+
+    missing = [
+        component
+        for component in target_variable_components(variable)
+        if component not in system.variables
+    ]
+    if missing:
+        raise ValueError(
+            f"Target variable expression {variable!r} includes unknown "
+            f"policyengine-us variables: {missing}"
+        )
+
+    existing = session.exec(
+        select(FieldValidValues).where(
+            FieldValidValues.field_name == "variable",
+            FieldValidValues.valid_value == variable,
+        )
+    ).first()
+    if existing is None:
+        session.add(
+            FieldValidValues(
+                field_name="variable",
+                valid_value=variable,
+                description="Additive calibration target expression",
+            )
+        )
+        session.flush()
+
 
 WIC_NATIONAL_ANNUAL_SUMMARY_SOURCE = (
     "https://www.fns.usda.gov/sites/default/files/resource-files/wisummary-4.xlsx"
@@ -305,7 +414,76 @@ def extract_national_targets(year: int = DEFAULT_YEAR):
     ]
     tax_expenditure_targets = [{**target} for target in raw_tax_expenditure_targets]
 
+    income_by_source = tax_benefit_system.parameters(
+        time_period
+    ).calibration.gov.cbo.income_by_source
+    for target in CBO_INCOME_BY_SOURCE_TARGETS:
+        try:
+            value = income_by_source._children[target["parameter"]]
+            tax_filer_targets.append(
+                {
+                    "variable": target["variable"],
+                    "value": float(value),
+                    "source": "CBO Revenue Projections",
+                    "notes": target["notes"],
+                    "year": time_period,
+                }
+            )
+        except (KeyError, AttributeError) as e:
+            print(
+                "Warning: Could not extract CBO income-by-source "
+                f"{target['parameter']} target: {e}"
+            )
+
     direct_sum_targets = [
+        {
+            "variable": "employment_income_before_lsr",
+            "value": BEA_NIPA_WAGES_AND_SALARIES_2024,
+            "source": "BEA NIPA Table 2.1",
+            "notes": (
+                "Gross wages and salaries for all workers, including "
+                "nonfilers; FRED/BEA series A034RC1A027NBEA"
+            ),
+            "year": 2024,
+        },
+        {
+            "variable": NIPA_PROPRIETORS_INCOME_VARIABLE,
+            "value": BEA_NIPA_PROPRIETORS_INCOME_2024,
+            "source": "BEA NIPA Table 2.1",
+            "notes": (
+                "Proprietors' income with IVA and CCAdj for all persons, "
+                "including nonfilers; FRED/BEA series A041RC1A027NBEA. "
+                "Mapped to the closest additive PolicyEngine aggregate: "
+                "total self-employment, farm operations, and "
+                "partnership/S-corp income."
+            ),
+            "year": 2024,
+        },
+        {
+            "variable": NIPA_PERSONAL_INTEREST_INCOME_VARIABLE,
+            "value": BEA_NIPA_PERSONAL_INTEREST_INCOME_2024,
+            "source": "BEA NIPA Table 2.1",
+            "notes": (
+                "Personal interest income for all persons, including "
+                "nonfilers; FRED/BEA series A064RC1A027NBEA. NIPA also "
+                "includes imputed interest, so this is a macro benchmark "
+                "rather than a pure tax concept."
+            ),
+            "year": 2024,
+        },
+        {
+            "variable": "dividend_income",
+            "value": BEA_NIPA_PERSONAL_DIVIDEND_INCOME_2024,
+            "source": "BEA NIPA Table 2.1",
+            "notes": (
+                "Personal dividend income for all persons, including "
+                "nonfilers; FRED/BEA series B703RC1A027NBEA. NIPA "
+                "includes dividends received through pension funds and "
+                "private trusts, so this is a macro benchmark rather than "
+                "a pure tax concept."
+            ),
+            "year": 2024,
+        },
         {
             "variable": "medicaid",
             "value": 871.7e9,
@@ -701,6 +879,7 @@ def load_national_targets(
         # Process direct sum targets
         for _, target_data in direct_targets_df.iterrows():
             target_year = target_data["year"]
+            _register_target_variable(session, target_data["variable"])
             # Check if target already exists
             existing_target = session.exec(
                 select(Target).where(
@@ -767,6 +946,7 @@ def load_national_targets(
             # Add tax-related targets to filer stratum
             for _, target_data in tax_filer_df.iterrows():
                 target_year = target_data["year"]
+                _register_target_variable(session, target_data["variable"])
                 # Check if target already exists
                 existing_target = session.exec(
                     select(Target).where(

--- a/policyengine_us_data/db/validate_database.py
+++ b/policyengine_us_data/db/validate_database.py
@@ -10,6 +10,7 @@ import sqlite3
 from pathlib import Path
 
 import pandas as pd
+from policyengine_us_data.utils.target_variables import target_variable_is_valid
 
 
 DEFAULT_DB_PATH = (
@@ -34,7 +35,7 @@ def validate_database(db_path: str | Path = DEFAULT_DB_PATH) -> None:
         targets_df = pd.read_sql("SELECT * FROM targets", conn)
 
         for var_name in set(targets_df["variable"]):
-            if var_name not in system.variables:
+            if not target_variable_is_valid(var_name, system.variables):
                 raise ValueError(f"{var_name} not a policyengine-us variable")
 
         for var_name in set(stratum_constraints_df["constraint_variable"]):

--- a/policyengine_us_data/utils/loss.py
+++ b/policyengine_us_data/utils/loss.py
@@ -25,6 +25,9 @@ from policyengine_us_data.db.etl_irs_soi import (
 )
 from policyengine_core.reforms import Reform
 from policyengine_us_data.utils.soi import pe_to_soi, get_soi, get_tracked_soi_row
+from policyengine_us_data.utils.target_variables import (
+    target_variable_components,
+)
 
 
 MEDICARE_PART_B_PREMIUM_VARIABLE = "medicare_part_b_premium"
@@ -35,6 +38,32 @@ MEDICARE_PART_B_PREMIUM_VARIABLE = "medicare_part_b_premium"
 # db/etl_national_targets.py which loads them into policy_data.db.
 # A future PR should wire build_loss_matrix() to read from the
 # database so this dict can be deleted.  See PR #488.
+
+BEA_NIPA_WAGES_AND_SALARIES_2024 = 12_387_929_000_000
+BEA_NIPA_PROPRIETORS_INCOME_2024 = 2_023_080_000_000
+BEA_NIPA_PERSONAL_INTEREST_INCOME_2024 = 1_926_644_000_000
+BEA_NIPA_PERSONAL_DIVIDEND_INCOME_2024 = 2_218_700_000_000
+
+NIPA_PROPRIETORS_INCOME_VARIABLE = (
+    "total_self_employment_income+farm_operations_income+partnership_s_corp_income"
+)
+NIPA_PERSONAL_INTEREST_INCOME_VARIABLE = "interest_income"
+TAXABLE_INTEREST_AND_ORDINARY_DIVIDENDS_VARIABLE = (
+    "taxable_interest_income+dividend_income"
+)
+
+CBO_INCOME_BY_SOURCE_TARGETS = [
+    ("irs_employment_income", "employment_income"),
+    ("self_employment_income", "self_employment_income"),
+    ("taxable_pension_income", "taxable_pension_income"),
+    ("taxable_social_security", "taxable_social_security"),
+    ("qualified_dividend_income", "qualified_dividend_income"),
+    ("loss_limited_net_capital_gains", "net_capital_gain"),
+    (
+        TAXABLE_INTEREST_AND_ORDINARY_DIVIDENDS_VARIABLE,
+        "taxable_interest_and_ordinary_dividends",
+    ),
+]
 
 HARD_CODED_TOTALS = {
     MEDICARE_PART_B_PREMIUM_VARIABLE: (
@@ -233,6 +262,41 @@ def fmt(x):
     if x < 1e9:
         return f"{x / 1e6:.0f}m"
     return f"{x / 1e9:.1f}bn"
+
+
+def _target_expression_entity(sim, variable):
+    entities = {
+        sim.tax_benefit_system.variables[component].entity.key
+        for component in target_variable_components(variable)
+    }
+    if len(entities) != 1:
+        raise ValueError(
+            "Additive target expressions must use variables with one "
+            f"entity; got {variable!r} with entities {entities}"
+        )
+    return entities.pop()
+
+
+def _calculate_expression(sim, variable, map_to, period):
+    result = None
+    for component in target_variable_components(variable):
+        values = sim.calculate(component, map_to=map_to, period=period).values
+        result = values if result is None else result + values
+    return result
+
+
+def _calculate_filer_target_values(sim, variable, time_period):
+    entity = _target_expression_entity(sim, variable)
+    values = _calculate_expression(sim, variable, entity, time_period)
+
+    is_filer = (
+        sim.calculate("tax_unit_is_filer", map_to=entity, period=time_period).values > 0
+    )
+    return sim.map_result(values * is_filer, entity, "household")
+
+
+def _calculate_household_target_values(sim, variable, time_period):
+    return _calculate_expression(sim, variable, "household", time_period)
 
 
 def _parse_constraint_value(value):
@@ -1171,40 +1235,51 @@ def build_loss_matrix(dataset: type, time_period):
             ).calibration.gov.cbo._children[param_name]
         )
 
-    # CBO income-by-source aggregate targets.
-    # Without these, the per-AGI-bracket SOI targets fail to constrain the
-    # *aggregate* (the optimizer can satisfy bracket-level totals while
-    # concentrating weight on a few records and blowing up the national sum).
-    # See issues #555 and #866 — single records with $60M+ raw LTCG were
-    # ending up with calibration weights of 50k-70k, inflating the national
-    # net_capital_gains aggregate to 12x the CBO target.
-    #
-    # Each entry maps a PolicyEngine variable (or sum of variables) to the
-    # corresponding CBO `income_by_source` parameter.
-    CBO_INCOME_BY_SOURCE_TARGETS = [
-        # (label_suffix, [pe_variables_to_sum], cbo_param_name)
-        ("net_capital_gains", ["net_capital_gains"], "net_capital_gain"),
-        (
-            "qualified_dividend_income",
-            ["qualified_dividend_income"],
-            "qualified_dividend_income",
-        ),
-        (
-            "taxable_interest_and_ordinary_dividends",
-            ["taxable_interest_income", "non_qualified_dividend_income"],
-            "taxable_interest_and_ordinary_dividends",
-        ),
-    ]
-
+    # CBO's detailed AGI-by-source targets are tax-return concepts,
+    # so keep them restricted to filing tax units.
     income_by_source = sim.tax_benefit_system.parameters(
         time_period
     ).calibration.gov.cbo.income_by_source
+    for variable, parameter in CBO_INCOME_BY_SOURCE_TARGETS:
+        label = f"nation/cbo/income_by_source/{variable}/filers"
+        loss_matrix[label] = _calculate_filer_target_values(
+            sim,
+            variable,
+            time_period,
+        )
+        targets_array.append(income_by_source._children[parameter])
 
-    for label_suffix, pe_variables, cbo_param_name in CBO_INCOME_BY_SOURCE_TARGETS:
-        label = f"nation/cbo/income_by_source/{label_suffix}"
-        values = sum(sim.calculate(v, map_to="household").values for v in pe_variables)
-        loss_matrix[label] = values
-        targets_array.append(income_by_source._children[cbo_param_name])
+    bea_nipa_targets = [
+        (
+            "nation/bea/nipa_wages_and_salaries",
+            "employment_income_before_lsr",
+            BEA_NIPA_WAGES_AND_SALARIES_2024,
+        ),
+        (
+            "nation/bea/nipa_proprietors_income",
+            NIPA_PROPRIETORS_INCOME_VARIABLE,
+            BEA_NIPA_PROPRIETORS_INCOME_2024,
+        ),
+        (
+            "nation/bea/nipa_personal_interest_income",
+            NIPA_PERSONAL_INTEREST_INCOME_VARIABLE,
+            BEA_NIPA_PERSONAL_INTEREST_INCOME_2024,
+        ),
+        (
+            "nation/bea/nipa_personal_dividend_income",
+            "dividend_income",
+            BEA_NIPA_PERSONAL_DIVIDEND_INCOME_2024,
+        ),
+    ]
+    for label, variable, target in bea_nipa_targets:
+        loss_matrix[label] = _calculate_household_target_values(
+            sim,
+            variable,
+            time_period,
+        )
+        if any(loss_matrix[label].isna()):
+            raise ValueError(f"Missing values for {label}")
+        targets_array.append(target)
 
     # IRS SOI aggregate capital-gains targets. This adds a long-term gains
     # control on top of the CBO net capital gains aggregate, which is important

--- a/policyengine_us_data/utils/target_variables.py
+++ b/policyengine_us_data/utils/target_variables.py
@@ -1,0 +1,15 @@
+def target_variable_components(variable: str) -> list[str]:
+    """Return component variables for a target expression.
+
+    Calibration targets normally name a single policyengine-us variable, but
+    some primary-source aggregates map to a sum of variables.  We support only
+    additive expressions so target values remain linear in survey weights.
+    """
+    return [part.strip() for part in variable.split("+")]
+
+
+def target_variable_is_valid(variable: str, valid_variables) -> bool:
+    return all(
+        component and component in valid_variables
+        for component in target_variable_components(variable)
+    )

--- a/tests/unit/calibration/test_unified_matrix_builder_constrained_values.py
+++ b/tests/unit/calibration/test_unified_matrix_builder_constrained_values.py
@@ -1,0 +1,78 @@
+import numpy as np
+import pandas as pd
+
+from policyengine_us_data.calibration.unified_matrix_builder import (
+    _calculate_target_values_standalone,
+)
+
+
+ENTITY_REL = pd.DataFrame(
+    {
+        "person_id": [1, 2, 3],
+        "household_id": [10, 10, 20],
+        "tax_unit_id": [100, 101, 102],
+        "spm_unit_id": [1000, 1001, 1002],
+    }
+)
+HOUSEHOLD_IDS = np.array([10, 20])
+ENTITY_HH_IDX_MAP = {"person": np.array([0, 0, 1])}
+PERSON_TO_ENTITY_IDX_MAP = {"person": np.array([0, 1, 2])}
+VARIABLE_ENTITY_MAP = {
+    "irs_employment_income": "person",
+    "taxable_interest_income": "person",
+    "dividend_income": "person",
+    "total_self_employment_income": "person",
+    "farm_operations_income": "person",
+    "partnership_s_corp_income": "person",
+}
+FILER_CONSTRAINT = [
+    {
+        "variable": "tax_unit_is_filer",
+        "operation": "==",
+        "value": "1",
+    }
+]
+
+
+def _calculate(target_variable):
+    return _calculate_target_values_standalone(
+        target_variable=target_variable,
+        non_geo_constraints=FILER_CONSTRAINT,
+        n_households=2,
+        hh_vars={},
+        reform_hh_vars={},
+        target_entity_vars={
+            "irs_employment_income": np.array([100, 200, 300]),
+            "taxable_interest_income": np.array([10, 20, 30]),
+            "dividend_income": np.array([1, 2, 3]),
+            "total_self_employment_income": np.array([1000, 2000, 3000]),
+            "farm_operations_income": np.array([100, 200, 300]),
+            "partnership_s_corp_income": np.array([10, 20, 30]),
+        },
+        person_vars={"tax_unit_is_filer": np.array([1, 0, 1])},
+        entity_rel=ENTITY_REL,
+        household_ids=HOUSEHOLD_IDS,
+        variable_entity_map=VARIABLE_ENTITY_MAP,
+        entity_hh_idx_map=ENTITY_HH_IDX_MAP,
+        person_to_entity_idx_map=PERSON_TO_ENTITY_IDX_MAP,
+    )
+
+
+def test_constrained_person_value_target_filters_before_household_mapping():
+    values = _calculate("irs_employment_income")
+
+    np.testing.assert_array_equal(values, np.array([100, 300]))
+
+
+def test_constrained_additive_value_target_filters_before_household_mapping():
+    values = _calculate("taxable_interest_income+dividend_income")
+
+    np.testing.assert_array_equal(values, np.array([11, 33]))
+
+
+def test_constrained_three_part_additive_target():
+    values = _calculate(
+        "total_self_employment_income+farm_operations_income+partnership_s_corp_income"
+    )
+
+    np.testing.assert_array_equal(values, np.array([1110, 3330]))

--- a/tests/unit/db/test_validate_database.py
+++ b/tests/unit/db/test_validate_database.py
@@ -1,13 +1,24 @@
 import sqlite3
 
+import pytest
+
 from policyengine_us_data.db.validate_database import validate_database
 
 
-def test_validate_database_accepts_total_self_employment_income(tmp_path):
-    db_path = tmp_path / "policy_data.db"
+TAX_EXPENDITURE_TARGETS = [
+    "salt_deduction",
+    "charitable_deduction",
+    "deductible_mortgage_interest",
+    "medical_expense_deduction",
+    "qualified_business_income_deduction",
+]
+
+
+def _write_policy_data_db(db_path, target_variables):
     conn = sqlite3.connect(db_path)
     try:
-        conn.executescript("""
+        conn.executescript(
+            """
             CREATE TABLE strata (
                 stratum_id INTEGER PRIMARY KEY,
                 parent_stratum_id INTEGER
@@ -22,7 +33,8 @@ def test_validate_database_accepts_total_self_employment_income(tmp_path):
                 active INTEGER,
                 reform_id INTEGER
             );
-        """)
+        """
+        )
         conn.execute(
             "INSERT INTO strata (stratum_id, parent_stratum_id) VALUES (?, ?)",
             (1, None),
@@ -33,29 +45,48 @@ def test_validate_database_accepts_total_self_employment_income(tmp_path):
             (1, "total_self_employment_income"),
         )
 
-        for reform_id, variable in enumerate(
-            [
-                "salt_deduction",
-                "charitable_deduction",
-                "deductible_mortgage_interest",
-                "medical_expense_deduction",
-                "qualified_business_income_deduction",
-            ],
-            start=1,
-        ):
+        for reform_id, variable in enumerate(TAX_EXPENDITURE_TARGETS, start=1):
             conn.execute(
                 "INSERT INTO targets (stratum_id, variable, active, reform_id) "
                 "VALUES (?, ?, ?, ?)",
                 (1, variable, 1, reform_id),
             )
 
-        conn.execute(
-            "INSERT INTO targets (stratum_id, variable, active, reform_id) "
-            "VALUES (?, ?, ?, ?)",
-            (1, "total_self_employment_income", 1, 0),
-        )
+        for variable in target_variables:
+            conn.execute(
+                "INSERT INTO targets (stratum_id, variable, active, reform_id) "
+                "VALUES (?, ?, ?, ?)",
+                (1, variable, 1, 0),
+            )
+
         conn.commit()
     finally:
         conn.close()
 
+
+def test_validate_database_accepts_total_self_employment_income(tmp_path):
+    db_path = tmp_path / "policy_data.db"
+    _write_policy_data_db(
+        db_path,
+        [
+            "total_self_employment_income",
+            "taxable_interest_income+tax_exempt_interest_income",
+        ],
+    )
+
     validate_database(db_path)
+
+
+@pytest.mark.parametrize(
+    "variable",
+    [
+        "taxable_interest_income+",
+        "taxable_interest_income++tax_exempt_interest_income",
+    ],
+)
+def test_validate_database_rejects_empty_additive_terms(tmp_path, variable):
+    db_path = tmp_path / "policy_data.db"
+    _write_policy_data_db(db_path, [variable])
+
+    with pytest.raises(ValueError, match="not a policyengine-us variable"):
+        validate_database(db_path)

--- a/tests/unit/test_etl_national_targets.py
+++ b/tests/unit/test_etl_national_targets.py
@@ -601,3 +601,222 @@ def test_load_national_targets_supports_wic_targets(tmp_path, monkeypatch):
         ).first()
         assert wic_count_target is not None
         assert wic_count_target.value == 6_704_000
+
+
+def test_loads_gross_wage_and_filer_tax_wage_targets(tmp_path, monkeypatch):
+    calibration_dir = tmp_path / "calibration"
+    calibration_dir.mkdir()
+    db_uri = f"sqlite:///{calibration_dir / 'policy_data.db'}"
+    engine = create_database(db_uri)
+
+    with Session(engine) as session:
+        _make_stratum(session, notes="United States")
+
+    monkeypatch.setattr(
+        "policyengine_us_data.db.etl_national_targets.STORAGE_FOLDER",
+        tmp_path,
+    )
+
+    load_national_targets(
+        direct_targets_df=pd.DataFrame(
+            [
+                {
+                    "variable": "employment_income_before_lsr",
+                    "value": 12_387_929_000_000,
+                    "source": "BEA NIPA Table 2.1",
+                    "notes": "Gross all-worker wages",
+                    "year": 2024,
+                },
+                {
+                    "variable": (
+                        etl_national_targets.NIPA_PERSONAL_INTEREST_INCOME_VARIABLE
+                    ),
+                    "value": 1_926_644_000_000,
+                    "source": "BEA NIPA Table 2.1",
+                    "notes": "Personal interest income",
+                    "year": 2024,
+                },
+                {
+                    "variable": etl_national_targets.NIPA_PROPRIETORS_INCOME_VARIABLE,
+                    "value": 2_023_080_000_000,
+                    "source": "BEA NIPA Table 2.1",
+                    "notes": "Proprietors' income",
+                    "year": 2024,
+                },
+            ]
+        ),
+        tax_filer_df=pd.DataFrame(
+            [
+                {
+                    "variable": "irs_employment_income",
+                    "value": 10_832_700_000_000,
+                    "source": "CBO Revenue Projections",
+                    "notes": "AGI-by-source wages",
+                    "year": 2024,
+                }
+            ]
+        ),
+        tax_expenditure_df=pd.DataFrame(),
+        conditional_targets=[],
+    )
+
+    with Session(engine) as session:
+        gross_wage_target = session.exec(
+            select(Target).where(Target.variable == "employment_income_before_lsr")
+        ).one()
+        tax_wage_target = session.exec(
+            select(Target).where(Target.variable == "irs_employment_income")
+        ).one()
+        interest_target = session.exec(
+            select(Target).where(
+                Target.variable
+                == etl_national_targets.NIPA_PERSONAL_INTEREST_INCOME_VARIABLE
+            )
+        ).one()
+        proprietors_target = session.exec(
+            select(Target).where(
+                Target.variable == etl_national_targets.NIPA_PROPRIETORS_INCOME_VARIABLE
+            )
+        ).one()
+        filer_constraints = session.exec(
+            select(StratumConstraint).where(
+                StratumConstraint.stratum_id == tax_wage_target.stratum_id
+            )
+        ).all()
+
+    assert gross_wage_target.value == 12_387_929_000_000
+    assert tax_wage_target.value == 10_832_700_000_000
+    assert interest_target.value == 1_926_644_000_000
+    assert proprietors_target.value == 2_023_080_000_000
+    assert gross_wage_target.stratum_id != tax_wage_target.stratum_id
+    assert [
+        (
+            constraint.constraint_variable,
+            constraint.operation,
+            constraint.value,
+        )
+        for constraint in filer_constraints
+    ] == [("tax_unit_is_filer", "==", "1")]
+
+
+def test_extracts_income_targets_from_primary_concepts(monkeypatch):
+    class FakeIncomeBySource:
+        _children = {
+            "employment_income": 10_832_700_000_000,
+            "self_employment_income": 1_916_000_000_000,
+            "taxable_pension_income": 1_522_500_000_000,
+            "taxable_social_security": 577_200_000_000,
+            "qualified_dividend_income": 354_300_000_000,
+            "net_capital_gain": 1_290_900_000_000,
+            "taxable_interest_and_ordinary_dividends": 309_700_000_000,
+        }
+
+    class FakeCBO:
+        income_by_source = FakeIncomeBySource()
+        _children = {
+            "income_tax": 0,
+            "snap": 0,
+            "social_security": 0,
+            "ssi": 0,
+            "unemployment_compensation": 0,
+        }
+
+    class FakeSOI:
+        _children = {"long_term_capital_gains": 0}
+
+    class FakeGov:
+        cbo = FakeCBO()
+        irs = type("FakeIRS", (), {"soi": FakeSOI()})()
+
+    class FakeCalibration:
+        gov = FakeGov()
+
+    class FakeParameters:
+        def __call__(self, year):
+            return self
+
+        calibration = FakeCalibration()
+
+    class FakeTaxBenefitSystem:
+        parameters = FakeParameters()
+
+    monkeypatch.setattr(
+        "policyengine_us.CountryTaxBenefitSystem",
+        FakeTaxBenefitSystem,
+    )
+
+    raw_targets = etl_national_targets.extract_national_targets(year=2024)
+
+    gross_wage_targets = [
+        target
+        for target in raw_targets["direct_sum_targets"]
+        if target["variable"] == "employment_income_before_lsr"
+    ]
+    proprietors_targets = [
+        target
+        for target in raw_targets["direct_sum_targets"]
+        if target["variable"] == etl_national_targets.NIPA_PROPRIETORS_INCOME_VARIABLE
+    ]
+    tax_wage_targets = [
+        target
+        for target in raw_targets["tax_filer_targets"]
+        if target["variable"] == "irs_employment_income"
+    ]
+    cbo_self_employment_targets = [
+        target
+        for target in raw_targets["tax_filer_targets"]
+        if target["variable"] == "self_employment_income"
+    ]
+
+    assert gross_wage_targets == [
+        {
+            "variable": "employment_income_before_lsr",
+            "value": etl_national_targets.BEA_NIPA_WAGES_AND_SALARIES_2024,
+            "source": "BEA NIPA Table 2.1",
+            "notes": (
+                "Gross wages and salaries for all workers, including "
+                "nonfilers; FRED/BEA series A034RC1A027NBEA"
+            ),
+            "year": 2024,
+        }
+    ]
+    assert tax_wage_targets == [
+        {
+            "variable": "irs_employment_income",
+            "value": 10_832_700_000_000,
+            "source": "CBO Revenue Projections",
+            "notes": (
+                "CBO detailed AGI-by-source employment income; restricted "
+                "to tax filers because this is an AGI tax-return concept"
+            ),
+            "year": 2024,
+        }
+    ]
+    assert proprietors_targets == [
+        {
+            "variable": etl_national_targets.NIPA_PROPRIETORS_INCOME_VARIABLE,
+            "value": etl_national_targets.BEA_NIPA_PROPRIETORS_INCOME_2024,
+            "source": "BEA NIPA Table 2.1",
+            "notes": (
+                "Proprietors' income with IVA and CCAdj for all persons, "
+                "including nonfilers; FRED/BEA series A041RC1A027NBEA. "
+                "Mapped to the closest additive PolicyEngine aggregate: "
+                "total self-employment, farm operations, and "
+                "partnership/S-corp income."
+            ),
+            "year": 2024,
+        }
+    ]
+    assert cbo_self_employment_targets == [
+        {
+            "variable": "self_employment_income",
+            "value": 1_916_000_000_000,
+            "source": "CBO Revenue Projections",
+            "notes": (
+                "CBO detailed AGI-by-source self-employment income; "
+                "restricted to tax filers because this is an AGI tax-return "
+                "concept"
+            ),
+            "year": 2024,
+        }
+    ]


### PR DESCRIPTION
## Summary
- add CBO AGI-by-source filer-only calibration targets for wages, self-employment, taxable pensions, taxable Social Security, qualified dividends, net capital gains, and taxable interest plus ordinary dividends
- add BEA/NIPA all-population macro targets for wages, proprietors' income, personal interest income, and personal dividend income
- support additive target expressions in the unified calibration matrix so targets like `taxable_interest_income+dividend_income` can stay linear in survey weights
- add IRS SOI wages (`00200`) as `irs_employment_income` and tests for the new target extraction/matrix filtering behavior

## Local Evaluation
Used `policyengine-us==1.691.13` with the public calibration `stratified_extended_cps.h5` and published calibration DB as the base. Private source impute/PUF clone was skipped because the raw private inputs were not locally available.

New-target local fit:
- matrix: 40,365 targets x 119,990 columns, 9.3M nonzeros
- diagnostics: mean absolute relative error 68.7%, median 48.6%, <10% = 13.9%, <25% = 29.4%

Old-target control fit under the same settings:
- matrix: 40,348 targets x 119,990 columns, 8.5M nonzeros
- diagnostics: mean absolute relative error 68.5%, median 48.2%, <10% = 13.9%, <25% = 29.7%

Selected old -> new aggregate estimates:
- NIPA wages: $4.128T -> $4.061T vs $12.388T target
- CBO filer employment income: $3.792T -> $3.728T vs $10.833T target
- NIPA proprietors' income: $1.078T -> $1.068T vs $2.023T target
- CBO filer self-employment income: $249.5B -> $251.7B vs $1.916T target
- NIPA dividends: $581.9B -> $577.5B vs $2.219T target

Baseline SPM under the local weights:
- SPM poverty: 59.69% -> 59.99%
- deep SPM poverty: 41.08% -> 41.27%

Interpretation: the new targets are included and build locally, but this default full-target local fit barely moves the aggregates. The next calibration improvement is likely target weighting/grouping rather than only adding rows.

## Tests
- `uv run --frozen --with policyengine-us==1.691.13 pytest policyengine_us_data/tests/test_etl_national_targets.py policyengine_us_data/tests/test_calibration/test_unified_matrix_builder_constrained_values.py -q`
- `uv run --frozen --with policyengine-us==1.691.13 python -m py_compile policyengine_us_data/db/etl_national_targets.py policyengine_us_data/utils/loss.py policyengine_us_data/calibration/unified_matrix_builder.py policyengine_us_data/db/validate_database.py policyengine_us_data/utils/target_variables.py`
- `git diff --check`
