### PR TITLE
Use model housing eligibility for take-up

### DIFF
--- a/changelog.d/housing_takeup.fixed.md
+++ b/changelog.d/housing_takeup.fixed.md
@@ -1,0 +1,1 @@
+Use model housing assistance eligibility for housing take-up draws.

--- a/policyengine_us_data/build_outputs/us_augmentations.py
+++ b/policyengine_us_data/build_outputs/us_augmentations.py
@@ -6,6 +6,9 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Mapping
 
 import numpy as np
+from policyengine_us.variables.gov.hud.is_eligible_for_housing_assistance import (
+    housing_assistance_eligibility_from_income_limits,
+)
 
 from policyengine_us_data.calibration.block_assignment import (
     derive_geography_from_blocks,
@@ -425,6 +428,7 @@ class USTakeupPostProcessor:
         }
         reported_anchors = _build_reported_takeup_anchors(data, time_period)
         eligibility_masks = self._build_eligibility_masks(
+            data=data,
             context=context,
             subentity_source_indices=subentity_source_indices,
         )
@@ -503,17 +507,67 @@ class USTakeupPostProcessor:
     def _build_eligibility_masks(
         self,
         *,
+        data: PayloadData,
         context: PayloadBuildContext,
         subentity_source_indices: Mapping[str, np.ndarray],
     ) -> dict[str, np.ndarray]:
         time_period = context.time_period
-        return {
-            "takes_up_housing_assistance_if_eligible": calculate_variable_values(
+        spm_unit_source_indices = subentity_source_indices["spm_unit"]
+        spm_unit_household_indices = (
+            context.reindexed.subentity_household_clone_indices["spm_unit"].astype(
+                np.int64
+            )
+        )
+        household_county_fips = _required_period_array(
+            data,
+            "county_fips",
+            time_period,
+            "US take-up housing assistance eligibility requires county_fips "
+            "from USGeographyPostProcessor",
+        )
+        if (
+            "receives_housing_assistance" in data
+            and time_period in data["receives_housing_assistance"]
+        ):
+            receives_housing_assistance = data["receives_housing_assistance"][
+                time_period
+            ].astype(bool)
+        else:
+            receives_housing_assistance = calculate_variable_values(
                 context.simulation,
-                "is_eligible_for_housing_assistance",
+                "receives_housing_assistance",
                 period=time_period,
                 map_to="spm_unit",
-            )[subentity_source_indices["spm_unit"]].astype(bool)
+            )[spm_unit_source_indices].astype(bool)
+
+        return {
+            "takes_up_housing_assistance_if_eligible": (
+                housing_assistance_eligibility_from_income_limits(
+                    county_fips=np.asarray(household_county_fips)[
+                        spm_unit_household_indices
+                    ],
+                    annual_income=calculate_variable_values(
+                        context.simulation,
+                        "hud_annual_income",
+                        period=time_period,
+                        map_to="spm_unit",
+                    )[spm_unit_source_indices],
+                    spm_unit_size=calculate_variable_values(
+                        context.simulation,
+                        "spm_unit_size",
+                        period=time_period,
+                        map_to="spm_unit",
+                    )[spm_unit_source_indices],
+                    spm_unit_tenure_type=calculate_variable_values(
+                        context.simulation,
+                        "spm_unit_tenure_type",
+                        period=time_period,
+                        map_to="spm_unit",
+                    )[spm_unit_source_indices],
+                    receives_housing_assistance=receives_housing_assistance,
+                    year=time_period,
+                ).astype(bool)
+            )
         }
 
 

--- a/policyengine_us_data/build_outputs/us_augmentations.py
+++ b/policyengine_us_data/build_outputs/us_augmentations.py
@@ -424,6 +424,10 @@ class USTakeupPostProcessor:
             "spm_unit": len(subentity_source_indices["spm_unit"]),
         }
         reported_anchors = _build_reported_takeup_anchors(data, time_period)
+        eligibility_masks = self._build_eligibility_masks(
+            context=context,
+            subentity_source_indices=subentity_source_indices,
+        )
         voluntary_filing_inputs = self._build_voluntary_filing_inputs(
             context=context,
             tax_unit_source_indices=subentity_source_indices["tax_unit"],
@@ -446,6 +450,7 @@ class USTakeupPostProcessor:
                 else None
             ),
             reported_anchors=reported_anchors,
+            eligibility_masks=eligibility_masks,
             voluntary_filing_inputs=voluntary_filing_inputs,
         )
 
@@ -493,6 +498,22 @@ class USTakeupPostProcessor:
                 period=time_period,
                 map_to="tax_unit",
             )[tax_unit_source_indices],
+        }
+
+    def _build_eligibility_masks(
+        self,
+        *,
+        context: PayloadBuildContext,
+        subentity_source_indices: Mapping[str, np.ndarray],
+    ) -> dict[str, np.ndarray]:
+        time_period = context.time_period
+        return {
+            "takes_up_housing_assistance_if_eligible": calculate_variable_values(
+                context.simulation,
+                "is_eligible_for_housing_assistance",
+                period=time_period,
+                map_to="spm_unit",
+            )[subentity_source_indices["spm_unit"]].astype(bool)
         }
 
 

--- a/policyengine_us_data/calibration/entity_clone.py
+++ b/policyengine_us_data/calibration/entity_clone.py
@@ -139,6 +139,13 @@ def _build_reported_takeup_anchors(data: dict, time_period: int) -> dict:
         reported_anchors["takes_up_medicaid_if_eligible"] = data[
             "has_medicaid_health_coverage_at_interview"
         ][time_period].astype(bool)
+    if (
+        "receives_housing_assistance" in data
+        and time_period in data["receives_housing_assistance"]
+    ):
+        reported_anchors["takes_up_housing_assistance_if_eligible"] = data[
+            "receives_housing_assistance"
+        ][time_period].astype(bool)
     return reported_anchors
 
 
@@ -423,6 +430,15 @@ def materialize_clone_household_chunk(
                 map_to="tax_unit",
             ).values[entity_clone_idx["tax_unit"]],
         }
+        eligibility_masks = {
+            "takes_up_housing_assistance_if_eligible": sim.calculate(
+                "is_eligible_for_housing_assistance",
+                time_period,
+                map_to="spm_unit",
+            )
+            .values[entity_clone_idx["spm_unit"]]
+            .astype(bool)
+        }
         takeup_results = apply_block_takeup_to_arrays(
             hh_blocks=active_blocks,
             hh_state_fips=clone_geo["state_fips"].astype(np.int32),
@@ -433,6 +449,7 @@ def materialize_clone_household_chunk(
             time_period=time_period,
             takeup_filter=takeup_filter,
             reported_anchors=reported_anchors,
+            eligibility_masks=eligibility_masks,
             voluntary_filing_inputs=voluntary_filing_inputs,
         )
         for variable, values in takeup_results.items():

--- a/policyengine_us_data/calibration/entity_clone.py
+++ b/policyengine_us_data/calibration/entity_clone.py
@@ -16,6 +16,9 @@ from typing import Optional
 
 import h5py
 import numpy as np
+from policyengine_us.variables.gov.hud.is_eligible_for_housing_assistance import (
+    housing_assistance_eligibility_from_income_limits,
+)
 
 from policyengine_us_data.calibration.block_assignment import (
     derive_geography_from_blocks,
@@ -430,14 +433,46 @@ def materialize_clone_household_chunk(
                 map_to="tax_unit",
             ).values[entity_clone_idx["tax_unit"]],
         }
-        eligibility_masks = {
-            "takes_up_housing_assistance_if_eligible": sim.calculate(
-                "is_eligible_for_housing_assistance",
-                time_period,
-                map_to="spm_unit",
+        if (
+            "receives_housing_assistance" in data
+            and time_period in data["receives_housing_assistance"]
+        ):
+            receives_housing_assistance = data["receives_housing_assistance"][
+                time_period
+            ].astype(bool)
+        else:
+            receives_housing_assistance = (
+                sim.calculate(
+                    "receives_housing_assistance",
+                    time_period,
+                    map_to="spm_unit",
+                )
+                .values[entity_clone_idx["spm_unit"]]
+                .astype(bool)
             )
-            .values[entity_clone_idx["spm_unit"]]
-            .astype(bool)
+        eligibility_masks = {
+            "takes_up_housing_assistance_if_eligible": (
+                housing_assistance_eligibility_from_income_limits(
+                    county_fips=clone_geo["county_fips"][entity_hh_indices["spm_unit"]],
+                    annual_income=sim.calculate(
+                        "hud_annual_income",
+                        time_period,
+                        map_to="spm_unit",
+                    ).values[entity_clone_idx["spm_unit"]],
+                    spm_unit_size=sim.calculate(
+                        "spm_unit_size",
+                        time_period,
+                        map_to="spm_unit",
+                    ).values[entity_clone_idx["spm_unit"]],
+                    spm_unit_tenure_type=sim.calculate(
+                        "spm_unit_tenure_type",
+                        time_period,
+                        map_to="spm_unit",
+                    ).values[entity_clone_idx["spm_unit"]],
+                    receives_housing_assistance=receives_housing_assistance,
+                    year=time_period,
+                ).astype(bool)
+            )
         }
         takeup_results = apply_block_takeup_to_arrays(
             hh_blocks=active_blocks,

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -27,7 +27,6 @@ from policyengine_us_data.parameters import load_take_up_rate
 from policyengine_us_data.datasets.cps.takeup import (
     align_reported_ssi_disability,
     prioritize_reported_recipients,
-    very_low_income_renter_mask,
 )
 from policyengine_us_data.datasets.org import (
     ORG_BOOL_VARIABLES,
@@ -579,15 +578,14 @@ def add_takeup(self):
         ),
         dtype=bool,
     )
-    very_low_income_renter = very_low_income_renter_mask(
-        baseline.calculate("hud_income_level").values,
-        baseline.calculate("spm_unit_tenure_type").values,
-    )
+    housing_assistance_eligible = baseline.calculate(
+        "is_eligible_for_housing_assistance"
+    ).values
     data["takes_up_housing_assistance_if_eligible"] = prioritize_reported_recipients(
         reported_housing_assistance,
         housing_assistance_rate,
         rng.random(n_spm_units),
-        eligible_mask=very_low_income_renter,
+        eligible_mask=housing_assistance_eligible,
     )
 
     # WIC: resolve draws to bools using category-specific rates

--- a/policyengine_us_data/datasets/cps/takeup.py
+++ b/policyengine_us_data/datasets/cps/takeup.py
@@ -1,33 +1,10 @@
 import numpy as np
 
-VERY_LOW_INCOME_LEVELS = {"ESPECIALLY_LOW", "VERY_LOW"}
-
 
 def _validate_same_shape(*arrays: np.ndarray) -> None:
     shapes = {np.asarray(array).shape for array in arrays}
     if len(shapes) != 1:
         raise ValueError("All arrays must have the same shape")
-
-
-def _enum_names(values: np.ndarray) -> np.ndarray:
-    return np.asarray(
-        [
-            getattr(value, "name", str(value))
-            for value in np.asarray(values, dtype=object)
-        ]
-    )
-
-
-def very_low_income_renter_mask(
-    income_level: np.ndarray,
-    tenure_type: np.ndarray,
-) -> np.ndarray:
-    income_level = _enum_names(income_level)
-    tenure_type = _enum_names(tenure_type)
-    _validate_same_shape(income_level, tenure_type)
-    return np.isin(income_level, list(VERY_LOW_INCOME_LEVELS)) & (
-        tenure_type == "RENTER"
-    )
 
 
 def prioritize_reported_recipients(

--- a/policyengine_us_data/utils/takeup.py
+++ b/policyengine_us_data/utils/takeup.py
@@ -190,6 +190,7 @@ def assign_takeup_with_reported_anchors(
     rates,
     reported_mask: Optional[np.ndarray] = None,
     group_keys: Optional[np.ndarray] = None,
+    eligible_mask: Optional[np.ndarray] = None,
 ) -> np.ndarray:
     """Apply the SSI/SNAP-style reported-first takeup pattern.
 
@@ -206,22 +207,30 @@ def assign_takeup_with_reported_anchors(
         if len(rates_arr) != len(draws):
             raise ValueError("rates and draws must align")
 
+    if eligible_mask is None:
+        eligible_mask = np.ones(len(draws), dtype=bool)
+    else:
+        eligible_mask = np.asarray(eligible_mask, dtype=bool)
+        if len(eligible_mask) != len(draws):
+            raise ValueError("eligible_mask and draws must align")
+
     baseline = draws < rates_arr
     if reported_mask is None:
-        return baseline
+        return eligible_mask & baseline
 
     reported_mask = np.asarray(reported_mask, dtype=bool)
     if len(reported_mask) != len(draws):
         raise ValueError("reported_mask and draws must align")
 
+    eligible_mask = eligible_mask | reported_mask
     result = reported_mask.copy()
 
     if group_keys is None:
         unique_rates = np.unique(rates_arr)
         if len(unique_rates) != 1:
             raise ValueError("group_keys required when rates vary by entity")
-        target_count = int(unique_rates[0] * len(draws))
-        non_reporters = ~reported_mask
+        target_count = int(unique_rates[0] * int(eligible_mask.sum()))
+        non_reporters = eligible_mask & ~reported_mask
         remaining_needed = max(0, target_count - int(reported_mask.sum()))
         adjusted_rate = (
             remaining_needed / int(non_reporters.sum()) if non_reporters.any() else 0
@@ -238,10 +247,11 @@ def assign_takeup_with_reported_anchors(
         group_rates = np.unique(rates_arr[group_mask])
         if len(group_rates) != 1:
             raise ValueError("Each takeup group must have a single rate")
-        target_count = int(group_rates[0] * int(group_mask.sum()))
+        group_eligible = group_mask & eligible_mask
+        target_count = int(group_rates[0] * int(group_eligible.sum()))
         group_reported = reported_mask[group_mask]
         remaining_needed = max(0, target_count - int(group_reported.sum()))
-        group_non_reporters = group_mask & ~reported_mask
+        group_non_reporters = group_eligible & ~reported_mask
         adjusted_rate = (
             remaining_needed / int(group_non_reporters.sum())
             if group_non_reporters.any()
@@ -423,6 +433,7 @@ def compute_block_takeup_for_entities(
     entity_hh_ids: np.ndarray = None,
     entity_clone_ids: np.ndarray = None,
     reported_mask: Optional[np.ndarray] = None,
+    eligible_mask: Optional[np.ndarray] = None,
 ) -> np.ndarray:
     """Compute boolean takeup via block-level seeded draws."""
     draws = compute_block_takeup_draws_for_entities(
@@ -448,6 +459,7 @@ def compute_block_takeup_for_entities(
         rates,
         reported_mask=reported_mask,
         group_keys=group_keys,
+        eligible_mask=eligible_mask,
     )
 
 
@@ -660,6 +672,7 @@ def apply_block_takeup_to_arrays(
     takeup_filter: List[str] = None,
     precomputed_rates: Optional[Dict[str, Any]] = None,
     reported_anchors: Optional[Dict[str, np.ndarray]] = None,
+    eligibility_masks: Optional[Dict[str, np.ndarray]] = None,
     voluntary_filing_inputs: Optional[Dict[str, np.ndarray]] = None,
 ) -> Dict[str, np.ndarray]:
     """Compute takeup draws from raw arrays.
@@ -686,6 +699,10 @@ def apply_block_takeup_to_arrays(
         precomputed_rates: Optional {rate_key: rate_or_dict} cache.
             When provided, skips ``load_take_up_rate`` calls and
             uses cached values instead.
+        reported_anchors: Optional {takeup variable: bool array}; reported
+            recipients are always assigned take-up.
+        eligibility_masks: Optional {takeup variable: bool array}; non-reported
+            take-up is drawn only from the matching eligible entity rows.
 
     Returns:
         {variable_name: bool_array} for each takeup variable.
@@ -693,6 +710,7 @@ def apply_block_takeup_to_arrays(
     filter_set = set(takeup_filter) if takeup_filter is not None else None
     result = {}
     reported_anchors = reported_anchors or {}
+    eligibility_masks = eligibility_masks or {}
 
     for spec in SIMPLE_TAKEUP_VARS:
         var_name = spec["variable"]
@@ -716,6 +734,9 @@ def apply_block_takeup_to_arrays(
         reported_mask = reported_anchors.get(var_name)
         if reported_mask is not None and len(reported_mask) != n_ent:
             raise ValueError(f"reported anchor for {var_name} has wrong length")
+        eligible_mask = eligibility_masks.get(var_name)
+        if eligible_mask is not None and len(eligible_mask) != n_ent:
+            raise ValueError(f"eligibility mask for {var_name} has wrong length")
         if var_name == "would_file_taxes_voluntarily":
             if voluntary_filing_inputs is None:
                 raise ValueError(
@@ -739,6 +760,7 @@ def apply_block_takeup_to_arrays(
                 ent_hh_ids,
                 ent_clone_indices,
                 reported_mask=reported_mask,
+                eligible_mask=eligible_mask,
             )
         result[var_name] = bools
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us==1.693.1",
+    "policyengine-us==1.693.2",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/tests/unit/build_outputs/test_us_augmentations.py
+++ b/tests/unit/build_outputs/test_us_augmentations.py
@@ -36,6 +36,7 @@ class _Simulation:
             ("tax_unit_child_dependents", "tax_unit"): np.array([1, 2]),
             ("employment_income", "person"): np.array([10, 20, 30]),
             ("age_head", "tax_unit"): np.array([40, 50]),
+            ("is_eligible_for_housing_assistance", "spm_unit"): np.array([False, True]),
         }[(variable, map_to)]
         return _Calculation(values)
 
@@ -307,6 +308,10 @@ def test_us_takeup_postprocessor_passes_takeup_contract_inputs():
     )
     assert seen["entity_counts"] == {"person": 3, "tax_unit": 2, "spm_unit": 2}
     assert seen["takeup_filter"] == ["takes_up_snap_if_eligible"]
+    np.testing.assert_array_equal(
+        seen["eligibility_masks"]["takes_up_housing_assistance_if_eligible"],
+        np.array([True, False]),
+    )
     np.testing.assert_array_equal(
         seen["voluntary_filing_inputs"]["tax_unit_child_dependents"],
         np.array([2, 1]),

--- a/tests/unit/build_outputs/test_us_augmentations.py
+++ b/tests/unit/build_outputs/test_us_augmentations.py
@@ -36,7 +36,10 @@ class _Simulation:
             ("tax_unit_child_dependents", "tax_unit"): np.array([1, 2]),
             ("employment_income", "person"): np.array([10, 20, 30]),
             ("age_head", "tax_unit"): np.array([40, 50]),
-            ("is_eligible_for_housing_assistance", "spm_unit"): np.array([False, True]),
+            ("hud_annual_income", "spm_unit"): np.array([200_000, 50_000]),
+            ("spm_unit_size", "spm_unit"): np.array([4, 4]),
+            ("spm_unit_tenure_type", "spm_unit"): np.array(["RENTER", "RENTER"]),
+            ("receives_housing_assistance", "spm_unit"): np.array([False, False]),
         }[(variable, map_to)]
         return _Calculation(values)
 

--- a/tests/unit/calibration/test_unified_calibration.py
+++ b/tests/unit/calibration/test_unified_calibration.py
@@ -315,6 +315,22 @@ class TestBlockSaltedDraws:
 
         np.testing.assert_array_equal(result, np.array([False, True]))
 
+    def test_eligible_mask_preserves_reported_and_limits_others(self):
+        result = compute_block_takeup_for_entities(
+            "takes_up_housing_assistance_if_eligible",
+            1.0,
+            np.array(["370010001001001"] * 4),
+            np.array([1, 2, 3, 4], dtype=np.int64),
+            np.zeros(4, dtype=np.int64),
+            reported_mask=np.array([True, False, False, False]),
+            eligible_mask=np.array([False, False, True, False]),
+        )
+
+        np.testing.assert_array_equal(
+            result,
+            np.array([True, False, True, False]),
+        )
+
 
 class TestApplyBlockTakeupToArrays:
     """Verify apply_block_takeup_to_arrays returns correct
@@ -486,6 +502,31 @@ class TestApplyBlockTakeupToArrays:
         np.testing.assert_array_equal(
             result["would_file_taxes_voluntarily"],
             np.array([False, True]),
+        )
+
+    def test_apply_block_takeup_passes_eligibility_masks(self):
+        args = self._make_arrays(4, 1, 1, 1)
+
+        result = apply_block_takeup_to_arrays(
+            *args,
+            time_period=2024,
+            takeup_filter=["takes_up_housing_assistance_if_eligible"],
+            precomputed_rates={"housing_assistance": 1.0},
+            reported_anchors={
+                "takes_up_housing_assistance_if_eligible": np.array(
+                    [True, False, False, False]
+                )
+            },
+            eligibility_masks={
+                "takes_up_housing_assistance_if_eligible": np.array(
+                    [False, False, True, False]
+                )
+            },
+        )
+
+        np.testing.assert_array_equal(
+            result["takes_up_housing_assistance_if_eligible"],
+            np.array([True, False, True, False]),
         )
 
 

--- a/tests/unit/datasets/test_cps_takeup.py
+++ b/tests/unit/datasets/test_cps_takeup.py
@@ -4,7 +4,6 @@ import pytest
 from policyengine_us_data.datasets.cps.takeup import (
     align_reported_ssi_disability,
     prioritize_reported_recipients,
-    very_low_income_renter_mask,
 )
 
 
@@ -47,41 +46,6 @@ def test_prioritize_reported_recipients_limits_draws_to_eligible_pool():
     np.testing.assert_array_equal(
         result,
         np.array([False, True, True, False]),
-    )
-
-
-def test_very_low_income_renter_mask_accepts_enum_like_values():
-    class EnumLike:
-        def __init__(self, name):
-            self.name = name
-
-        def __str__(self):
-            return f"EnumLike.{self.name}"
-
-    result = very_low_income_renter_mask(
-        np.array(
-            [
-                EnumLike("VERY_LOW"),
-                EnumLike("ESPECIALLY_LOW"),
-                EnumLike("LOW"),
-                "VERY_LOW",
-            ],
-            dtype=object,
-        ),
-        np.array(
-            [
-                EnumLike("RENTER"),
-                EnumLike("OWNER_WITH_MORTGAGE"),
-                EnumLike("RENTER"),
-                "RENTER",
-            ],
-            dtype=object,
-        ),
-    )
-
-    np.testing.assert_array_equal(
-        result,
-        np.array([True, False, False, True]),
     )
 
 

--- a/tests/unit/test_policyengine_us_dependency_contract.py
+++ b/tests/unit/test_policyengine_us_dependency_contract.py
@@ -22,3 +22,20 @@ def test_policyengine_us_defines_housing_assistance_formulas():
 
         assert variable.entity.key == "spm_unit"
         assert getattr(variable, "formulas", None)
+
+
+def test_policyengine_us_defines_housing_income_limit_contract():
+    from policyengine_us.variables.gov.hud.is_eligible_for_housing_assistance import (
+        housing_assistance_eligibility_from_income_limits,
+    )
+
+    assert callable(housing_assistance_eligibility_from_income_limits)
+
+    tax_benefit_system = CountryTaxBenefitSystem()
+    for variable_name in (
+        "hud_extremely_low_income_limit",
+        "hud_very_low_income_limit",
+        "hud_low_income_limit",
+    ):
+        variable = tax_benefit_system.variables[variable_name]
+        assert variable.entity.key == "spm_unit"

--- a/tests/unit/test_stochastic_variables.py
+++ b/tests/unit/test_stochastic_variables.py
@@ -186,6 +186,20 @@ class TestReportedTakeupAnchors:
         )
         np.testing.assert_array_equal(result, [True, False, True, False])
 
+    def test_eligible_mask_limits_non_reported_takeup(self):
+        draws = np.array([0.1, 0.1, 0.1])
+        reported = np.array([True, False, False])
+        eligible = np.array([False, False, True])
+
+        result = assign_takeup_with_reported_anchors(
+            draws,
+            1.0,
+            reported_mask=reported,
+            eligible_mask=eligible,
+        )
+
+        np.testing.assert_array_equal(result, [True, False, True])
+
     def test_any_person_flag_by_entity_aggregates_correctly(self):
         person_tax_unit_ids = np.array([10, 10, 20, 30])
         tax_unit_ids = np.array([10, 20, 30])

--- a/uv.lock
+++ b/uv.lock
@@ -2122,7 +2122,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.693.1"
+version = "1.693.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2132,9 +2132,9 @@ dependencies = [
     { name = "tables" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/a0/88505640ce5ea0fa21ca7bd73ce59f86d010a77312d8f22df3b70e3ea08a/policyengine_us-1.693.1.tar.gz", hash = "sha256:e5e38e4504c19bedc54cc71f7debe9186e47ee86a24871fa2d05e72efd1e6166", size = 9610252, upload-time = "2026-05-17T19:02:54.606Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/7f/a1a4c6cde0243aec8d511db3f2ae8e2fe2ff89c00328396d6198501492a0/policyengine_us-1.693.2.tar.gz", hash = "sha256:7c2fe96189a6678724add6efb5bacbd2f58f713a40564558862d2b2a25d8842f", size = 9760480, upload-time = "2026-05-18T00:35:56.503Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/de/963541eaf3afee9551c6c133ba4ad737852b9c47f054f9f458818bb35670/policyengine_us-1.693.1-py3-none-any.whl", hash = "sha256:2d566d4b68a895f74598a6c9fef42bec01a618a0ca2027d3c1b1dae2d4a88859", size = 10141153, upload-time = "2026-05-17T19:02:51.598Z" },
+    { url = "https://files.pythonhosted.org/packages/56/67/83f6ffaff987b221e38976d6e9ebfcb9c7f0f096e256d82430ea7f433d8b/policyengine_us-1.693.2-py3-none-any.whl", hash = "sha256:880dab89b87bfef10682cdabcd0092027b33709f7175299a7e1883eed9854bab", size = 10299358, upload-time = "2026-05-18T00:35:53.094Z" },
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", specifier = "==1.693.1" },
+    { name = "policyengine-us", specifier = "==1.693.2" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },


### PR DESCRIPTION
## Summary
- use policyengine-us `is_eligible_for_housing_assistance` for CPS housing assistance take-up instead of the local very-low-income renter helper
- pass the same policyengine-us income-limit eligibility helper into local-H5 take-up postprocessing and clone materialization, using cloned/local county FIPS rather than source county FIPS
- extend shared take-up helpers so reported recipients are preserved while non-reported draws are limited to the eligible pool
- add a dependency contract test so this cannot merge against a `policyengine-us` release without the HUD income-limit contract
- pin `policyengine-us==1.693.2`, which includes PolicyEngine/policyengine-us#8333

## Tests
- `uv run ruff check policyengine_us_data/datasets/cps/cps.py policyengine_us_data/datasets/cps/takeup.py policyengine_us_data/utils/takeup.py policyengine_us_data/build_outputs/us_augmentations.py policyengine_us_data/calibration/entity_clone.py tests/unit/datasets/test_cps_takeup.py tests/unit/build_outputs/test_us_augmentations.py tests/unit/test_stochastic_variables.py tests/unit/calibration/test_unified_calibration.py tests/unit/test_policyengine_us_dependency_contract.py`
- `uv run pytest tests/unit/datasets/test_cps_takeup.py tests/unit/build_outputs/test_us_augmentations.py tests/unit/test_stochastic_variables.py tests/unit/calibration/test_unified_calibration.py tests/unit/test_policyengine_us_dependency_contract.py -q`
- earlier cross-repo pre-release check: `uv pip install -e /Users/maxghenis/policyengine-upstream-prs/policyengine-us && uv run --no-sync pytest tests/unit/datasets/test_cps_takeup.py tests/unit/build_outputs/test_us_augmentations.py tests/unit/test_stochastic_variables.py tests/unit/calibration/test_unified_calibration.py tests/unit/test_policyengine_us_dependency_contract.py -q`