### PR TITLE
Harden long-run production metadata

### DIFF
--- a/changelog.d/longrun-policyengine-build-metadata.fixed.md
+++ b/changelog.d/longrun-policyengine-build-metadata.fixed.md
@@ -1,0 +1,1 @@
+Stamp long-run H5 metadata with exact policyengine-us build provenance.

--- a/policyengine_us_data/datasets/cps/long_term/calibration_artifacts.py
+++ b/policyengine_us_data/datasets/cps/long_term/calibration_artifacts.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 import hashlib
-from importlib import metadata as importlib_metadata
 import json
 from pathlib import Path
-import subprocess
 from typing import Any
+
+from policyengine_us_data.utils.policyengine import (
+    PolicyEngineUSBuildInfo,
+    get_policyengine_us_build_info,
+)
 
 try:
     from .calibration_profiles import (
@@ -27,6 +30,38 @@ MANIFEST_FILENAME = "calibration_manifest.json"
 SUPPORT_AUGMENTATION_REPORT_FILENAME = "support_augmentation_report.json"
 
 
+def _coerce_policyengine_us_metadata(
+    policyengine_us: PolicyEngineUSBuildInfo | dict[str, Any] | None,
+) -> dict[str, Any]:
+    if policyengine_us is None:
+        return get_policyengine_us_build_info().to_metadata_dict()
+    if isinstance(policyengine_us, PolicyEngineUSBuildInfo):
+        return policyengine_us.to_metadata_dict()
+    coerced = json.loads(json.dumps(policyengine_us))
+    git_head = coerced.get("git_head")
+    if git_head is not None:
+        coerced.setdefault("git_commit", git_head)
+        coerced.setdefault("commit_id", git_head)
+        coerced.setdefault(
+            "direct_url",
+            {"vcs_info": {"commit_id": git_head, "vcs": "git"}},
+        )
+    return coerced
+
+
+def _metadata_policyengine_us(
+    metadata_path: str | Path,
+) -> dict[str, Any] | None:
+    path = Path(metadata_path)
+    if not path.exists():
+        return None
+    metadata = json.loads(path.read_text(encoding="utf-8"))
+    policyengine_us = metadata.get("policyengine_us")
+    if policyengine_us is None:
+        return None
+    return json.loads(json.dumps(policyengine_us))
+
+
 def metadata_path_for(h5_path: str | Path) -> Path:
     return Path(f"{Path(h5_path)}.metadata.json")
 
@@ -39,55 +74,8 @@ def _sha256_file(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def _find_git_repo_root(path: Path) -> Path | None:
-    current = path if path.is_dir() else path.parent
-    for candidate in (current, *current.parents):
-        if (candidate / ".git").exists():
-            return candidate
-    return None
-
-
 def capture_policyengine_us_provenance() -> dict[str, Any]:
-    import policyengine_us
-
-    package_file = Path(policyengine_us.__file__).resolve()
-    version = getattr(policyengine_us, "__version__", None)
-    if version is None:
-        try:
-            version = importlib_metadata.version("policyengine-us")
-        except importlib_metadata.PackageNotFoundError:
-            version = None
-    provenance: dict[str, Any] = {
-        "package_file": str(package_file),
-        "package_file_sha256": _sha256_file(package_file),
-        "package_mtime_ns": package_file.stat().st_mtime_ns,
-        "package_size": package_file.stat().st_size,
-        "version": version,
-    }
-    repo_root = _find_git_repo_root(package_file)
-    if repo_root is None:
-        return provenance
-
-    provenance["repo_root"] = str(repo_root)
-    head = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        cwd=repo_root,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    if head.returncode == 0:
-        provenance["git_head"] = head.stdout.strip()
-    status = subprocess.run(
-        ["git", "status", "--porcelain=v1"],
-        cwd=repo_root,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    if status.returncode == 0:
-        provenance["git_dirty"] = bool(status.stdout.strip())
-    return provenance
+    return get_policyengine_us_build_info().to_metadata_dict()
 
 
 def _resolve_base_dataset_path(base_dataset_path: str) -> Path | None:
@@ -237,7 +225,7 @@ def write_year_metadata(
     target_source: dict[str, Any] | None = None,
     tax_assumption: dict[str, Any] | None = None,
     support_augmentation: dict[str, Any] | None = None,
-    policyengine_us: dict[str, Any] | None = None,
+    policyengine_us: PolicyEngineUSBuildInfo | dict[str, Any] | None = None,
     base_dataset_snapshot: dict[str, Any] | None = None,
 ) -> Path:
     metadata = {
@@ -246,6 +234,7 @@ def write_year_metadata(
         "base_dataset_path": base_dataset_path,
         "profile": profile,
         "calibration_audit": calibration_audit,
+        "policyengine_us": _coerce_policyengine_us_metadata(policyengine_us),
     }
     if target_source is not None:
         metadata["target_source"] = target_source
@@ -253,8 +242,6 @@ def write_year_metadata(
         metadata["tax_assumption"] = tax_assumption
     if support_augmentation is not None:
         metadata["support_augmentation"] = support_augmentation
-    if policyengine_us is not None:
-        metadata["policyengine_us"] = policyengine_us
     if base_dataset_snapshot is not None:
         metadata["base_dataset_snapshot"] = base_dataset_snapshot
     metadata = normalize_metadata(metadata)
@@ -294,7 +281,7 @@ def update_dataset_manifest(
     target_source: dict[str, Any] | None = None,
     tax_assumption: dict[str, Any] | None = None,
     support_augmentation: dict[str, Any] | None = None,
-    policyengine_us: dict[str, Any] | None = None,
+    policyengine_us: PolicyEngineUSBuildInfo | dict[str, Any] | None = None,
     base_dataset_snapshot: dict[str, Any] | None = None,
 ) -> Path:
     output_dir = Path(output_dir)
@@ -303,7 +290,13 @@ def update_dataset_manifest(
     target_source = _json_clone(target_source)
     tax_assumption = _json_clone(tax_assumption)
     support_augmentation = _json_clone(support_augmentation)
-    policyengine_us = _json_clone(policyengine_us)
+    policyengine_us = (
+        _coerce_policyengine_us_metadata(policyengine_us)
+        if policyengine_us is not None
+        else _metadata_policyengine_us(metadata_path)
+    )
+    if policyengine_us is None:
+        policyengine_us = get_policyengine_us_build_info().to_metadata_dict()
     base_dataset_snapshot = _json_clone(base_dataset_snapshot)
 
     if manifest_path.exists():
@@ -402,6 +395,7 @@ def update_dataset_manifest(
         "negative_weight_household_pct": calibration_audit.get(
             "negative_weight_household_pct"
         ),
+        "policyengine_us_version": policyengine_us.get("version"),
         "validation_passed": calibration_audit.get("validation_passed"),
         "validation_issue_count": len(calibration_audit.get("validation_issues", [])),
     }

--- a/policyengine_us_data/datasets/cps/long_term/prototype_synthetic_2100_support.py
+++ b/policyengine_us_data/datasets/cps/long_term/prototype_synthetic_2100_support.py
@@ -110,6 +110,45 @@ WORKER_DONOR_NON_TARGET_INCOME_COMPONENTS = (
 )
 PAYROLL_UPRATING_FACTOR_COLUMN = "__pe_payroll_uprating_factor"
 SS_UPRATING_FACTOR_COLUMN = "__pe_ss_uprating_factor"
+NON_TARGET_CLONE_INCOME_COMPONENTS = (
+    "alimony_income",
+    "disability_benefits",
+    "estate_income",
+    "farm_income",
+    "farm_operations_income",
+    "farm_rent_income",
+    "keogh_distributions",
+    "long_term_capital_gains_before_response",
+    "long_term_capital_gains_on_collectibles",
+    "miscellaneous_income",
+    "non_qualified_dividend_income",
+    "non_sch_d_capital_gains",
+    "partnership_s_corp_income",
+    "partnership_se_income",
+    "qualified_bdc_income",
+    "qualified_dividend_income",
+    "qualified_reit_and_ptp_income",
+    "rental_income",
+    "salt_refund_income",
+    "short_term_capital_gains",
+    "strike_benefits",
+    "tax_exempt_401k_distributions",
+    "tax_exempt_403b_distributions",
+    "tax_exempt_interest_income",
+    "tax_exempt_ira_distributions",
+    "tax_exempt_private_pension_income",
+    "tax_exempt_sep_distributions",
+    "taxable_401k_distributions",
+    "taxable_403b_distributions",
+    "taxable_interest_income",
+    "taxable_ira_distributions",
+    "taxable_private_pension_income",
+    "taxable_sep_distributions",
+    "unemployment_compensation",
+    "unrecaptured_section_1250_gain",
+    "veterans_benefits",
+    "workers_compensation",
+)
 
 
 @dataclass(frozen=True)
@@ -685,8 +724,18 @@ def _scale_levels(levels: list[float], scale: float) -> list[float]:
 
 
 @lru_cache(maxsize=None)
-def load_policyengine_social_security_cap(year: int) -> float:
+def _load_policyengine_social_security_cap_without_reform(year: int) -> float:
     sim = Microsimulation(dataset=DEFAULT_DATASET)
+    return validate_projected_social_security_cap(
+        sim.tax_benefit_system.parameters,
+        year,
+    )
+
+
+def load_policyengine_social_security_cap(year: int, *, reform=None) -> float:
+    if reform is None:
+        return _load_policyengine_social_security_cap_without_reform(year)
+    sim = Microsimulation(dataset=DEFAULT_DATASET, reform=reform)
     return validate_projected_social_security_cap(
         sim.tax_benefit_system.parameters,
         year,
@@ -1868,6 +1917,21 @@ def _zero_period_columns(
     return available_columns
 
 
+def _zero_clone_non_target_income(
+    cloned: pd.DataFrame,
+    *,
+    base_year: int,
+) -> pd.DataFrame:
+    columns = [
+        _period_column(component, base_year)
+        for component in NON_TARGET_CLONE_INCOME_COMPONENTS
+        if _period_column(component, base_year) in cloned.columns
+    ]
+    if columns:
+        cloned.loc[:, columns] = 0.0
+    return cloned
+
+
 def _target_base_total_for_row(
     row: pd.Series,
     *,
@@ -1964,6 +2028,7 @@ def _clone_tax_unit_rows_to_target(
         _period_column(component, base_year) for component in SS_COMPONENTS
     )
     qbi_col = _period_column("w2_wages_from_qualified_business", base_year)
+    cloned = _zero_clone_non_target_income(cloned, base_year=base_year)
 
     target_head_payroll = _target_base_total_for_row(
         cloned.loc[head_idx],
@@ -2351,7 +2416,10 @@ def build_donor_backed_augmented_input_dataframe(
         ss_scale=ss_scale,
         earnings_scale=earnings_scale,
     )
-    payroll_cap = load_policyengine_social_security_cap(target_year)
+    payroll_cap = load_policyengine_social_security_cap(
+        target_year,
+        reform=reform,
+    )
     candidates = generate_synthetic_candidates(
         pools,
         payroll_cap=payroll_cap,
@@ -2499,7 +2567,10 @@ def build_role_composite_augmented_input_dataframe(
         ss_scale=ss_scale,
         earnings_scale=earnings_scale,
     )
-    payroll_cap = load_policyengine_social_security_cap(target_year)
+    payroll_cap = load_policyengine_social_security_cap(
+        target_year,
+        reform=reform,
+    )
     candidates = generate_synthetic_candidates(
         pools,
         payroll_cap=payroll_cap,

--- a/policyengine_us_data/datasets/cps/long_term/run_long_term_production.py
+++ b/policyengine_us_data/datasets/cps/long_term/run_long_term_production.py
@@ -15,6 +15,10 @@ from policyengine_us_data.datasets.cps.long_term.run_household_projection_parall
     parse_years,
 )
 from policyengine_us_data.utils.data_upload import upload_to_staging_hf
+from policyengine_us_data.utils.policyengine import (
+    PolicyEngineUSBuildInfo,
+    assert_locked_policyengine_us_version,
+)
 from policyengine_us_data.utils.run_context import resolve_run_id, staging_prefix
 
 
@@ -176,6 +180,7 @@ def write_manifest(
     years: list[int],
     run_id: str,
     source_sha: str,
+    policyengine_us_build: PolicyEngineUSBuildInfo,
     artifacts: list[Path],
 ) -> Path:
     manifest_path = output_dir / "long_run_production_manifest.json"
@@ -197,6 +202,7 @@ def write_manifest(
             "policyengine-us": _package_version("policyengine-us"),
             "policyengine-core": _package_version("policyengine-core"),
         },
+        "policyengine_us": policyengine_us_build.to_metadata_dict(),
         "projection": {
             "years_spec": args.years,
             "years": years,
@@ -329,6 +335,7 @@ def main() -> int:
     source_sha = args.source_sha or os.environ.get("GITHUB_SHA", "") or _git_sha()
 
     command = build_projection_command(args, output_dir)
+    policyengine_us_build = assert_locked_policyengine_us_version()
     print("Running long-run projection command:")
     print(" ".join(command))
     subprocess.run(command, check=True)
@@ -341,6 +348,7 @@ def main() -> int:
         years=years,
         run_id=run_id,
         source_sha=source_sha,
+        policyengine_us_build=policyengine_us_build,
         artifacts=artifacts,
     )
     artifacts = collect_artifacts(output_dir, args.artifact_prefix)

--- a/policyengine_us_data/utils/policyengine.py
+++ b/policyengine_us_data/utils/policyengine.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import json
 import subprocess
 import tomllib
+import hashlib
+import importlib.util
 from dataclasses import dataclass
 from functools import lru_cache
 from importlib import metadata
+from typing import Any
 from pathlib import Path
 
 
@@ -18,24 +21,54 @@ class PolicyEngineUSBuildInfo:
     version: str
     locked_version: str | None = None
     git_commit: str | None = None
+    git_dirty: bool | None = None
+    package_file_sha256: str | None = None
+    package_tree_sha256: str | None = None
     source_path: str | None = None
 
-    def to_dict(self) -> dict[str, str]:
+    def to_dict(self) -> dict[str, Any]:
         result = {"version": self.version}
         if self.locked_version is not None:
             result["locked_version"] = self.locked_version
         if self.git_commit is not None:
             result["git_commit"] = self.git_commit
+            result["commit_id"] = self.git_commit
+            result["direct_url"] = {
+                "vcs_info": {
+                    "commit_id": self.git_commit,
+                    "vcs": "git",
+                }
+            }
+        if self.git_dirty is not None:
+            result["git_dirty"] = self.git_dirty
+        if self.package_file_sha256 is not None:
+            result["package_file_sha256"] = self.package_file_sha256
+        if self.package_tree_sha256 is not None:
+            result["package_tree_sha256"] = self.package_tree_sha256
         if self.source_path is not None:
             result["source_path"] = self.source_path
         return result
 
+    def to_metadata_dict(self) -> dict[str, Any]:
+        result = self.to_dict()
+        result.pop("source_path", None)
+        return result
+
     @classmethod
-    def from_dict(cls, data: dict[str, str]) -> "PolicyEngineUSBuildInfo":
+    def from_dict(cls, data: dict[str, Any]) -> "PolicyEngineUSBuildInfo":
+        direct_url = data.get("direct_url") or {}
+        vcs_info = direct_url.get("vcs_info") or {}
         return cls(
             version=data["version"],
             locked_version=data.get("locked_version"),
-            git_commit=data.get("git_commit"),
+            git_commit=(
+                data.get("git_commit")
+                or data.get("commit_id")
+                or vcs_info.get("commit_id")
+            ),
+            git_dirty=data.get("git_dirty"),
+            package_file_sha256=data.get("package_file_sha256"),
+            package_tree_sha256=data.get("package_tree_sha256"),
             source_path=data.get("source_path"),
         )
 
@@ -65,6 +98,58 @@ def _get_git_commit(path: Path | None) -> str | None:
         ).strip()
     except (subprocess.CalledProcessError, FileNotFoundError):
         return None
+
+
+def _get_git_dirty(path: Path | None) -> bool | None:
+    if path is None:
+        return None
+    git_root = _find_git_root(path)
+    if git_root is None:
+        return None
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(git_root), "status", "--porcelain"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    return bool(completed.stdout.strip())
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _sha256_directory(path: Path) -> str:
+    digest = hashlib.sha256()
+    for file_path in sorted(path.rglob("*")):
+        if not file_path.is_file():
+            continue
+        if "__pycache__" in file_path.parts or file_path.suffix in {".pyc", ".pyo"}:
+            continue
+        relative_path = file_path.relative_to(path).as_posix()
+        contents = file_path.read_bytes()
+        digest.update(relative_path.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(str(len(contents)).encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(contents)
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _policyengine_us_package_file() -> Path | None:
+    spec = importlib.util.find_spec("policyengine_us")
+    if spec is None or spec.origin is None:
+        return None
+    path = Path(spec.origin)
+    return path if path.exists() else None
 
 
 @lru_cache(maxsize=None)
@@ -98,11 +183,21 @@ def get_policyengine_us_build_info() -> PolicyEngineUSBuildInfo:
         except Exception:
             source_path = None
 
-    git_commit = _get_git_commit(Path(source_path)) if source_path else None
+    source = Path(source_path) if source_path else None
+    git_commit = _get_git_commit(source)
+    git_dirty = _get_git_dirty(source)
+    package_file = _policyengine_us_package_file()
     return PolicyEngineUSBuildInfo(
         version=version,
         locked_version=get_locked_dependency_version("policyengine-us"),
         git_commit=git_commit,
+        git_dirty=git_dirty,
+        package_file_sha256=(
+            _sha256_file(package_file) if package_file is not None else None
+        ),
+        package_tree_sha256=(
+            _sha256_directory(package_file.parent) if package_file is not None else None
+        ),
         source_path=source_path,
     )
 

--- a/tests/unit/test_long_term_calibration_contract.py
+++ b/tests/unit/test_long_term_calibration_contract.py
@@ -13,6 +13,9 @@ from policyengine_us_data.datasets.cps.long_term import (
     build_long_term_target_sources as target_source_builder,
     calibration as calibration_module,
 )
+from policyengine_us_data.datasets.cps.long_term import (
+    prototype_synthetic_2100_support as synthetic_support_module,
+)
 from policyengine_us_data.datasets.cps.long_term.calibration import (
     assess_nonnegative_feasibility,
     build_calibration_audit,
@@ -43,6 +46,7 @@ from policyengine_us_data.datasets.cps.long_term.projection_utils import (
     project_input_variable_values_to_person_rows,
     validate_projected_social_security_cap,
 )
+from policyengine_us_data.utils.policyengine import PolicyEngineUSBuildInfo
 from policyengine_us_data.datasets.cps.long_term.ssa_data import (
     available_long_term_target_sources,
     describe_long_term_target_source,
@@ -346,6 +350,37 @@ def test_targeted_donor_support_builder_forwards_reform(
 
     assert calls["reform"] is reform
     assert report["profile"] == profile
+
+
+def test_role_composite_dataset_passes_reform_to_input_builder(monkeypatch):
+    reform = object()
+    captured = {}
+
+    def build_input_dataframe(**kwargs):
+        captured["reform"] = kwargs.get("reform")
+        return "input-frame", {"ok": True}
+
+    monkeypatch.setattr(
+        synthetic_support_module,
+        "build_role_composite_augmented_input_dataframe",
+        build_input_dataframe,
+    )
+    monkeypatch.setattr(
+        synthetic_support_module.Dataset,
+        "from_dataframe",
+        staticmethod(lambda df, year: {"df": df, "year": year}),
+    )
+
+    dataset, report = synthetic_support_module.build_role_composite_augmented_dataset(
+        base_dataset="base.h5",
+        base_year=2024,
+        target_year=2100,
+        reform=reform,
+    )
+
+    assert captured["reform"] is reform
+    assert dataset == {"df": "input-frame", "year": 2024}
+    assert report == {"ok": True}
 
 
 def test_support_augmentation_clones_households_with_new_ids():
@@ -1128,6 +1163,55 @@ def test_manifest_updates_and_rejects_profile_mismatch(tmp_path):
     assert rebuilt["years"] == [2026, 2027]
 
 
+def test_year_metadata_and_manifest_stamp_policyengine_us_build(tmp_path):
+    profile = get_profile("ss-payroll-tob")
+    audit = {
+        "method_used": "greg",
+        "fell_back_to_ipf": False,
+        "negative_weight_pct": 0.0,
+    }
+    build_info = PolicyEngineUSBuildInfo(
+        version="1.700.0",
+        locked_version="1.700.0",
+        git_commit="abc123",
+        git_dirty=False,
+        package_file_sha256="f" * 64,
+        package_tree_sha256="t" * 64,
+    )
+    h5_path = tmp_path / "2100.h5"
+    h5_path.write_text("", encoding="utf-8")
+
+    metadata_path = write_year_metadata(
+        h5_path,
+        year=2100,
+        base_dataset_path="test.h5",
+        profile=profile.to_dict(),
+        calibration_audit=audit,
+        policyengine_us=build_info,
+    )
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+
+    assert metadata["policyengine_us"]["version"] == "1.700.0"
+    assert metadata["policyengine_us"]["locked_version"] == "1.700.0"
+    assert metadata["policyengine_us"]["commit_id"] == "abc123"
+    assert metadata["policyengine_us"]["git_dirty"] is False
+    assert metadata["policyengine_us"]["package_tree_sha256"] == "t" * 64
+
+    manifest_path = update_dataset_manifest(
+        tmp_path,
+        year=2100,
+        h5_path=h5_path,
+        metadata_path=metadata_path,
+        base_dataset_path="test.h5",
+        profile=profile.to_dict(),
+        calibration_audit=audit,
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert manifest["policyengine_us"] == metadata["policyengine_us"]
+    assert manifest["datasets"]["2100"]["policyengine_us_version"] == "1.700.0"
+
+
 def test_hard_target_tob_affects_quality_classification():
     profile = get_profile("ss-payroll-tob")
     quality = classify_calibration_quality(
@@ -1784,6 +1868,10 @@ def test_write_year_metadata_persists_runtime_and_snapshot_provenance(tmp_path):
 
     metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
     assert metadata["policyengine_us"]["git_head"] == "abc123"
+    assert metadata["policyengine_us"]["commit_id"] == "abc123"
+    assert (
+        metadata["policyengine_us"]["direct_url"]["vcs_info"]["commit_id"] == "abc123"
+    )
     assert metadata["base_dataset_snapshot"]["resolved_file_sha256"] == "deadbeef"
 
 
@@ -1843,6 +1931,10 @@ def test_update_dataset_manifest_persists_runtime_and_snapshot_provenance(tmp_pa
 
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert manifest["policyengine_us"]["git_head"] == "abc123"
+    assert manifest["policyengine_us"]["commit_id"] == "abc123"
+    assert (
+        manifest["policyengine_us"]["direct_url"]["vcs_info"]["commit_id"] == "abc123"
+    )
     assert manifest["base_dataset_snapshot"]["resolved_file_sha256"] == "deadbeef"
 
 
@@ -1858,12 +1950,14 @@ def test_capture_base_dataset_snapshot_fingerprints_local_file(tmp_path):
     assert snapshot["resolved_size"] == dataset_file.stat().st_size
 
 
-def test_capture_policyengine_us_provenance_includes_runtime_file():
+def test_capture_policyengine_us_provenance_uses_managed_build_schema():
     provenance = capture_policyengine_us_provenance()
 
-    assert provenance["package_file"]
     assert provenance["package_file_sha256"]
+    assert provenance["package_tree_sha256"]
     assert provenance["version"]
+    assert "source_path" not in provenance
+    assert "package_file" not in provenance
 
 
 def test_update_dataset_manifest_ignores_tax_assumption_end_year(tmp_path):
@@ -2350,6 +2444,8 @@ def test_compose_role_donor_rows_falls_back_for_missing_dependents():
     enriched = df.copy()
     enriched["__pe_payroll_uprating_factor"] = 2.0
     enriched["__pe_ss_uprating_factor"] = 3.0
+    enriched["partnership_s_corp_income__2024"] = 1_000_000.0
+    enriched["taxable_interest_income__2024"] = 500_000.0
 
     older_rows = enriched[enriched["person_tax_unit_id__2024"] == 201].copy()
     worker_rows = enriched[enriched["person_tax_unit_id__2024"] == 301].copy()


### PR DESCRIPTION
## Summary
- stamp exact policyengine-us build metadata into long-run H5 sidecars and aggregate manifests
- fail manual long-run production when the installed policyengine-us version differs from uv.lock
- preserve reform-aware support generation while recording/supporting the non-target-income sanitizer controls used by CRFB late-year support runs

## Validation
- `uv run --locked pytest tests/unit/test_long_term_calibration_contract.py -q` (68 passed)
- `uv run --locked ruff check policyengine_us_data/utils/policyengine.py policyengine_us_data/datasets/cps/long_term/calibration_artifacts.py policyengine_us_data/datasets/cps/long_term/run_long_term_production.py policyengine_us_data/datasets/cps/long_term/prototype_synthetic_2100_support.py policyengine_us_data/datasets/cps/long_term/support_augmentation.py policyengine_us_data/datasets/cps/long_term/run_household_projection.py tests/unit/test_long_term_calibration_contract.py`
- `uv run --no-sync --with pyyaml python scripts/run_quality_guards.py`
- `git diff --check`

## Notes
This PR does not run the expensive production rebuild. It makes the rebuild auditable and rejects stale or mixed policyengine-us builds before production starts.