### PR TITLE
Fix extended CPS export contract

### DIFF
--- a/changelog.d/998.fixed.md
+++ b/changelog.d/998.fixed.md
@@ -1,0 +1,1 @@
+Fix Extended CPS export validation by dropping recomputable computed outputs before writing the dataset.

--- a/policyengine_us_data/datasets/cps/extended_cps.py
+++ b/policyengine_us_data/datasets/cps/extended_cps.py
@@ -680,6 +680,12 @@ _HOUSING_ASSISTANCE_FORMULA_OUTPUTS = {
     "housing_assistance",
     "spm_unit_capped_housing_subsidy",
 }
+_FINAL_COMPUTED_OUTPUTS_TO_DROP = {
+    "dividend_income",
+    "interest_income",
+    "rent",
+    "spm_unit_capped_work_childcare_expenses",
+}
 _MIN_MODELED_HOUSING_SHARE_OF_BENCHMARK = 0.01
 
 
@@ -970,6 +976,7 @@ class ExtendedCPS(Dataset):
                 self.time_period,
                 had_positive_mortgage_input,
             )
+        new_data = self._drop_final_computed_outputs(new_data)
         new_data = self._assert_no_computed_variables_exported(
             new_data,
             self.time_period,
@@ -1416,6 +1423,14 @@ class ExtendedCPS(Dataset):
         """Remove housing assistance formula outputs after validation."""
 
         for variable in sorted(set(data) & _HOUSING_ASSISTANCE_FORMULA_OUTPUTS):
+            del data[variable]
+        return data
+
+    @classmethod
+    def _drop_final_computed_outputs(cls, data):
+        """Remove final aggregates that policyengine-us recomputes from leaves."""
+
+        for variable in sorted(set(data) & _FINAL_COMPUTED_OUTPUTS_TO_DROP):
             del data[variable]
         return data
 

--- a/policyengine_us_data/utils/dataset_validation.py
+++ b/policyengine_us_data/utils/dataset_validation.py
@@ -22,9 +22,17 @@ ENTITY_ID_VARIABLES = {
     "household": "household_id",
 }
 
-# policyengine-us defines a fallback formula for person_id, but persisted
-# datasets need stable person IDs for entity links and downstream joins.
-STRUCTURAL_COMPUTED_EXPORT_VARIABLES = frozenset({"person_id"})
+# policyengine-us defines fallback or derivation formulas for these variables,
+# but persisted datasets intentionally carry them as stable structural/cache
+# fields for entity links, immigration identification, and geography joins.
+STRUCTURAL_COMPUTED_EXPORT_VARIABLES = frozenset(
+    {
+        "person_id",
+        "has_tin",
+        "has_itin",
+        "in_nyc",
+    }
+)
 
 AUXILIARY_ENTITY_PREFIXES = {
     "person_": "person",

--- a/tests/unit/test_extended_cps.py
+++ b/tests/unit/test_extended_cps.py
@@ -213,6 +213,57 @@ class TestVariableListConsistency:
         with pytest.raises(DatasetContractError, match="social_security"):
             ExtendedCPS._assert_no_computed_variables_exported(data, 2024)
 
+    def test_final_export_contract_allows_structural_cache_variables(self):
+        data = {
+            "person_id": {2024: np.array([1])},
+            "has_tin": {2024: np.array([True])},
+            "has_itin": {2024: np.array([True])},
+            "in_nyc": {2024: np.array([False])},
+        }
+
+        ExtendedCPS._assert_no_computed_variables_exported(data, 2024)
+
+    def test_drop_final_computed_outputs_keeps_leaf_inputs(self):
+        data = {
+            "interest_income": {2024: np.array([100.0])},
+            "taxable_interest_income": {2024: np.array([80.0])},
+            "tax_exempt_interest_income": {2024: np.array([20.0])},
+            "dividend_income": {2024: np.array([50.0])},
+            "qualified_dividend_income": {2024: np.array([30.0])},
+            "non_qualified_dividend_income": {2024: np.array([20.0])},
+            "rent": {2024: np.array([1_000.0])},
+            "pre_subsidy_rent": {2024: np.array([1_000.0])},
+            "spm_unit_capped_work_childcare_expenses": {2024: np.array([500.0])},
+            "spm_unit_pre_subsidy_childcare_expenses": {2024: np.array([600.0])},
+            "has_tin": {2024: np.array([True])},
+            "has_itin": {2024: np.array([True])},
+            "in_nyc": {2024: np.array([False])},
+        }
+
+        result = ExtendedCPS._drop_final_computed_outputs(data)
+
+        for variable in (
+            "interest_income",
+            "dividend_income",
+            "rent",
+            "spm_unit_capped_work_childcare_expenses",
+        ):
+            assert variable not in result
+        for variable in (
+            "taxable_interest_income",
+            "tax_exempt_interest_income",
+            "qualified_dividend_income",
+            "non_qualified_dividend_income",
+            "pre_subsidy_rent",
+            "spm_unit_pre_subsidy_childcare_expenses",
+            "has_tin",
+            "has_itin",
+            "in_nyc",
+        ):
+            assert variable in result
+
+        ExtendedCPS._assert_no_computed_variables_exported(result, 2024)
+
     def test_drop_puf_computed_intermediates_after_clone(self):
         data = {
             "cdcc_relevant_expenses": {2024: np.array([1_000.0])},


### PR DESCRIPTION
## Summary

This draft fixes the Modal data-build failure in `policyengine_us_data.datasets.cps.extended_cps` by aligning the final Extended CPS export with the current policyengine-us computed-variable contract.

Changes:
- drop final aggregate/formula outputs that policyengine-us can recompute from persisted leaf inputs:
  - `interest_income`
  - `dividend_income`
  - `rent`
  - `spm_unit_capped_work_childcare_expenses`
- allow intentional structural/cache fields through the export contract:
  - `person_id`
  - `has_tin`
  - `has_itin`
  - `in_nyc`
- add unit coverage for both the dropped aggregate outputs and the allowed cache variables.

## Issue for follow-up agents

GitHub Actions showed green because the `Run Pipeline` workflow only deploys/spawns Modal and exits. The actual data build failed asynchronously in Modal later.

Observed failing run:
- GitHub run: https://github.com/PolicyEngine/policyengine-us-data/actions/runs/26004188441
- Modal app: `us-data-1-115-2-minor-usdata-gha26004180733-a1`
- Modal run ID: `usdata-gha26004180733-a1`
- Source SHA: `52327d6ffbacae6e9da6c026e8b9c00eef2fbe8d`
- Candidate scope: `1.115.2-minor`
- Intended HF staging prefix: `staging/1.115.2-minor-usdata-gha26004180733-a1`
- Failed stage: `1_build_datasets`
- Failed command: `python -u -m policyengine_us_data.datasets.cps.extended_cps`
- Failure time: `2026-05-17T23:48:06Z`

The Modal status payload reported only a wrapper `CalledProcessError`, but a local half-sample reproduction exposed the underlying exception:

```text
DatasetContractError: extended_cps_2024_half exports policyengine-us computed variables for 2024: dividend_income, has_itin, has_tin, in_nyc, interest_income, rent, spm_unit_capped_work_childcare_expenses.
```

The failed Modal run had already built `policy_data.db`, `cps_2024.h5`, `puf_2024.h5`, `acs_2022.h5`, `irs_puf_2015.h5`, and `uprating_factors.csv`. The checkpointed `policy_data.db` did include the new NIPA targets from PR #994:

- `employment_income_before_lsr = 12,387,929,000,000`
- `total_self_employment_income+farm_operations_income+partnership_s_corp_income = 2,023,080,000,000`

So this PR is fixing the later Extended CPS export-contract blocker, not the target insertion.

Note: the same async Modal stage also failed on an earlier post-#995 run before PR #994, so this is not caused by the NIPA target change.

## Validation

Passed locally on the clean PR worktree:

```bash
ruff format --check policyengine_us_data/datasets/cps/extended_cps.py policyengine_us_data/utils/dataset_validation.py tests/unit/test_extended_cps.py
ruff check policyengine_us_data/datasets/cps/extended_cps.py policyengine_us_data/utils/dataset_validation.py tests/unit/test_extended_cps.py
uv run pytest tests/unit/test_extended_cps.py tests/unit/test_etl_national_targets.py tests/unit/db/test_validate_database.py -q
```

Focused pytest result: `72 passed, 1 warning in 110.04s`.

The half-sample generation that reproduced the original export-contract failure now exits successfully:

```bash
uv run python - <<'PY'
from policyengine_us_data.datasets.cps.extended_cps import ExtendedCPS_2024_Half
ExtendedCPS_2024_Half().generate()
PY
```

## Remaining verification

Before marking ready, rerun or resume the Modal pipeline once this lands, since GitHub Actions will not by itself prove the async Modal build completed.
