### PR TITLE
Update PolicyEngine US dependency and long-run support gating

### DIFF
--- a/.github/workflows/long_run_projection.yaml
+++ b/.github/workflows/long_run_projection.yaml
@@ -269,6 +269,6 @@ jobs:
             echo "- Tax assumption: \`${TAX_ASSUMPTION}\`"
             echo "- HF staging upload: \`${UPLOAD_TO_HF_STAGING}\`"
             if [ "${UPLOAD_TO_HF_STAGING}" = "true" ]; then
-              echo "- HF staging prefix: \`staging/${CHECKED_OUT_SHA}/${RUN_ID}/long_term/\`"
+              echo "- HF staging prefix: \`staging/${CHECKED_OUT_SHA}-${RUN_ID}/long_term/\`"
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/changelog.d/999.fixed.md
+++ b/changelog.d/999.fixed.md
@@ -1,0 +1,2 @@
+Update the pinned PolicyEngine US dependency and allow long-run production builds
+to mix pre- and post-support-augmentation years.

--- a/policyengine_us_data/datasets/cps/long_term/README.md
+++ b/policyengine_us_data/datasets/cps/long_term/README.md
@@ -74,7 +74,7 @@ python run_long_term_production.py \
 - `.github/workflows/long_run_projection.yaml` is `workflow_dispatch` only. It does not run on pull requests, normal merges, or the standard `push.yaml` publication path.
 - The workflow calls `run_long_term_production.py`, which wraps the parallel runner, writes `long_run_production_manifest.json`, and preserves per-year logs with the run metadata.
 - The default year set builds the 10-year budget window plus 5-year sampled points through `2100`; override `years` for full annual builds or narrower diagnostics.
-- Hugging Face upload is disabled by default. Set `upload_to_hf_staging=true` only for a candidate run that should publish generated H5s and metadata under `staging/{source_sha}/{run_id}/long_term/`.
+- Hugging Face upload is disabled by default. Set `upload_to_hf_staging=true` only for a candidate run that should publish generated H5s and metadata under `staging/{source_sha}-{run_id}/long_term/`.
 - Late-year support augmentation remains an explicit input. The workflow exposes the donor-backed controls, but it does not silently enable experimental support profiles.
 
 **Named profiles:**

--- a/policyengine_us_data/datasets/cps/long_term/run_household_projection.py
+++ b/policyengine_us_data/datasets/cps/long_term/run_household_projection.py
@@ -691,11 +691,23 @@ if SUPPORT_AUGMENTATION_PROFILE is not None:
             "Support-augmentation non-target income sanitization is only "
             "supported with donor-backed-composite-v1."
         )
-    if START_YEAR < SUPPORT_AUGMENTATION_START_YEAR:
-        raise ValueError(
-            "Support augmentation is only supported for late-year runs. "
-            f"Received START_YEAR={START_YEAR}, requires >= "
+    if END_YEAR < SUPPORT_AUGMENTATION_START_YEAR:
+        print(
+            "Support augmentation requested but disabled for this pre-activation "
+            f"run ({START_YEAR}-{END_YEAR}); activation starts in "
             f"{SUPPORT_AUGMENTATION_START_YEAR}."
+        )
+        SUPPORT_AUGMENTATION_PROFILE = None
+    elif (
+        START_YEAR < SUPPORT_AUGMENTATION_START_YEAR
+        and not SUPPORT_AUGMENTATION_ALIGN_TO_RUN_YEAR
+    ):
+        raise ValueError(
+            "Static support augmentation cannot span both pre-activation and "
+            "late-year runs in a single process. Use the parallel production "
+            "runner, split the run, or pass --support-augmentation-align-to-run-year. "
+            f"Received START_YEAR={START_YEAR}, END_YEAR={END_YEAR}, activation "
+            f"starts in {SUPPORT_AUGMENTATION_START_YEAR}."
         )
 
 legacy_flags_used = any([USE_GREG, USE_SS, USE_PAYROLL, USE_H6_REFORM, USE_TOB])

--- a/policyengine_us_data/datasets/cps/long_term/run_household_projection_parallel.py
+++ b/policyengine_us_data/datasets/cps/long_term/run_household_projection_parallel.py
@@ -16,6 +16,22 @@ except ImportError:  # pragma: no cover - script execution fallback
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 RUNNER_PATH = SCRIPT_DIR / "run_household_projection.py"
+DEFAULT_SUPPORT_AUGMENTATION_START_YEAR = 2075
+SUPPORT_AUGMENTATION_VALUE_FLAGS = {
+    "--support-augmentation-profile",
+    "--support-augmentation-target-year",
+    "--support-augmentation-start-year",
+    "--support-augmentation-top-n-targets",
+    "--support-augmentation-donors-per-target",
+    "--support-augmentation-max-distance",
+    "--support-augmentation-clone-weight-scale",
+    "--support-augmentation-blueprint-base-weight-scale",
+}
+SUPPORT_AUGMENTATION_BOOLEAN_FLAGS = {
+    "--support-augmentation-align-to-run-year",
+    "--support-augmentation-sanitize-worker-non-target-income",
+    "--support-augmentation-sanitize-clone-non-target-income",
+}
 
 
 def parse_years(spec: str) -> list[int]:
@@ -81,6 +97,53 @@ def validate_forwarded_args(forwarded_args: list[str]) -> None:
             )
 
 
+def _option_value(args: list[str], flag: str) -> str | None:
+    if flag not in args:
+        return None
+    index = args.index(flag)
+    if index + 1 >= len(args):
+        raise ValueError(f"{flag} requires a value")
+    return args[index + 1]
+
+
+def _has_support_augmentation_profile(args: list[str]) -> bool:
+    return "--support-augmentation-profile" in args
+
+
+def _support_augmentation_start_year(args: list[str]) -> int:
+    raw_value = _option_value(args, "--support-augmentation-start-year")
+    if raw_value is None:
+        return DEFAULT_SUPPORT_AUGMENTATION_START_YEAR
+    return int(raw_value)
+
+
+def _strip_support_augmentation_args(args: list[str]) -> list[str]:
+    stripped: list[str] = []
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg in SUPPORT_AUGMENTATION_VALUE_FLAGS:
+            if index + 1 >= len(args):
+                raise ValueError(f"{arg} requires a value")
+            index += 2
+            continue
+        if arg in SUPPORT_AUGMENTATION_BOOLEAN_FLAGS:
+            index += 1
+            continue
+        stripped.append(arg)
+        index += 1
+    return stripped
+
+
+def forwarded_args_for_year(year: int, forwarded_args: list[str]) -> list[str]:
+    """Return runner args with late-year support disabled before activation."""
+    if not _has_support_augmentation_profile(forwarded_args):
+        return list(forwarded_args)
+    if year >= _support_augmentation_start_year(forwarded_args):
+        return list(forwarded_args)
+    return _strip_support_augmentation_args(forwarded_args)
+
+
 def year_output_dir(root: Path, year: int) -> Path:
     return root / ".parallel_tmp" / str(year)
 
@@ -123,7 +186,7 @@ def run_year(
         "--output-dir",
         str(output_dir),
         "--save-h5",
-        *forwarded_args,
+        *forwarded_args_for_year(year, forwarded_args),
     ]
 
     with log_path.open("w", encoding="utf-8") as log_file:
@@ -168,6 +231,44 @@ def _json_clone(value):
     return json.loads(json.dumps(value))
 
 
+def _normalize_support_augmentation_contract(value):
+    if value is None:
+        return None
+    normalized = _json_clone(value)
+    if normalized.get("target_year_strategy") == "run_year":
+        normalized.pop("target_year", None)
+    normalized.pop("report_file", None)
+    normalized.pop("report_summary", None)
+    return normalized
+
+
+def _support_augmentation_activation_start(value) -> int | None:
+    if not isinstance(value, dict):
+        return None
+    raw_value = value.get("activation_start_year")
+    if raw_value is None:
+        return None
+    return int(raw_value)
+
+
+def support_augmentation_contracts_compatible(left, right, *, year: int) -> bool:
+    if _normalize_support_augmentation_contract(
+        left
+    ) == _normalize_support_augmentation_contract(right):
+        return True
+    if left is None and right is not None:
+        activation_year = _support_augmentation_activation_start(right)
+        return activation_year is not None and year >= activation_year
+    if left is not None and right is None:
+        activation_year = _support_augmentation_activation_start(left)
+        return activation_year is not None and year < activation_year
+    return False
+
+
+def merge_support_augmentation_contract(left, right):
+    return _json_clone(left if left is not None else right)
+
+
 def manifest_contract(manifest: dict) -> dict:
     tax_assumption = _json_clone(manifest.get("tax_assumption"))
     if isinstance(tax_assumption, dict):
@@ -209,6 +310,22 @@ def merge_outputs(
             manifest_seed = temp_contract
         else:
             for key, value in manifest_seed.items():
+                if key == "support_augmentation":
+                    support_augmentation = temp_contract.get(key)
+                    if not support_augmentation_contracts_compatible(
+                        value,
+                        support_augmentation,
+                        year=year,
+                    ):
+                        raise ValueError(
+                            f"Temp manifest mismatch for {key} in year {year}: "
+                            f"{support_augmentation} != {value}"
+                        )
+                    manifest_seed[key] = merge_support_augmentation_contract(
+                        value,
+                        support_augmentation,
+                    )
+                    continue
                 if temp_contract.get(key) != value:
                     raise ValueError(
                         f"Temp manifest mismatch for {key} in year {year}: "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us==1.693.2",
+    "policyengine-us==1.693.4",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/tests/unit/test_long_term_calibration_contract.py
+++ b/tests/unit/test_long_term_calibration_contract.py
@@ -79,6 +79,7 @@ from policyengine_us_data.datasets.cps.long_term.prototype_synthetic_2100_suppor
     summarize_realized_clone_translation,
 )
 from policyengine_us_data.datasets.cps.long_term.run_household_projection_parallel import (
+    forwarded_args_for_year,
     merge_outputs,
     parse_years,
     run_year,
@@ -2124,6 +2125,34 @@ def test_parallel_projection_validate_forwarded_args_rejects_wrapper_flags():
         validate_forwarded_args(["--save-h5"])
 
 
+def test_parallel_projection_strips_support_augmentation_before_activation_year():
+    forwarded_args = [
+        "--profile",
+        "ss-payroll-tob",
+        "--target-source",
+        "trustees_2025_current_law",
+        "--support-augmentation-profile",
+        "donor-backed-composite-v1",
+        "--support-augmentation-target-year",
+        "2100",
+        "--support-augmentation-start-year",
+        "2075",
+        "--support-augmentation-blueprint-base-weight-scale",
+        "5.0",
+        "--support-augmentation-sanitize-clone-non-target-income",
+    ]
+
+    early_args = forwarded_args_for_year(2026, forwarded_args)
+    late_args = forwarded_args_for_year(2075, forwarded_args)
+
+    assert "--profile" in early_args
+    assert "--target-source" in early_args
+    assert "--support-augmentation-profile" not in early_args
+    assert "--support-augmentation-target-year" not in early_args
+    assert "--support-augmentation-sanitize-clone-non-target-income" not in early_args
+    assert late_args == forwarded_args
+
+
 def _write_parallel_temp_year(
     *,
     root,
@@ -2219,6 +2248,190 @@ def test_parallel_projection_merge_outputs_rebuilds_manifest(tmp_path):
     assert (tmp_path / "2045.h5").exists()
     assert (tmp_path / "2049.h5.metadata.json").exists()
     assert not (tmp_path / ".parallel_tmp").exists()
+
+
+def test_parallel_projection_merge_outputs_allows_support_activation_window(tmp_path):
+    profile = get_profile("ss-payroll-tob").to_dict()
+    audit = {
+        "method_used": "entropy",
+        "fell_back_to_ipf": False,
+        "age_max_pct_error": 0.0,
+        "negative_weight_pct": 0.0,
+        "positive_weight_count": 70000,
+        "effective_sample_size": 5000.0,
+        "top_10_weight_share_pct": 1.5,
+        "top_100_weight_share_pct": 10.0,
+        "max_constraint_pct_error": 0.0,
+        "constraints": {},
+        "validation_passed": True,
+        "validation_issues": [],
+        "calibration_quality": "exact",
+    }
+    tax_assumption = {
+        "name": "trustees-2025-core-thresholds-v1",
+        "start_year": 2035,
+        "end_year": 2100,
+    }
+    support_augmentation = {
+        "name": "donor-backed-composite-v1",
+        "family": "targeted_donor",
+        "activation_start_year": 2075,
+        "target_year": 2100,
+        "target_year_strategy": "fixed",
+        "report_file": "support_augmentation_report.json",
+        "report_summary": {"clone_household_count": 10},
+    }
+
+    _write_parallel_temp_year(
+        root=tmp_path,
+        year=2026,
+        profile=profile,
+        audit=audit,
+        tax_assumption=tax_assumption,
+    )
+    _write_parallel_temp_year(
+        root=tmp_path,
+        year=2075,
+        profile=profile,
+        audit=audit,
+        tax_assumption=tax_assumption,
+        support_augmentation=support_augmentation,
+    )
+
+    manifest_path = merge_outputs(
+        years=[2026, 2075],
+        output_root=tmp_path,
+        keep_temp=True,
+    )
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["years"] == [2026, 2075]
+    assert manifest["support_augmentation"]["name"] == "donor-backed-composite-v1"
+    early_metadata = json.loads(
+        (tmp_path / "2026.h5.metadata.json").read_text(encoding="utf-8")
+    )
+    late_metadata = json.loads(
+        (tmp_path / "2075.h5.metadata.json").read_text(encoding="utf-8")
+    )
+    assert "support_augmentation" not in early_metadata
+    assert late_metadata["support_augmentation"]["activation_start_year"] == 2075
+
+
+def test_parallel_projection_merge_outputs_rejects_different_fixed_support_targets(
+    tmp_path,
+):
+    profile = get_profile("ss-payroll-tob").to_dict()
+    audit = {
+        "method_used": "entropy",
+        "fell_back_to_ipf": False,
+        "age_max_pct_error": 0.0,
+        "negative_weight_pct": 0.0,
+        "positive_weight_count": 70000,
+        "effective_sample_size": 5000.0,
+        "top_10_weight_share_pct": 1.5,
+        "top_100_weight_share_pct": 10.0,
+        "max_constraint_pct_error": 0.0,
+        "constraints": {},
+        "validation_passed": True,
+        "validation_issues": [],
+        "calibration_quality": "exact",
+    }
+    base_support = {
+        "name": "donor-backed-composite-v1",
+        "family": "targeted_donor",
+        "activation_start_year": 2075,
+        "target_year": 2100,
+        "target_year_strategy": "fixed",
+        "report_file": "support_augmentation_report.json",
+        "report_summary": {"clone_household_count": 10},
+    }
+    different_support = dict(base_support, target_year=2090)
+
+    _write_parallel_temp_year(
+        root=tmp_path,
+        year=2075,
+        profile=profile,
+        audit=audit,
+        support_augmentation=base_support,
+    )
+    _write_parallel_temp_year(
+        root=tmp_path,
+        year=2080,
+        profile=profile,
+        audit=audit,
+        support_augmentation=different_support,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Temp manifest mismatch for support_augmentation",
+    ):
+        merge_outputs(
+            years=[2075, 2080],
+            output_root=tmp_path,
+            keep_temp=True,
+        )
+
+
+def test_parallel_projection_merge_outputs_allows_dynamic_support_target_years(
+    tmp_path,
+):
+    profile = get_profile("ss-payroll-tob").to_dict()
+    audit = {
+        "method_used": "entropy",
+        "fell_back_to_ipf": False,
+        "age_max_pct_error": 0.0,
+        "negative_weight_pct": 0.0,
+        "positive_weight_count": 70000,
+        "effective_sample_size": 5000.0,
+        "top_10_weight_share_pct": 1.5,
+        "top_100_weight_share_pct": 10.0,
+        "max_constraint_pct_error": 0.0,
+        "constraints": {},
+        "validation_passed": True,
+        "validation_issues": [],
+        "calibration_quality": "exact",
+    }
+    support_2075 = {
+        "name": "donor-backed-composite-v1",
+        "family": "targeted_donor",
+        "activation_start_year": 2075,
+        "target_year": 2075,
+        "target_year_strategy": "run_year",
+        "report_file": "support_augmentation_report_2075.json",
+        "report_summary": {"clone_household_count": 10},
+    }
+    support_2080 = dict(
+        support_2075,
+        target_year=2080,
+        report_file="support_augmentation_report_2080.json",
+        report_summary={"clone_household_count": 12},
+    )
+
+    _write_parallel_temp_year(
+        root=tmp_path,
+        year=2075,
+        profile=profile,
+        audit=audit,
+        support_augmentation=support_2075,
+    )
+    _write_parallel_temp_year(
+        root=tmp_path,
+        year=2080,
+        profile=profile,
+        audit=audit,
+        support_augmentation=support_2080,
+    )
+
+    manifest_path = merge_outputs(
+        years=[2075, 2080],
+        output_root=tmp_path,
+        keep_temp=True,
+    )
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["years"] == [2075, 2080]
+    assert manifest["support_augmentation"]["target_year_strategy"] == "run_year"
 
 
 def test_parallel_projection_run_year_skips_existing_complete_temp_output(

--- a/uv.lock
+++ b/uv.lock
@@ -2122,7 +2122,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.693.2"
+version = "1.693.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2132,9 +2132,9 @@ dependencies = [
     { name = "tables" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/7f/a1a4c6cde0243aec8d511db3f2ae8e2fe2ff89c00328396d6198501492a0/policyengine_us-1.693.2.tar.gz", hash = "sha256:7c2fe96189a6678724add6efb5bacbd2f58f713a40564558862d2b2a25d8842f", size = 9760480, upload-time = "2026-05-18T00:35:56.503Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/94/9091420d0b522f1de5f12ddd5e46648d425fe9369ac6ccc6441abd80f27e/policyengine_us-1.693.4.tar.gz", hash = "sha256:1980b0e4bc2ba307ae544181b6b32ac9b769ceb64f4378ed23f7788443aa752c", size = 9762870, upload-time = "2026-05-18T02:16:25.348Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/67/83f6ffaff987b221e38976d6e9ebfcb9c7f0f096e256d82430ea7f433d8b/policyengine_us-1.693.2-py3-none-any.whl", hash = "sha256:880dab89b87bfef10682cdabcd0092027b33709f7175299a7e1883eed9854bab", size = 10299358, upload-time = "2026-05-18T00:35:53.094Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/02/f2378dd108e96abf0a5e2323c6beef256fb99c2e9fb45192063f7328eddd/policyengine_us-1.693.4-py3-none-any.whl", hash = "sha256:fd9c702644c266df93fde1b9d679ab5f8877feac81b0338e307f919054f05030", size = 10302695, upload-time = "2026-05-18T02:16:21.583Z" },
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", specifier = "==1.693.2" },
+    { name = "policyengine-us", specifier = "==1.693.4" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },


### PR DESCRIPTION
## Summary
- update the pinned `policyengine-us` dependency to `1.693.4`
- let parallel long-run production builds strip support-augmentation flags before the activation year, so one run can cover 2026-2100 while only applying donor-composite support in late years
- allow the merged calibration manifest to combine pre-activation no-support sidecars with post-activation support sidecars under one top-level support contract
- fix the long-run workflow summary/README to show the actual HF staging prefix shape

## Tests
- `uv run --locked pytest tests/unit/test_long_term_calibration_contract.py -q`
- `uv run --locked ruff check policyengine_us_data/datasets/cps/long_term/run_household_projection_parallel.py policyengine_us_data/datasets/cps/long_term/run_household_projection.py tests/unit/test_long_term_calibration_contract.py`
- `uv run --locked ruff format --check policyengine_us_data/datasets/cps/long_term/run_household_projection_parallel.py policyengine_us_data/datasets/cps/long_term/run_household_projection.py tests/unit/test_long_term_calibration_contract.py`
- `git diff --check`
- `uv run python .github/scripts/check_policyengine_us_dependency.py --mode fail`
