### PR TITLE
Align Stage 1 validation contracts

### DIFF
--- a/changelog.d/1003.fixed.md
+++ b/changelog.d/1003.fixed.md
@@ -1,0 +1,1 @@
+Align Stage 1 validators with the central dataset export and calibration target contracts.

--- a/validation/stage_1/test_no_formula_variables_stored.py
+++ b/validation/stage_1/test_no_formula_variables_stored.py
@@ -13,13 +13,15 @@ import h5py
 import numpy as np
 import pytest
 from policyengine_us_data.datasets.cps.extended_cps import ExtendedCPS_2024
+from policyengine_us_data.utils.dataset_validation import (
+    STRUCTURAL_COMPUTED_EXPORT_VARIABLES,
+)
 
 KNOWN_FORMULA_EXCEPTIONS = {
-    "person_id",
     "interest_deduction",
     "self_employed_health_insurance_ald",
     "self_employed_pension_contribution_ald",
-}
+} | STRUCTURAL_COMPUTED_EXPORT_VARIABLES
 
 
 @pytest.fixture(scope="module")

--- a/validation/stage_1/test_policy_data_db.py
+++ b/validation/stage_1/test_policy_data_db.py
@@ -3,6 +3,7 @@
 import sqlite3
 
 import pytest
+from policyengine_us_data.utils.target_variables import target_variable_is_valid
 
 from policyengine_us_data.storage import STORAGE_FOLDER
 
@@ -322,14 +323,16 @@ def test_congressional_district_strata(built_db):
 
 
 def test_all_target_variables_exist_in_policyengine(built_db):
-    """Every target variable must be a valid policyengine-us variable."""
+    """Every target variable/expression must use policyengine-us variables."""
     from policyengine_us.system import system
 
     conn = sqlite3.connect(str(built_db))
     variables = {r[0] for r in conn.execute("SELECT DISTINCT variable FROM targets")}
     conn.close()
 
-    missing = [v for v in variables if v not in system.variables]
+    missing = sorted(
+        v for v in variables if not target_variable_is_valid(v, system.variables)
+    )
     assert not missing, f"Target variables not in policyengine-us: {missing}"
 
 


### PR DESCRIPTION
## Summary
- Reuse the central structural computed export allowlist in the Stage 1 no-formula-variable validator
- Validate additive calibration target expressions by their PolicyEngine component variables

## Context
The current housing-assistance data run `usdata-gha26011712365-a1` failed Stage 1 validation because these two Stage 1 tests lagged the build-time contracts already used elsewhere in the repo.

## Tests
- `uv run pytest tests/unit/db/test_validate_database.py -q`
- `uv run pytest tests/unit/test_extended_cps.py::TestVariableListConsistency::test_final_export_contract_allows_structural_cache_variables tests/unit/test_extended_cps.py::TestVariableListConsistency::test_drop_final_computed_outputs_keeps_leaf_inputs -q`
- `uv run pytest validation/stage_1/test_no_formula_variables_stored.py::test_no_formula_variables_stored -q` (skips locally without Extended CPS artifact)
- `uv run pytest validation/stage_1/test_policy_data_db.py::test_all_target_variables_exist_in_policyengine -q` (skips locally without policy_data.db artifact)
- `uv run ruff check validation/stage_1/test_no_formula_variables_stored.py validation/stage_1/test_policy_data_db.py`
- `uv run ruff format --check validation/stage_1/test_no_formula_variables_stored.py validation/stage_1/test_policy_data_db.py`
- `git diff --check`