### PR TITLE
Add housing assistance count calibration targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ database:
 	python -m policyengine_us_data.db.etl_age --year $(YEAR)
 	python -m policyengine_us_data.db.etl_medicaid --year $(YEAR)
 	python -m policyengine_us_data.db.etl_snap --year $(YEAR)
+	python -m policyengine_us_data.db.etl_housing_assistance --year $(YEAR)
 	python -m policyengine_us_data.db.etl_tanf --year $(YEAR)
 	python -m policyengine_us_data.db.etl_state_income_tax --year $(YEAR)
 	python -m policyengine_us_data.db.etl_irs_soi --year $(YEAR)

--- a/changelog.d/housing-assistance-admin-targets.added.md
+++ b/changelog.d/housing-assistance-admin-targets.added.md
@@ -1,0 +1,1 @@
+Add HUD Picture of Subsidized Households assisted-household count targets for housing assistance calibration.

--- a/policyengine_us_data/calibration/target_config.yaml
+++ b/policyengine_us_data/calibration/target_config.yaml
@@ -51,6 +51,9 @@ include:
   - variable: household_count
     geo_level: state
     domain_variable: snap
+  - variable: household_count
+    geo_level: state
+    domain_variable: housing_assistance
   - variable: tanf
     geo_level: state
   - variable: adjusted_gross_income
@@ -199,6 +202,9 @@ include:
   - variable: household_count
     geo_level: national
     domain_variable: spm_unit_energy_subsidy_reported
+  - variable: household_count
+    geo_level: national
+    domain_variable: housing_assistance
   - variable: tip_income
     geo_level: national
   - variable: unemployment_compensation

--- a/policyengine_us_data/calibration/unified_matrix_builder.py
+++ b/policyengine_us_data/calibration/unified_matrix_builder.py
@@ -50,6 +50,7 @@ _GEO_VARS = {
 
 COUNTY_DEPENDENT_VARS = {
     "aca_ptc",
+    "housing_assistance",
 }
 
 
@@ -1316,6 +1317,10 @@ def _process_single_clone(
             ent_hh_ids = household_ids[ent_hh]
             ent_ci = np.full(n_ent, clone_idx, dtype=np.int64)
 
+            eligible_mask = None
+            if takeup_var == "takes_up_housing_assistance_if_eligible":
+                eligible_mask = ent_eligible > 0
+
             ent_takeup = compute_block_takeup_for_entities(
                 takeup_var,
                 precomputed_rates[info["rate_key"]],
@@ -1323,6 +1328,7 @@ def _process_single_clone(
                 ent_hh_ids,
                 ent_ci,
                 reported_mask=reported_takeup_anchors.get(takeup_var),
+                eligible_mask=eligible_mask,
             )
 
             ent_values = (ent_eligible * ent_takeup).astype(np.float32)
@@ -1548,7 +1554,7 @@ class UnifiedMatrixBuilder:
         # Identify takeup-affected targets before the state loop
         affected_targets = {}
         if rerandomize_takeup:
-            for tvar in target_vars:
+            for tvar in target_vars | constraint_vars:
                 for key, info in TAKEUP_AFFECTED_TARGETS.items():
                     if tvar == key or tvar.startswith(key):
                         affected_targets[tvar] = info
@@ -2672,8 +2678,15 @@ class UnifiedMatrixBuilder:
             for _, row in targets_df.iterrows()
             if int(row.get("reform_id", 0)) > 0
         }
+
+        # 5a. Collect unique constraint variables
+        unique_constraint_vars = set()
+        for constraints in non_geo_constraints_list:
+            for c in constraints:
+                unique_constraint_vars.add(c["variable"])
+
         variable_entity_map: Dict[str, str] = {}
-        for var in unique_variables:
+        for var in unique_variables | unique_constraint_vars:
             if var in sim.tax_benefit_system.variables:
                 variable_entity_map[var] = sim.tax_benefit_system.variables[
                     var
@@ -2689,12 +2702,6 @@ class UnifiedMatrixBuilder:
                     var
                 ].entity.key
 
-        # 5a. Collect unique constraint variables
-        unique_constraint_vars = set()
-        for constraints in non_geo_constraints_list:
-            for c in constraints:
-                unique_constraint_vars.add(c["variable"])
-
         # 5b. Per-state precomputation (51 sims on one object)
         self._entity_rel_cache = None
         state_values = self._build_state_values(
@@ -2709,7 +2716,9 @@ class UnifiedMatrixBuilder:
         )
 
         # 5b-county. Per-county precomputation for county-dependent vars
-        county_dep_targets = unique_variables & COUNTY_DEPENDENT_VARS
+        county_dep_targets = (
+            unique_variables | unique_constraint_vars
+        ) & COUNTY_DEPENDENT_VARS
         county_values = self._build_county_values(
             sim,
             county_dep_targets,
@@ -2773,8 +2782,15 @@ class UnifiedMatrixBuilder:
                     reported_takeup_anchors["takes_up_medicaid_if_eligible"] = f[
                         "has_medicaid_health_coverage_at_interview"
                     ][period_key][...].astype(bool)
+                if (
+                    "receives_housing_assistance" in f
+                    and period_key in f["receives_housing_assistance"]
+                ):
+                    reported_takeup_anchors[
+                        "takes_up_housing_assistance_if_eligible"
+                    ] = f["receives_housing_assistance"][period_key][...].astype(bool)
 
-            for tvar in unique_variables:
+            for tvar in unique_variables | unique_constraint_vars:
                 for key, info in TAKEUP_AFFECTED_TARGETS.items():
                     if tvar == key:
                         affected_target_info[tvar] = info
@@ -3111,6 +3127,10 @@ class UnifiedMatrixBuilder:
                         ent_hh_ids = household_ids[ent_hh]
                         ent_ci = np.full(n_ent, clone_idx, dtype=np.int64)
 
+                        eligible_mask = None
+                        if takeup_var == "takes_up_housing_assistance_if_eligible":
+                            eligible_mask = ent_eligible > 0
+
                         ent_takeup = compute_block_takeup_for_entities(
                             takeup_var,
                             precomputed_rates[info["rate_key"]],
@@ -3118,6 +3138,7 @@ class UnifiedMatrixBuilder:
                             ent_hh_ids,
                             ent_ci,
                             reported_mask=reported_takeup_anchors.get(takeup_var),
+                            eligible_mask=eligible_mask,
                         )
 
                         ent_values = (ent_eligible * ent_takeup).astype(np.float32)

--- a/policyengine_us_data/db/DATABASE_GUIDE.md
+++ b/policyengine_us_data/db/DATABASE_GUIDE.md
@@ -29,11 +29,12 @@ make database-refresh   # Force re-download all sources and rebuild
 | 4 | `etl_age.py` | Census ACS 1-year | Age distribution: 18 bins x 488 geographies |
 | 5 | `etl_medicaid.py` | Census ACS + CMS | Medicaid enrollment (admin state-level, survey district-level) |
 | 6 | `etl_snap.py` | USDA FNS + Census ACS | SNAP participation (admin state-level, survey district-level) |
-| 7 | `etl_tanf.py` | HHS ACF | TANF caseload families and cash-assistance spending (FY2024) |
-| 8 | `etl_state_income_tax.py` | Census STC | State income tax collections (Census STC FY2023 `T40`, downloaded and cached) |
-| 9 | `etl_irs_soi.py` | IRS | Tax variables, EITC by child count, AGI brackets, conditional strata |
-| 10 | `etl_pregnancy.py` | CDC VSRR + Census ACS | Pregnancy prevalence by state (provisional birth counts) |
-| 11 | `validate_database.py` | No | Checks all target variables exist in policyengine-us |
+| 7 | `etl_housing_assistance.py` | HUD | HUD-assisted household counts from Picture of Subsidized Households |
+| 8 | `etl_tanf.py` | HHS ACF | TANF caseload families and cash-assistance spending (FY2024) |
+| 9 | `etl_state_income_tax.py` | Census STC | State income tax collections (Census STC FY2023 `T40`, downloaded and cached) |
+| 10 | `etl_irs_soi.py` | IRS | Tax variables, EITC by child count, AGI brackets, conditional strata |
+| 11 | `etl_pregnancy.py` | CDC VSRR + Census ACS | Pregnancy prevalence by state (provisional birth counts) |
+| 12 | `validate_database.py` | No | Checks all target variables exist in policyengine-us |
 
 ### Raw Input Caching
 
@@ -152,6 +153,7 @@ Strata are categorized by their **constraints**, not by a separate group ID fiel
 | `adjusted_gross_income` | Income/AGI brackets |
 | `snap` | SNAP recipient strata |
 | `medicaid_enrolled` | Medicaid enrollment strata |
+| `housing_assistance` | HUD-assisted household strata |
 | `is_pregnant` | Pregnancy prevalence strata |
 | `eitc_child_count` | EITC recipients by qualifying children |
 | `state_income_tax` | State-level income tax collections |

--- a/policyengine_us_data/db/create_field_valid_values.py
+++ b/policyengine_us_data/db/create_field_valid_values.py
@@ -74,6 +74,7 @@ def populate_field_valid_values(session: Session) -> None:
         ("source", "CMS Marketplace", "administrative"),
         ("source", "CMS 2024 OEP state metal status PUF", "administrative"),
         ("source", "CMS Medicaid", "administrative"),
+        ("source", "HUD Picture of Subsidized Households", "administrative"),
         ("source", "Census ACS S2704", "survey"),
         ("source", "USDA FNS SNAP", "administrative"),
         ("source", "Census ACS S2201", "survey"),

--- a/policyengine_us_data/db/etl_housing_assistance.py
+++ b/policyengine_us_data/db/etl_housing_assistance.py
@@ -1,0 +1,184 @@
+"""ETL for HUD-assisted household count calibration targets."""
+
+from __future__ import annotations
+
+import io
+import logging
+
+import pandas as pd
+import requests
+from sqlmodel import Session, create_engine
+
+from policyengine_us_data.db.create_database_tables import (
+    Stratum,
+    StratumConstraint,
+    Target,
+)
+from policyengine_us_data.storage import STORAGE_FOLDER
+from policyengine_us_data.utils.census import STATE_ABBREV_TO_FIPS
+from policyengine_us_data.utils.db import (
+    etl_argparser,
+    get_geographic_strata,
+    parse_ucgid,
+)
+from policyengine_us_data.utils.raw_cache import (
+    is_cached,
+    load_bytes,
+    save_bytes,
+)
+
+logger = logging.getLogger(__name__)
+
+HUD_PICTURE_SOURCE = "HUD Picture of Subsidized Households"
+
+
+def _hud_picture_state_url(year: int) -> str:
+    return (
+        "https://www.huduser.gov/portal/datasets/pictures/files/"
+        f"STATE_{year}_2020census.xlsx"
+    )
+
+
+def extract_hud_picture_state_data(year: int) -> bytes:
+    """Download HUD Picture of Subsidized Households state extract."""
+    cache_file = f"hud_picture_state_{year}_2020census.xlsx"
+    if is_cached(cache_file):
+        logger.info("Using cached %s", cache_file)
+        return load_bytes(cache_file)
+
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/123.0.0.0 Safari/537.36"
+        ),
+        "Accept": (
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,"
+            "application/vnd.ms-excel,*/*"
+        ),
+        "Accept-Language": "en-US,en;q=0.9",
+    }
+    response = requests.get(
+        _hud_picture_state_url(year),
+        headers=headers,
+        timeout=60,
+    )
+    response.raise_for_status()
+    if not response.content.startswith(b"PK"):
+        raise ValueError(
+            "HUD Picture state extract did not return an Excel workbook. "
+            f"HTTP status={response.status_code}, "
+            f"x-amzn-waf-action={response.headers.get('x-amzn-waf-action')!r}"
+        )
+    save_bytes(cache_file, response.content)
+    return response.content
+
+
+def transform_hud_picture_state_data(workbook_content: bytes) -> pd.DataFrame:
+    """Return state assisted-household targets from a HUD Picture workbook."""
+    raw_df = pd.read_excel(io.BytesIO(workbook_content))
+    summary = raw_df.loc[
+        raw_df["program_label"].eq("Summary of All HUD Programs")
+        & raw_df["State"].isin(STATE_ABBREV_TO_FIPS)
+    ].copy()
+    summary["STATE_FIPS"] = summary["State"].map(STATE_ABBREV_TO_FIPS)
+    summary["ucgid_str"] = "0400000US" + summary["STATE_FIPS"]
+    summary["assisted_households"] = pd.to_numeric(
+        summary["number_reported"],
+        errors="raise",
+    )
+    return (
+        summary[["ucgid_str", "assisted_households"]]
+        .sort_values("ucgid_str")
+        .reset_index(drop=True)
+    )
+
+
+def load_housing_assistance_data(state_df: pd.DataFrame, year: int) -> None:
+    """Load national and state assisted-household count targets."""
+    database_url = f"sqlite:///{STORAGE_FOLDER / 'calibration' / 'policy_data.db'}"
+    engine = create_engine(database_url)
+    national_households = float(state_df["assisted_households"].sum())
+
+    with Session(engine) as session:
+        geo_strata = get_geographic_strata(session)
+        if geo_strata["national"] is None:
+            raise ValueError(
+                "National stratum not found. Run create_initial_strata.py first."
+            )
+
+        national_stratum = Stratum(
+            parent_stratum_id=geo_strata["national"],
+            notes="National HUD-assisted households",
+        )
+        national_stratum.constraints_rel = [
+            StratumConstraint(
+                constraint_variable="housing_assistance",
+                operation=">",
+                value="0",
+            )
+        ]
+        national_stratum.targets_rel.append(
+            Target(
+                variable="household_count",
+                period=year,
+                value=national_households,
+                active=True,
+                source=HUD_PICTURE_SOURCE,
+                notes=(
+                    "HUD Picture of Subsidized Households state extract, "
+                    "Summary of All HUD Programs, number_reported column. "
+                    "This is a December point-in-time assisted-household count."
+                ),
+            )
+        )
+        session.add(national_stratum)
+        session.flush()
+
+        for _, row in state_df.iterrows():
+            state_fips = parse_ucgid(row["ucgid_str"])["state_fips"]
+            parent_stratum_id = geo_strata["state"][state_fips]
+            state_stratum = Stratum(
+                parent_stratum_id=parent_stratum_id,
+                notes=f"State FIPS {state_fips} HUD-assisted households",
+            )
+            state_stratum.constraints_rel = [
+                StratumConstraint(
+                    constraint_variable="state_fips",
+                    operation="==",
+                    value=str(state_fips),
+                ),
+                StratumConstraint(
+                    constraint_variable="housing_assistance",
+                    operation=">",
+                    value="0",
+                ),
+            ]
+            state_stratum.targets_rel.append(
+                Target(
+                    variable="household_count",
+                    period=year,
+                    value=float(row["assisted_households"]),
+                    active=True,
+                    source=HUD_PICTURE_SOURCE,
+                    notes=(
+                        "HUD Picture of Subsidized Households state extract, "
+                        "Summary of All HUD Programs, number_reported column. "
+                        "This is a December point-in-time assisted-household count."
+                    ),
+                )
+            )
+            session.add(state_stratum)
+
+        session.commit()
+
+
+def main() -> None:
+    _, year = etl_argparser("ETL for HUD housing assistance count targets")
+    workbook = extract_hud_picture_state_data(year)
+    state_df = transform_hud_picture_state_data(workbook)
+    load_housing_assistance_data(state_df, year)
+
+
+if __name__ == "__main__":
+    main()

--- a/policyengine_us_data/utils/takeup.py
+++ b/policyengine_us_data/utils/takeup.py
@@ -76,7 +76,7 @@ SIMPLE_TAKEUP_VARS = [
         "variable": "takes_up_housing_assistance_if_eligible",
         "entity": "spm_unit",
         "rate_key": "housing_assistance",
-        "target": None,
+        "target": "housing_assistance",
     },
 ]
 

--- a/tests/unit/calibration/test_target_config.py
+++ b/tests/unit/calibration/test_target_config.py
@@ -206,6 +206,28 @@ class TestLoadTargetConfig:
             "domain_variable": "adjusted_gross_income,non_refundable_ctc",
         } in include_rules
 
+    def test_training_config_includes_housing_assistance_count_targets(self):
+        config = load_target_config(
+            str(
+                Path(__file__).resolve().parents[3]
+                / "policyengine_us_data"
+                / "calibration"
+                / "target_config.yaml"
+            )
+        )
+
+        include_rules = config["include"]
+        assert {
+            "variable": "household_count",
+            "geo_level": "state",
+            "domain_variable": "housing_assistance",
+        } in include_rules
+        assert {
+            "variable": "household_count",
+            "geo_level": "national",
+            "domain_variable": "housing_assistance",
+        } in include_rules
+
     def test_training_config_includes_national_capital_income_agi_targets(self):
         config = load_target_config(
             str(

--- a/tests/unit/calibration/test_unified_matrix_builder.py
+++ b/tests/unit/calibration/test_unified_matrix_builder.py
@@ -1033,6 +1033,38 @@ class TestBuildStateValues(unittest.TestCase):
         return_value=[],
     )
     @patch("policyengine_us.Microsimulation")
+    def test_takeup_affected_constraint_vars_precompute_entity_values(
+        self,
+        mock_msim_cls,
+        mock_gcv,
+    ):
+        sim = _FakeSimulation()
+        mock_msim_cls.return_value = sim
+
+        builder = self._make_builder()
+        geo = self._make_geo([37])
+
+        builder._build_state_values(
+            sim=None,
+            target_vars={"household_count"},
+            constraint_vars={"housing_assistance"},
+            reform_vars=set(),
+            geography=geo,
+            rerandomize_takeup=True,
+        )
+
+        assert (
+            "housing_assistance",
+            2024,
+            "spm_unit",
+        ) in sim.calculate_calls
+
+    @patch(
+        "policyengine_us_data.calibration"
+        ".unified_matrix_builder.get_calculated_variables",
+        return_value=[],
+    )
+    @patch("policyengine_us.Microsimulation")
     def test_count_vars_skipped(self, mock_msim_cls, mock_gcv):
         sim = _FakeSimulation()
         mock_msim_cls.return_value = sim

--- a/tests/unit/test_etl_housing_assistance.py
+++ b/tests/unit/test_etl_housing_assistance.py
@@ -1,0 +1,105 @@
+import io
+
+import pandas as pd
+import pytest
+from sqlalchemy import text
+from sqlmodel import Session
+
+from policyengine_us_data.db import etl_housing_assistance
+from policyengine_us_data.db.create_database_tables import (
+    Stratum,
+    StratumConstraint,
+    create_database,
+)
+
+
+def _workbook_bytes(df: pd.DataFrame) -> bytes:
+    output = io.BytesIO()
+    with pd.ExcelWriter(output, engine="openpyxl") as writer:
+        df.to_excel(writer, index=False)
+    return output.getvalue()
+
+
+def _add_geo_strata(session: Session):
+    national = Stratum(notes="United States")
+    session.add(national)
+    session.flush()
+
+    for state_fips, name in [(1, "Alabama"), (6, "California")]:
+        state = Stratum(
+            parent_stratum_id=national.stratum_id,
+            notes=name,
+        )
+        state.constraints_rel = [
+            StratumConstraint(
+                constraint_variable="state_fips",
+                operation="==",
+                value=str(state_fips),
+            )
+        ]
+        session.add(state)
+    session.commit()
+
+
+def test_transform_hud_picture_state_data_filters_summary_states():
+    raw = pd.DataFrame(
+        {
+            "program_label": [
+                "Summary of All HUD Programs",
+                "Public Housing",
+                "Summary of All HUD Programs",
+                "Summary of All HUD Programs",
+            ],
+            "State": ["AL", "AL", "CA", "PR"],
+            "number_reported": [81_143, 25_762, 469_502, 96_625],
+        }
+    )
+
+    result = etl_housing_assistance.transform_hud_picture_state_data(
+        _workbook_bytes(raw)
+    )
+
+    assert result["ucgid_str"].tolist() == ["0400000US01", "0400000US06"]
+    assert result["assisted_households"].tolist() == [81_143, 469_502]
+
+
+def test_load_housing_assistance_data_creates_count_targets(tmp_path, monkeypatch):
+    calibration_dir = tmp_path / "calibration"
+    calibration_dir.mkdir()
+    db_uri = f"sqlite:///{calibration_dir / 'policy_data.db'}"
+    engine = create_database(db_uri)
+
+    with Session(engine) as session:
+        _add_geo_strata(session)
+
+    monkeypatch.setattr(etl_housing_assistance, "STORAGE_FOLDER", tmp_path)
+    state_df = pd.DataFrame(
+        {
+            "ucgid_str": ["0400000US01", "0400000US06"],
+            "assisted_households": [81_143, 469_502],
+        }
+    )
+
+    etl_housing_assistance.load_housing_assistance_data(state_df, 2024)
+
+    with Session(engine) as session:
+        rows = session.execute(
+            text(
+                """
+                SELECT variable, value, geo_level, geographic_id, domain_variable
+                FROM target_overview
+                WHERE domain_variable = 'housing_assistance'
+                ORDER BY geo_level, geographic_id
+                """
+            )
+        ).fetchall()
+
+    assert len(rows) == 3
+    national = [row for row in rows if row.geo_level == "national"][0]
+    assert national.variable == "household_count"
+    assert national.value == pytest.approx(550_645)
+
+    states = {
+        int(row.geographic_id): row.value for row in rows if row.geo_level == "state"
+    }
+    assert states == {1: 81_143, 6: 469_502}


### PR DESCRIPTION
## Summary
- add a HUD Picture of Subsidized Households ETL that loads national and state assisted-household count targets
- include housing assistance household-count targets in calibration target_config
- make take-up-affected constraint variables, including housing_assistance, participate in matrix precomputation and county-dependent take-up rerandomization

## Validation
- uv run pytest tests/unit/test_etl_housing_assistance.py tests/unit/datasets/test_cps_takeup.py tests/unit/calibration/test_target_config.py tests/unit/calibration/test_unified_matrix_builder.py -q
- uv run ruff check policyengine_us_data/db/etl_housing_assistance.py policyengine_us_data/calibration/unified_matrix_builder.py policyengine_us_data/utils/takeup.py tests/unit/test_etl_housing_assistance.py tests/unit/calibration/test_target_config.py tests/unit/calibration/test_unified_matrix_builder.py
- live HUD 2024 extract smoke test: 51 states/DC, 4,479,550 assisted households