### PR TITLE
Fail stale PolicyEngine US dependency in PR checks

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -35,8 +35,8 @@ jobs:
             exit 1
           }
 
-  policyengine-us-freshness:
-    name: PolicyEngine US freshness
+  require-current-policyengine-us:
+    name: Require current PolicyEngine US dependency
     runs-on: ubuntu-latest
     needs: check-fork
     steps:
@@ -44,8 +44,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-      - name: Warn if policyengine-us is stale
-        run: python .github/scripts/check_policyengine_us_dependency.py --mode warn
+      - name: Require current policyengine-us pin
+        run: python .github/scripts/check_policyengine_us_dependency.py --mode fail
 
   lint:
     runs-on: ubuntu-latest

--- a/changelog.d/1009.fixed
+++ b/changelog.d/1009.fixed
@@ -1,0 +1,1 @@
+Fail PR checks when the pinned policyengine-us data-build dependency is stale.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us==1.693.4",
+    "policyengine-us==1.693.5",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/tests/unit/test_publication_scripts.py
+++ b/tests/unit/test_publication_scripts.py
@@ -348,6 +348,18 @@ def test_policyengine_us_dependency_check_allow_stale_keeps_local_errors_fatal(
     assert module.main() == 1
 
 
+def test_pr_workflow_fails_on_stale_policyengine_us_dependency():
+    workflow = (REPO_ROOT / ".github/workflows/pr.yaml").read_text()
+
+    assert "require-current-policyengine-us:" in workflow
+    assert "name: Require current PolicyEngine US dependency" in workflow
+    assert (
+        "python .github/scripts/check_policyengine_us_dependency.py --mode fail"
+        in workflow
+    )
+    assert "check_policyengine_us_dependency.py --mode warn" not in workflow
+
+
 def test_restore_publication_changelog_restores_candidate_snapshot(
     tmp_path,
     monkeypatch,

--- a/uv.lock
+++ b/uv.lock
@@ -2122,7 +2122,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.693.4"
+version = "1.693.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2132,9 +2132,9 @@ dependencies = [
     { name = "tables" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/20/94/9091420d0b522f1de5f12ddd5e46648d425fe9369ac6ccc6441abd80f27e/policyengine_us-1.693.4.tar.gz", hash = "sha256:1980b0e4bc2ba307ae544181b6b32ac9b769ceb64f4378ed23f7788443aa752c", size = 9762870, upload-time = "2026-05-18T02:16:25.348Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/89/e5bea38e41b51d4b2be12d73d4d6d4bfa77ffef6cdffe45ea211f82cc93c/policyengine_us-1.693.5.tar.gz", hash = "sha256:2b7590033199201dab0d1b10cce0908ab77240b7ac23e14636b2ec8c37e39b71", size = 9763724, upload-time = "2026-05-18T14:38:42.175Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/02/f2378dd108e96abf0a5e2323c6beef256fb99c2e9fb45192063f7328eddd/policyengine_us-1.693.4-py3-none-any.whl", hash = "sha256:fd9c702644c266df93fde1b9d679ab5f8877feac81b0338e307f919054f05030", size = 10302695, upload-time = "2026-05-18T02:16:21.583Z" },
+    { url = "https://files.pythonhosted.org/packages/20/70/e5f54264a6e1ddd3dba54cb6d1eae8433401eec1e737b483d9068fd921b4/policyengine_us-1.693.5-py3-none-any.whl", hash = "sha256:4878e1de70ad92bb37502e5cb5e59a1b8246911243902a62a72329e86779e351", size = 10303717, upload-time = "2026-05-18T14:38:39.638Z" },
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", specifier = "==1.693.4" },
+    { name = "policyengine-us", specifier = "==1.693.5" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },


### PR DESCRIPTION
Fixes #1009

## Summary
- Make the PR PolicyEngine US dependency check a hard failing status instead of a warning-only check.
- Rename the PR job so it clearly mirrors the production publication dependency gate.
- Bump `policyengine-us` from `1.693.4` to `1.693.5` and refresh `uv.lock`.

## Testing
- `python -m pytest tests/unit/test_publication_scripts.py -q`
- `make lint`