### PR TITLE
Fail CI on stale PolicyEngine US dependency

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -44,8 +44,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-      - name: Warn if policyengine-us is stale
-        run: python .github/scripts/check_policyengine_us_dependency.py --mode warn
+      - name: Require current PolicyEngine US dependency
+        run: python .github/scripts/check_policyengine_us_dependency.py --mode fail
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -30,6 +30,17 @@ jobs:
         id: run-context
         run: python .github/scripts/resolve_run_context.py
 
+  policyengine-us-freshness:
+    name: PolicyEngine US freshness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+      - name: Require current PolicyEngine US dependency
+        run: python .github/scripts/check_policyengine_us_dependency.py --mode fail
+
   # ── Documentation ──────────────────────────────────────────
   docs:
     name: Documentation
@@ -66,7 +77,9 @@ jobs:
   versioning:
     name: Versioning
     runs-on: ubuntu-latest
-    needs: run-context
+    needs:
+      - run-context
+      - policyengine-us-freshness
     if: |
       github.event.head_commit.message != 'Update publication candidate' &&
       github.event.head_commit.message != 'Finalize package version'
@@ -112,6 +125,7 @@ jobs:
     needs:
       - lint
       - run-context
+      - policyengine-us-freshness
     if: github.event.head_commit.message == 'Update publication candidate'
     permissions:
       actions: write

--- a/changelog.d/1009.fixed.md
+++ b/changelog.d/1009.fixed.md
@@ -1,0 +1,1 @@
+Fail CI when policyengine-us is stale before publication.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us==1.693.4",
+    "policyengine-us==1.693.5",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/uv.lock
+++ b/uv.lock
@@ -2122,7 +2122,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.693.4"
+version = "1.693.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2132,9 +2132,9 @@ dependencies = [
     { name = "tables" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/20/94/9091420d0b522f1de5f12ddd5e46648d425fe9369ac6ccc6441abd80f27e/policyengine_us-1.693.4.tar.gz", hash = "sha256:1980b0e4bc2ba307ae544181b6b32ac9b769ceb64f4378ed23f7788443aa752c", size = 9762870, upload-time = "2026-05-18T02:16:25.348Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/89/e5bea38e41b51d4b2be12d73d4d6d4bfa77ffef6cdffe45ea211f82cc93c/policyengine_us-1.693.5.tar.gz", hash = "sha256:2b7590033199201dab0d1b10cce0908ab77240b7ac23e14636b2ec8c37e39b71", size = 9763724, upload-time = "2026-05-18T14:38:42.175Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/02/f2378dd108e96abf0a5e2323c6beef256fb99c2e9fb45192063f7328eddd/policyengine_us-1.693.4-py3-none-any.whl", hash = "sha256:fd9c702644c266df93fde1b9d679ab5f8877feac81b0338e307f919054f05030", size = 10302695, upload-time = "2026-05-18T02:16:21.583Z" },
+    { url = "https://files.pythonhosted.org/packages/20/70/e5f54264a6e1ddd3dba54cb6d1eae8433401eec1e737b483d9068fd921b4/policyengine_us-1.693.5-py3-none-any.whl", hash = "sha256:4878e1de70ad92bb37502e5cb5e59a1b8246911243902a62a72329e86779e351", size = 10303717, upload-time = "2026-05-18T14:38:39.638Z" },
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", specifier = "==1.693.4" },
+    { name = "policyengine-us", specifier = "==1.693.5" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },


### PR DESCRIPTION
## Summary
- make the PR PolicyEngine US freshness job fail instead of warn when uv.lock lags latest PyPI
- add the same blocking freshness gate to main push CI before publication candidate versioning or pipeline dispatch
- bump policyengine-us from 1.693.4 to 1.693.5 so the current main publication can launch again

## Why
Latest main publication runs 26049411391 and 26051699164 failed only after merge, at the Run Pipeline dependency gate, because uv.lock still had policyengine-us 1.693.4 while PyPI latest was 1.693.5. This PR moves that failure into pre-merge PR CI and into push CI before a candidate dispatch is created.

## Verification
- uv run --no-sync python .github/scripts/check_policyengine_us_dependency.py --mode fail
- uv lock --locked
- uv run --no-sync --with pyyaml python scripts/run_quality_guards.py
- workflow YAML parsed and asserted freshness dependencies
- git diff --check