### PR TITLE
Add publication snapshot for housing data run

### DIFF
--- a/.github/publication_candidates/usdata-gha26059694992-a1/changelog.d/data-release-version-guard.changed.md
+++ b/.github/publication_candidates/usdata-gha26059694992-a1/changelog.d/data-release-version-guard.changed.md
@@ -1,0 +1,1 @@
+Ensure publication candidates fail before launch when the package version lags the latest finalized data release.

--- a/.github/publication_candidates/usdata-gha26059694992-a1/changelog.d/policyengine-us-1.694.0.changed.md
+++ b/.github/publication_candidates/usdata-gha26059694992-a1/changelog.d/policyengine-us-1.694.0.changed.md
@@ -1,0 +1,1 @@
+Update the PolicyEngine US dependency to 1.694.0.

--- a/.github/publication_candidates/usdata-gha26059694992-a1/publication_scope.json
+++ b/.github/publication_candidates/usdata-gha26059694992-a1/publication_scope.json
@@ -1,0 +1,7 @@
+{
+  "base_release_version": "1.115.3",
+  "candidate_scope": "1.115.3-patch",
+  "release_bump": "patch",
+  "run_id": "usdata-gha26059694992-a1",
+  "would_release_as_at_build_time": "1.115.4"
+}

--- a/changelog.d/data-release-version-guard.changed.md
+++ b/changelog.d/data-release-version-guard.changed.md
@@ -1,0 +1,1 @@
+Ensure publication candidates fail before launch when the package version lags the latest finalized data release.

--- a/changelog.d/policyengine-us-1.694.0.changed.md
+++ b/changelog.d/policyengine-us-1.694.0.changed.md
@@ -1,0 +1,1 @@
+Update the PolicyEngine US dependency to 1.694.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us==1.693.5",
+    "policyengine-us==1.694.0",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/uv.lock
+++ b/uv.lock
@@ -2122,7 +2122,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.693.5"
+version = "1.694.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2132,9 +2132,9 @@ dependencies = [
     { name = "tables" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/89/e5bea38e41b51d4b2be12d73d4d6d4bfa77ffef6cdffe45ea211f82cc93c/policyengine_us-1.693.5.tar.gz", hash = "sha256:2b7590033199201dab0d1b10cce0908ab77240b7ac23e14636b2ec8c37e39b71", size = 9763724, upload-time = "2026-05-18T14:38:42.175Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/08/236f8e9838e5beab2fc24cd90672128e6c90525a26c8b291c400d66d72d3/policyengine_us-1.694.0.tar.gz", hash = "sha256:61f148afb4095553573bc9285d701b82b28f496fdc91ea3640d2353dd2ba0a4f", size = 9765990, upload-time = "2026-05-19T03:50:02.182Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/70/e5f54264a6e1ddd3dba54cb6d1eae8433401eec1e737b483d9068fd921b4/policyengine_us-1.693.5-py3-none-any.whl", hash = "sha256:4878e1de70ad92bb37502e5cb5e59a1b8246911243902a62a72329e86779e351", size = 10303717, upload-time = "2026-05-18T14:38:39.638Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/03/fc6d4613cbe265db18d07a6a5a5cfd5f9f989e6686a4df1f7bfbe59576b4/policyengine_us-1.694.0-py3-none-any.whl", hash = "sha256:20202d3a66c6e6595ac9786e22da3696b122cef86d4545a612c7710f54463c3e", size = 10307601, upload-time = "2026-05-19T03:49:58.646Z" },
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", specifier = "==1.693.5" },
+    { name = "policyengine-us", specifier = "==1.694.0" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },


### PR DESCRIPTION
## Summary
- add the publication candidate snapshot for the successful housing-assistance data run `usdata-gha26059694992-a1`
- unblock the promote workflow, which already promoted staged data but failed before finalizing the package because the run-id-specific changelog snapshot was missing

## Test
- `US_DATA_RUN_ID=usdata-gha26059694992-a1 uv run python .github/scripts/restore_publication_changelog.py`