### PR TITLE
Fix publication promotion retry finalization

### DIFF
--- a/.github/scripts/promote_publication_pipeline.py
+++ b/.github/scripts/promote_publication_pipeline.py
@@ -59,16 +59,19 @@ def _promotion_context_from_status(context: RunContext, status: dict) -> RunCont
         raise RuntimeError("Run manifest is missing candidate_version.")
     if not release_bump:
         raise RuntimeError("Run manifest is missing release_bump.")
+    release_version = _manifest_field(manifest, "release_version")
+    if not release_version:
+        release_version = release_version_from_bump(
+            _current_package_version(),
+            release_bump,
+        )
     return RunContext.from_mapping(
         manifest.get("run_context"),
         run_id=context.run_id,
         modal_app_name=context.modal_app_name,
         modal_environment=context.modal_environment,
         candidate_version=candidate_version,
-        release_version=release_version_from_bump(
-            _current_package_version(),
-            release_bump,
-        ),
+        release_version=release_version,
         base_release_version=base_release_version,
         release_bump=release_bump,
     )

--- a/.github/scripts/restore_publication_changelog.py
+++ b/.github/scripts/restore_publication_changelog.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import filecmp
+import json
 import os
 import shutil
 import sys
@@ -11,6 +12,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 ROOT_CHANGELOG_DIR = REPO_ROOT / "changelog.d"
+PUBLICATION_SCOPE_PATH = REPO_ROOT / ".github" / "publication_scope.json"
 PUBLICATION_CANDIDATES_DIR = REPO_ROOT / ".github" / "publication_candidates"
 CHANGELOG_KEEP_FILE = ".gitkeep"
 
@@ -53,16 +55,61 @@ def _validate_root_fragments_match_snapshot(
         )
 
 
+def _publication_scope() -> dict[str, str]:
+    if not PUBLICATION_SCOPE_PATH.exists():
+        return {}
+    return json.loads(PUBLICATION_SCOPE_PATH.read_text())
+
+
+def _scope_matches_environment(scope: dict[str, str]) -> bool:
+    expected = {
+        "candidate_scope": os.environ.get("US_DATA_CANDIDATE_VERSION")
+        or os.environ.get("CANDIDATE_VERSION"),
+        "base_release_version": os.environ.get("US_DATA_BASE_RELEASE_VERSION")
+        or os.environ.get("BASE_RELEASE_VERSION"),
+        "release_bump": os.environ.get("US_DATA_RELEASE_BUMP")
+        or os.environ.get("RELEASE_BUMP"),
+    }
+    return all(
+        not value or not scope.get(key) or scope[key] == value
+        for key, value in expected.items()
+    )
+
+
+def _snapshot_dir(run_id: str) -> Path:
+    return PUBLICATION_CANDIDATES_DIR / run_id / "changelog.d"
+
+
+def _resolve_snapshot_dir(run_id: str) -> Path:
+    requested_dir = _snapshot_dir(run_id)
+    if _fragments(requested_dir):
+        return requested_dir
+
+    scope = _publication_scope()
+    scope_run_id = scope.get("run_id", "")
+    if scope_run_id and scope_run_id != run_id and _scope_matches_environment(scope):
+        scope_dir = _snapshot_dir(scope_run_id)
+        if _fragments(scope_dir):
+            print(
+                "No changelog snapshot found for promotion run "
+                f"{run_id}; using publication scope snapshot {scope_run_id}.",
+            )
+            return scope_dir
+
+    details = (
+        f"No candidate changelog fragments found for run {run_id}: {requested_dir}"
+    )
+    if scope_run_id and scope_run_id != run_id:
+        details += f"; publication scope points to {scope_run_id}: {_snapshot_dir(scope_run_id)}"
+    raise RuntimeError(details)
+
+
 def restore_candidate_changelog(run_id: str) -> Path:
     if not run_id:
         raise RuntimeError("US_DATA_RUN_ID is required to restore changelog fragments.")
 
-    snapshot_dir = PUBLICATION_CANDIDATES_DIR / run_id / "changelog.d"
+    snapshot_dir = _resolve_snapshot_dir(run_id)
     snapshot_fragments = _fragments(snapshot_dir)
-    if not snapshot_fragments:
-        raise RuntimeError(
-            f"No candidate changelog fragments found for run {run_id}: {snapshot_dir}"
-        )
 
     ROOT_CHANGELOG_DIR.mkdir(parents=True, exist_ok=True)
     root_fragments = _fragments(ROOT_CHANGELOG_DIR)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.115.4] - 2026-05-19
+
+### Changed
+
+- Ensure publication candidates fail before launch when the package version lags the latest finalized data release.
+
+
 ## [1.115.3] - 2026-05-14
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "policyengine_us_data"
-version = "1.115.3"
+version = "1.115.4"
 description = "A package to create representative microdata for the US."
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us==1.693.5",
+    "policyengine-us==1.694.0",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/tests/unit/test_publication_scripts.py
+++ b/tests/unit/test_publication_scripts.py
@@ -406,6 +406,42 @@ def test_restore_publication_changelog_restores_candidate_snapshot(
     assert (root_changelog / "123.changed.md").read_text() == "Changed a thing.\n"
 
 
+def test_restore_publication_changelog_falls_back_to_scope_snapshot(
+    tmp_path,
+    monkeypatch,
+):
+    module = _load_script(
+        ".github/scripts/restore_publication_changelog.py",
+        "restore_publication_changelog_scope_fallback_test",
+    )
+    root_changelog = tmp_path / "changelog.d"
+    publication_dir = tmp_path / ".github" / "publication_candidates"
+    snapshot = publication_dir / "versioning-run" / "changelog.d"
+    snapshot.mkdir(parents=True)
+    (snapshot / "123.changed.md").write_text("Changed a thing.\n")
+    scope_path = tmp_path / ".github" / "publication_scope.json"
+    scope_path.write_text(
+        json.dumps(
+            {
+                "base_release_version": "1.115.3",
+                "candidate_scope": "1.115.3-patch",
+                "release_bump": "patch",
+                "run_id": "versioning-run",
+            }
+        )
+    )
+    monkeypatch.setenv("US_DATA_CANDIDATE_VERSION", "1.115.3-patch")
+    monkeypatch.setenv("US_DATA_BASE_RELEASE_VERSION", "1.115.3")
+    monkeypatch.setenv("US_DATA_RELEASE_BUMP", "patch")
+    monkeypatch.setattr(module, "ROOT_CHANGELOG_DIR", root_changelog)
+    monkeypatch.setattr(module, "PUBLICATION_SCOPE_PATH", scope_path)
+    monkeypatch.setattr(module, "PUBLICATION_CANDIDATES_DIR", publication_dir)
+
+    module.restore_candidate_changelog("pipeline-run")
+
+    assert (root_changelog / "123.changed.md").read_text() == "Changed a thing.\n"
+
+
 def test_restore_publication_changelog_rejects_unrelated_root_fragments(
     tmp_path,
     monkeypatch,
@@ -648,6 +684,49 @@ def test_promote_publication_script_derives_release_from_status(
     ]
     assert "US_DATA_RELEASE_VERSION=1.74.0" in github_env.read_text()
     assert "VERSION_OVERRIDE" not in json.dumps(captured["calls"])
+
+
+def test_promote_publication_script_prefers_manifest_release_version(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setitem(
+        sys.modules,
+        "modal",
+        types.SimpleNamespace(Function=types.SimpleNamespace()),
+    )
+    module = _load_script(
+        ".github/scripts/promote_publication_pipeline.py",
+        "promote_publication_pipeline_release_version_test",
+    )
+    _write_pyproject(tmp_path, "1.74.0")
+    monkeypatch.setattr(module, "_REPO_ROOT", tmp_path)
+    context = module.RunContext.from_mapping(
+        {"run_id": "run-123"},
+        modal_app_name="app",
+        modal_environment="main",
+    )
+
+    promoted_context = module._promotion_context_from_status(
+        context,
+        {
+            "run_manifest": {
+                "run_id": "run-123",
+                "candidate_version": "1.73.0-minor",
+                "base_release_version": "1.73.0",
+                "release_bump": "minor",
+                "release_version": "1.74.0",
+                "run_context": {
+                    "run_id": "run-123",
+                    "candidate_version": "1.73.0-minor",
+                    "base_release_version": "1.73.0",
+                    "release_bump": "minor",
+                },
+            }
+        },
+    )
+
+    assert promoted_context.release_version == "1.74.0"
 
 
 def test_promote_publication_script_requires_release_bump(

--- a/uv.lock
+++ b/uv.lock
@@ -2122,7 +2122,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.693.5"
+version = "1.694.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2132,9 +2132,9 @@ dependencies = [
     { name = "tables" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/89/e5bea38e41b51d4b2be12d73d4d6d4bfa77ffef6cdffe45ea211f82cc93c/policyengine_us-1.693.5.tar.gz", hash = "sha256:2b7590033199201dab0d1b10cce0908ab77240b7ac23e14636b2ec8c37e39b71", size = 9763724, upload-time = "2026-05-18T14:38:42.175Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/08/236f8e9838e5beab2fc24cd90672128e6c90525a26c8b291c400d66d72d3/policyengine_us-1.694.0.tar.gz", hash = "sha256:61f148afb4095553573bc9285d701b82b28f496fdc91ea3640d2353dd2ba0a4f", size = 9765990, upload-time = "2026-05-19T03:50:02.182Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/70/e5f54264a6e1ddd3dba54cb6d1eae8433401eec1e737b483d9068fd921b4/policyengine_us-1.693.5-py3-none-any.whl", hash = "sha256:4878e1de70ad92bb37502e5cb5e59a1b8246911243902a62a72329e86779e351", size = 10303717, upload-time = "2026-05-18T14:38:39.638Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/03/fc6d4613cbe265db18d07a6a5a5cfd5f9f989e6686a4df1f7bfbe59576b4/policyengine_us-1.694.0-py3-none-any.whl", hash = "sha256:20202d3a66c6e6595ac9786e22da3696b122cef86d4545a612c7710f54463c3e", size = 10307601, upload-time = "2026-05-19T03:49:58.646Z" },
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", specifier = "==1.693.5" },
+    { name = "policyengine-us", specifier = "==1.694.0" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -2139,7 +2139,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us-data"
-version = "1.115.3"
+version = "1.115.4"
 source = { editable = "." }
 dependencies = [
     { name = "google-auth" },


### PR DESCRIPTION
## Summary
- restore promotion changelog fragments from the publication-scope snapshot when the promotion run ID differs from the versioning run ID
- prefer the release version recorded in the run manifest when rerunning promotion, avoiding accidental bumps after package finalization
- add regression coverage for the 1.115.4 promotion failure path

## Incident context
Promotion run [26088803454](https://github.com/PolicyEngine/policyengine-us-data/actions/runs/26088803454) promoted Modal run `usdata-gha26059694992-a1` as data release `1.115.4`, but then failed in `Finalize package version` because it looked for changelog fragments at `.github/publication_candidates/usdata-gha26059694992-a1/changelog.d`. The checked-in snapshot is actually under the versioning run ID from `.github/publication_scope.json`: `usdata-gha26059662779-a1`.

The release data artifacts are already promoted; this PR is for the package-finalization/retry path, not for rebuilding the dataset.

## Tests
- `uv run pytest tests/unit/test_publication_scripts.py -q`
- `uv run ruff check .github/scripts/restore_publication_changelog.py .github/scripts/promote_publication_pipeline.py tests/unit/test_publication_scripts.py`
- `uv run ruff format --check .github/scripts/restore_publication_changelog.py .github/scripts/promote_publication_pipeline.py tests/unit/test_publication_scripts.py`