### PR TITLE
Enforce NIPA employment target in calibration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,25 @@ artifacts, or public library functions, read
 When diagnosing a deployed Modal pipeline run or a failed publication pipeline,
 read `docs/engineering/skills/pipeline_operations.md`.
 
+When adding, changing, or reviewing calibration target definitions, read
+`docs/engineering/skills/calibration_targets.md`.
+
+## Calibration targets
+
+Manually sourced national or local-file calibration targets must be registered
+in every active target path before merging:
+
+1. `policyengine_us_data/utils/loss.py` for the ECPS loss matrix.
+2. `policyengine_us_data/db/etl_national_targets.py` for `policy_data.db` and
+   local H5 validation inputs.
+3. `policyengine_us_data/calibration/target_config.yaml` when the default
+   calibration uses an `include:` list; otherwise the target can exist in
+   `policy_data.db` but still be omitted from calibration.
+
+Do not treat a target appearing in `policy_data.db` as proof that published
+datasets were calibrated to it. Add or update tests that fail if a new target is
+present in one path but missing from another.
+
 ## GitHub PRs
 
 Read `docs/engineering/skills/github-prs.md` before opening, replacing, or

--- a/changelog.d/1019.fixed
+++ b/changelog.d/1019.fixed
@@ -1,0 +1,1 @@
+Ensure BEA NIPA direct-sum targets are selected by default calibration and fail publication validation when enhanced CPS employment income misses the wages target.

--- a/docs/engineering/skills/calibration_targets.md
+++ b/docs/engineering/skills/calibration_targets.md
@@ -1,0 +1,32 @@
+# Calibration Target Changes
+
+Use this workflow when adding, changing, or reviewing manually sourced
+calibration targets.
+
+## Dual Registration
+
+New targets must be registered in both active target systems:
+
+- `policyengine_us_data/utils/loss.py` for the ECPS `build_loss_matrix()` path.
+- `policyengine_us_data/db/etl_national_targets.py` for `policy_data.db`, local
+  H5 outputs, and validation inputs.
+
+If the default calibration path uses `policyengine_us_data/calibration/target_config.yaml`
+with an `include:` list, also add the matching include rule there. A target can
+exist in `policy_data.db` and still be ignored by calibration if it is missing
+from `target_config.yaml`.
+
+## Tests
+
+Every target change should add or update tests that prove the target is wired
+through every active path. For manually sourced national targets, cover:
+
+- the ECPS loss matrix registration in `tests/unit/calibration/test_loss_targets.py`;
+- the DB ETL row in `tests/unit/test_etl_national_targets.py`;
+- the default calibration include rule in
+  `tests/unit/calibration/test_target_config.py`;
+- any publication guard in `tests/unit/test_upload_completed_datasets.py` when
+  a missing target would make a released dataset materially wrong.
+
+Do not use a successful DB ETL test as a substitute for a calibration-selection
+test.

--- a/policyengine_us_data/calibration/target_config.yaml
+++ b/policyengine_us_data/calibration/target_config.yaml
@@ -164,6 +164,14 @@ include:
     geo_level: national
   - variable: childcare_expenses
     geo_level: national
+  - variable: employment_income_before_lsr
+    geo_level: national
+  - variable: nipa_proprietors_income
+    geo_level: national
+  - variable: interest_income
+    geo_level: national
+  - variable: dividend_income
+    geo_level: national
   - variable: long_term_capital_gains
     geo_level: national
   - variable: medicaid

--- a/policyengine_us_data/db/etl_national_targets.py
+++ b/policyengine_us_data/db/etl_national_targets.py
@@ -30,14 +30,16 @@ from policyengine_us_data.utils.target_variables import (
     target_variable_components,
 )
 
+# Manually sourced national targets must be registered in both active target
+# systems: policyengine_us_data/utils/loss.py for ECPS calibration and this
+# file for policy_data.db/local H5 targets. If the default calibration include
+# list should train on the target, add it to calibration/target_config.yaml too.
 BEA_NIPA_WAGES_AND_SALARIES_2024 = 12_387_929_000_000
 BEA_NIPA_PROPRIETORS_INCOME_2024 = 2_023_080_000_000
 BEA_NIPA_PERSONAL_INTEREST_INCOME_2024 = 1_926_644_000_000
 BEA_NIPA_PERSONAL_DIVIDEND_INCOME_2024 = 2_218_700_000_000
 
-NIPA_PROPRIETORS_INCOME_VARIABLE = (
-    "total_self_employment_income+farm_operations_income+partnership_s_corp_income"
-)
+NIPA_PROPRIETORS_INCOME_VARIABLE = "nipa_proprietors_income"
 NIPA_PERSONAL_INTEREST_INCOME_VARIABLE = "interest_income"
 TAXABLE_INTEREST_AND_ORDINARY_DIVIDENDS_VARIABLE = (
     "taxable_interest_income+dividend_income"
@@ -453,9 +455,8 @@ def extract_national_targets(year: int = DEFAULT_YEAR):
             "notes": (
                 "Proprietors' income with IVA and CCAdj for all persons, "
                 "including nonfilers; FRED/BEA series A041RC1A027NBEA. "
-                "Mapped to the closest additive PolicyEngine aggregate: "
-                "total self-employment, farm operations, and "
-                "partnership/S-corp income."
+                "Mapped to the PolicyEngine-US NIPA proprietors' income "
+                "aggregate."
             ),
             "year": 2024,
         },

--- a/policyengine_us_data/storage/upload_completed_datasets.py
+++ b/policyengine_us_data/storage/upload_completed_datasets.py
@@ -8,6 +8,9 @@ from huggingface_hub import HfApi, hf_hub_download
 from policyengine_core.data import Dataset
 
 from policyengine_us_data.__version__ import __version__ as DATA_PACKAGE_VERSION
+from policyengine_us_data.db.etl_national_targets import (
+    BEA_NIPA_WAGES_AND_SALARIES_2024,
+)
 from policyengine_us_data.datasets import EnhancedCPS_2024
 from policyengine_us_data.datasets.cps.cps import CPS_2024
 from policyengine_us_data.datasets.cps.enhanced_cps import clone_diagnostics_path
@@ -125,7 +128,14 @@ INCOME_GROUPS = [
 ]
 
 # Aggregate thresholds for broad sanity checks (year 2024).
-MIN_EMPLOYMENT_INCOME_SUM = 5e12  # $5 trillion
+MIN_PLAUSIBLE_EMPLOYMENT_INCOME_SUM = 5e12  # $5 trillion
+NIPA_EMPLOYMENT_INCOME_TOLERANCE = 0.10
+MIN_ENHANCED_CPS_EMPLOYMENT_INCOME_SUM = BEA_NIPA_WAGES_AND_SALARIES_2024 * (
+    1 - NIPA_EMPLOYMENT_INCOME_TOLERANCE
+)
+MAX_ENHANCED_CPS_EMPLOYMENT_INCOME_SUM = BEA_NIPA_WAGES_AND_SALARIES_2024 * (
+    1 + NIPA_EMPLOYMENT_INCOME_TOLERANCE
+)
 MIN_HOUSEHOLD_WEIGHT_SUM = 100e6  # 100 million
 MAX_HOUSEHOLD_WEIGHT_SUM = 200e6  # 200 million
 
@@ -152,9 +162,10 @@ MICROSIMULATION_AGGREGATE_CHECKS_BY_FILENAME = {
     "enhanced_cps_2024.h5": (
         MicrosimulationAggregateCheck(
             variable="employment_income",
-            label="employment_income sum",
+            label="employment_income sum vs NIPA wages target",
             statistic="sum",
-            min_value=MIN_EMPLOYMENT_INCOME_SUM,
+            min_value=MIN_ENHANCED_CPS_EMPLOYMENT_INCOME_SUM,
+            max_value=MAX_ENHANCED_CPS_EMPLOYMENT_INCOME_SUM,
         ),
         MicrosimulationAggregateCheck(
             variable="social_security_retirement",
@@ -188,7 +199,7 @@ MICROSIMULATION_AGGREGATE_CHECKS_BY_FILENAME = {
             variable="employment_income",
             label="employment_income sum",
             statistic="sum",
-            min_value=MIN_EMPLOYMENT_INCOME_SUM,
+            min_value=MIN_PLAUSIBLE_EMPLOYMENT_INCOME_SUM,
         ),
     ),
 }

--- a/policyengine_us_data/utils/loss.py
+++ b/policyengine_us_data/utils/loss.py
@@ -34,22 +34,45 @@ MEDICARE_PART_B_PREMIUM_VARIABLE = "medicare_part_b_premium"
 
 # National calibration targets consumed by build_loss_matrix().
 # These values are specific to 2024 — they should NOT be applied to
-# other years without re-sourcing.  They are duplicated in
-# db/etl_national_targets.py which loads them into policy_data.db.
-# A future PR should wire build_loss_matrix() to read from the
-# database so this dict can be deleted.  See PR #488.
+# other years without re-sourcing. They must stay registered here for
+# ECPS calibration, in db/etl_national_targets.py for policy_data.db,
+# and in calibration/target_config.yaml when the default calibration
+# include list should train on them. A future PR should wire
+# build_loss_matrix() to read from the database so this duplication can
+# be deleted. See PR #488.
 
 BEA_NIPA_WAGES_AND_SALARIES_2024 = 12_387_929_000_000
 BEA_NIPA_PROPRIETORS_INCOME_2024 = 2_023_080_000_000
 BEA_NIPA_PERSONAL_INTEREST_INCOME_2024 = 1_926_644_000_000
 BEA_NIPA_PERSONAL_DIVIDEND_INCOME_2024 = 2_218_700_000_000
 
-NIPA_PROPRIETORS_INCOME_VARIABLE = (
-    "total_self_employment_income+farm_operations_income+partnership_s_corp_income"
-)
+NIPA_PROPRIETORS_INCOME_VARIABLE = "nipa_proprietors_income"
 NIPA_PERSONAL_INTEREST_INCOME_VARIABLE = "interest_income"
 TAXABLE_INTEREST_AND_ORDINARY_DIVIDENDS_VARIABLE = (
     "taxable_interest_income+dividend_income"
+)
+
+BEA_NIPA_DIRECT_SUM_TARGETS = (
+    (
+        "nation/bea/nipa_wages_and_salaries",
+        "employment_income_before_lsr",
+        BEA_NIPA_WAGES_AND_SALARIES_2024,
+    ),
+    (
+        "nation/bea/nipa_proprietors_income",
+        NIPA_PROPRIETORS_INCOME_VARIABLE,
+        BEA_NIPA_PROPRIETORS_INCOME_2024,
+    ),
+    (
+        "nation/bea/nipa_personal_interest_income",
+        NIPA_PERSONAL_INTEREST_INCOME_VARIABLE,
+        BEA_NIPA_PERSONAL_INTEREST_INCOME_2024,
+    ),
+    (
+        "nation/bea/nipa_personal_dividend_income",
+        "dividend_income",
+        BEA_NIPA_PERSONAL_DIVIDEND_INCOME_2024,
+    ),
 )
 
 CBO_INCOME_BY_SOURCE_TARGETS = [
@@ -1249,29 +1272,7 @@ def build_loss_matrix(dataset: type, time_period):
         )
         targets_array.append(income_by_source._children[parameter])
 
-    bea_nipa_targets = [
-        (
-            "nation/bea/nipa_wages_and_salaries",
-            "employment_income_before_lsr",
-            BEA_NIPA_WAGES_AND_SALARIES_2024,
-        ),
-        (
-            "nation/bea/nipa_proprietors_income",
-            NIPA_PROPRIETORS_INCOME_VARIABLE,
-            BEA_NIPA_PROPRIETORS_INCOME_2024,
-        ),
-        (
-            "nation/bea/nipa_personal_interest_income",
-            NIPA_PERSONAL_INTEREST_INCOME_VARIABLE,
-            BEA_NIPA_PERSONAL_INTEREST_INCOME_2024,
-        ),
-        (
-            "nation/bea/nipa_personal_dividend_income",
-            "dividend_income",
-            BEA_NIPA_PERSONAL_DIVIDEND_INCOME_2024,
-        ),
-    ]
-    for label, variable, target in bea_nipa_targets:
+    for label, variable, target in BEA_NIPA_DIRECT_SUM_TARGETS:
         loss_matrix[label] = _calculate_household_target_values(
             sim,
             variable,

--- a/tests/unit/calibration/test_loss_targets.py
+++ b/tests/unit/calibration/test_loss_targets.py
@@ -10,6 +10,7 @@ from policyengine_us_data.utils.loss import (
     AGE_BUCKETED_HEALTH_TARGETS,
     AGGREGATE_LEVEL_TARGETED_VARIABLES,
     AGI_LEVEL_TARGETED_VARIABLES,
+    BEA_NIPA_DIRECT_SUM_TARGETS,
     BLS_CE_TOTALS,
     HARD_CODED_TOTALS,
     TRANSFER_BALANCE_TARGETS,
@@ -32,11 +33,33 @@ from policyengine_us_data.utils.loss import (
     build_loss_matrix,
     get_target_error_normalisation,
 )
+from policyengine_us_data.db import etl_national_targets
 
 
 def test_legacy_loss_targets_include_aggregate_qbi_deduction():
     assert "qualified_business_income_deduction" in AGGREGATE_LEVEL_TARGETED_VARIABLES
     assert "qualified_business_income_deduction" not in AGI_LEVEL_TARGETED_VARIABLES
+
+
+def test_bea_nipa_direct_sum_targets_match_targets_db():
+    loss_targets_by_variable = {
+        variable: target for _, variable, target in BEA_NIPA_DIRECT_SUM_TARGETS
+    }
+
+    assert loss_targets_by_variable == {
+        "employment_income_before_lsr": (
+            etl_national_targets.BEA_NIPA_WAGES_AND_SALARIES_2024
+        ),
+        etl_national_targets.NIPA_PROPRIETORS_INCOME_VARIABLE: (
+            etl_national_targets.BEA_NIPA_PROPRIETORS_INCOME_2024
+        ),
+        etl_national_targets.NIPA_PERSONAL_INTEREST_INCOME_VARIABLE: (
+            etl_national_targets.BEA_NIPA_PERSONAL_INTEREST_INCOME_2024
+        ),
+        "dividend_income": (
+            etl_national_targets.BEA_NIPA_PERSONAL_DIVIDEND_INCOME_2024
+        ),
+    }
 
 
 def test_aca_targets_roll_forward_to_2025():

--- a/tests/unit/calibration/test_target_config.py
+++ b/tests/unit/calibration/test_target_config.py
@@ -14,6 +14,7 @@ from policyengine_us_data.calibration.unified_calibration import (
     save_calibration_package,
     load_calibration_package,
 )
+from policyengine_us_data.db import etl_national_targets
 
 
 @pytest.fixture
@@ -344,6 +345,25 @@ class TestLoadTargetConfig:
             "variable": "medicare_part_b_premium",
             "geo_level": "national",
         } in config["include"]
+
+    def test_training_config_includes_bea_nipa_direct_sum_targets(self):
+        config = load_target_config(
+            str(
+                Path(__file__).resolve().parents[3]
+                / "policyengine_us_data"
+                / "calibration"
+                / "target_config.yaml"
+            )
+        )
+
+        include_rules = config["include"]
+        for variable in [
+            "employment_income_before_lsr",
+            etl_national_targets.NIPA_PROPRIETORS_INCOME_VARIABLE,
+            etl_national_targets.NIPA_PERSONAL_INTEREST_INCOME_VARIABLE,
+            "dividend_income",
+        ]:
+            assert {"variable": variable, "geo_level": "national"} in include_rules
 
     def test_training_config_includes_soi_ltcg_target(self):
         config = load_target_config(

--- a/tests/unit/test_etl_national_targets.py
+++ b/tests/unit/test_etl_national_targets.py
@@ -643,6 +643,13 @@ def test_loads_gross_wage_and_filer_tax_wage_targets(tmp_path, monkeypatch):
                     "notes": "Proprietors' income",
                     "year": 2024,
                 },
+                {
+                    "variable": "dividend_income",
+                    "value": 2_218_700_000_000,
+                    "source": "BEA NIPA Table 2.1",
+                    "notes": "Personal dividend income",
+                    "year": 2024,
+                },
             ]
         ),
         tax_filer_df=pd.DataFrame(
@@ -678,6 +685,9 @@ def test_loads_gross_wage_and_filer_tax_wage_targets(tmp_path, monkeypatch):
                 Target.variable == etl_national_targets.NIPA_PROPRIETORS_INCOME_VARIABLE
             )
         ).one()
+        dividend_target = session.exec(
+            select(Target).where(Target.variable == "dividend_income")
+        ).one()
         filer_constraints = session.exec(
             select(StratumConstraint).where(
                 StratumConstraint.stratum_id == tax_wage_target.stratum_id
@@ -688,6 +698,7 @@ def test_loads_gross_wage_and_filer_tax_wage_targets(tmp_path, monkeypatch):
     assert tax_wage_target.value == 10_832_700_000_000
     assert interest_target.value == 1_926_644_000_000
     assert proprietors_target.value == 2_023_080_000_000
+    assert dividend_target.value == 2_218_700_000_000
     assert gross_wage_target.stratum_id != tax_wage_target.stratum_id
     assert [
         (
@@ -757,6 +768,17 @@ def test_extracts_income_targets_from_primary_concepts(monkeypatch):
         for target in raw_targets["direct_sum_targets"]
         if target["variable"] == etl_national_targets.NIPA_PROPRIETORS_INCOME_VARIABLE
     ]
+    interest_targets = [
+        target
+        for target in raw_targets["direct_sum_targets"]
+        if target["variable"]
+        == etl_national_targets.NIPA_PERSONAL_INTEREST_INCOME_VARIABLE
+    ]
+    dividend_targets = [
+        target
+        for target in raw_targets["direct_sum_targets"]
+        if target["variable"] == "dividend_income"
+    ]
     tax_wage_targets = [
         target
         for target in raw_targets["tax_filer_targets"]
@@ -800,9 +822,37 @@ def test_extracts_income_targets_from_primary_concepts(monkeypatch):
             "notes": (
                 "Proprietors' income with IVA and CCAdj for all persons, "
                 "including nonfilers; FRED/BEA series A041RC1A027NBEA. "
-                "Mapped to the closest additive PolicyEngine aggregate: "
-                "total self-employment, farm operations, and "
-                "partnership/S-corp income."
+                "Mapped to the PolicyEngine-US NIPA proprietors' income "
+                "aggregate."
+            ),
+            "year": 2024,
+        }
+    ]
+    assert interest_targets == [
+        {
+            "variable": etl_national_targets.NIPA_PERSONAL_INTEREST_INCOME_VARIABLE,
+            "value": etl_national_targets.BEA_NIPA_PERSONAL_INTEREST_INCOME_2024,
+            "source": "BEA NIPA Table 2.1",
+            "notes": (
+                "Personal interest income for all persons, including "
+                "nonfilers; FRED/BEA series A064RC1A027NBEA. NIPA also "
+                "includes imputed interest, so this is a macro benchmark "
+                "rather than a pure tax concept."
+            ),
+            "year": 2024,
+        }
+    ]
+    assert dividend_targets == [
+        {
+            "variable": "dividend_income",
+            "value": (etl_national_targets.BEA_NIPA_PERSONAL_DIVIDEND_INCOME_2024),
+            "source": "BEA NIPA Table 2.1",
+            "notes": (
+                "Personal dividend income for all persons, including "
+                "nonfilers; FRED/BEA series B703RC1A027NBEA. NIPA "
+                "includes dividends received through pension funds and "
+                "private trusts, so this is a macro benchmark rather than "
+                "a pure tax concept."
             ),
             "year": 2024,
         }

--- a/tests/unit/test_upload_completed_datasets.py
+++ b/tests/unit/test_upload_completed_datasets.py
@@ -19,6 +19,10 @@ from policyengine_us_data.utils.dataset_validation import validate_dataset_contr
 from policyengine_us_data.utils.policyengine import PolicyEngineUSBuildInfo
 
 
+ORIGINAL_MICROSIMULATION_AGGREGATE_CHECKS_BY_FILENAME = (
+    upload_module.MICROSIMULATION_AGGREGATE_CHECKS_BY_FILENAME
+)
+
 VALID_CLONE_DIAGNOSTICS = {
     "period": 2024,
     "clone_household_weight_share_pct": 5.0,
@@ -411,6 +415,51 @@ def test_validate_dataset_rejects_configured_implausible_mapped_aggregate(
         2024,
         "person",
     ) in _TimePeriodCheckingAggregateMicrosimulation.calls
+
+
+def test_enhanced_cps_employment_income_gate_rejects_missing_nipa_target(
+    monkeypatch,
+):
+    target = upload_module.BEA_NIPA_WAGES_AND_SALARIES_2024
+
+    assert upload_module.MIN_ENHANCED_CPS_EMPLOYMENT_INCOME_SUM == pytest.approx(
+        target * 0.9
+    )
+    assert upload_module.MAX_ENHANCED_CPS_EMPLOYMENT_INCOME_SUM == pytest.approx(
+        target * 1.1
+    )
+
+    monkeypatch.setattr(
+        upload_module,
+        "MICROSIMULATION_AGGREGATE_CHECKS_BY_FILENAME",
+        ORIGINAL_MICROSIMULATION_AGGREGATE_CHECKS_BY_FILENAME,
+    )
+    _TimePeriodCheckingAggregateMicrosimulation.overrides = {
+        "employment_income": [8_805_350_912_424.707],
+        "social_security_retirement": [1.0e12],
+        "person_in_poverty": [0.2, 0.2, 0.2],
+        "age": [20, 67, 80],
+    }
+    errors = []
+    results = upload_module._run_microsimulation_aggregate_checks(
+        _TimePeriodCheckingAggregateMicrosimulation(
+            dataset=SimpleNamespace(time_period=2024)
+        ),
+        filename="enhanced_cps_2024.h5",
+        period=2024,
+        errors=errors,
+    )
+
+    assert (
+        "employment_income sum vs NIPA wages target",
+        8_805_350_912_424.707,
+    ) in results
+    assert errors == [
+        (
+            "employment_income sum vs NIPA wages target = "
+            "8,805,350,912,425, expected >= 11,149,136,100,000."
+        )
+    ]
 
 
 def _prepare_release_files(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes #1019

## Summary
- pin `policyengine-us==1.694.0`, the latest PyPI release, and use its canonical `nipa_proprietors_income` variable for the BEA NIPA proprietors' income target
- include the BEA NIPA direct-sum targets in the default unified calibration target config
- add an enhanced CPS upload gate requiring 2024 employment income to be within 10% of the BEA NIPA wages target
- document the loss.py + targets DB + target_config registration rule for future target changes
- refactor the already-existing `loss.py` NIPA targets into a named tuple so tests can enforce loss/DB parity; this is not intended to change legacy ECPS loss behavior
- add tests covering loss/DB target parity, target_config selection, ETL rows, and the upload validation gate

## Verification
- `uv lock --upgrade-package policyengine-us` (resolved to `policyengine-us==1.694.0`)
- `uv run python - <<'PY' ...` confirmed `nipa_proprietors_income` exists in `CountryTaxBenefitSystem().variables`
- `make lint`
- `uv run pytest tests/unit/calibration/test_target_config.py tests/unit/calibration/test_loss_targets.py tests/unit/test_etl_national_targets.py tests/unit/test_upload_completed_datasets.py`
- `/sr` read-only subagent review: no actionable findings

## Local pipeline probe
- Restarted local data + unified calibration sequence from commit `5a294cf0` after switching to `nipa_proprietors_income`.
- Initial `make calibrate` hit missing HF auth for the private PUF repo, so I copied the same prerequisite files from an existing local us-data worktree and reran the equivalent sequence without the download step.
- Current log: `/tmp/us-data-pr1020-local-calibrate-5a294cf0.log`