### PR TITLE
Temporarily disable grouped target loss

### DIFF
--- a/changelog.d/1030.fixed.md
+++ b/changelog.d/1030.fixed.md
@@ -1,0 +1,1 @@
+Temporarily disable grouped target loss during unified L0 calibration.

--- a/policyengine_us_data/calibration/unified_calibration.py
+++ b/policyengine_us_data/calibration/unified_calibration.py
@@ -41,9 +41,6 @@ from policyengine_us_data.calibration.signatures import (
     build_checkpoint_signature,
     checkpoint_signature_mismatches,
 )
-from policyengine_us_data.calibration.calibration_utils import (
-    create_target_groups,
-)
 from policyengine_us_data.pipeline_metadata import pipeline_node
 from policyengine_us_data.stage_contracts.calibration_package import (
     CalibrationPackageParameters,
@@ -1363,7 +1360,9 @@ def run_calibration(
 
         initial_weights = package.get("initial_weights")
         targets = targets_df["value"].values
-        target_groups, _ = create_target_groups(targets_df)
+        # Temporarily disable grouped target loss until target precedence
+        # and tolerance handling can make grouped fitting safe.
+        target_groups = None
         row_sums = np.array(X_sparse.sum(axis=1)).flatten()
         pkg_achievable = row_sums > 0
         weights = fit_l0_weights(
@@ -1704,7 +1703,9 @@ def run_calibration(
 
     # Step 7: L0 calibration
     targets = targets_df["value"].values
-    target_groups, _ = create_target_groups(targets_df)
+    # Temporarily disable grouped target loss until target precedence
+    # and tolerance handling can make grouped fitting safe.
+    target_groups = None
 
     row_sums = np.array(X_sparse.sum(axis=1)).flatten()
     achievable = row_sums > 0


### PR DESCRIPTION
Fixes #1030

## Same-repository PR check

- [x] This PR is from a branch in `PolicyEngine/policyengine-us-data`, not a personal fork.

## Summary

- Temporarily disables grouped target loss in `run_calibration()` by passing `target_groups=None` for both package-loaded and freshly built calibration packages.
- Leaves the lower-level `fit_l0_weights()` target-group argument intact so a safer grouped-loss design can be implemented and tested separately.
- Rebased onto current `origin/main`; the current base already includes `policyengine-us==1.696.0`.
- This is intended as a temporary rollback: I am hoping to disable grouped loss now, then implement an improved target precedence/tolerance system before re-enabling it.

## Validation

- `make lint` passed after rebase.
- `uv run --no-sync python .github/scripts/check_policyengine_us_dependency.py --mode fail` passed after rebase: `policyengine-us` is current at `1.696.0`.
- `uv run --no-sync --with pyyaml python scripts/run_quality_guards.py` passed before rebase.
- `uv run --no-sync --with pyyaml --with pytest pytest tests/unit/test_pipeline_docs_extractor.py tests/unit/test_pipeline_doc_guards.py -q` passed before rebase: 7 tests.
- `uv run pytest tests/unit/calibration/test_unified_calibration.py -q` could not run locally because the locked `torch==2.9.1` dependency does not publish a macOS x86_64 wheel for this environment.

## Documentation Review

Complete this section when the PR changes pipeline behavior, stage boundaries,
generated artifacts, or public library functions. Otherwise mark it `N/A`.

- Touched stages/substages: calibration weight fitting / unified L0 calibration.
- Pipeline map/decorators updated: not required; this changes a fitting option passed into the existing node, not the stage boundary or artifact graph.
- Pydoc/docstrings updated: not required; the durable public API remains unchanged and `fit_l0_weights()` still accepts explicit target groups.
- Generated docs refreshed: not required manually; structural docs guards passed.
- Documentation commands run: `uv run --no-sync --with pyyaml python scripts/run_quality_guards.py`; `uv run --no-sync --with pyyaml --with pytest pytest tests/unit/test_pipeline_docs_extractor.py tests/unit/test_pipeline_doc_guards.py -q`.
- Impact: medium.
- Confidence: high.
- Known documentation gaps: follow-up design should document target precedence, target tolerances, and grouped-loss semantics before grouped loss is re-enabled.