### PR TITLE
Fix long-run support for household-derived weights

### DIFF
--- a/changelog.d/1032.fixed.md
+++ b/changelog.d/1032.fixed.md
@@ -1,0 +1,1 @@
+Fix long-run support augmentation and H5 materialization under household-derived microsimulation weights.

--- a/policyengine_us_data/datasets/cps/long_term/projection_utils.py
+++ b/policyengine_us_data/datasets/cps/long_term/projection_utils.py
@@ -8,6 +8,62 @@ from policyengine_us import Microsimulation
 from policyengine_core.data.dataset import Dataset
 
 
+PERSON_LEVEL_IDENTITY_INPUTS = (
+    "person_id",
+    "household_id",
+    "person_household_id",
+    "family_id",
+    "person_family_id",
+    "tax_unit_id",
+    "person_tax_unit_id",
+    "spm_unit_id",
+    "person_spm_unit_id",
+    "marital_unit_id",
+    "person_marital_unit_id",
+)
+
+
+def _row_values(series):
+    """Return unweighted row values from a MicroSeries-like object."""
+    if hasattr(series, "array"):
+        return np.asarray(series.array)
+    if hasattr(series, "values"):
+        return np.asarray(series.values)
+    return np.asarray(series)
+
+
+def _person_level_values(sim, variable, *, period):
+    try:
+        series = sim.calculate(variable, period=period, map_to="person")
+    except Exception:
+        series = sim.calculate(variable, period=period)
+    return _row_values(series)
+
+
+def ensure_person_level_identity_inputs(df, sim, *, base_period):
+    """
+    Rehydrate identity columns omitted by newer policyengine-core input exports.
+
+    policyengine-core derives relationships and weights from household-level
+    inputs. The H5 materialization path still needs explicit person-row identity
+    columns so ``Dataset.from_dataframe`` can rebuild a runtime dataset.
+    """
+    output = df.copy()
+    person_row_count = len(output)
+    for variable in PERSON_LEVEL_IDENTITY_INPUTS:
+        column = f"{variable}__{base_period}"
+        if column in output.columns:
+            continue
+        values = _person_level_values(sim, variable, period=base_period)
+        if len(values) != person_row_count:
+            raise ValueError(
+                f"Expected {variable} to map to {person_row_count} person rows; "
+                f"got {len(values)}."
+            )
+        output[column] = values
+    return output
+
+
 def validate_projected_social_security_cap(
     parameter_accessor,
     year: int,
@@ -256,6 +312,7 @@ def create_household_year_h5(
     base_period = int(sim.default_calculation_period)
 
     df = sim.to_input_dataframe()
+    df = ensure_person_level_identity_inputs(df, sim, base_period=base_period)
 
     # Remove pseudo-input variables (aggregates of calculated values)
     pseudo_inputs = get_pseudo_input_variables(sim)
@@ -271,9 +328,9 @@ def create_household_year_h5(
     person_household_id = df[f"person_household_id__{base_period}"]
 
     hh_to_weight = dict(zip(household_ids, household_weights))
-    person_weights = person_household_id.map(hh_to_weight)
+    person_level_household_weights = person_household_id.map(hh_to_weight)
 
-    df[f"household_weight__{year}"] = person_weights
+    df[f"household_weight__{year}"] = person_level_household_weights
     df.drop(
         columns=[
             f"household_weight__{base_period}",
@@ -370,6 +427,8 @@ def calculate_year_statistics(
     income_tax_values = income_tax_hh.values
 
     household_microseries = sim.calculate("household_id", map_to="household")
+    # Explicit weight access is reserved for the household-level calibration
+    # decision vector; ordinary aggregates should use MicroSeries methods.
     baseline_weights_actual = household_microseries.weights.values
 
     ss_values = None

--- a/policyengine_us_data/datasets/cps/long_term/prototype_synthetic_2100_support.py
+++ b/policyengine_us_data/datasets/cps/long_term/prototype_synthetic_2100_support.py
@@ -470,6 +470,15 @@ def _period_column(name: str, base_year: int) -> str:
     return f"{name}__{base_year}"
 
 
+def _row_values(series: object) -> np.ndarray:
+    """Return unweighted row values from a MicroSeries-like object."""
+    if hasattr(series, "array"):
+        return np.asarray(series.array)
+    if hasattr(series, "values"):
+        return np.asarray(series.values)
+    return np.asarray(series)
+
+
 def classify_archetype(
     *,
     head_age: float,
@@ -520,37 +529,49 @@ def build_tax_unit_summary(
     reform: object | None = None,
 ) -> pd.DataFrame:
     sim = Microsimulation(dataset=dataset, reform=reform)
-    input_df = sim.to_input_dataframe()
+    # policyengine-core derives all microsimulation weights from household_weight.
+    # Build the person-row donor summary from that source of truth.
+    household_weight_at_person_level = _row_values(
+        sim.calculate("household_weight", period=period, map_to="person")
+    ).astype(float)
 
     person_df = pd.DataFrame(
         {
-            "tax_unit_id": sim.calculate("person_tax_unit_id", period=period).values,
-            "household_id": sim.calculate("person_household_id", period=period).values,
-            "age": sim.calculate("age", period=period).values,
-            "is_head": sim.calculate("is_tax_unit_head", period=period).values,
-            "is_spouse": sim.calculate("is_tax_unit_spouse", period=period).values,
-            "is_dependent": sim.calculate(
-                "is_tax_unit_dependent", period=period
-            ).values,
-            "social_security": sim.calculate("social_security", period=period).values,
-            "payroll": (
-                sim.calculate(
-                    "taxable_earnings_for_social_security", period=period
-                ).values
-                + sim.calculate(
-                    "social_security_taxable_self_employment_income", period=period
-                ).values
+            "tax_unit_id": _row_values(
+                sim.calculate("person_tax_unit_id", period=period)
             ),
-            "dividend_income": sim.calculate(
-                "qualified_dividend_income", period=period
-            ).values,
-            "pension_income": sim.calculate(
-                "taxable_pension_income", period=period
-            ).values,
-            "person_weight": input_df[f"person_weight__{period}"].astype(float).values,
-            "household_weight": input_df[f"household_weight__{period}"]
-            .astype(float)
-            .values,
+            "household_id": _row_values(
+                sim.calculate("person_household_id", period=period)
+            ),
+            "age": _row_values(sim.calculate("age", period=period)),
+            "is_head": _row_values(sim.calculate("is_tax_unit_head", period=period)),
+            "is_spouse": _row_values(
+                sim.calculate("is_tax_unit_spouse", period=period)
+            ),
+            "is_dependent": _row_values(
+                sim.calculate("is_tax_unit_dependent", period=period)
+            ),
+            "social_security": _row_values(
+                sim.calculate("social_security", period=period)
+            ),
+            "payroll": (
+                _row_values(
+                    sim.calculate("taxable_earnings_for_social_security", period=period)
+                )
+                + _row_values(
+                    sim.calculate(
+                        "social_security_taxable_self_employment_income",
+                        period=period,
+                    )
+                )
+            ),
+            "dividend_income": _row_values(
+                sim.calculate("qualified_dividend_income", period=period)
+            ),
+            "pension_income": _row_values(
+                sim.calculate("taxable_pension_income", period=period)
+            ),
+            "household_weight": household_weight_at_person_level,
         }
     )
 
@@ -594,7 +615,6 @@ def build_tax_unit_summary(
             "dividend_income": float(group["dividend_income"].sum()),
             "pension_income": float(group["pension_income"].sum()),
             "support_count_weight": 1.0,
-            "person_weight_proxy": float(group["person_weight"].max()),
             "household_weight_proxy": float(group["household_weight"].max()),
         }
         row["archetype"] = classify_archetype(
@@ -646,11 +666,11 @@ def attach_person_uprating_factors(
         else np.zeros(len(df), dtype=float)
     )
     uprated_payroll = sum(
-        sim.calculate(component, period=target_year).values.astype(float)
+        _row_values(sim.calculate(component, period=target_year)).astype(float)
         for component in PAYROLL_COMPONENTS
     )
     uprated_ss = sum(
-        sim.calculate(component, period=target_year).values.astype(float)
+        _row_values(sim.calculate(component, period=target_year)).astype(float)
         for component in SS_COMPONENTS
     )
     df[PAYROLL_UPRATING_FACTOR_COLUMN] = np.where(
@@ -666,32 +686,80 @@ def attach_person_uprating_factors(
     return df
 
 
+def _person_level_values(
+    sim: Microsimulation,
+    variable: str,
+    *,
+    period: int,
+) -> np.ndarray:
+    try:
+        series = sim.calculate(variable, period=period, map_to="person")
+    except Exception:
+        series = sim.calculate(variable, period=period)
+    return _row_values(series)
+
+
+def ensure_person_level_core_inputs(
+    input_df: pd.DataFrame,
+    sim: Microsimulation,
+    *,
+    base_year: int,
+) -> pd.DataFrame:
+    """Fill aliases that newer policyengine-core omits from input exports.
+
+    policyengine-core#497 made household_weight the source of truth for all
+    microsimulation weights and stopped relying on redundant stored person
+    weights. The support augmentation code still needs person-row IDs so it can
+    clone donors and assign fresh entity identifiers.
+    """
+    df = input_df.copy()
+    person_row_count = len(df)
+    required_person_level_inputs = [
+        PERSON_ID_COLUMN,
+        *(column for columns in ENTITY_ID_COLUMNS.values() for column in columns),
+        "household_weight",
+    ]
+    for variable in required_person_level_inputs:
+        column = _period_column(variable, base_year)
+        if column in df.columns:
+            continue
+        values = _person_level_values(sim, variable, period=base_year)
+        if len(values) != person_row_count:
+            raise ValueError(
+                f"Expected {variable} to map to {person_row_count} person rows; "
+                f"got {len(values)}."
+            )
+        df[column] = values
+    df.drop(
+        columns=[_period_column("person_weight", base_year)],
+        inplace=True,
+        errors="ignore",
+    )
+    return df
+
+
 def load_base_aggregates(
     base_dataset: str,
     *,
     reform: object | None = None,
 ) -> dict[str, float]:
     sim = Microsimulation(dataset=base_dataset, reform=reform)
-    household_series = sim.calculate(
-        "household_id", period=BASE_YEAR, map_to="household"
+    ss = sim.calculate("social_security", period=BASE_YEAR, map_to="household")
+    taxable_wages = sim.calculate(
+        "taxable_earnings_for_social_security",
+        period=BASE_YEAR,
+        map_to="household",
     )
-    weights = household_series.weights.values.astype(float)
-    ss = sim.calculate("social_security", period=BASE_YEAR, map_to="household").values
-    payroll = (
-        sim.calculate(
-            "taxable_earnings_for_social_security",
-            period=BASE_YEAR,
-            map_to="household",
-        ).values
-        + sim.calculate(
-            "social_security_taxable_self_employment_income",
-            period=BASE_YEAR,
-            map_to="household",
-        ).values
+    taxable_self_employment = sim.calculate(
+        "social_security_taxable_self_employment_income",
+        period=BASE_YEAR,
+        map_to="household",
     )
     return {
-        "weighted_ss_total": float(np.sum(ss * weights)),
-        "weighted_payroll_total": float(np.sum(payroll * weights)),
+        "weighted_ss_total": float(ss.sum()),
+        "weighted_payroll_total": float(
+            taxable_wages.sum() + taxable_self_employment.sum()
+        ),
     }
 
 
@@ -1961,7 +2029,6 @@ def _clone_tax_unit_rows_to_target(
 ) -> tuple[pd.DataFrame, dict[str, int]] | tuple[None, dict[str, int]]:
     age_col = _period_column("age", base_year)
     household_weight_col = _period_column("household_weight", base_year)
-    person_weight_col = _period_column("person_weight", base_year)
     person_id_col = _period_column(PERSON_ID_COLUMN, base_year)
 
     adults = donor_rows[donor_rows[age_col] >= 18].sort_values(age_col, ascending=False)
@@ -1975,7 +2042,10 @@ def _clone_tax_unit_rows_to_target(
     ):
         return None, id_counters
 
-    cloned = donor_rows.copy()
+    cloned = donor_rows.drop(
+        columns=[_period_column("person_weight", base_year)],
+        errors="ignore",
+    ).copy()
     household_id = id_counters["household"]
     id_counters["household"] += 1
     for entity_name, columns in ENTITY_ID_COLUMNS.items():
@@ -2003,13 +2073,6 @@ def _clone_tax_unit_rows_to_target(
             * clone_weight_scale
             / max(clone_weight_divisor, 1)
         )
-    if person_weight_col in cloned.columns:
-        cloned[person_weight_col] = (
-            cloned[person_weight_col].astype(float)
-            * clone_weight_scale
-            / max(clone_weight_divisor, 1)
-        )
-
     adult_indices = adults.index.tolist()
     head_idx = adult_indices[0]
     spouse_idx = adult_indices[1] if target_has_spouse else None
@@ -2115,7 +2178,6 @@ def _compose_role_donor_rows_to_target(
 ) -> tuple[pd.DataFrame, dict[str, int]] | tuple[None, dict[str, int]]:
     age_col = _period_column("age", base_year)
     household_weight_col = _period_column("household_weight", base_year)
-    person_weight_col = _period_column("person_weight", base_year)
     person_id_col = _period_column(PERSON_ID_COLUMN, base_year)
 
     def _adult_rows(df: pd.DataFrame | None) -> pd.DataFrame:
@@ -2248,6 +2310,11 @@ def _compose_role_donor_rows_to_target(
     # Reset duplicate donor indices so later row-specific retargeting only touches
     # the intended clone row.
     cloned = pd.DataFrame(selected_rows).reset_index(drop=True).copy()
+    cloned.drop(
+        columns=[_period_column("person_weight", base_year)],
+        inplace=True,
+        errors="ignore",
+    )
     cloned_sources = pd.Series(selected_sources, index=cloned.index)
     household_id = id_counters["household"]
     id_counters["household"] += 1
@@ -2276,13 +2343,6 @@ def _compose_role_donor_rows_to_target(
             * clone_weight_scale
             / max(clone_weight_divisor, 1)
         )
-    if person_weight_col in cloned.columns:
-        cloned[person_weight_col] = (
-            cloned[person_weight_col].astype(float)
-            * clone_weight_scale
-            / max(clone_weight_divisor, 1)
-        )
-
     head_idx = cloned.index[0]
     spouse_idx = cloned.index[1] if target_candidate.spouse_age is not None else None
     dependent_indices = (
@@ -2400,6 +2460,11 @@ def build_donor_backed_augmented_input_dataframe(
         sim,
         base_year=base_year,
         target_year=target_year,
+    )
+    input_df = ensure_person_level_core_inputs(
+        input_df,
+        sim,
+        base_year=base_year,
     )
     actual_summary = build_actual_tax_unit_summary(base_dataset, reform=reform)
     base_aggregates = load_base_aggregates(base_dataset, reform=reform)
@@ -2551,6 +2616,11 @@ def build_role_composite_augmented_input_dataframe(
         sim,
         base_year=base_year,
         target_year=target_year,
+    )
+    input_df = ensure_person_level_core_inputs(
+        input_df,
+        sim,
+        base_year=base_year,
     )
     actual_summary = build_actual_tax_unit_summary(base_dataset, reform=reform)
     base_aggregates = load_base_aggregates(base_dataset, reform=reform)

--- a/policyengine_us_data/datasets/cps/long_term/run_household_projection.py
+++ b/policyengine_us_data/datasets/cps/long_term/run_household_projection.py
@@ -1115,6 +1115,8 @@ for year_idx in range(n_years):
     income_tax_values = income_tax_hh.values
 
     household_microseries = sim.calculate("household_id", map_to="household")
+    # This is the calibrated household-weight decision vector. All ordinary
+    # baseline aggregates should continue to use MicroSeries methods directly.
     baseline_weights = household_microseries.weights.values
     household_ids_hh = household_microseries.values
 

--- a/policyengine_us_data/datasets/cps/long_term/support_augmentation.py
+++ b/policyengine_us_data/datasets/cps/long_term/support_augmentation.py
@@ -8,6 +8,11 @@ import pandas as pd
 from policyengine_core.data.dataset import Dataset
 from policyengine_us import Microsimulation
 
+try:
+    from .projection_utils import ensure_person_level_identity_inputs
+except ImportError:  # pragma: no cover - script execution fallback
+    from projection_utils import ensure_person_level_identity_inputs
+
 
 SS_COMPONENTS = (
     "social_security_retirement",
@@ -700,7 +705,6 @@ def clone_households_with_age_shift(
     person_id_col = _period_column(PERSON_ID_COLUMN, base_year)
     age_col = _period_column("age", base_year)
     household_weight_col = _period_column("household_weight", base_year)
-    person_weight_col = _period_column("person_weight", base_year)
 
     donors = input_df[input_df[household_id_col].isin(household_ids)].copy()
 
@@ -762,10 +766,6 @@ def clone_households_with_age_shift(
     if household_weight_col in donors.columns:
         donors[household_weight_col] = (
             donors[household_weight_col].astype(float) * clone_weight_scale
-        )
-    if person_weight_col in donors.columns:
-        donors[person_weight_col] = (
-            donors[person_weight_col].astype(float) * clone_weight_scale
         )
 
     return donors, next_ids
@@ -848,14 +848,12 @@ def _clone_single_donor_person_row(
     base_year: int,
     shared_household_id: int,
     household_weight: float,
-    person_weight: float,
     donor_age_shift: int,
     id_counters: dict[str, int],
 ) -> tuple[pd.Series, dict[str, int]]:
     cloned = donor_row.copy()
     person_id_col = _period_column(PERSON_ID_COLUMN, base_year)
     household_weight_col = _period_column("household_weight", base_year)
-    person_weight_col = _period_column("person_weight", base_year)
     age_col = _period_column("age", base_year)
 
     cloned[person_id_col] = id_counters["person"]
@@ -878,8 +876,6 @@ def _clone_single_donor_person_row(
     cloned[age_col] = min(float(cloned[age_col]) + donor_age_shift, 85)
     if household_weight_col in cloned.index:
         cloned[household_weight_col] = household_weight
-    if person_weight_col in cloned.index:
-        cloned[person_weight_col] = person_weight
     return cloned, id_counters
 
 
@@ -1028,7 +1024,6 @@ def synthesize_single_person_grid_households(
     age_col = _period_column("age", base_year)
     person_id_col = _period_column(PERSON_ID_COLUMN, base_year)
     household_weight_col = _period_column("household_weight", base_year)
-    person_weight_col = _period_column("person_weight", base_year)
     employment_col = _period_column("employment_income_before_lsr", base_year)
     self_employment_col = _period_column("self_employment_income_before_lsr", base_year)
     qbi_col = _period_column("w2_wages_from_qualified_business", base_year)
@@ -1102,10 +1097,6 @@ def synthesize_single_person_grid_households(
                     base_row[household_weight_col] = (
                         float(base_row[household_weight_col]) * rule.clone_weight_scale
                     )
-                if person_weight_col in base_row:
-                    base_row[person_weight_col] = (
-                        float(base_row[person_weight_col]) * rule.clone_weight_scale
-                    )
                 synthetic_rows.append(base_row)
 
     synthetic_df = pd.DataFrame(synthetic_rows, columns=input_df.columns)
@@ -1172,7 +1163,6 @@ def synthesize_mixed_age_households(
     )
 
     household_id_col = _period_column("household_id", base_year)
-    person_weight_col = _period_column("person_weight", base_year)
 
     original_recipients = pd.unique(
         input_df[
@@ -1201,17 +1191,11 @@ def synthesize_mixed_age_households(
         household_weight = float(
             cloned_household_rows.iloc[0][_period_column("household_weight", base_year)]
         )
-        person_weight = (
-            float(cloned_household_rows.iloc[0][person_weight_col])
-            if person_weight_col in cloned_household_rows.columns
-            else household_weight
-        )
         donor_row, next_ids = _clone_single_donor_person_row(
             donor_rows.loc[donor_row_idx],
             base_year=base_year,
             shared_household_id=cloned_household_id,
             household_weight=household_weight,
-            person_weight=person_weight,
             donor_age_shift=rule.donor_age_shift,
             id_counters=next_ids,
         )
@@ -1325,6 +1309,11 @@ def augment_input_dataframe(
         augmented_df = pd.concat([input_df, *clone_frames], ignore_index=True)
     else:
         augmented_df = input_df.copy()
+    augmented_df.drop(
+        columns=[_period_column("person_weight", base_year)],
+        inplace=True,
+        errors="ignore",
+    )
 
     report = {
         "profile": profile_obj.name,
@@ -1350,6 +1339,11 @@ def build_augmented_dataset(
 ) -> tuple[Dataset, dict[str, Any]]:
     sim = Microsimulation(dataset=base_dataset)
     input_df = sim.to_input_dataframe()
+    input_df = ensure_person_level_identity_inputs(
+        input_df,
+        sim,
+        base_period=base_year,
+    )
     augmented_df, report = augment_input_dataframe(
         input_df,
         base_year=base_year,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us==1.694.0",
+    "policyengine-us==1.696.0",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/tests/unit/test_long_term_calibration_contract.py
+++ b/tests/unit/test_long_term_calibration_contract.py
@@ -47,6 +47,8 @@ from policyengine_us_data.datasets.cps.long_term.projection_utils import (
     aggregate_age_targets,
     aggregate_household_age_matrix,
     build_age_bins,
+    create_household_year_h5,
+    ensure_person_level_identity_inputs,
     project_input_variable_values_to_person_rows,
     validate_projected_social_security_cap,
 )
@@ -65,6 +67,7 @@ from policyengine_us_data.datasets.cps.long_term.support_augmentation import (
     SinglePersonSyntheticGridRule,
     SupportAugmentationProfile,
     augment_input_dataframe,
+    build_augmented_dataset,
     build_targeted_donor_augmented_dataset,
     household_support_summary,
     is_targeted_donor_support_augmentation_profile,
@@ -165,6 +168,111 @@ def test_named_profile_lookup():
     assert profile.min_effective_sample_size == 75.0
     assert profile.max_top_10_weight_share_pct == 25.0
     assert profile.max_top_100_weight_share_pct == 95.0
+
+
+def test_identity_inputs_fill_missing_person_id_for_h5_materialization():
+    import pandas as pd
+
+    data = _toy_support_dataframe()
+    data.pop("person_id__2024")
+    df = pd.DataFrame(data)
+
+    class FakeSim:
+        def calculate(self, variable, *, period=None, map_to=None):
+            assert variable == "person_id"
+            assert period == 2024
+            assert map_to == "person"
+            return SimpleNamespace(values=np.array([501, 502, 503, 504, 505]))
+
+    enriched = ensure_person_level_identity_inputs(
+        df,
+        FakeSim(),
+        base_period=2024,
+    )
+
+    assert enriched["person_id__2024"].tolist() == [501, 502, 503, 504, 505]
+
+
+def test_rule_based_support_builder_rehydrates_missing_person_id(monkeypatch):
+    import pandas as pd
+    from policyengine_us import Microsimulation
+
+    dataset = Dataset.from_dataframe(pd.DataFrame(_toy_support_dataframe()), 2024)
+    original_to_input_dataframe = Microsimulation.to_input_dataframe
+
+    def without_redundant_core_columns(self, *args, **kwargs):
+        return original_to_input_dataframe(self, *args, **kwargs).drop(
+            columns=["person_id__2024", "person_weight__2024"],
+            errors="ignore",
+        )
+
+    monkeypatch.setattr(
+        Microsimulation,
+        "to_input_dataframe",
+        without_redundant_core_columns,
+    )
+    profile = SupportAugmentationProfile(
+        name="test-profile",
+        description="Toy support augmentation profile.",
+        rules=(
+            AgeShiftCloneRule(
+                name="older_ss_pay",
+                min_max_age=65,
+                max_max_age=74,
+                age_shift=10,
+                ss_state="positive",
+                payroll_state="positive",
+                clone_weight_scale=0.5,
+            ),
+        ),
+    )
+
+    _, report = build_augmented_dataset(
+        base_dataset=dataset,
+        base_year=2024,
+        profile=profile,
+    )
+
+    assert report["base_household_count"] == 3
+    assert report["augmented_household_count"] == 4
+
+
+def test_create_household_year_h5_rehydrates_identity_without_person_weight(
+    tmp_path,
+    monkeypatch,
+):
+    import h5py
+    import pandas as pd
+    from policyengine_us import Microsimulation
+
+    dataset = Dataset.from_dataframe(pd.DataFrame(_toy_support_dataframe()), 2024)
+    original_to_input_dataframe = Microsimulation.to_input_dataframe
+
+    def without_redundant_core_columns(self, *args, **kwargs):
+        return original_to_input_dataframe(self, *args, **kwargs).drop(
+            columns=["person_id__2024", "person_weight__2024"],
+            errors="ignore",
+        )
+
+    monkeypatch.setattr(
+        Microsimulation,
+        "to_input_dataframe",
+        without_redundant_core_columns,
+    )
+
+    h5_path = create_household_year_h5(
+        2025,
+        np.array([10.0, 8.0, 5.0]),
+        dataset,
+        tmp_path,
+    )
+
+    with h5py.File(h5_path) as h5_file:
+        assert h5_file["person_id"]["2025"].shape == (5,)
+        assert h5_file["person_household_id"]["2025"].shape == (5,)
+        assert h5_file["household_id"]["2025"].shape == (3,)
+        assert h5_file["household_weight"]["2025"].shape == (3,)
+        assert "person_weight" not in h5_file
 
 
 def test_project_input_variable_values_aligns_tax_unit_outputs_to_person_rows():
@@ -312,6 +420,49 @@ def test_support_augmentation_profile_registry_includes_runner_profiles():
     assert not is_targeted_donor_support_augmentation_profile("late-clone-v1")
 
 
+def test_tax_unit_summary_uses_household_weight_without_person_weight_input():
+    import pandas as pd
+
+    data = _toy_support_dataframe()
+    data.pop("person_weight__2024")
+    dataset = Dataset.from_dataframe(pd.DataFrame(data), 2024)
+
+    summary = synthetic_support_module.build_tax_unit_summary(
+        dataset,
+        period=2024,
+    )
+
+    by_tax_unit = summary.set_index("tax_unit_id")
+    assert by_tax_unit.loc[101, "household_weight_proxy"] == pytest.approx(10.0)
+    assert by_tax_unit.loc[201, "household_weight_proxy"] == pytest.approx(8.0)
+    assert by_tax_unit.loc[301, "household_weight_proxy"] == pytest.approx(5.0)
+    assert "person_weight_proxy" not in summary.columns
+
+
+def test_support_inputs_fill_missing_person_ids_without_person_weight():
+    import pandas as pd
+
+    data = _toy_support_dataframe()
+    data.pop("person_id__2024")
+    data.pop("person_weight__2024")
+    df = pd.DataFrame(data)
+
+    class FakeSim:
+        def calculate(self, variable, *, period=None, map_to=None):
+            assert period == 2024
+            assert variable == "person_id"
+            return SimpleNamespace(values=np.array([501, 502, 503, 504, 505]))
+
+    enriched = synthetic_support_module.ensure_person_level_core_inputs(
+        df,
+        FakeSim(),
+        base_year=2024,
+    )
+
+    assert enriched["person_id__2024"].tolist() == [501, 502, 503, 504, 505]
+    assert "person_weight__2024" not in enriched.columns
+
+
 def test_targeted_donor_support_builder_rejects_unknown_profile():
     with pytest.raises(ValueError, match="Unknown targeted donor support profile"):
         build_targeted_donor_augmented_dataset(
@@ -428,6 +579,7 @@ def test_support_augmentation_clones_households_with_new_ids():
     assert cloned_rows["age__2024"].max() == pytest.approx(80.0)
     assert cloned_rows["household_weight__2024"].iloc[0] == pytest.approx(5.0)
     assert cloned_rows["person_id__2024"].min() > df["person_id__2024"].max()
+    assert "person_weight__2024" not in augmented_df.columns
 
 
 def test_support_augmentation_synthesizes_composite_payroll_household():
@@ -633,7 +785,6 @@ def test_role_donor_composites_build_structural_candidate_from_role_donors():
                 "dividend_income": 2_000.0,
                 "pension_income": 8_000.0,
                 "support_count_weight": 1.0,
-                "person_weight_proxy": 1.0,
                 "archetype": "older_beneficiary_single",
             },
             {
@@ -652,7 +803,6 @@ def test_role_donor_composites_build_structural_candidate_from_role_donors():
                 "dividend_income": 0.0,
                 "pension_income": 0.0,
                 "support_count_weight": 1.0,
-                "person_weight_proxy": 1.0,
                 "archetype": "prime_worker_family",
             },
         ]
@@ -713,7 +863,6 @@ def test_role_donor_composites_preserve_taxable_payroll_under_cap():
                 "dividend_income": 0.0,
                 "pension_income": 0.0,
                 "support_count_weight": 1.0,
-                "person_weight_proxy": 1.0,
                 "archetype": "prime_worker_couple",
             },
         ]

--- a/uv.lock
+++ b/uv.lock
@@ -2122,7 +2122,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.694.0"
+version = "1.696.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2132,9 +2132,9 @@ dependencies = [
     { name = "tables" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/08/236f8e9838e5beab2fc24cd90672128e6c90525a26c8b291c400d66d72d3/policyengine_us-1.694.0.tar.gz", hash = "sha256:61f148afb4095553573bc9285d701b82b28f496fdc91ea3640d2353dd2ba0a4f", size = 9765990, upload-time = "2026-05-19T03:50:02.182Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/2b/1273935d971ba3d7b2dfb23f57970b4a1562f6bc046674ddd2b3b3f72aaa/policyengine_us-1.696.0.tar.gz", hash = "sha256:be2e28871260aef69f7f24142394dde83036c70b71558cd67887cca491759072", size = 9773473, upload-time = "2026-05-19T15:21:42.887Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/03/fc6d4613cbe265db18d07a6a5a5cfd5f9f989e6686a4df1f7bfbe59576b4/policyengine_us-1.694.0-py3-none-any.whl", hash = "sha256:20202d3a66c6e6595ac9786e22da3696b122cef86d4545a612c7710f54463c3e", size = 10307601, upload-time = "2026-05-19T03:49:58.646Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/1e/938b10a2740dec6cc30b29b2960478774f8a9cea8e94fe9e21867829d440/policyengine_us-1.696.0-py3-none-any.whl", hash = "sha256:41b6331ef0a3164aaa60686845517414a743c1b2333e17bb46b20d98aade14bd", size = 10332273, upload-time = "2026-05-19T15:21:39.563Z" },
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", specifier = "==1.694.0" },
+    { name = "policyengine-us", specifier = "==1.696.0" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },


### PR DESCRIPTION
## Summary
- derive long-run support donor weights from `household_weight` and drop legacy `person_weight` outputs
- rehydrate person-row identity inputs when newer policyengine-core omits redundant columns from `to_input_dataframe()`
- add regression coverage for rule-based support augmentation and H5 materialization without `person_id`/`person_weight` exports

## Verification
- `ruff check policyengine_us_data/datasets/cps/long_term/support_augmentation.py policyengine_us_data/datasets/cps/long_term/prototype_synthetic_2100_support.py policyengine_us_data/datasets/cps/long_term/projection_utils.py policyengine_us_data/datasets/cps/long_term/run_household_projection.py tests/unit/test_long_term_calibration_contract.py`
- `pytest tests/unit/test_long_term_calibration_contract.py`
- local 2075 CRFB sentinel completed and wrote `/tmp/crfb_2075_sentinel_v2/2075.h5`; generated H5 includes `person_id`, `household_id`, `person_household_id`, and `household_weight`, with no `person_weight` dataset

## Notes
- explicit `.weights` access remains only where constructing the household-level calibration decision vector
- reviewed by two subagents; second pass reported no actionable findings
