### PR TITLE
Centralize Stage 3 fit specs and artifacts

### DIFF
--- a/changelog.d/1040.changed
+++ b/changelog.d/1040.changed
@@ -1,0 +1,1 @@
+Centralized Stage 3 fitted-weight specs and artifact filenames.

--- a/docs/engineering/stages/fit_weights.md
+++ b/docs/engineering/stages/fit_weights.md
@@ -1,0 +1,23 @@
+# Stage 3: Fit Weights
+
+Stage 3 produces scoped fitted-weight artifacts for regional and national H5
+builds. The public identity boundary lives in `policyengine_us_data.fit_weights`:
+
+- `FitScope` names the durable regional and national scopes.
+- `FittedWeightsSpec` defines the scoped optimization parameters recorded in
+  step manifests for reuse decisions.
+- `ScopedFitArtifacts` defines the artifact filenames written by the Modal fit
+  step and consumed by downstream H5 builders.
+
+The current artifact names remain behavior-compatible:
+
+- regional: `calibration_weights.npy`, `geography_assignment.npz`,
+  `unified_run_config.json`, `unified_diagnostics.csv`, and
+  `calibration_log.csv`;
+- national: `national_calibration_weights.npy`,
+  `national_geography_assignment.npz`, `national_unified_run_config.json`,
+  `national_unified_diagnostics.csv`, and `national_calibration_log.csv`.
+
+When changing Stage 3 fitting parameters, artifact names, or scope behavior,
+update the central specs first and then adapt Modal callers to consume those
+specs. Do not add parallel filename constants in orchestration code.

--- a/docs/pipeline_map.yaml
+++ b/docs/pipeline_map.yaml
@@ -947,6 +947,8 @@ stages:
     label: run_calibration()
     description: 'Fit phase: initialize weights, optimize sparse calibration weights, and emit artifacts plus diagnostics'
     node_ids:
+    - fit_spec_regional
+    - fit_artifacts_regional
     - init_weights
     - create_model
     - fit_model
@@ -964,6 +966,14 @@ stages:
     label: Modal GPU Container
     node_type: external
     description: T4 / A10 / A100 / H100 - 32GB RAM, 8 CPU
+  - id: fit_spec_regional
+    label: FittedWeightsSpec regional
+    node_type: library
+    description: Regional Stage 3 fit hyperparameters and deterministic reuse identity
+  - id: fit_artifacts_regional
+    label: ScopedFitArtifacts regional
+    node_type: library
+    description: Regional fitted-weight artifact filenames and remote result mapping
   - id: create_model
     label: Create SparseCalibrationWeights
     node_type: process
@@ -977,7 +987,7 @@ stages:
     node_type: artifact
     description: 'Shape: (n_records x n_clones) - most entries zero'
   - id: out_geo_s6
-    label: geography.npz
+    label: geography_assignment.npz
     node_type: artifact
     description: block_geoid, cd_geoid, county_fips, state_fips
   - id: out_diag
@@ -1000,6 +1010,21 @@ stages:
   - source: in_pkg_s6
     target: init_weights
     edge_type: data_flow
+  - source: fit_spec_regional
+    target: fit_model
+    edge_type: uses_library
+  - source: fit_artifacts_regional
+    target: out_weights
+    edge_type: documents
+  - source: fit_artifacts_regional
+    target: out_geo_s6
+    edge_type: documents
+  - source: fit_artifacts_regional
+    target: out_diag
+    edge_type: documents
+  - source: fit_artifacts_regional
+    target: out_config_s6
+    edge_type: documents
   - source: init_weights
     target: create_model
     edge_type: data_flow
@@ -1047,6 +1072,8 @@ stages:
     label: run_calibration() national
     description: 'National fit phase: initialize national weights, optimize sparse calibration weights, and emit national artifacts plus diagnostics'
     node_ids:
+    - fit_spec_national
+    - fit_artifacts_national
     - init_weights
     - create_model_national
     - fit_model
@@ -1064,6 +1091,14 @@ stages:
     label: Modal GPU Container
     node_type: external
     description: T4 / A10 / A100 / H100 for national calibration
+  - id: fit_spec_national
+    label: FittedWeightsSpec national
+    node_type: library
+    description: National Stage 3 fit hyperparameters and deterministic reuse identity
+  - id: fit_artifacts_national
+    label: ScopedFitArtifacts national
+    node_type: library
+    description: National fitted-weight artifact filenames and remote result mapping
   - id: create_model_national
     label: Create National SparseCalibrationWeights
     node_type: process
@@ -1100,6 +1135,21 @@ stages:
   - source: in_pkg_national_s6
     target: init_weights
     edge_type: data_flow
+  - source: fit_spec_national
+    target: fit_model
+    edge_type: uses_library
+  - source: fit_artifacts_national
+    target: out_national_weights
+    edge_type: documents
+  - source: fit_artifacts_national
+    target: out_national_geo_s6
+    edge_type: documents
+  - source: fit_artifacts_national
+    target: out_national_diag
+    edge_type: documents
+  - source: fit_artifacts_national
+    target: out_national_config_s6
+    edge_type: documents
   - source: init_weights
     target: create_model_national
     edge_type: data_flow

--- a/modal_app/local_area.py
+++ b/modal_app/local_area.py
@@ -55,6 +55,10 @@ from policyengine_us_data.build_outputs.worker_responses import (  # noqa: E402
 from policyengine_us_data.build_outputs.worker_inputs import (  # noqa: E402
     WorkerCalibrationInputs,
 )
+from policyengine_us_data.fit_weights import (  # noqa: E402
+    FitScope,
+    fit_artifacts_for_scope,
+)
 from policyengine_us_data.pipeline_metadata import pipeline_node  # noqa: E402
 from policyengine_us_data.pipeline_schema import PipelineNode  # noqa: E402
 from policyengine_us_data.utils.run_context import (  # noqa: E402
@@ -1310,11 +1314,12 @@ def coordinate_publish(
     artifacts = (
         Path(f"/pipeline/artifacts/{run_id}") if run_id else Path("/pipeline/artifacts")
     )
-    weights_path = artifacts / "calibration_weights.npy"
-    geography_path = artifacts / "geography_assignment.npz"
+    regional_fit_artifacts = fit_artifacts_for_scope(FitScope.REGIONAL)
+    weights_path = artifacts / regional_fit_artifacts.weights.filename
+    geography_path = artifacts / regional_fit_artifacts.geography.filename
     db_path = artifacts / "policy_data.db"
     dataset_path = artifacts / "source_imputed_stratified_extended_cps.h5"
-    config_json_path = artifacts / "unified_run_config.json"
+    config_json_path = artifacts / regional_fit_artifacts.run_config.filename
     calibration_package_path = artifacts / "calibration_package.pkl"
 
     required = {
@@ -1609,11 +1614,13 @@ def coordinate_national_publish(
     artifacts = (
         Path(f"/pipeline/artifacts/{run_id}") if run_id else Path("/pipeline/artifacts")
     )
-    weights_path = artifacts / "national_calibration_weights.npy"
-    geography_path = artifacts / "national_geography_assignment.npz"
+    regional_fit_artifacts = fit_artifacts_for_scope(FitScope.REGIONAL)
+    national_fit_artifacts = fit_artifacts_for_scope(FitScope.NATIONAL)
+    weights_path = artifacts / national_fit_artifacts.weights.filename
+    geography_path = artifacts / national_fit_artifacts.geography.filename
     db_path = artifacts / "policy_data.db"
     dataset_path = artifacts / "source_imputed_stratified_extended_cps.h5"
-    config_json_path = artifacts / "national_unified_run_config.json"
+    config_json_path = artifacts / national_fit_artifacts.run_config.filename
 
     required = {
         "weights": weights_path,
@@ -1641,8 +1648,8 @@ def coordinate_national_publish(
         config_json_path,
         artifacts,
         filename_remap={
-            "calibration_weights.npy": "national_calibration_weights.npy",
-            "geography_assignment.npz": "national_geography_assignment.npz",
+            regional_fit_artifacts.weights.filename: national_fit_artifacts.weights.filename,
+            regional_fit_artifacts.geography.filename: national_fit_artifacts.geography.filename,
         },
     )
     fingerprint_inputs = _build_publishing_input_bundle(

--- a/modal_app/pipeline.py
+++ b/modal_app/pipeline.py
@@ -108,6 +108,12 @@ from policyengine_us_data.utils.step_manifest import (  # noqa: E402
 )
 from policyengine_us_data.pipeline_metadata import pipeline_node  # noqa: E402
 from policyengine_us_data.pipeline_schema import PipelineNode  # noqa: E402
+from policyengine_us_data.fit_weights import (  # noqa: E402
+    FitScope,
+    NATIONAL_FIT_LAMBDA_L0 as _NATIONAL_FIT_LAMBDA_L0,
+    fit_artifacts_for_scope,
+    fitted_weights_spec_for_scope,
+)
 
 # ── Modal resources ──────────────────────────────────────────────
 
@@ -117,7 +123,7 @@ app = modal.App(
     or "policyengine-us-data-pipeline"
 )
 
-NATIONAL_FIT_LAMBDA_L0 = 1e-4
+NATIONAL_FIT_LAMBDA_L0 = _NATIONAL_FIT_LAMBDA_L0
 
 hf_secret = modal.Secret.from_name("huggingface-token")
 gcp_secret = modal.Secret.from_name("gcp-credentials")
@@ -272,16 +278,14 @@ def archive_diagnostics(
     result_bytes: dict,
     vol: modal.Volume,
     prefix: str = "",
+    scope: FitScope | str | None = None,
 ) -> None:
     """Archive calibration diagnostics to the run directory."""
     diag_dir = Path(RUNS_DIR) / run_id / "diagnostics"
     diag_dir.mkdir(parents=True, exist_ok=True)
 
-    file_map = {
-        "log": f"{prefix}unified_diagnostics.csv",
-        "cal_log": f"{prefix}calibration_log.csv",
-        "config": f"{prefix}unified_run_config.json",
-    }
+    scope = scope or (FitScope.NATIONAL if prefix == "national_" else FitScope.REGIONAL)
+    file_map = fit_artifacts_for_scope(scope).diagnostic_result_filenames()
 
     for key, filename in file_map.items():
         data = result_bytes.get(key)
@@ -1317,25 +1321,19 @@ def run_pipeline(
                 / "calibration_package.pkl",
             }
         )
-        regional_fit_parameters = {
-            "gpu": gpu,
-            "epochs": epochs,
-            "target_config": "policyengine_us_data/calibration/target_config.yaml",
-            "beta": 0.65,
-            "lambda_l0": 1e-7,
-            "lambda_l2": 1e-8,
-            "log_freq": 100,
-        }
-        national_fit_parameters = {
-            "gpu": national_gpu,
-            "epochs": national_epochs,
-            "target_config": "policyengine_us_data/calibration/target_config.yaml",
-            "beta": 0.65,
-            "lambda_l0": NATIONAL_FIT_LAMBDA_L0,
-            "lambda_l2": 1e-12,
-            "log_freq": 100,
-            "skip_national": skip_national,
-        }
+        regional_fit_spec = fitted_weights_spec_for_scope(FitScope.REGIONAL)
+        national_fit_spec = fitted_weights_spec_for_scope(FitScope.NATIONAL)
+        regional_fit_artifacts = fit_artifacts_for_scope(FitScope.REGIONAL)
+        national_fit_artifacts = fit_artifacts_for_scope(FitScope.NATIONAL)
+        regional_fit_parameters = regional_fit_spec.manifest_parameters(
+            gpu=gpu,
+            epochs=epochs,
+        )
+        national_fit_parameters = national_fit_spec.manifest_parameters(
+            gpu=national_gpu,
+            epochs=national_epochs,
+            extra={"skip_national": skip_national},
+        )
         regional_fit_reuse = _step_reusable(
             meta,
             WEIGHT_FITTING_REGIONAL,
@@ -1375,7 +1373,6 @@ def run_pipeline(
             step_start = time.time()
 
             vol_path = f"{artifacts_dir_for_run(run_id)}/calibration_package.pkl"
-            target_cfg = "policyengine_us_data/calibration/target_config.yaml"
 
             # Spawn regional fit
             regional_func = PACKAGE_GPU_FUNCTIONS[gpu]
@@ -1384,11 +1381,7 @@ def run_pipeline(
                 branch=branch,
                 epochs=epochs,
                 volume_package_path=vol_path,
-                target_config=target_cfg,
-                beta=0.65,
-                lambda_l0=1e-7,
-                lambda_l2=1e-8,
-                log_freq=100,
+                **regional_fit_spec.runtime_kwargs(),
             )
             print(f"    → regional fit fc: {regional_handle.object_id}")
             regional_fit_manifest = _start_step_manifest(
@@ -1416,11 +1409,7 @@ def run_pipeline(
                     branch=branch,
                     epochs=national_epochs,
                     volume_package_path=vol_path,
-                    target_config=target_cfg,
-                    beta=0.65,
-                    lambda_l0=NATIONAL_FIT_LAMBDA_L0,
-                    lambda_l2=1e-12,
-                    log_freq=100,
+                    **national_fit_spec.runtime_kwargs(),
                 )
                 print(f"    → national fit fc: {national_handle.object_id}")
                 national_fit_manifest = _start_step_manifest(
@@ -1443,31 +1432,27 @@ def run_pipeline(
             with pipeline_volume.batch_upload(force=True) as batch:
                 batch.put_file(
                     BytesIO(regional_result["weights"]),
-                    f"{artifacts_rel}/calibration_weights.npy",
+                    f"{artifacts_rel}/{regional_fit_artifacts.weights.filename}",
                 )
                 if regional_result.get("geography"):
                     batch.put_file(
                         BytesIO(regional_result["geography"]),
-                        f"{artifacts_rel}/geography_assignment.npz",
+                        f"{artifacts_rel}/{regional_fit_artifacts.geography.filename}",
                     )
                 if regional_result.get("config"):
                     batch.put_file(
                         BytesIO(regional_result["config"]),
-                        f"{artifacts_rel}/unified_run_config.json",
+                        f"{artifacts_rel}/{regional_fit_artifacts.run_config.filename}",
                     )
 
             archive_diagnostics(
                 run_id,
                 regional_result,
                 pipeline_volume,
-                prefix="",
+                scope=FitScope.REGIONAL,
             )
             regional_outputs = collect_artifacts(
-                [
-                    _artifacts_dir(run_id) / "calibration_weights.npy",
-                    _artifacts_dir(run_id) / "geography_assignment.npz",
-                    _artifacts_dir(run_id) / "unified_run_config.json",
-                ],
+                regional_fit_artifacts.artifact_paths(_artifacts_dir(run_id)),
                 missing_ok=True,
             )
             regional_fit_reuse_measurement = ReuseMeasurement(
@@ -1493,31 +1478,27 @@ def run_pipeline(
                 with pipeline_volume.batch_upload(force=True) as batch:
                     batch.put_file(
                         BytesIO(national_result["weights"]),
-                        f"{artifacts_rel}/national_calibration_weights.npy",
+                        f"{artifacts_rel}/{national_fit_artifacts.weights.filename}",
                     )
                     if national_result.get("geography"):
                         batch.put_file(
                             BytesIO(national_result["geography"]),
-                            f"{artifacts_rel}/national_geography_assignment.npz",
+                            f"{artifacts_rel}/{national_fit_artifacts.geography.filename}",
                         )
                     if national_result.get("config"):
                         batch.put_file(
                             BytesIO(national_result["config"]),
-                            f"{artifacts_rel}/national_unified_run_config.json",
+                            f"{artifacts_rel}/{national_fit_artifacts.run_config.filename}",
                         )
 
                 archive_diagnostics(
                     run_id,
                     national_result,
                     pipeline_volume,
-                    prefix="national_",
+                    scope=FitScope.NATIONAL,
                 )
                 national_outputs = collect_artifacts(
-                    [
-                        _artifacts_dir(run_id) / "national_calibration_weights.npy",
-                        _artifacts_dir(run_id) / "national_geography_assignment.npz",
-                        _artifacts_dir(run_id) / "national_unified_run_config.json",
-                    ],
+                    national_fit_artifacts.artifact_paths(_artifacts_dir(run_id)),
                     missing_ok=True,
                 )
                 _complete_step_manifest(
@@ -1544,12 +1525,15 @@ def run_pipeline(
         #   4e. upload_run_diagnostics (validation diagnostics → HF)
         regional_h5_inputs = _artifact_identities(
             {
-                "weights": _artifacts_dir(run_id) / "calibration_weights.npy",
-                "geography": _artifacts_dir(run_id) / "geography_assignment.npz",
+                "weights": _artifacts_dir(run_id)
+                / regional_fit_artifacts.weights.filename,
+                "geography": _artifacts_dir(run_id)
+                / regional_fit_artifacts.geography.filename,
                 "dataset": _artifacts_dir(run_id)
                 / "source_imputed_stratified_extended_cps.h5",
                 "database": _artifacts_dir(run_id) / "policy_data.db",
-                "run_config": _artifacts_dir(run_id) / "unified_run_config.json",
+                "run_config": _artifacts_dir(run_id)
+                / regional_fit_artifacts.run_config.filename,
                 "calibration_package": _artifacts_dir(run_id)
                 / "calibration_package.pkl",
             }
@@ -1562,14 +1546,15 @@ def run_pipeline(
         }
         national_h5_inputs = _artifact_identities(
             {
-                "weights": _artifacts_dir(run_id) / "national_calibration_weights.npy",
+                "weights": _artifacts_dir(run_id)
+                / national_fit_artifacts.weights.filename,
                 "geography": _artifacts_dir(run_id)
-                / "national_geography_assignment.npz",
+                / national_fit_artifacts.geography.filename,
                 "dataset": _artifacts_dir(run_id)
                 / "source_imputed_stratified_extended_cps.h5",
                 "database": _artifacts_dir(run_id) / "policy_data.db",
                 "run_config": _artifacts_dir(run_id)
-                / "national_unified_run_config.json",
+                / national_fit_artifacts.run_config.filename,
             }
         )
         national_h5_parameters = {

--- a/modal_app/remote_calibration_runner.py
+++ b/modal_app/remote_calibration_runner.py
@@ -12,6 +12,11 @@ for _p in (_baked, _local):
         sys.path.insert(0, _p)
 
 from modal_app.images import gpu_image as image  # noqa: E402
+from policyengine_us_data.fit_weights import (  # noqa: E402
+    FitScope,
+    NATIONAL_FIT_LAMBDA_L0,
+    fit_artifacts_for_scope,
+)
 
 app = modal.App(
     os.environ.get("US_DATA_FIT_WEIGHTS_APP_NAME") or "policyengine-us-data-fit-weights"
@@ -140,6 +145,42 @@ def _collect_outputs(cal_lines):
         "log": log_bytes,
         "cal_log": cal_log_bytes,
         "config": config_bytes,
+    }
+
+
+def _fit_output_filenames(
+    *,
+    scope: FitScope | str,
+    output: str | None,
+    log_output: str | None,
+) -> dict[str, str]:
+    """Return local and pipeline-volume filenames for one fit scope."""
+
+    scope = FitScope.parse(scope)
+    scoped = fit_artifacts_for_scope(scope)
+    regional = fit_artifacts_for_scope(FitScope.REGIONAL)
+    output = output or regional.weights.filename
+    log_output = log_output or regional.diagnostics.filename
+    if scope == FitScope.NATIONAL:
+        output = (
+            scoped.weights.filename
+            if output == regional.weights.filename
+            else f"national_{output}"
+        )
+        log_output = (
+            scoped.diagnostics.filename
+            if log_output == regional.diagnostics.filename
+            else f"national_{log_output}"
+        )
+    return {
+        "output": output,
+        "log_output": log_output,
+        "geography": scoped.geography.filename,
+        "calibration_log": scoped.epoch_log.filename,
+        "run_config": scoped.run_config.filename,
+        "pipeline_weights": scoped.weights.filename,
+        "pipeline_geography": scoped.geography.filename,
+        "pipeline_run_config": scoped.run_config.filename,
     }
 
 
@@ -947,12 +988,18 @@ def main(
     trigger_publish: bool = False,
     national: bool = False,
 ):
+    scope = FitScope.NATIONAL if national else FitScope.REGIONAL
     prefix = "national_" if national else ""
+    output_filenames = _fit_output_filenames(
+        scope=scope,
+        output=output,
+        log_output=log_output,
+    )
+    output = output_filenames["output"]
+    log_output = output_filenames["log_output"]
     if national:
         if lambda_l0 is None:
-            lambda_l0 = 1e-4
-        output = f"{prefix}{output}"
-        log_output = f"{prefix}{log_output}"
+            lambda_l0 = NATIONAL_FIT_LAMBDA_L0
 
     if gpu not in GPU_FUNCTIONS:
         raise ValueError(
@@ -1060,11 +1107,11 @@ def main(
                 flush=True,
             )
             print(
-                f"  - calibration/{prefix}calibration_weights.npy",
+                f"  - calibration/{output_filenames['pipeline_weights']}",
                 flush=True,
             )
             print(
-                f"  - calibration/{prefix}geography_assignment.npz",
+                f"  - calibration/{output_filenames['pipeline_geography']}",
                 flush=True,
             )
             print(
@@ -1098,19 +1145,19 @@ def main(
             f.write(result["log"])
         print(f"Diagnostics log saved to: {log_output}")
 
-    geography_output = f"{prefix}geography_assignment.npz"
+    geography_output = output_filenames["geography"]
     if result.get("geography"):
         with open(geography_output, "wb") as f:
             f.write(result["geography"])
         print(f"Geography saved to: {geography_output}")
 
-    cal_log_output = f"{prefix}calibration_log.csv"
+    cal_log_output = output_filenames["calibration_log"]
     if result.get("cal_log"):
         with open(cal_log_output, "wb") as f:
             f.write(result["cal_log"])
         print(f"Calibration log saved to: {cal_log_output}")
 
-    config_output = f"{prefix}unified_run_config.json"
+    config_output = output_filenames["run_config"]
     if result.get("config"):
         with open(config_output, "wb") as f:
             f.write(result["config"])
@@ -1123,17 +1170,17 @@ def main(
     with pipeline_vol.batch_upload(force=True) as batch:
         batch.put_file(
             BytesIO(result["weights"]),
-            f"artifacts/{prefix}calibration_weights.npy",
+            f"artifacts/{output_filenames['pipeline_weights']}",
         )
         if result.get("geography"):
             batch.put_file(
                 BytesIO(result["geography"]),
-                f"artifacts/{prefix}geography_assignment.npz",
+                f"artifacts/{output_filenames['pipeline_geography']}",
             )
         if result.get("config"):
             batch.put_file(
                 BytesIO(result["config"]),
-                f"artifacts/{prefix}unified_run_config.json",
+                f"artifacts/{output_filenames['pipeline_run_config']}",
             )
     pipeline_vol.commit()
     print("Weights committed to pipeline volume", flush=True)

--- a/policyengine_us_data/fit_weights/__init__.py
+++ b/policyengine_us_data/fit_weights/__init__.py
@@ -1,0 +1,43 @@
+"""Stage 3 fitted-weight specifications and artifact identities."""
+
+from policyengine_us_data.fit_weights.artifacts import (
+    FitArtifactLocation,
+    FitArtifactRole,
+    FitArtifactSpec,
+    ScopedFitArtifacts,
+    fit_artifacts_for_scope,
+)
+from policyengine_us_data.fit_weights.specs import (
+    FIT_BETA,
+    FIT_LOG_FREQ,
+    FIT_TARGET_CONFIG_PATH,
+    FIT_WEIGHTS_SPEC_SCHEMA_VERSION,
+    NATIONAL_FIT_LAMBDA_L0,
+    NATIONAL_FIT_LAMBDA_L2,
+    REGIONAL_FIT_LAMBDA_L0,
+    REGIONAL_FIT_LAMBDA_L2,
+    FitHyperparameters,
+    FitScope,
+    FittedWeightsSpec,
+    fitted_weights_spec_for_scope,
+)
+
+__all__ = [
+    "FIT_BETA",
+    "FIT_LOG_FREQ",
+    "FIT_TARGET_CONFIG_PATH",
+    "FIT_WEIGHTS_SPEC_SCHEMA_VERSION",
+    "NATIONAL_FIT_LAMBDA_L0",
+    "NATIONAL_FIT_LAMBDA_L2",
+    "REGIONAL_FIT_LAMBDA_L0",
+    "REGIONAL_FIT_LAMBDA_L2",
+    "FitArtifactLocation",
+    "FitArtifactRole",
+    "FitArtifactSpec",
+    "FitHyperparameters",
+    "FitScope",
+    "FittedWeightsSpec",
+    "ScopedFitArtifacts",
+    "fit_artifacts_for_scope",
+    "fitted_weights_spec_for_scope",
+]

--- a/policyengine_us_data/fit_weights/artifacts.py
+++ b/policyengine_us_data/fit_weights/artifacts.py
@@ -1,0 +1,201 @@
+"""Scoped Stage 3 fitted-weight artifact identities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+from policyengine_us_data.fit_weights.specs import FitScope
+from policyengine_us_data.pipeline_metadata import pipeline_node
+from policyengine_us_data.pipeline_schema import PipelineNode
+
+
+class FitArtifactLocation(str, Enum):
+    """Pipeline-volume location for a fitted-weight artifact."""
+
+    ARTIFACTS = "artifacts"
+    DIAGNOSTICS = "diagnostics"
+
+
+class FitArtifactRole(str, Enum):
+    """Logical role for one fitted-weight artifact."""
+
+    WEIGHTS = "weights"
+    GEOGRAPHY = "geography"
+    RUN_CONFIG = "run_config"
+    DIAGNOSTICS = "diagnostics"
+    EPOCH_LOG = "epoch_log"
+
+
+@dataclass(frozen=True)
+class FitArtifactSpec:
+    """Filename and remote-result mapping for one Stage 3 artifact."""
+
+    role: FitArtifactRole
+    filename: str
+    location: FitArtifactLocation
+    result_key: str | None = None
+    required: bool = True
+
+    def path_under(self, root: str | Path) -> Path:
+        """Return this artifact path under an artifacts or diagnostics root."""
+
+        return Path(root) / self.filename
+
+
+@dataclass(frozen=True)
+class ScopedFitArtifacts:
+    """The artifact contract for one fitted-weight scope."""
+
+    scope: FitScope | str
+    weights: FitArtifactSpec
+    geography: FitArtifactSpec
+    run_config: FitArtifactSpec
+    diagnostics: FitArtifactSpec
+    epoch_log: FitArtifactSpec
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "scope", FitScope.parse(self.scope))
+
+    def artifact_specs(self) -> tuple[FitArtifactSpec, ...]:
+        """Return primary Stage 3 output artifacts."""
+
+        return (self.weights, self.geography, self.run_config)
+
+    def diagnostic_specs(self) -> tuple[FitArtifactSpec, ...]:
+        """Return diagnostic Stage 3 artifacts archived under run diagnostics."""
+
+        return (self.diagnostics, self.epoch_log, self.run_config)
+
+    def artifact_paths(self, artifacts_root: str | Path) -> list[Path]:
+        """Return primary artifact paths under the pipeline artifacts root."""
+
+        return [
+            artifact.path_under(artifacts_root) for artifact in self.artifact_specs()
+        ]
+
+    def diagnostic_result_filenames(self) -> dict[str, str]:
+        """Map remote result byte keys to diagnostic archive filenames."""
+
+        return {
+            artifact.result_key: artifact.filename
+            for artifact in self.diagnostic_specs()
+            if artifact.result_key is not None
+        }
+
+
+REGIONAL_FIT_ARTIFACTS = ScopedFitArtifacts(
+    scope=FitScope.REGIONAL,
+    weights=FitArtifactSpec(
+        role=FitArtifactRole.WEIGHTS,
+        filename="calibration_weights.npy",
+        location=FitArtifactLocation.ARTIFACTS,
+        result_key="weights",
+    ),
+    geography=FitArtifactSpec(
+        role=FitArtifactRole.GEOGRAPHY,
+        filename="geography_assignment.npz",
+        location=FitArtifactLocation.ARTIFACTS,
+        result_key="geography",
+    ),
+    run_config=FitArtifactSpec(
+        role=FitArtifactRole.RUN_CONFIG,
+        filename="unified_run_config.json",
+        location=FitArtifactLocation.ARTIFACTS,
+        result_key="config",
+    ),
+    diagnostics=FitArtifactSpec(
+        role=FitArtifactRole.DIAGNOSTICS,
+        filename="unified_diagnostics.csv",
+        location=FitArtifactLocation.DIAGNOSTICS,
+        result_key="log",
+        required=False,
+    ),
+    epoch_log=FitArtifactSpec(
+        role=FitArtifactRole.EPOCH_LOG,
+        filename="calibration_log.csv",
+        location=FitArtifactLocation.DIAGNOSTICS,
+        result_key="cal_log",
+        required=False,
+    ),
+)
+NATIONAL_FIT_ARTIFACTS = ScopedFitArtifacts(
+    scope=FitScope.NATIONAL,
+    weights=FitArtifactSpec(
+        role=FitArtifactRole.WEIGHTS,
+        filename="national_calibration_weights.npy",
+        location=FitArtifactLocation.ARTIFACTS,
+        result_key="weights",
+    ),
+    geography=FitArtifactSpec(
+        role=FitArtifactRole.GEOGRAPHY,
+        filename="national_geography_assignment.npz",
+        location=FitArtifactLocation.ARTIFACTS,
+        result_key="geography",
+    ),
+    run_config=FitArtifactSpec(
+        role=FitArtifactRole.RUN_CONFIG,
+        filename="national_unified_run_config.json",
+        location=FitArtifactLocation.ARTIFACTS,
+        result_key="config",
+    ),
+    diagnostics=FitArtifactSpec(
+        role=FitArtifactRole.DIAGNOSTICS,
+        filename="national_unified_diagnostics.csv",
+        location=FitArtifactLocation.DIAGNOSTICS,
+        result_key="log",
+        required=False,
+    ),
+    epoch_log=FitArtifactSpec(
+        role=FitArtifactRole.EPOCH_LOG,
+        filename="national_calibration_log.csv",
+        location=FitArtifactLocation.DIAGNOSTICS,
+        result_key="cal_log",
+        required=False,
+    ),
+)
+
+
+@pipeline_node(
+    PipelineNode(
+        id="fitted_weights_artifacts",
+        label="Fitted Weights Artifacts",
+        node_type="library",
+        description=(
+            "Canonical regional and national fitted-weight artifact filenames."
+        ),
+        source_file="policyengine_us_data/fit_weights/artifacts.py",
+        status="current",
+        stability="moving",
+        pathways=["fit_weights", "artifact_identity"],
+        artifacts_in=["remote fit result bytes"],
+        artifacts_out=[
+            "calibration_weights.npy",
+            "geography_assignment.npz",
+            "unified_run_config.json",
+            "national_calibration_weights.npy",
+            "national_geography_assignment.npz",
+            "national_unified_run_config.json",
+        ],
+        validation_commands=["uv run pytest tests/unit/fit_weights/test_artifacts.py"],
+    )
+)
+def fit_artifacts_for_scope(scope: FitScope | str) -> ScopedFitArtifacts:
+    """Return canonical fitted-weight artifacts for a regional or national scope."""
+
+    scope = FitScope.parse(scope)
+    if scope == FitScope.REGIONAL:
+        return REGIONAL_FIT_ARTIFACTS
+    if scope == FitScope.NATIONAL:
+        return NATIONAL_FIT_ARTIFACTS
+    raise ValueError(f"Unknown fit scope: {scope!r}")
+
+
+__all__ = [
+    "FitArtifactLocation",
+    "FitArtifactRole",
+    "FitArtifactSpec",
+    "ScopedFitArtifacts",
+    "fit_artifacts_for_scope",
+]

--- a/policyengine_us_data/fit_weights/specs.py
+++ b/policyengine_us_data/fit_weights/specs.py
@@ -1,0 +1,202 @@
+"""Scoped Stage 3 fitted-weight parameter specifications."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Mapping
+
+from policyengine_us_data.pipeline_metadata import pipeline_node
+from policyengine_us_data.pipeline_schema import PipelineNode
+from policyengine_us_data.stage_contracts.fingerprints import fingerprint_material
+
+FIT_WEIGHTS_SPEC_SCHEMA_VERSION = "1"
+FIT_TARGET_CONFIG_PATH = "policyengine_us_data/calibration/target_config.yaml"
+FIT_BETA = 0.65
+FIT_LOG_FREQ = 100
+REGIONAL_FIT_LAMBDA_L0 = 1e-7
+REGIONAL_FIT_LAMBDA_L2 = 1e-8
+NATIONAL_FIT_LAMBDA_L0 = 1e-4
+NATIONAL_FIT_LAMBDA_L2 = 1e-12
+
+
+class FitScope(str, Enum):
+    """Supported fitted-weight output scopes."""
+
+    REGIONAL = "regional"
+    NATIONAL = "national"
+
+    @classmethod
+    def parse(cls, value: "FitScope | str") -> "FitScope":
+        """Return a `FitScope` or raise a clear error for unknown scopes."""
+
+        if isinstance(value, cls):
+            return value
+        try:
+            return cls(str(value))
+        except ValueError as exc:
+            allowed = ", ".join(scope.value for scope in cls)
+            raise ValueError(
+                f"Unknown fit scope {value!r}; expected one of {allowed}"
+            ) from exc
+
+
+@dataclass(frozen=True)
+class FitHyperparameters:
+    """Hyperparameters that define one fitted-weight optimization run."""
+
+    target_config: str
+    beta: float
+    lambda_l0: float
+    lambda_l2: float
+    log_freq: int
+    learning_rate: float | None = None
+
+    def __post_init__(self) -> None:
+        if not self.target_config:
+            raise ValueError("target_config must be non-empty")
+        for name in ("beta", "lambda_l0", "lambda_l2"):
+            if getattr(self, name) < 0:
+                raise ValueError(f"{name} must be non-negative")
+        if self.log_freq <= 0:
+            raise ValueError("log_freq must be positive")
+        if self.learning_rate is not None and self.learning_rate <= 0:
+            raise ValueError("learning_rate must be positive when supplied")
+
+    def to_manifest_parameters(self) -> dict[str, Any]:
+        """Return deterministic manifest parameters for reuse checks."""
+
+        params = {
+            "target_config": self.target_config,
+            "beta": self.beta,
+            "lambda_l0": self.lambda_l0,
+            "lambda_l2": self.lambda_l2,
+            "learning_rate": self.learning_rate,
+            "log_freq": self.log_freq,
+        }
+        return {key: value for key, value in params.items() if value is not None}
+
+    def to_runtime_kwargs(self) -> dict[str, Any]:
+        """Return Modal remote-call keyword arguments for this fit."""
+
+        return self.to_manifest_parameters()
+
+
+@dataclass(frozen=True)
+class FittedWeightsSpec:
+    """A scoped Stage 3 fitted-weight run specification."""
+
+    scope: FitScope | str
+    hyperparameters: FitHyperparameters
+    schema_version: str = FIT_WEIGHTS_SPEC_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "scope", FitScope.parse(self.scope))
+        if self.schema_version != FIT_WEIGHTS_SPEC_SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported fitted-weight spec schema version: {self.schema_version}"
+            )
+
+    def parameter_identity(self, *, gpu: str, epochs: int) -> str:
+        """Return a deterministic identity for fit parameters and scope."""
+
+        material = {
+            "schema_version": self.schema_version,
+            "scope": self.scope.value,
+            "gpu": gpu,
+            "epochs": int(epochs),
+            "hyperparameters": self.hyperparameters.to_manifest_parameters(),
+        }
+        return fingerprint_material(material).value
+
+    def manifest_parameters(
+        self,
+        *,
+        gpu: str,
+        epochs: int,
+        extra: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Return step-manifest parameters for this scoped fit."""
+
+        params = {
+            "scope": self.scope.value,
+            "gpu": gpu,
+            "epochs": epochs,
+            **self.hyperparameters.to_manifest_parameters(),
+            "fit_parameter_identity": self.parameter_identity(
+                gpu=gpu,
+                epochs=epochs,
+            ),
+        }
+        if extra:
+            params.update(dict(extra))
+        return params
+
+    def runtime_kwargs(self) -> dict[str, Any]:
+        """Return keyword arguments passed to the remote fit function."""
+
+        return self.hyperparameters.to_runtime_kwargs()
+
+
+REGIONAL_FITTED_WEIGHTS_SPEC = FittedWeightsSpec(
+    scope=FitScope.REGIONAL,
+    hyperparameters=FitHyperparameters(
+        target_config=FIT_TARGET_CONFIG_PATH,
+        beta=FIT_BETA,
+        lambda_l0=REGIONAL_FIT_LAMBDA_L0,
+        lambda_l2=REGIONAL_FIT_LAMBDA_L2,
+        log_freq=FIT_LOG_FREQ,
+    ),
+)
+NATIONAL_FITTED_WEIGHTS_SPEC = FittedWeightsSpec(
+    scope=FitScope.NATIONAL,
+    hyperparameters=FitHyperparameters(
+        target_config=FIT_TARGET_CONFIG_PATH,
+        beta=FIT_BETA,
+        lambda_l0=NATIONAL_FIT_LAMBDA_L0,
+        lambda_l2=NATIONAL_FIT_LAMBDA_L2,
+        log_freq=FIT_LOG_FREQ,
+    ),
+)
+
+
+@pipeline_node(
+    PipelineNode(
+        id="fitted_weights_spec",
+        label="Fitted Weights Spec",
+        node_type="library",
+        description=("Scoped Stage 3 fit parameters and deterministic reuse identity."),
+        source_file="policyengine_us_data/fit_weights/specs.py",
+        status="current",
+        stability="moving",
+        pathways=["fit_weights", "reuse_identity"],
+        artifacts_in=["calibration_package.pkl"],
+        artifacts_out=["fit_parameter_identity"],
+        validation_commands=["uv run pytest tests/unit/fit_weights/test_specs.py"],
+    )
+)
+def fitted_weights_spec_for_scope(scope: FitScope | str) -> FittedWeightsSpec:
+    """Return the current fitted-weight spec for a regional or national scope."""
+
+    scope = FitScope.parse(scope)
+    if scope == FitScope.REGIONAL:
+        return REGIONAL_FITTED_WEIGHTS_SPEC
+    if scope == FitScope.NATIONAL:
+        return NATIONAL_FITTED_WEIGHTS_SPEC
+    raise ValueError(f"Unknown fit scope: {scope!r}")
+
+
+__all__ = [
+    "FIT_BETA",
+    "FIT_LOG_FREQ",
+    "FIT_TARGET_CONFIG_PATH",
+    "FIT_WEIGHTS_SPEC_SCHEMA_VERSION",
+    "NATIONAL_FIT_LAMBDA_L0",
+    "NATIONAL_FIT_LAMBDA_L2",
+    "REGIONAL_FIT_LAMBDA_L0",
+    "REGIONAL_FIT_LAMBDA_L2",
+    "FitHyperparameters",
+    "FitScope",
+    "FittedWeightsSpec",
+    "fitted_weights_spec_for_scope",
+]

--- a/tests/unit/fit_weights/__init__.py
+++ b/tests/unit/fit_weights/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for Stage 3 fitted-weight helpers."""

--- a/tests/unit/fit_weights/test_artifacts.py
+++ b/tests/unit/fit_weights/test_artifacts.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import pytest
+
+from policyengine_us_data.fit_weights import FitScope, fit_artifacts_for_scope
+
+
+def test_regional_artifact_specs_match_current_filenames() -> None:
+    artifacts = fit_artifacts_for_scope(FitScope.REGIONAL)
+
+    assert artifacts.weights.filename == "calibration_weights.npy"
+    assert artifacts.geography.filename == "geography_assignment.npz"
+    assert artifacts.run_config.filename == "unified_run_config.json"
+    assert artifacts.diagnostics.filename == "unified_diagnostics.csv"
+    assert artifacts.epoch_log.filename == "calibration_log.csv"
+
+
+def test_national_artifact_specs_match_current_filenames() -> None:
+    artifacts = fit_artifacts_for_scope("national")
+
+    assert artifacts.weights.filename == "national_calibration_weights.npy"
+    assert artifacts.geography.filename == "national_geography_assignment.npz"
+    assert artifacts.run_config.filename == "national_unified_run_config.json"
+    assert artifacts.diagnostics.filename == "national_unified_diagnostics.csv"
+    assert artifacts.epoch_log.filename == "national_calibration_log.csv"
+
+
+def test_result_key_mappings_cover_current_remote_result_shape() -> None:
+    artifacts = fit_artifacts_for_scope(FitScope.REGIONAL)
+
+    assert artifacts.diagnostic_result_filenames() == {
+        "log": "unified_diagnostics.csv",
+        "cal_log": "calibration_log.csv",
+        "config": "unified_run_config.json",
+    }
+    assert {artifact.result_key for artifact in artifacts.artifact_specs()} == {
+        "weights",
+        "geography",
+        "config",
+    }
+
+
+def test_artifact_paths_are_under_supplied_root() -> None:
+    artifacts = fit_artifacts_for_scope(FitScope.NATIONAL)
+
+    assert artifacts.artifact_paths("/pipeline/artifacts/run-1") == [
+        Path("/pipeline/artifacts/run-1/national_calibration_weights.npy"),
+        Path("/pipeline/artifacts/run-1/national_geography_assignment.npz"),
+        Path("/pipeline/artifacts/run-1/national_unified_run_config.json"),
+    ]
+
+
+def test_unknown_artifact_scope_is_rejected() -> None:
+    with pytest.raises(ValueError, match="Unknown fit scope"):
+        fit_artifacts_for_scope("zip")

--- a/tests/unit/fit_weights/test_pipeline_docs.py
+++ b/tests/unit/fit_weights/test_pipeline_docs.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+import yaml
+
+from policyengine_us_data.fit_weights import FitScope, fit_artifacts_for_scope
+from scripts.extract_pipeline_docs import scan_decorated_objects
+
+
+def _substage(substage_id: str) -> dict:
+    data = yaml.safe_load(Path("docs/pipeline_map.yaml").read_text())
+    return next(
+        substage for substage in data["stages"] if substage["id"] == substage_id
+    )
+
+
+def test_fit_weights_identity_nodes_are_in_generated_pipeline_docs() -> None:
+    decorated = scan_decorated_objects()
+
+    assert "fitted_weights_spec" in decorated
+    assert "fitted_weights_artifacts" in decorated
+    assert "fit_weights" in decorated["fitted_weights_spec"].metadata["pathways"]
+    assert "fit_weights" in decorated["fitted_weights_artifacts"].metadata["pathways"]
+
+
+def test_stage_3_pipeline_map_labels_match_scoped_artifacts() -> None:
+    regional_artifacts = fit_artifacts_for_scope(FitScope.REGIONAL)
+    national_artifacts = fit_artifacts_for_scope(FitScope.NATIONAL)
+    regional = _substage("3a_weight_fitting_regional")
+    national = _substage("3b_weight_fitting_national")
+
+    regional_nodes = {node["id"]: node for node in regional["extra_nodes"]}
+    national_nodes = {node["id"]: node for node in national["extra_nodes"]}
+
+    assert "fit_spec_regional" in regional["groups"][0]["node_ids"]
+    assert "fit_artifacts_regional" in regional["groups"][0]["node_ids"]
+    assert regional_nodes["out_weights"]["label"] == regional_artifacts.weights.filename
+    assert regional_nodes["out_geo_s6"]["label"] == (
+        regional_artifacts.geography.filename
+    )
+    assert regional_nodes["out_config_s6"]["label"] == (
+        regional_artifacts.run_config.filename
+    )
+
+    assert "fit_spec_national" in national["groups"][0]["node_ids"]
+    assert "fit_artifacts_national" in national["groups"][0]["node_ids"]
+    assert national_nodes["out_national_weights"]["label"] == (
+        national_artifacts.weights.filename
+    )
+    assert national_nodes["out_national_geo_s6"]["label"] == (
+        national_artifacts.geography.filename
+    )
+    assert national_nodes["out_national_config_s6"]["label"] == (
+        national_artifacts.run_config.filename
+    )

--- a/tests/unit/fit_weights/test_specs.py
+++ b/tests/unit/fit_weights/test_specs.py
@@ -1,0 +1,67 @@
+import pytest
+
+from policyengine_us_data.fit_weights import (
+    FIT_TARGET_CONFIG_PATH,
+    NATIONAL_FIT_LAMBDA_L0,
+    REGIONAL_FIT_LAMBDA_L0,
+    FitHyperparameters,
+    FitScope,
+    fitted_weights_spec_for_scope,
+)
+
+
+def test_manifest_parameters_preserve_current_runtime_shape() -> None:
+    spec = fitted_weights_spec_for_scope(FitScope.REGIONAL)
+
+    params = spec.manifest_parameters(gpu="T4", epochs=200)
+
+    assert params["scope"] == "regional"
+    assert params["gpu"] == "T4"
+    assert params["epochs"] == 200
+    assert params["target_config"] == FIT_TARGET_CONFIG_PATH
+    assert params["beta"] == pytest.approx(0.65)
+    assert params["lambda_l0"] == pytest.approx(REGIONAL_FIT_LAMBDA_L0)
+    assert params["lambda_l2"] == pytest.approx(1e-8)
+    assert params["log_freq"] == 100
+    assert params["fit_parameter_identity"].startswith("sha256:")
+
+
+def test_national_spec_tracks_current_lambda_l0() -> None:
+    spec = fitted_weights_spec_for_scope("national")
+
+    assert spec.hyperparameters.lambda_l0 == pytest.approx(NATIONAL_FIT_LAMBDA_L0)
+    assert spec.runtime_kwargs()["lambda_l0"] == pytest.approx(1e-4)
+
+
+def test_fit_parameter_identity_is_deterministic() -> None:
+    spec = fitted_weights_spec_for_scope(FitScope.REGIONAL)
+
+    first = spec.parameter_identity(gpu="A10", epochs=5)
+    second = spec.parameter_identity(gpu="A10", epochs=5)
+
+    assert first == second
+
+
+def test_fit_parameter_identity_tracks_scope() -> None:
+    regional = fitted_weights_spec_for_scope(FitScope.REGIONAL)
+    national = fitted_weights_spec_for_scope(FitScope.NATIONAL)
+
+    assert regional.parameter_identity(gpu="T4", epochs=1) != (
+        national.parameter_identity(gpu="T4", epochs=1)
+    )
+
+
+def test_fit_scope_rejects_unknown_scopes() -> None:
+    with pytest.raises(ValueError, match="Unknown fit scope"):
+        FitScope.parse("county")
+
+
+def test_fit_hyperparameters_reject_invalid_identity_values() -> None:
+    with pytest.raises(ValueError, match="lambda_l0"):
+        FitHyperparameters(
+            target_config=FIT_TARGET_CONFIG_PATH,
+            beta=0.65,
+            lambda_l0=-1.0,
+            lambda_l2=1e-8,
+            log_freq=100,
+        )

--- a/tests/unit/test_pipeline_source_contracts.py
+++ b/tests/unit/test_pipeline_source_contracts.py
@@ -109,6 +109,36 @@ def test_run_pipeline_refreshes_diagnostics_even_when_h5_outputs_reused() -> Non
     assert "Upload validation diagnostics even when H5 outputs are reused." in source
 
 
+def test_run_pipeline_uses_stage_3_fit_specs_for_reuse_and_paths() -> None:
+    source_text = PIPELINE_SOURCE.read_text()
+    tree = ast.parse(source_text)
+    run_pipeline = _function_def(tree, "run_pipeline")
+    archive_diagnostics = _function_def(tree, "archive_diagnostics")
+    source = ast.get_source_segment(source_text, run_pipeline)
+    archive_source = ast.get_source_segment(source_text, archive_diagnostics)
+
+    assert "fitted_weights_spec_for_scope(FitScope.REGIONAL)" in source
+    assert "fitted_weights_spec_for_scope(FitScope.NATIONAL)" in source
+    assert "fit_artifacts_for_scope(FitScope.REGIONAL)" in source
+    assert "fit_artifacts_for_scope(FitScope.NATIONAL)" in source
+    assert "regional_fit_spec.manifest_parameters(" in source
+    assert "national_fit_spec.manifest_parameters(" in source
+    assert "regional_fit_spec.runtime_kwargs()" in source
+    assert "national_fit_spec.runtime_kwargs()" in source
+    assert "regional_fit_artifacts.artifact_paths(_artifacts_dir(run_id))" in source
+    assert "national_fit_artifacts.artifact_paths(_artifacts_dir(run_id))" in source
+    assert "diagnostic_result_filenames()" in archive_source
+
+
+def test_local_area_consumes_centralized_stage_3_artifact_specs() -> None:
+    source = Path("modal_app/local_area.py").read_text()
+
+    assert "fit_artifacts_for_scope(FitScope.REGIONAL)" in source
+    assert "fit_artifacts_for_scope(FitScope.NATIONAL)" in source
+    assert "regional_fit_artifacts.weights.filename" in source
+    assert "national_fit_artifacts.weights.filename" in source
+
+
 def test_run_pipeline_tolerates_post_h5_pipeline_volume_open_files() -> None:
     source_text = PIPELINE_SOURCE.read_text()
     tree = ast.parse(source_text)

--- a/tests/unit/test_remote_calibration_runner.py
+++ b/tests/unit/test_remote_calibration_runner.py
@@ -88,6 +88,56 @@ def test_collect_outputs_returns_pipeline_artifact_bytes(tmp_path):
     }
 
 
+def test_fit_output_filenames_match_scoped_artifacts():
+    remote_runner = _load_remote_calibration_runner_module()
+    regional = remote_runner.fit_artifacts_for_scope(remote_runner.FitScope.REGIONAL)
+    national = remote_runner.fit_artifacts_for_scope(remote_runner.FitScope.NATIONAL)
+
+    assert remote_runner._fit_output_filenames(
+        scope=remote_runner.FitScope.REGIONAL,
+        output=regional.weights.filename,
+        log_output=regional.diagnostics.filename,
+    ) == {
+        "output": regional.weights.filename,
+        "log_output": regional.diagnostics.filename,
+        "geography": regional.geography.filename,
+        "calibration_log": regional.epoch_log.filename,
+        "run_config": regional.run_config.filename,
+        "pipeline_weights": regional.weights.filename,
+        "pipeline_geography": regional.geography.filename,
+        "pipeline_run_config": regional.run_config.filename,
+    }
+    assert remote_runner._fit_output_filenames(
+        scope=remote_runner.FitScope.NATIONAL,
+        output=regional.weights.filename,
+        log_output=regional.diagnostics.filename,
+    ) == {
+        "output": national.weights.filename,
+        "log_output": national.diagnostics.filename,
+        "geography": national.geography.filename,
+        "calibration_log": national.epoch_log.filename,
+        "run_config": national.run_config.filename,
+        "pipeline_weights": national.weights.filename,
+        "pipeline_geography": national.geography.filename,
+        "pipeline_run_config": national.run_config.filename,
+    }
+
+
+def test_national_fit_output_filenames_preserve_explicit_overrides():
+    remote_runner = _load_remote_calibration_runner_module()
+    national = remote_runner.fit_artifacts_for_scope(remote_runner.FitScope.NATIONAL)
+
+    filenames = remote_runner._fit_output_filenames(
+        scope=remote_runner.FitScope.NATIONAL,
+        output="custom_weights.npy",
+        log_output="custom_diagnostics.csv",
+    )
+
+    assert filenames["output"] == "national_custom_weights.npy"
+    assert filenames["log_output"] == "national_custom_diagnostics.csv"
+    assert filenames["pipeline_weights"] == national.weights.filename
+
+
 def test_ensure_geography_prerequisites_downloads_only_geography(monkeypatch):
     remote_runner = _load_remote_calibration_runner_module()
     from policyengine_us_data.storage import download_prerequisites as prereq_module


### PR DESCRIPTION
Fixes #1040

## Summary
- Add `policyengine_us_data.fit_weights` scoped fit specs, deterministic fit parameter identity, and regional/national artifact catalogs.
- Wire existing Stage 3 Modal pipeline, remote runner, and local-area handoff filename/parameter usage to the central specs without changing runtime behavior.
- Document the Stage 3 identity boundary and update pipeline map/tests for the new spec/artifact nodes.

## Validation
- `ruff check modal_app/local_area.py modal_app/pipeline.py modal_app/remote_calibration_runner.py policyengine_us_data/fit_weights/__init__.py policyengine_us_data/fit_weights/artifacts.py policyengine_us_data/fit_weights/specs.py tests/unit/fit_weights/__init__.py tests/unit/fit_weights/test_artifacts.py tests/unit/fit_weights/test_pipeline_docs.py tests/unit/fit_weights/test_specs.py tests/unit/test_pipeline_source_contracts.py tests/unit/test_remote_calibration_runner.py`
- `ruff format --check modal_app/local_area.py modal_app/pipeline.py modal_app/remote_calibration_runner.py policyengine_us_data/fit_weights/__init__.py policyengine_us_data/fit_weights/artifacts.py policyengine_us_data/fit_weights/specs.py tests/unit/fit_weights/__init__.py tests/unit/fit_weights/test_artifacts.py tests/unit/fit_weights/test_pipeline_docs.py tests/unit/fit_weights/test_specs.py tests/unit/test_pipeline_source_contracts.py tests/unit/test_remote_calibration_runner.py`
- `uv run --no-sync --with pytest --with pyyaml --with huggingface-hub python -m pytest tests/unit/fit_weights/test_artifacts.py tests/unit/fit_weights/test_pipeline_docs.py tests/unit/fit_weights/test_specs.py tests/unit/test_pipeline.py tests/unit/test_pipeline_doc_guards.py tests/unit/test_pipeline_docs_extractor.py tests/unit/test_pipeline_source_contracts.py tests/unit/test_remote_calibration_runner.py`
- `uv run --no-sync --with pytest --with pyyaml python -m pytest tests/unit/fit_weights/test_pipeline_docs.py tests/unit/test_pipeline_doc_guards.py tests/unit/test_pipeline_docs_extractor.py`
- `uv run --no-sync --with pyyaml python scripts/run_quality_guards.py`
- `uv run --no-sync --with pyyaml python scripts/extract_pipeline_docs.py --json /private/tmp/stage3-pr3a-restart-pipeline-docs/pipeline_map.json --api-json /private/tmp/stage3-pr3a-restart-pipeline-docs/pipeline_api.json --markdown /private/tmp/stage3-pr3a-restart-pipeline-docs/pipeline-map.md`
- `make lint`
- `uv run --no-sync --with towncrier towncrier check --compare-with origin/main`
- `git diff --check`