### PR TITLE
Bump policyengine-us to 1.699.0

### DIFF
--- a/changelog.d/1055.changed
+++ b/changelog.d/1055.changed
@@ -1,0 +1,1 @@
+Bump policyengine-us to 1.699.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us==1.698.0",
+    "policyengine-us==1.699.0",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/uv.lock
+++ b/uv.lock
@@ -2122,7 +2122,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.698.0"
+version = "1.699.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2132,9 +2132,9 @@ dependencies = [
     { name = "tables" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/ca/783762ba4b4671bdeddb06d678d473e2c354d9a56f08503f24c2d6df2e40/policyengine_us-1.698.0.tar.gz", hash = "sha256:9399922aa1262d3542299d5aabbd48be26851592c7c79bf4b624692a4b9e7cdc", size = 9845268, upload-time = "2026-05-19T19:51:55.123Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/40/cd4c50475950ff3b61a8e5e0a04e692574b9da6cab5da4f166b7321c8fbf/policyengine_us-1.699.0.tar.gz", hash = "sha256:d3d1e4f2a4aea72ae72dc534de6fb454e14ad685cb429067ad4d9265339e6fd1", size = 9852436, upload-time = "2026-05-19T21:48:40.971Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/65/e0010ec50399c8765c62d7801493746ee5f3edef160ded1f30b3b0258dd7/policyengine_us-1.698.0-py3-none-any.whl", hash = "sha256:9a34ccdb927cced00400414f1bb0e087df55ec36a073f7d4e642a16aeb21f196", size = 10568450, upload-time = "2026-05-19T19:51:52.09Z" },
+    { url = "https://files.pythonhosted.org/packages/96/58/0514ac39397664bbb53d0a3b3dd964afe1776bbc1142cdc0eac258ebb10d/policyengine_us-1.699.0-py3-none-any.whl", hash = "sha256:87aea45b9204f0831ea9e9b572b2e8c30fbe7fa888c370f5cdc3760df3793db8", size = 10583733, upload-time = "2026-05-19T21:48:37.436Z" },
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", specifier = "==1.698.0" },
+    { name = "policyengine-us", specifier = "==1.699.0" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },


### PR DESCRIPTION
## Summary
- bump policyengine-us from 1.698.0 to 1.699.0
- refresh uv.lock
- unblock the main publication freshness gate after #1052

## Verification
- /Users/maxghenis/.local/bin/python3.13 .github/scripts/check_policyengine_us_dependency.py --mode fail
- env -u UV_FROZEN uv lock --check
- git diff --check