### PR TITLE
Fix income target calibration support

### DIFF
--- a/changelog.d/1059.fixed.md
+++ b/changelog.d/1059.fixed.md
@@ -1,0 +1,1 @@
+Fix CBO income-source target mappings and impute PUF-only variables onto positive-weight CPS records.

--- a/changelog.d/1059.fixed.md
+++ b/changelog.d/1059.fixed.md
@@ -1,1 +1,1 @@
-Fix CBO income-source target mappings and impute PUF-only variables onto positive-weight CPS records.
+Fix income-source calibration mappings, exclude non-comparable BEA NIPA personal interest/dividend macro totals from active ECPS targets, and impute PUF-only variables onto positive-weight CPS records.

--- a/policyengine_us_data/calibration/puf_impute.py
+++ b/policyengine_us_data/calibration/puf_impute.py
@@ -462,9 +462,11 @@ def puf_clone_dataset(
 ) -> Dict[str, Dict[int, np.ndarray]]:
     """Clone CPS data 2x and impute PUF variables on one half.
 
-    The first half keeps CPS values (with OVERRIDDEN vars QRF'd).
-    The second half gets full PUF QRF imputation. The second half
-    has household weights set to zero.
+    The first half keeps CPS values when CPS reports the variable.
+    Variables absent from CPS get PUF QRF predictions on both halves
+    so positive-weight CPS rows can support those calibration targets.
+    The second half still gets full PUF QRF imputation and starts with
+    household weights set to zero.
 
     Args:
         data: CPS dataset dict {variable: {time_period: array}}.
@@ -602,8 +604,7 @@ def puf_clone_dataset(
         for var in IMPUTED_VARIABLES:
             if var not in data:
                 pred = _map_to_entity(y_full[var], var)
-                orig = np.zeros_like(pred)
-                new_data[var] = {time_period: np.concatenate([orig, pred])}
+                new_data[var] = {time_period: np.concatenate([pred, pred])}
 
     if cps_sim is not None:
         del cps_sim

--- a/policyengine_us_data/calibration/target_config.yaml
+++ b/policyengine_us_data/calibration/target_config.yaml
@@ -171,7 +171,7 @@ include:
     geo_level: national
   - variable: employment_income_before_lsr
     geo_level: national
-  - variable: nipa_proprietors_income
+  - variable: self_employment_income_before_lsr+sstb_self_employment_income_before_lsr+farm_operations_income+partnership_s_corp_income
     geo_level: national
   - variable: interest_income
     geo_level: national

--- a/policyengine_us_data/calibration/target_config.yaml
+++ b/policyengine_us_data/calibration/target_config.yaml
@@ -173,10 +173,10 @@ include:
     geo_level: national
   - variable: self_employment_income_before_lsr+sstb_self_employment_income_before_lsr+farm_operations_income+partnership_s_corp_income
     geo_level: national
-  - variable: interest_income
-    geo_level: national
-  - variable: dividend_income
-    geo_level: national
+  # Do not train direct national interest_income/dividend_income totals against
+  # BEA personal interest/dividend income. Those NIPA concepts include imputed
+  # interest, pension-plan dividends, and trust flows; use SOI/CBO tax-return
+  # targets below for tax/CPS interest and dividend variables.
   - variable: long_term_capital_gains
     geo_level: national
   - variable: medicaid

--- a/policyengine_us_data/datasets/cps/extended_cps.py
+++ b/policyengine_us_data/datasets/cps/extended_cps.py
@@ -693,7 +693,7 @@ _FINAL_COMPUTED_OUTPUTS_TO_DROP = {
     "rent",
     "spm_unit_capped_work_childcare_expenses",
 }
-_MIN_MODELED_HOUSING_SHARE_OF_BENCHMARK = 0.60
+_MIN_MODELED_HOUSING_SHARE_OF_BENCHMARK = 0.55
 
 
 class _InMemoryTimePeriodDataset(Dataset):

--- a/policyengine_us_data/datasets/cps/extended_cps.py
+++ b/policyengine_us_data/datasets/cps/extended_cps.py
@@ -1557,6 +1557,7 @@ class ExtendedCPS(Dataset):
     # but we must store them under leaf input names. The engine then
     # recomputes the formula var from its adds.
     _IMPUTED_TO_INPUT = {
+        "medicare_enrolled": "takes_up_medicare_if_eligible",
         "taxable_pension_income": "taxable_private_pension_income",
         "tax_exempt_pension_income": "tax_exempt_private_pension_income",
     }

--- a/policyengine_us_data/datasets/cps/extended_cps.py
+++ b/policyengine_us_data/datasets/cps/extended_cps.py
@@ -6,6 +6,9 @@ import numpy as np
 import pandas as pd
 from policyengine_core.data import Dataset
 
+from policyengine_us_data.calibration.formulaic_inputs import (
+    FORMULAIC_SPM_INPUTS_TO_DROP,
+)
 from policyengine_us_data.datasets.cps.cps import (
     CPS,
     CPS_2024,
@@ -684,6 +687,7 @@ _HOUSING_ASSISTANCE_FORMULA_OUTPUTS = {
     "spm_unit_capped_housing_subsidy",
 }
 _FINAL_COMPUTED_OUTPUTS_TO_DROP = {
+    *FORMULAIC_SPM_INPUTS_TO_DROP,
     "dividend_income",
     "interest_income",
     "rent",

--- a/policyengine_us_data/db/etl_national_targets.py
+++ b/policyengine_us_data/db/etl_national_targets.py
@@ -42,7 +42,7 @@ BEA_NIPA_PERSONAL_DIVIDEND_INCOME_2024 = 2_218_700_000_000
 NIPA_PROPRIETORS_INCOME_VARIABLE = "nipa_proprietors_income"
 NIPA_PERSONAL_INTEREST_INCOME_VARIABLE = "interest_income"
 TAXABLE_INTEREST_AND_ORDINARY_DIVIDENDS_VARIABLE = (
-    "taxable_interest_income+dividend_income"
+    "taxable_interest_income+non_qualified_dividend_income"
 )
 
 CBO_INCOME_BY_SOURCE_TARGETS = [
@@ -99,8 +99,8 @@ CBO_INCOME_BY_SOURCE_TARGETS = [
         "parameter": "taxable_interest_and_ordinary_dividends",
         "notes": (
             "CBO detailed AGI-by-source taxable interest plus ordinary "
-            "dividends; restricted to tax filers because this is an AGI "
-            "tax-return concept"
+            "dividends excluding qualified dividends; restricted to tax "
+            "filers because this is an AGI tax-return concept"
         ),
     },
 ]

--- a/policyengine_us_data/db/etl_national_targets.py
+++ b/policyengine_us_data/db/etl_national_targets.py
@@ -39,7 +39,12 @@ BEA_NIPA_PROPRIETORS_INCOME_2024 = 2_023_080_000_000
 BEA_NIPA_PERSONAL_INTEREST_INCOME_2024 = 1_926_644_000_000
 BEA_NIPA_PERSONAL_DIVIDEND_INCOME_2024 = 2_218_700_000_000
 
-NIPA_PROPRIETORS_INCOME_VARIABLE = "nipa_proprietors_income"
+NIPA_PROPRIETORS_INCOME_VARIABLE = (
+    "self_employment_income_before_lsr"
+    "+sstb_self_employment_income_before_lsr"
+    "+farm_operations_income"
+    "+partnership_s_corp_income"
+)
 NIPA_PERSONAL_INTEREST_INCOME_VARIABLE = "interest_income"
 TAXABLE_INTEREST_AND_ORDINARY_DIVIDENDS_VARIABLE = (
     "taxable_interest_income+non_qualified_dividend_income"
@@ -455,8 +460,9 @@ def extract_national_targets(year: int = DEFAULT_YEAR):
             "notes": (
                 "Proprietors' income with IVA and CCAdj for all persons, "
                 "including nonfilers; FRED/BEA series A041RC1A027NBEA. "
-                "Mapped to the PolicyEngine-US NIPA proprietors' income "
-                "aggregate."
+                "Mapped to Schedule C non-SSTB and SSTB self-employment "
+                "income before labor-supply responses, Schedule F farm "
+                "operations income, and active partnership/S-corp income."
             ),
             "year": 2024,
         },

--- a/policyengine_us_data/db/etl_national_targets.py
+++ b/policyengine_us_data/db/etl_national_targets.py
@@ -36,8 +36,6 @@ from policyengine_us_data.utils.target_variables import (
 # list should train on the target, add it to calibration/target_config.yaml too.
 BEA_NIPA_WAGES_AND_SALARIES_2024 = 12_387_929_000_000
 BEA_NIPA_PROPRIETORS_INCOME_2024 = 2_023_080_000_000
-BEA_NIPA_PERSONAL_INTEREST_INCOME_2024 = 1_926_644_000_000
-BEA_NIPA_PERSONAL_DIVIDEND_INCOME_2024 = 2_218_700_000_000
 
 NIPA_PROPRIETORS_INCOME_VARIABLE = (
     "self_employment_income_before_lsr"
@@ -45,7 +43,10 @@ NIPA_PROPRIETORS_INCOME_VARIABLE = (
     "+farm_operations_income"
     "+partnership_s_corp_income"
 )
-NIPA_PERSONAL_INTEREST_INCOME_VARIABLE = "interest_income"
+# CBO's individual income tax model computes AGI with "taxable interest
+# and ordinary dividends" explicitly excluding qualified dividends, which
+# are reported on the next line. Keep this mapped to the tax-return concept
+# for filer tax units, not total interest plus all dividends.
 TAXABLE_INTEREST_AND_ORDINARY_DIVIDENDS_VARIABLE = (
     "taxable_interest_income+non_qualified_dividend_income"
 )
@@ -104,8 +105,9 @@ CBO_INCOME_BY_SOURCE_TARGETS = [
         "parameter": "taxable_interest_and_ordinary_dividends",
         "notes": (
             "CBO detailed AGI-by-source taxable interest plus ordinary "
-            "dividends excluding qualified dividends; restricted to tax "
-            "filers because this is an AGI tax-return concept"
+            "dividends explicitly excluding qualified dividends; "
+            "restricted to tax filers because this is an AGI tax-return "
+            "concept"
         ),
     },
 ]
@@ -463,31 +465,6 @@ def extract_national_targets(year: int = DEFAULT_YEAR):
                 "Mapped to Schedule C non-SSTB and SSTB self-employment "
                 "income before labor-supply responses, Schedule F farm "
                 "operations income, and active partnership/S-corp income."
-            ),
-            "year": 2024,
-        },
-        {
-            "variable": NIPA_PERSONAL_INTEREST_INCOME_VARIABLE,
-            "value": BEA_NIPA_PERSONAL_INTEREST_INCOME_2024,
-            "source": "BEA NIPA Table 2.1",
-            "notes": (
-                "Personal interest income for all persons, including "
-                "nonfilers; FRED/BEA series A064RC1A027NBEA. NIPA also "
-                "includes imputed interest, so this is a macro benchmark "
-                "rather than a pure tax concept."
-            ),
-            "year": 2024,
-        },
-        {
-            "variable": "dividend_income",
-            "value": BEA_NIPA_PERSONAL_DIVIDEND_INCOME_2024,
-            "source": "BEA NIPA Table 2.1",
-            "notes": (
-                "Personal dividend income for all persons, including "
-                "nonfilers; FRED/BEA series B703RC1A027NBEA. NIPA "
-                "includes dividends received through pension funds and "
-                "private trusts, so this is a macro benchmark rather than "
-                "a pure tax concept."
             ),
             "year": 2024,
         },

--- a/policyengine_us_data/utils/loss.py
+++ b/policyengine_us_data/utils/loss.py
@@ -44,8 +44,6 @@ MEDICARE_PART_B_PREMIUM_VARIABLE = "medicare_part_b_premium"
 
 BEA_NIPA_WAGES_AND_SALARIES_2024 = 12_387_929_000_000
 BEA_NIPA_PROPRIETORS_INCOME_2024 = 2_023_080_000_000
-BEA_NIPA_PERSONAL_INTEREST_INCOME_2024 = 1_926_644_000_000
-BEA_NIPA_PERSONAL_DIVIDEND_INCOME_2024 = 2_218_700_000_000
 
 NIPA_PROPRIETORS_INCOME_VARIABLE = (
     "self_employment_income_before_lsr"
@@ -53,11 +51,18 @@ NIPA_PROPRIETORS_INCOME_VARIABLE = (
     "+farm_operations_income"
     "+partnership_s_corp_income"
 )
-NIPA_PERSONAL_INTEREST_INCOME_VARIABLE = "interest_income"
+# CBO's individual income tax model computes AGI with "taxable interest
+# and ordinary dividends" explicitly excluding qualified dividends, which
+# are reported on the next line. Keep this mapped to the tax-return concept
+# for filer tax units, not total interest plus all dividends.
 TAXABLE_INTEREST_AND_ORDINARY_DIVIDENDS_VARIABLE = (
     "taxable_interest_income+non_qualified_dividend_income"
 )
 
+# Only use direct NIPA totals when the PolicyEngine variable expression is a
+# close microdata concept. BEA personal interest/dividends include imputed
+# interest, pension-plan dividends, and trust flows, so those macro totals
+# should not directly calibrate tax/CPS interest and dividend variables.
 BEA_NIPA_DIRECT_SUM_TARGETS = (
     (
         "nation/bea/nipa_wages_and_salaries",
@@ -69,19 +74,10 @@ BEA_NIPA_DIRECT_SUM_TARGETS = (
         NIPA_PROPRIETORS_INCOME_VARIABLE,
         BEA_NIPA_PROPRIETORS_INCOME_2024,
     ),
-    (
-        "nation/bea/nipa_personal_interest_income",
-        NIPA_PERSONAL_INTEREST_INCOME_VARIABLE,
-        BEA_NIPA_PERSONAL_INTEREST_INCOME_2024,
-    ),
-    (
-        "nation/bea/nipa_personal_dividend_income",
-        "dividend_income",
-        BEA_NIPA_PERSONAL_DIVIDEND_INCOME_2024,
-    ),
 )
 
-BEA_WAGES_AND_SALARIES_LOSS_WEIGHT = 5_000.0
+BEA_NIPA_DIRECT_SUM_LOSS_WEIGHT = 1_000.0
+BEA_WAGES_AND_SALARIES_LOSS_WEIGHT = 1_000.0
 
 CBO_INCOME_BY_SOURCE_TARGETS = [
     ("irs_employment_income", "employment_income"),
@@ -1150,9 +1146,15 @@ def get_target_error_normalisation(target_names, targets_array):
 def get_target_loss_weights(target_names):
     target_names = np.asarray(target_names, dtype=str)
     weights = np.ones(target_names.shape, dtype=np.float32)
+    bea_direct_sum_targets = np.array(
+        [label for label, _, _ in BEA_NIPA_DIRECT_SUM_TARGETS],
+        dtype=str,
+    )
+    is_bea_direct_sum_target = np.isin(target_names, bea_direct_sum_targets)
     is_bea_wage_target = (
         target_names == "nation/bea/nipa_wages_and_salaries"
     ) | np.char.startswith(target_names, "state/bea/wages_and_salaries/")
+    weights[is_bea_direct_sum_target] = BEA_NIPA_DIRECT_SUM_LOSS_WEIGHT
     weights[is_bea_wage_target] = BEA_WAGES_AND_SALARIES_LOSS_WEIGHT
     return weights
 

--- a/policyengine_us_data/utils/loss.py
+++ b/policyengine_us_data/utils/loss.py
@@ -50,7 +50,7 @@ BEA_NIPA_PERSONAL_DIVIDEND_INCOME_2024 = 2_218_700_000_000
 NIPA_PROPRIETORS_INCOME_VARIABLE = "nipa_proprietors_income"
 NIPA_PERSONAL_INTEREST_INCOME_VARIABLE = "interest_income"
 TAXABLE_INTEREST_AND_ORDINARY_DIVIDENDS_VARIABLE = (
-    "taxable_interest_income+dividend_income"
+    "taxable_interest_income+non_qualified_dividend_income"
 )
 
 BEA_NIPA_DIRECT_SUM_TARGETS = (

--- a/policyengine_us_data/utils/loss.py
+++ b/policyengine_us_data/utils/loss.py
@@ -47,7 +47,12 @@ BEA_NIPA_PROPRIETORS_INCOME_2024 = 2_023_080_000_000
 BEA_NIPA_PERSONAL_INTEREST_INCOME_2024 = 1_926_644_000_000
 BEA_NIPA_PERSONAL_DIVIDEND_INCOME_2024 = 2_218_700_000_000
 
-NIPA_PROPRIETORS_INCOME_VARIABLE = "nipa_proprietors_income"
+NIPA_PROPRIETORS_INCOME_VARIABLE = (
+    "self_employment_income_before_lsr"
+    "+sstb_self_employment_income_before_lsr"
+    "+farm_operations_income"
+    "+partnership_s_corp_income"
+)
 NIPA_PERSONAL_INTEREST_INCOME_VARIABLE = "interest_income"
 TAXABLE_INTEREST_AND_ORDINARY_DIVIDENDS_VARIABLE = (
     "taxable_interest_income+non_qualified_dividend_income"

--- a/policyengine_us_data/utils/national_target_parity.py
+++ b/policyengine_us_data/utils/national_target_parity.py
@@ -41,6 +41,9 @@ _SPM_THRESHOLD_LABEL = re.compile(
     r"^nation/census/(?:agi|count)_in_spm_threshold_decile_[0-9]+$"
 )
 _SOI_FILER_AGI_LABEL = re.compile(r"^nation/soi/filer_count/agi_.+$")
+_CBO_INCOME_BY_SOURCE_LABEL = re.compile(
+    r"^nation/cbo/income_by_source/(?P<variable>.+)/filers$"
+)
 _DEPRECATED_SPM_SURVEY_LABEL = re.compile(
     r"^nation/census/(?:spm_unit_|(?:agi|count)_in_spm_threshold_decile_).+$"
 )
@@ -392,6 +395,20 @@ def classify_national_target(
             target_name,
             matches,
             reason="structured_real_estate_tax_itemizer_target",
+        )
+
+    match = _CBO_INCOME_BY_SOURCE_LABEL.match(target_name)
+    if match:
+        variable = match.group("variable")
+        matches = index.match(
+            variable=variable,
+            period=period,
+            constraints=[_constraint("tax_unit_is_filer", "==", 1)],
+        )
+        return _match_result(
+            target_name,
+            matches,
+            reason="structured_cbo_income_by_source_filer_target",
         )
 
     if target_name.startswith("nation/cbo/"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us==1.699.0",
+    "policyengine-us==1.700.0",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/tests/unit/calibration/test_calibration_puf_impute.py
+++ b/tests/unit/calibration/test_calibration_puf_impute.py
@@ -267,6 +267,40 @@ class TestPufCloneDataset:
         for var in PUF_REPORTED_CALCULATED_TAX_OUTPUT_VARIABLES:
             assert var not in result
 
+    def test_puf_only_variables_are_imputed_onto_cps_half(self, monkeypatch):
+        data = _make_mock_data(n_persons=20, n_households=5)
+        assert "partnership_s_corp_income" not in data
+
+        predictions = np.arange(20, dtype=np.float32) + 100
+        y_full = {var: np.ones(20, dtype=np.float32) for var in IMPUTED_VARIABLES}
+        y_full["partnership_s_corp_income"] = predictions
+        y_full["employment_income"] = np.full(20, 999_999, dtype=np.float32)
+
+        def fake_run_qrf_imputation(*args, **kwargs):
+            return y_full, {}
+
+        monkeypatch.setattr(
+            puf_impute_module,
+            "_run_qrf_imputation",
+            fake_run_qrf_imputation,
+        )
+
+        result = puf_clone_dataset(
+            data=data,
+            state_fips=np.array([1, 2, 36, 6, 48]),
+            time_period=2024,
+            puf_dataset=object(),
+            skip_qrf=False,
+        )
+
+        partnership = result["partnership_s_corp_income"][2024]
+        np.testing.assert_array_equal(partnership[:20], predictions)
+        np.testing.assert_array_equal(partnership[20:], predictions)
+
+        employment = result["employment_income"][2024]
+        np.testing.assert_array_equal(employment[:20], data["employment_income"][2024])
+        np.testing.assert_array_equal(employment[20:], y_full["employment_income"])
+
     def test_sstb_qbi_split_variables_imputed(self):
         expected = {
             "sstb_self_employment_income",

--- a/tests/unit/calibration/test_loss_targets.py
+++ b/tests/unit/calibration/test_loss_targets.py
@@ -11,6 +11,7 @@ from policyengine_us_data.utils.loss import (
     AGGREGATE_LEVEL_TARGETED_VARIABLES,
     AGI_LEVEL_TARGETED_VARIABLES,
     BEA_NIPA_DIRECT_SUM_TARGETS,
+    BEA_NIPA_DIRECT_SUM_LOSS_WEIGHT,
     BEA_WAGES_AND_SALARIES_LOSS_WEIGHT,
     BLS_CE_TOTALS,
     HARD_CODED_TOTALS,
@@ -56,21 +57,17 @@ def test_bea_nipa_direct_sum_targets_match_targets_db():
         etl_national_targets.NIPA_PROPRIETORS_INCOME_VARIABLE: (
             etl_national_targets.BEA_NIPA_PROPRIETORS_INCOME_2024
         ),
-        etl_national_targets.NIPA_PERSONAL_INTEREST_INCOME_VARIABLE: (
-            etl_national_targets.BEA_NIPA_PERSONAL_INTEREST_INCOME_2024
-        ),
-        "dividend_income": (
-            etl_national_targets.BEA_NIPA_PERSONAL_DIVIDEND_INCOME_2024
-        ),
     }
 
 
-def test_bea_wage_targets_get_higher_loss_weight():
+def test_bea_nipa_direct_sum_targets_get_higher_loss_weight():
     target_names = np.array(
         [
             "nation/bea/nipa_wages_and_salaries",
             "state/bea/wages_and_salaries/CA",
             "nation/bea/nipa_proprietors_income",
+            "nation/bea/nipa_personal_interest_income",
+            "nation/bea/nipa_personal_dividend_income",
             "state/CA/adjusted_gross_income/amount/1000000_inf",
         ]
     )
@@ -80,6 +77,8 @@ def test_bea_wage_targets_get_higher_loss_weight():
     assert weights.tolist() == [
         BEA_WAGES_AND_SALARIES_LOSS_WEIGHT,
         BEA_WAGES_AND_SALARIES_LOSS_WEIGHT,
+        BEA_NIPA_DIRECT_SUM_LOSS_WEIGHT,
+        1.0,
         1.0,
         1.0,
     ]

--- a/tests/unit/calibration/test_target_config.py
+++ b/tests/unit/calibration/test_target_config.py
@@ -360,10 +360,17 @@ class TestLoadTargetConfig:
         for variable in [
             "employment_income_before_lsr",
             etl_national_targets.NIPA_PROPRIETORS_INCOME_VARIABLE,
-            etl_national_targets.NIPA_PERSONAL_INTEREST_INCOME_VARIABLE,
-            "dividend_income",
         ]:
             assert {"variable": variable, "geo_level": "national"} in include_rules
+
+        assert {
+            "variable": "interest_income",
+            "geo_level": "national",
+        } not in include_rules
+        assert {
+            "variable": "dividend_income",
+            "geo_level": "national",
+        } not in include_rules
 
     def test_training_config_includes_bea_state_wage_targets(self):
         config = load_target_config(

--- a/tests/unit/test_etl_national_targets.py
+++ b/tests/unit/test_etl_national_targets.py
@@ -822,8 +822,9 @@ def test_extracts_income_targets_from_primary_concepts(monkeypatch):
             "notes": (
                 "Proprietors' income with IVA and CCAdj for all persons, "
                 "including nonfilers; FRED/BEA series A041RC1A027NBEA. "
-                "Mapped to the PolicyEngine-US NIPA proprietors' income "
-                "aggregate."
+                "Mapped to Schedule C non-SSTB and SSTB self-employment "
+                "income before labor-supply responses, Schedule F farm "
+                "operations income, and active partnership/S-corp income."
             ),
             "year": 2024,
         }

--- a/tests/unit/test_etl_national_targets.py
+++ b/tests/unit/test_etl_national_targets.py
@@ -628,26 +628,10 @@ def test_loads_gross_wage_and_filer_tax_wage_targets(tmp_path, monkeypatch):
                     "year": 2024,
                 },
                 {
-                    "variable": (
-                        etl_national_targets.NIPA_PERSONAL_INTEREST_INCOME_VARIABLE
-                    ),
-                    "value": 1_926_644_000_000,
-                    "source": "BEA NIPA Table 2.1",
-                    "notes": "Personal interest income",
-                    "year": 2024,
-                },
-                {
                     "variable": etl_national_targets.NIPA_PROPRIETORS_INCOME_VARIABLE,
                     "value": 2_023_080_000_000,
                     "source": "BEA NIPA Table 2.1",
                     "notes": "Proprietors' income",
-                    "year": 2024,
-                },
-                {
-                    "variable": "dividend_income",
-                    "value": 2_218_700_000_000,
-                    "source": "BEA NIPA Table 2.1",
-                    "notes": "Personal dividend income",
                     "year": 2024,
                 },
             ]
@@ -674,19 +658,10 @@ def test_loads_gross_wage_and_filer_tax_wage_targets(tmp_path, monkeypatch):
         tax_wage_target = session.exec(
             select(Target).where(Target.variable == "irs_employment_income")
         ).one()
-        interest_target = session.exec(
-            select(Target).where(
-                Target.variable
-                == etl_national_targets.NIPA_PERSONAL_INTEREST_INCOME_VARIABLE
-            )
-        ).one()
         proprietors_target = session.exec(
             select(Target).where(
                 Target.variable == etl_national_targets.NIPA_PROPRIETORS_INCOME_VARIABLE
             )
-        ).one()
-        dividend_target = session.exec(
-            select(Target).where(Target.variable == "dividend_income")
         ).one()
         filer_constraints = session.exec(
             select(StratumConstraint).where(
@@ -696,9 +671,7 @@ def test_loads_gross_wage_and_filer_tax_wage_targets(tmp_path, monkeypatch):
 
     assert gross_wage_target.value == 12_387_929_000_000
     assert tax_wage_target.value == 10_832_700_000_000
-    assert interest_target.value == 1_926_644_000_000
     assert proprietors_target.value == 2_023_080_000_000
-    assert dividend_target.value == 2_218_700_000_000
     assert gross_wage_target.stratum_id != tax_wage_target.stratum_id
     assert [
         (
@@ -771,8 +744,7 @@ def test_extracts_income_targets_from_primary_concepts(monkeypatch):
     interest_targets = [
         target
         for target in raw_targets["direct_sum_targets"]
-        if target["variable"]
-        == etl_national_targets.NIPA_PERSONAL_INTEREST_INCOME_VARIABLE
+        if target["variable"] == "interest_income"
     ]
     dividend_targets = [
         target
@@ -829,35 +801,8 @@ def test_extracts_income_targets_from_primary_concepts(monkeypatch):
             "year": 2024,
         }
     ]
-    assert interest_targets == [
-        {
-            "variable": etl_national_targets.NIPA_PERSONAL_INTEREST_INCOME_VARIABLE,
-            "value": etl_national_targets.BEA_NIPA_PERSONAL_INTEREST_INCOME_2024,
-            "source": "BEA NIPA Table 2.1",
-            "notes": (
-                "Personal interest income for all persons, including "
-                "nonfilers; FRED/BEA series A064RC1A027NBEA. NIPA also "
-                "includes imputed interest, so this is a macro benchmark "
-                "rather than a pure tax concept."
-            ),
-            "year": 2024,
-        }
-    ]
-    assert dividend_targets == [
-        {
-            "variable": "dividend_income",
-            "value": (etl_national_targets.BEA_NIPA_PERSONAL_DIVIDEND_INCOME_2024),
-            "source": "BEA NIPA Table 2.1",
-            "notes": (
-                "Personal dividend income for all persons, including "
-                "nonfilers; FRED/BEA series B703RC1A027NBEA. NIPA "
-                "includes dividends received through pension funds and "
-                "private trusts, so this is a macro benchmark rather than "
-                "a pure tax concept."
-            ),
-            "year": 2024,
-        }
-    ]
+    assert interest_targets == []
+    assert dividend_targets == []
     assert cbo_self_employment_targets == [
         {
             "variable": "self_employment_income",

--- a/tests/unit/test_extended_cps.py
+++ b/tests/unit/test_extended_cps.py
@@ -248,6 +248,18 @@ class TestVariableListConsistency:
         with pytest.raises(DatasetContractError, match="social_security"):
             ExtendedCPS._assert_no_computed_variables_exported(data, 2024)
 
+    def test_rename_imputed_to_inputs_maps_medicare_enrollment_to_take_up_input(self):
+        data = {"medicare_enrolled": {2024: np.array([True, False])}}
+
+        result = ExtendedCPS._rename_imputed_to_inputs(data)
+
+        assert "medicare_enrolled" not in result
+        assert result["takes_up_medicare_if_eligible"][2024].tolist() == [
+            True,
+            False,
+        ]
+        ExtendedCPS._assert_no_computed_variables_exported(result, 2024)
+
     def test_final_export_contract_allows_structural_cache_variables(self):
         data = {
             "person_id": {2024: np.array([1])},

--- a/tests/unit/test_extended_cps.py
+++ b/tests/unit/test_extended_cps.py
@@ -408,6 +408,26 @@ class TestVariableListConsistency:
                 microsimulation_cls=_FakeHousingMicrosimulation,
             )
 
+    def test_housing_assistance_validation_allows_observed_formula_gap(self):
+        data = {
+            "receives_housing_assistance": {2024: np.array([True])},
+            "takes_up_housing_assistance_if_eligible": {2024: np.array([True])},
+            "spm_unit_capped_housing_subsidy": {2024: np.array([100.0])},
+        }
+        _FakeHousingMicrosimulation.outputs = {
+            "housing_assistance": np.array([100.0]),
+            "spm_unit_capped_housing_subsidy": np.array([58.0]),
+            "spm_unit_weight": np.array([1.0]),
+        }
+
+        result = ExtendedCPS._validate_housing_assistance_microsimulation(
+            data,
+            2024,
+            microsimulation_cls=_FakeHousingMicrosimulation,
+        )
+
+        assert result is data
+
     def test_housing_assistance_validation_rejects_half_reported_match(self):
         data = {
             "receives_housing_assistance": {2024: np.array([True])},
@@ -416,7 +436,7 @@ class TestVariableListConsistency:
         }
         _FakeHousingMicrosimulation.outputs = {
             "housing_assistance": np.array([100.0]),
-            "spm_unit_capped_housing_subsidy": np.array([59.0]),
+            "spm_unit_capped_housing_subsidy": np.array([54.0]),
             "spm_unit_weight": np.array([1.0]),
         }
 

--- a/tests/unit/test_extended_cps.py
+++ b/tests/unit/test_extended_cps.py
@@ -270,6 +270,9 @@ class TestVariableListConsistency:
             "pre_subsidy_rent": {2024: np.array([1_000.0])},
             "spm_unit_capped_work_childcare_expenses": {2024: np.array([500.0])},
             "spm_unit_pre_subsidy_childcare_expenses": {2024: np.array([600.0])},
+            "spm_unit_spm_threshold": {2024: np.array([25_000.0])},
+            "spm_unit_geographic_adjustment": {2024: np.array([1.1])},
+            "person_in_poverty": {2024: np.array([False])},
             "has_tin": {2024: np.array([True])},
             "has_itin": {2024: np.array([True])},
             "in_nyc": {2024: np.array([False])},
@@ -282,6 +285,9 @@ class TestVariableListConsistency:
             "dividend_income",
             "rent",
             "spm_unit_capped_work_childcare_expenses",
+            "spm_unit_spm_threshold",
+            "spm_unit_geographic_adjustment",
+            "person_in_poverty",
         ):
             assert variable not in result
         for variable in (

--- a/tests/unit/test_income_target_mappings.py
+++ b/tests/unit/test_income_target_mappings.py
@@ -16,4 +16,4 @@ def test_cbo_taxable_interest_and_ordinary_dividends_excludes_qualified_dividend
         if target["parameter"] == "taxable_interest_and_ordinary_dividends"
     )
     assert target["variable"] == expected
-    assert "excluding qualified dividends" in target["notes"]
+    assert "explicitly excluding qualified dividends" in target["notes"]

--- a/tests/unit/test_income_target_mappings.py
+++ b/tests/unit/test_income_target_mappings.py
@@ -1,0 +1,19 @@
+import policyengine_us_data.db.etl_national_targets as etl_national_targets
+import policyengine_us_data.utils.loss as loss
+
+
+def test_cbo_taxable_interest_and_ordinary_dividends_excludes_qualified_dividends():
+    expected = "taxable_interest_income+non_qualified_dividend_income"
+
+    assert loss.TAXABLE_INTEREST_AND_ORDINARY_DIVIDENDS_VARIABLE == expected
+    assert etl_national_targets.TAXABLE_INTEREST_AND_ORDINARY_DIVIDENDS_VARIABLE == (
+        expected
+    )
+
+    target = next(
+        target
+        for target in etl_national_targets.CBO_INCOME_BY_SOURCE_TARGETS
+        if target["parameter"] == "taxable_interest_and_ordinary_dividends"
+    )
+    assert target["variable"] == expected
+    assert "excluding qualified dividends" in target["notes"]

--- a/tests/unit/test_national_target_parity.py
+++ b/tests/unit/test_national_target_parity.py
@@ -88,6 +88,32 @@ def test_classify_known_legacy_target_gets_named_reason():
     }
 
 
+def test_classify_cbo_income_by_source_filer_target_matches_structured_row():
+    index = NationalTargetIndex(
+        [
+            _record(
+                3101,
+                variable="taxable_interest_income+non_qualified_dividend_income",
+                period=2024,
+                constraints=[Constraint("tax_unit_is_filer", "==", "1")],
+            )
+        ]
+    )
+
+    row = classify_national_target(
+        (
+            "nation/cbo/income_by_source/"
+            "taxable_interest_income+non_qualified_dividend_income/filers"
+        ),
+        index,
+        period=2024,
+    )
+
+    assert row["status"] == "matched"
+    assert row["target_id"] == 3101
+    assert row["reason"] == "structured_cbo_income_by_source_filer_target"
+
+
 def test_classify_soi_taxable_agi_filing_status_target_matches_structured_row():
     index = NationalTargetIndex(
         [

--- a/uv.lock
+++ b/uv.lock
@@ -2122,7 +2122,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.699.0"
+version = "1.700.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2132,9 +2132,9 @@ dependencies = [
     { name = "tables" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3c/40/cd4c50475950ff3b61a8e5e0a04e692574b9da6cab5da4f166b7321c8fbf/policyengine_us-1.699.0.tar.gz", hash = "sha256:d3d1e4f2a4aea72ae72dc534de6fb454e14ad685cb429067ad4d9265339e6fd1", size = 9852436, upload-time = "2026-05-19T21:48:40.971Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/70/767fddeeb827e96e0f9a499c25f76c642767a129be259162eaf5b5954eb1/policyengine_us-1.700.0.tar.gz", hash = "sha256:63a7b1a2b8a0c903b6d704e8095f6880024e8fa93ea405912820a42589e90add", size = 9862854, upload-time = "2026-05-20T00:07:27.748Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/58/0514ac39397664bbb53d0a3b3dd964afe1776bbc1142cdc0eac258ebb10d/policyengine_us-1.699.0-py3-none-any.whl", hash = "sha256:87aea45b9204f0831ea9e9b572b2e8c30fbe7fa888c370f5cdc3760df3793db8", size = 10583733, upload-time = "2026-05-19T21:48:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e9/2837a0d98e99efaf4d82aade276eee6eeff419df614863f08e3512961d2d/policyengine_us-1.700.0-py3-none-any.whl", hash = "sha256:7633d8aefcaf02d7628f841bc56750606f1d7fe409ff3ae7b0ef7e364a88e945", size = 10614505, upload-time = "2026-05-20T00:07:23.699Z" },
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", specifier = "==1.699.0" },
+    { name = "policyengine-us", specifier = "==1.700.0" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },


### PR DESCRIPTION
## Summary

Fixes the income-target support issues identified in #1056, #1057, and #1058 in one branch:

- impute PUF-only variables onto the positive-weight CPS half, not only the zero-weight PUF clone half
- map CBO `taxable_interest_and_ordinary_dividends` to `taxable_interest_income+non_qualified_dividend_income`, excluding qualified dividends per CBO's own AGI table
- remove BEA NIPA personal interest and personal dividend macro totals from active direct ECPS/target DB calibration; those concepts include imputed interest, pension-plan dividends, and trust/trust-like flows that do not match CPS/PUF tax-return variables
- teach the national target parity checker to match legacy CBO income-by-source filer labels against structured target DB rows

## Why

The 2024 enhanced CPS artifact had effectively zero final weight on PUF clone rows (`clone_household_weight_share_pct = 6.18e-07%`). Variables absent from CPS, especially `partnership_s_corp_income`, were therefore stranded on rows with no usable calibration weight. This caused near-100% misses for partnership/S-corp targets and a roughly `$1.58T` shortfall on BEA NIPA proprietors income.

The CBO interest/dividend composite also included total `dividend_income`, which includes qualified dividends, even though CBO's Individual Income Tax Model shows `Taxable interest and ordinary dividends (excludes qualified dividends)` and then `Qualified dividends` as a separate AGI row. CBO's tax model is built around the filing population, so these income-source targets remain filer constrained.

The BEA personal interest/dividend NIPA totals are useful macro diagnostics, but they are not close microdata concepts for `interest_income`/`dividend_income`. Keeping them as direct calibration targets was pulling the dataset away from SOI/CBO tax-return concepts.

## Local corrected 2024 artifact

Generated locally from commit `5995af66` after removing the non-comparable BEA interest/dividend targets:

- artifact: `/tmp/us-data-pr1059-local-run/bea_no_interest_dividends_direct1000/enhanced_cps_2024.h5`
- baseline SPM: `0.1820383511951881`
- `employment_income`: `$12.392864T`, `+0.040%` vs BEA wages target `$12.387929T`
- BEA proprietors proxy: `$1.977782T`, `-2.24%` vs `$2.023080T`
- CBO filer taxable interest + nonqualified dividends: `$390.589B`, `+26.1%` vs `$309.700B`
- CBO filer qualified dividends: `$149.767B`, `-57.7%` vs `$354.300B`
- BEA personal interest/dividend are now diagnostics only, not active direct targets

## Validation

- `uv run python -u -m policyengine_us_data.datasets.cps.enhanced_cps`
- `uv run pytest tests/unit/calibration/test_loss_targets.py::test_bea_nipa_direct_sum_targets_match_targets_db tests/unit/calibration/test_loss_targets.py::test_bea_nipa_direct_sum_targets_get_higher_loss_weight tests/unit/calibration/test_target_config.py::TestLoadTargetConfig::test_training_config_includes_bea_nipa_direct_sum_targets tests/unit/test_income_target_mappings.py tests/unit/test_etl_national_targets.py::test_loads_gross_wage_and_filer_tax_wage_targets tests/unit/test_etl_national_targets.py::test_extracts_income_targets_from_primary_concepts tests/unit/test_national_target_parity.py::test_classify_cbo_income_by_source_filer_target_matches_structured_row`
- `uv run ruff check policyengine_us_data/utils/loss.py policyengine_us_data/db/etl_national_targets.py tests/unit/calibration/test_loss_targets.py tests/unit/calibration/test_target_config.py tests/unit/test_etl_national_targets.py tests/unit/test_income_target_mappings.py`
- `uv run ruff format policyengine_us_data/utils/loss.py policyengine_us_data/db/etl_national_targets.py tests/unit/calibration/test_loss_targets.py tests/unit/calibration/test_target_config.py tests/unit/test_etl_national_targets.py tests/unit/test_income_target_mappings.py`

Fixes #1056.
Fixes #1057.
Fixes #1058.