### PR TITLE
Add income target wiring preflight tests

### DIFF
--- a/changelog.d/publication-target-wiring-tests.fixed.md
+++ b/changelog.d/publication-target-wiring-tests.fixed.md
@@ -1,0 +1,1 @@
+Add CI coverage for income target wiring and a local publication preflight script for built enhanced CPS artifacts.

--- a/docs/engineering/skills/pipeline_operations.md
+++ b/docs/engineering/skills/pipeline_operations.md
@@ -119,3 +119,22 @@ repository root.
   may show a running run with no durable error. In that case, report the last
   completed/running manifest and then use Modal dashboard logs as secondary
   evidence.
+
+## Local Publication Preflight
+
+When you already have a locally built or checkpointed
+`enhanced_cps_2024.h5`, run the publication preflight before launching or
+resuming the long local-area publication stages:
+
+```bash
+uv run python scripts/run_publication_preflight.py \
+  --enhanced-cps /path/to/enhanced_cps_2024.h5 \
+  --calibration-log /path/to/calibration_log.csv
+```
+
+This reuses the upload dataset contract, computes baseline SPM, checks
+`employment_income` against the BEA NIPA wages target with a tight tolerance,
+and runs final-epoch JCT diagnostics plus ACA/Medicaid state checks unless
+explicitly skipped. Do not treat a completed local data build as publication
+ready until this preflight or the equivalent Stage 1 publication validation has
+passed.

--- a/policyengine_us_data/storage/upload_completed_datasets.py
+++ b/policyengine_us_data/storage/upload_completed_datasets.py
@@ -129,7 +129,10 @@ INCOME_GROUPS = [
 
 # Aggregate thresholds for broad sanity checks (year 2024).
 MIN_PLAUSIBLE_EMPLOYMENT_INCOME_SUM = 5e12  # $5 trillion
-NIPA_EMPLOYMENT_INCOME_TOLERANCE = 0.10
+# This is a publication gate, not a broad plausibility check: enhanced CPS
+# calibration should hit the BEA NIPA wages target closely enough that missing
+# target wiring fails before local-area outputs are built.
+NIPA_EMPLOYMENT_INCOME_TOLERANCE = 0.01
 MIN_ENHANCED_CPS_EMPLOYMENT_INCOME_SUM = BEA_NIPA_WAGES_AND_SALARIES_2024 * (
     1 - NIPA_EMPLOYMENT_INCOME_TOLERANCE
 )

--- a/scripts/run_publication_preflight.py
+++ b/scripts/run_publication_preflight.py
@@ -1,0 +1,288 @@
+"""Run fast artifact checks before launching the full publication pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from policyengine_core.data import Dataset
+from policyengine_us import Microsimulation
+
+from policyengine_us_data.db.etl_national_targets import (
+    BEA_NIPA_WAGES_AND_SALARIES_2024,
+)
+from policyengine_us_data.storage import STORAGE_FOLDER
+from policyengine_us_data.storage.upload_completed_datasets import (
+    DatasetValidationError,
+    validate_dataset,
+)
+from policyengine_us_data.utils import ABSOLUTE_ERROR_SCALE_TARGETS
+
+DEFAULT_ENHANCED_CPS_PATH = STORAGE_FOLDER / "enhanced_cps_2024.h5"
+DEFAULT_CALIBRATION_LOG_PATH = Path("calibration_log.csv")
+DEFAULT_PERIOD = 2024
+DEFAULT_EMPLOYMENT_TOLERANCE = 0.01
+DEFAULT_FINAL_EPOCH_TARGET_SHARE = 60.0
+MEDICAID_VALIDATION_PERIOD = 2025
+MEDICAID_STATE_TOLERANCE = 10.0
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass(frozen=True)
+class PreflightResult:
+    enhanced_cps_path: str
+    calibration_log_path: str | None
+    period: int
+    baseline_spm: float
+    employment_income: float
+    employment_income_target: float
+    employment_income_relative_error: float
+    dataset_validation_passed: bool
+    jct_diagnostics_passed: bool | None
+    final_epoch_target_share_within_tolerance: float | None
+    aca_state_calibration_passed: bool | None
+    medicaid_state_calibration_passed: bool | None
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate a built enhanced CPS artifact before spending publication "
+            "time on local-area outputs."
+        )
+    )
+    parser.add_argument(
+        "--enhanced-cps",
+        type=Path,
+        default=DEFAULT_ENHANCED_CPS_PATH,
+        help="Path to enhanced_cps_2024.h5.",
+    )
+    parser.add_argument(
+        "--calibration-log",
+        type=Path,
+        default=DEFAULT_CALIBRATION_LOG_PATH,
+        help="Path to calibration_log.csv.",
+    )
+    parser.add_argument(
+        "--period",
+        type=int,
+        default=DEFAULT_PERIOD,
+        help="PolicyEngine year for SPM and income aggregates.",
+    )
+    parser.add_argument(
+        "--employment-tolerance",
+        type=float,
+        default=DEFAULT_EMPLOYMENT_TOLERANCE,
+        help="Allowed relative error against the BEA NIPA wages target.",
+    )
+    parser.add_argument(
+        "--skip-dataset-validation",
+        action="store_true",
+        help="Skip upload-contract validation of the enhanced CPS H5.",
+    )
+    parser.add_argument(
+        "--skip-calibration-log",
+        action="store_true",
+        help="Skip calibration_log.csv diagnostics.",
+    )
+    parser.add_argument(
+        "--skip-state-health",
+        action="store_true",
+        help="Skip ACA and Medicaid state calibration checks.",
+    )
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        default=None,
+        help="Optional path for a JSON summary.",
+    )
+    return parser.parse_args()
+
+
+def load_simulation(path: Path) -> Microsimulation:
+    return Microsimulation(dataset=Dataset.from_file(path))
+
+
+def ensure_repo_root_on_path() -> None:
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+
+
+def calculate_baseline_spm(sim: Microsimulation, period: int) -> float:
+    try:
+        return float(sim.calculate("in_poverty", period, map_to="person").mean())
+    except ValueError:
+        return float(sim.calculate("person_in_poverty", period, map_to="person").mean())
+
+
+def calculate_employment_income(sim: Microsimulation, period: int) -> float:
+    return float(sim.calculate("employment_income", period, map_to="person").sum())
+
+
+def validate_employment_income(
+    value: float,
+    *,
+    target: float,
+    tolerance: float,
+) -> float:
+    relative_error = (value - target) / target
+    if abs(relative_error) > tolerance:
+        raise AssertionError(
+            "employment_income is outside the NIPA wages tolerance: "
+            f"value={value:,.0f}, target={target:,.0f}, "
+            f"relative_error={relative_error:.4%}, tolerance={tolerance:.2%}"
+        )
+    return relative_error
+
+
+def final_epoch_target_share_within_tolerance(calibration_log: pd.DataFrame) -> float:
+    final_epoch = calibration_log["epoch"].max()
+    final_rows = calibration_log[calibration_log["epoch"] == final_epoch].copy()
+    if final_rows.empty:
+        raise AssertionError("No final-epoch calibration diagnostics found.")
+
+    tolerance = 0.10 * final_rows["target"].abs()
+    for target_name, scale in ABSOLUTE_ERROR_SCALE_TARGETS.items():
+        tolerance.loc[final_rows["target_name"] == target_name] = 0.10 * scale
+    return float((final_rows["abs_error"] <= tolerance).mean() * 100)
+
+
+def validate_calibration_log(path: Path) -> float:
+    ensure_repo_root_on_path()
+    from validation.stage_1.jct_calibration import (
+        assert_no_unexpected_high_error_jct_diagnostics,
+    )
+
+    calibration_log = pd.read_csv(path)
+    assert_no_unexpected_high_error_jct_diagnostics(calibration_log)
+    share = final_epoch_target_share_within_tolerance(calibration_log)
+    if share <= DEFAULT_FINAL_EPOCH_TARGET_SHARE:
+        raise AssertionError(
+            "Too few final-epoch calibration targets are within tolerance: "
+            f"{share:.1f}% <= {DEFAULT_FINAL_EPOCH_TARGET_SHARE:.1f}%"
+        )
+    return share
+
+
+def validate_medicaid_state_calibration(sim: Microsimulation) -> None:
+    targets_path = (
+        Path("policyengine_us_data/storage/calibration_targets")
+        / f"medicaid_enrollment_{MEDICAID_VALIDATION_PERIOD}.csv"
+    )
+    targets = pd.read_csv(targets_path)
+    state_code_hh = sim.calculate("state_code", map_to="household").values
+    medicaid_enrolled = sim.calculate(
+        "medicaid_enrolled",
+        MEDICAID_VALIDATION_PERIOD,
+        map_to="household",
+    )
+
+    failures = []
+    for row in targets.itertuples(index=False):
+        target_enrollment = float(row.enrollment)
+        simulated = float(medicaid_enrolled[state_code_hh == row.state].sum())
+        pct_error = (
+            np.inf
+            if target_enrollment <= 0
+            else abs(simulated - target_enrollment) / target_enrollment
+        )
+        if pct_error > MEDICAID_STATE_TOLERANCE:
+            failures.append(
+                f"{row.state}: simulated {simulated:,.0f}, "
+                f"target {target_enrollment:,.0f}, error {pct_error:.2%}"
+            )
+
+    if failures:
+        raise AssertionError(
+            "One or more Medicaid state targets exceeded tolerance of "
+            f"{MEDICAID_STATE_TOLERANCE:.0%}:\n" + "\n".join(failures)
+        )
+
+
+def write_summary(result: PreflightResult, path: Path | None) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(asdict(result), indent=2, sort_keys=True) + "\n")
+
+
+def main() -> None:
+    args = parse_args()
+    enhanced_cps_path = args.enhanced_cps.expanduser().resolve()
+    calibration_log_path = args.calibration_log.expanduser().resolve()
+
+    if not enhanced_cps_path.exists():
+        raise FileNotFoundError(enhanced_cps_path)
+
+    dataset_validation_passed = False
+    if not args.skip_dataset_validation:
+        try:
+            validate_dataset(enhanced_cps_path)
+        except DatasetValidationError:
+            raise
+        dataset_validation_passed = True
+
+    sim = load_simulation(enhanced_cps_path)
+    baseline_spm = calculate_baseline_spm(sim, args.period)
+    employment_income = calculate_employment_income(sim, args.period)
+    employment_relative_error = validate_employment_income(
+        employment_income,
+        target=BEA_NIPA_WAGES_AND_SALARIES_2024,
+        tolerance=args.employment_tolerance,
+    )
+
+    jct_diagnostics_passed = None
+    target_share = None
+    if not args.skip_calibration_log:
+        if not calibration_log_path.exists():
+            raise FileNotFoundError(calibration_log_path)
+        target_share = validate_calibration_log(calibration_log_path)
+        jct_diagnostics_passed = True
+
+    aca_state_calibration_passed = None
+    medicaid_state_calibration_passed = None
+    if not args.skip_state_health:
+        ensure_repo_root_on_path()
+        from validation.stage_1.aca_calibration import assert_aca_ptc_calibration
+
+        assert_aca_ptc_calibration(sim, emit=print)
+        aca_state_calibration_passed = True
+        validate_medicaid_state_calibration(sim)
+        medicaid_state_calibration_passed = True
+
+    result = PreflightResult(
+        enhanced_cps_path=str(enhanced_cps_path),
+        calibration_log_path=(
+            str(calibration_log_path) if not args.skip_calibration_log else None
+        ),
+        period=args.period,
+        baseline_spm=baseline_spm,
+        employment_income=employment_income,
+        employment_income_target=BEA_NIPA_WAGES_AND_SALARIES_2024,
+        employment_income_relative_error=employment_relative_error,
+        dataset_validation_passed=dataset_validation_passed,
+        jct_diagnostics_passed=jct_diagnostics_passed,
+        final_epoch_target_share_within_tolerance=target_share,
+        aca_state_calibration_passed=aca_state_calibration_passed,
+        medicaid_state_calibration_passed=medicaid_state_calibration_passed,
+    )
+    write_summary(result, args.json_output)
+
+    print("\nPublication preflight passed.")
+    print(f"  enhanced CPS: {enhanced_cps_path}")
+    print(f"  baseline SPM ({args.period}): {baseline_spm:.6f}")
+    print(f"  employment_income ({args.period}): {employment_income:,.0f}")
+    print(f"  employment_income vs NIPA wages: {employment_relative_error:.4%}")
+    if target_share is not None:
+        print(
+            f"  final-epoch calibration targets within tolerance: {target_share:.1f}%"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_income_target_mappings.py
+++ b/tests/unit/test_income_target_mappings.py
@@ -1,5 +1,21 @@
 import policyengine_us_data.db.etl_national_targets as etl_national_targets
 import policyengine_us_data.utils.loss as loss
+from policyengine_us_data.calibration.unified_calibration import load_target_config
+
+
+TARGET_CONFIG_PATH = "policyengine_us_data/calibration/target_config.yaml"
+
+
+def _target_config_include_entries():
+    config = load_target_config(TARGET_CONFIG_PATH)
+    return {
+        (
+            rule["variable"],
+            rule["geo_level"],
+            rule.get("domain_variable"),
+        )
+        for rule in config["include"]
+    }
 
 
 def test_cbo_taxable_interest_and_ordinary_dividends_excludes_qualified_dividends():
@@ -17,3 +33,53 @@ def test_cbo_taxable_interest_and_ordinary_dividends_excludes_qualified_dividend
     )
     assert target["variable"] == expected
     assert "explicitly excluding qualified dividends" in target["notes"]
+
+
+def test_cbo_income_by_source_targets_match_between_legacy_and_target_db():
+    legacy_targets = {
+        parameter: variable for variable, parameter in loss.CBO_INCOME_BY_SOURCE_TARGETS
+    }
+    db_targets = {
+        target["parameter"]: target["variable"]
+        for target in etl_national_targets.CBO_INCOME_BY_SOURCE_TARGETS
+    }
+
+    assert legacy_targets == db_targets
+
+
+def test_bea_nipa_direct_sum_targets_match_between_legacy_and_target_db():
+    assert (
+        loss.BEA_NIPA_WAGES_AND_SALARIES_2024
+        == etl_national_targets.BEA_NIPA_WAGES_AND_SALARIES_2024
+    )
+    assert (
+        loss.BEA_NIPA_PROPRIETORS_INCOME_2024
+        == etl_national_targets.BEA_NIPA_PROPRIETORS_INCOME_2024
+    )
+    assert (
+        loss.NIPA_PROPRIETORS_INCOME_VARIABLE
+        == etl_national_targets.NIPA_PROPRIETORS_INCOME_VARIABLE
+    )
+
+    legacy_targets = {
+        variable: target for _, variable, target in loss.BEA_NIPA_DIRECT_SUM_TARGETS
+    }
+    assert legacy_targets == {
+        "employment_income_before_lsr": (
+            etl_national_targets.BEA_NIPA_WAGES_AND_SALARIES_2024
+        ),
+        etl_national_targets.NIPA_PROPRIETORS_INCOME_VARIABLE: (
+            etl_national_targets.BEA_NIPA_PROPRIETORS_INCOME_2024
+        ),
+    }
+
+
+def test_bea_nipa_direct_sum_targets_are_in_default_target_config():
+    include_entries = _target_config_include_entries()
+
+    expected_entries = {
+        ("employment_income_before_lsr", "national", None),
+        (etl_national_targets.NIPA_PROPRIETORS_INCOME_VARIABLE, "national", None),
+    }
+
+    assert expected_entries <= include_entries

--- a/tests/unit/test_publication_preflight.py
+++ b/tests/unit/test_publication_preflight.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import json
+import sys
+import types
+
+import pytest
+
+from scripts import run_publication_preflight as preflight
+
+
+class FakeSimulation:
+    pass
+
+
+def _patch_fast_simulation(monkeypatch, *, spm=0.125, employment_income=None):
+    if employment_income is None:
+        employment_income = preflight.BEA_NIPA_WAGES_AND_SALARIES_2024
+
+    monkeypatch.setattr(preflight, "load_simulation", lambda _: FakeSimulation())
+    monkeypatch.setattr(preflight, "calculate_baseline_spm", lambda *_: spm)
+    monkeypatch.setattr(
+        preflight,
+        "calculate_employment_income",
+        lambda *_: employment_income,
+    )
+
+
+def test_main_runs_preflight_and_writes_json_summary(tmp_path, monkeypatch):
+    enhanced_cps = tmp_path / "enhanced_cps_2024.h5"
+    calibration_log = tmp_path / "calibration_log.csv"
+    json_output = tmp_path / "preflight.json"
+    enhanced_cps.write_text("not a real h5")
+    calibration_log.write_text("epoch,target_name,target,abs_error\n")
+    calls = []
+
+    monkeypatch.setattr(preflight, "validate_dataset", lambda path: calls.append(path))
+    monkeypatch.setattr(preflight, "validate_calibration_log", lambda _: 75.0)
+    _patch_fast_simulation(
+        monkeypatch,
+        spm=0.182489,
+        employment_income=preflight.BEA_NIPA_WAGES_AND_SALARIES_2024 * 0.999,
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_publication_preflight.py",
+            "--enhanced-cps",
+            str(enhanced_cps),
+            "--calibration-log",
+            str(calibration_log),
+            "--skip-state-health",
+            "--json-output",
+            str(json_output),
+        ],
+    )
+
+    preflight.main()
+
+    assert calls == [enhanced_cps.resolve()]
+    result = json.loads(json_output.read_text())
+    assert result["enhanced_cps_path"] == str(enhanced_cps.resolve())
+    assert result["calibration_log_path"] == str(calibration_log.resolve())
+    assert result["baseline_spm"] == pytest.approx(0.182489)
+    assert result["dataset_validation_passed"] is True
+    assert result["jct_diagnostics_passed"] is True
+    assert result["final_epoch_target_share_within_tolerance"] == 75.0
+    assert result["aca_state_calibration_passed"] is None
+    assert result["medicaid_state_calibration_passed"] is None
+
+
+def test_main_honors_skip_flags_without_optional_artifacts(tmp_path, monkeypatch):
+    enhanced_cps = tmp_path / "enhanced_cps_2024.h5"
+    enhanced_cps.write_text("not a real h5")
+    monkeypatch.setattr(
+        preflight,
+        "validate_dataset",
+        lambda _: pytest.fail("dataset validation should be skipped"),
+    )
+    monkeypatch.setattr(
+        preflight,
+        "validate_calibration_log",
+        lambda _: pytest.fail("calibration log validation should be skipped"),
+    )
+    _patch_fast_simulation(monkeypatch)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_publication_preflight.py",
+            "--enhanced-cps",
+            str(enhanced_cps),
+            "--calibration-log",
+            str(tmp_path / "missing_calibration_log.csv"),
+            "--skip-dataset-validation",
+            "--skip-calibration-log",
+            "--skip-state-health",
+        ],
+    )
+
+    preflight.main()
+
+
+def test_main_runs_state_health_checks_by_default(tmp_path, monkeypatch):
+    enhanced_cps = tmp_path / "enhanced_cps_2024.h5"
+    calibration_log = tmp_path / "calibration_log.csv"
+    enhanced_cps.write_text("not a real h5")
+    calibration_log.write_text("epoch,target_name,target,abs_error\n")
+    calls = []
+
+    fake_aca_module = types.ModuleType("validation.stage_1.aca_calibration")
+
+    def fake_aca_check(sim, emit):
+        calls.append(("aca", sim, emit))
+
+    fake_aca_module.assert_aca_ptc_calibration = fake_aca_check
+    monkeypatch.setitem(
+        sys.modules,
+        "validation.stage_1.aca_calibration",
+        fake_aca_module,
+    )
+    monkeypatch.setattr(preflight, "validate_dataset", lambda _: None)
+    monkeypatch.setattr(preflight, "validate_calibration_log", lambda _: 80.0)
+    monkeypatch.setattr(
+        preflight,
+        "validate_medicaid_state_calibration",
+        lambda sim: calls.append(("medicaid", sim)),
+    )
+    _patch_fast_simulation(monkeypatch)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_publication_preflight.py",
+            "--enhanced-cps",
+            str(enhanced_cps),
+            "--calibration-log",
+            str(calibration_log),
+        ],
+    )
+
+    preflight.main()
+
+    sim = calls[0][1]
+    assert calls == [
+        ("aca", sim, print),
+        ("medicaid", sim),
+    ]
+
+
+def test_main_raises_for_missing_enhanced_cps(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "run_publication_preflight.py",
+            "--enhanced-cps",
+            str(tmp_path / "missing.h5"),
+            "--skip-dataset-validation",
+            "--skip-calibration-log",
+            "--skip-state-health",
+        ],
+    )
+
+    with pytest.raises(FileNotFoundError):
+        preflight.main()

--- a/tests/unit/test_upload_completed_datasets.py
+++ b/tests/unit/test_upload_completed_datasets.py
@@ -423,10 +423,10 @@ def test_enhanced_cps_employment_income_gate_rejects_missing_nipa_target(
     target = upload_module.BEA_NIPA_WAGES_AND_SALARIES_2024
 
     assert upload_module.MIN_ENHANCED_CPS_EMPLOYMENT_INCOME_SUM == pytest.approx(
-        target * 0.9
+        target * 0.99
     )
     assert upload_module.MAX_ENHANCED_CPS_EMPLOYMENT_INCOME_SUM == pytest.approx(
-        target * 1.1
+        target * 1.01
     )
 
     monkeypatch.setattr(
@@ -457,7 +457,7 @@ def test_enhanced_cps_employment_income_gate_rejects_missing_nipa_target(
     assert errors == [
         (
             "employment_income sum vs NIPA wages target = "
-            "8,805,350,912,425, expected >= 11,149,136,100,000."
+            "8,805,350,912,425, expected >= 12,264,049,710,000."
         )
     ]
 


### PR DESCRIPTION
## Summary

Adds fast preflight coverage for the failure modes that delayed the 2024 eCPS publication.

This PR now adds:

- Unit tests that assert CBO income-by-source targets are mapped identically in legacy ECPS calibration (`utils/loss.py`) and the structured target DB ETL (`db/etl_national_targets.py`).
- Unit tests that assert BEA NIPA direct-sum targets use the same constants and variables in both target paths.
- A unit test that asserts BEA NIPA direct-sum targets used for calibration are present in the default local-area `target_config.yaml` include list.
- A stricter upload/publication gate: enhanced CPS `employment_income` must be within 1% of the BEA NIPA wages target, not just within a broad 10% plausibility band.
- `scripts/run_publication_preflight.py`, a local artifact preflight command for already-built `enhanced_cps_2024.h5` and `calibration_log.csv` artifacts.
- Pipeline-operations docs telling agents/developers to run the local preflight before launching or resuming long publication stages when an artifact already exists.
- Production publication defaults now use `A100-40GB` for both regional and national calibration fits, with a source-level unit test. The current 20,680-target matrix OOMs on T4 before epoch 1.

## Why

The publication work exposed that a target can appear correct in one path while the other active path silently misses it. That is severe because a PR can pass normal CI, then spend hours building/publishing before we discover the published artifact did not train on the intended target.

Recent severity markers from the publication run:

- 2024 `employment_income` needed to hit the NIPA wages target of `$12,387,929,000,000`.
- The built checkpoint now gets `$12,384,936,890,614`, only `-0.024%` off target, but we only confirmed this after the long data build.
- The old 10% upload gate would have allowed materially under-target artifacts through; this PR changes that gate to 1% so missing wage-target wiring fails before local-area outputs are built.
- The same overnight run also reached a late JCT diagnostic failure before #1063 allowed the known QBI variance: JCT QBI target `$63.1B`, estimate `$145.3B`, rel_abs_error `1.302`.
- The same 20,680-target, 5,159,570-column package immediately OOMed on T4 for both regional (`fc-01KS2TFYAN0VG2985M3ED4WRNH`) and national (`fc-01KS2TFYDDSZKRQFWJ36EPCEKQ`) fits: CUDA tried to allocate another `3.65 GiB` with only `3.33 GiB` free on a `14.56 GiB` T4. The A100-40GB retry has passed epoch 100 for both fits.

The preflight script is meant to be run as soon as a built artifact exists, before spending publication time on local-area outputs. It prints the baseline SPM, aggregate `employment_income`, the NIPA relative error, calibration-log diagnostics, and optional ACA/Medicaid state checks.

## Local checks

```bash
uv run pytest tests/unit/test_upload_completed_datasets.py tests/unit/test_income_target_mappings.py -q
uv run pytest tests/unit/test_income_target_mappings.py tests/unit/test_upload_completed_datasets.py::test_enhanced_cps_employment_income_gate_rejects_missing_nipa_target tests/unit/calibration/test_loss_targets.py::test_bea_nipa_direct_sum_targets_match_targets_db tests/unit/calibration/test_loss_targets.py::test_bea_nipa_direct_sum_targets_get_higher_loss_weight -q
uv run pytest tests/unit/test_pipeline_source_contracts.py tests/unit/test_upload_completed_datasets.py tests/unit/test_income_target_mappings.py -q
uv run ruff check scripts/run_publication_preflight.py tests/unit/test_income_target_mappings.py tests/unit/test_upload_completed_datasets.py policyengine_us_data/storage/upload_completed_datasets.py modal_app/pipeline.py tests/unit/test_pipeline_source_contracts.py
uv run ruff format --check scripts/run_publication_preflight.py tests/unit/test_income_target_mappings.py tests/unit/test_upload_completed_datasets.py policyengine_us_data/storage/upload_completed_datasets.py modal_app/pipeline.py tests/unit/test_pipeline_source_contracts.py
git diff --check
```

Ran against the current checkpoint artifact:

```bash
uv run python scripts/run_publication_preflight.py \
  --enhanced-cps /Users/maxghenis/.cache/usdata-runs/usdata-gha26139116626-a1/enhanced_cps_2024.h5 \
  --calibration-log /Users/maxghenis/.cache/usdata-runs/usdata-gha26139116626-a1/calibration_log.csv \
  --skip-state-health
```

Output included:

- baseline SPM: `0.182489`
- employment_income: `$12,384,936,890,614`
- employment_income vs NIPA wages: `-0.0242%`
- final-epoch calibration targets within tolerance: `60.0%`
