### PR TITLE
Bump us-data package to 1.115.5

### DIFF
--- a/changelog.d/1090.changed
+++ b/changelog.d/1090.changed
@@ -1,0 +1,1 @@
+Aligned package and model dependency versions with the finalized US data release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "policyengine_us_data"
-version = "1.115.4"
+version = "1.115.5"
 description = "A package to create representative microdata for the US."
 readme = "README.md"
 authors = [
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us==1.700.0",
+    "policyengine-us==1.700.1",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/uv.lock
+++ b/uv.lock
@@ -2122,7 +2122,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.700.0"
+version = "1.700.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2132,14 +2132,14 @@ dependencies = [
     { name = "tables" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/70/767fddeeb827e96e0f9a499c25f76c642767a129be259162eaf5b5954eb1/policyengine_us-1.700.0.tar.gz", hash = "sha256:63a7b1a2b8a0c903b6d704e8095f6880024e8fa93ea405912820a42589e90add", size = 9862854, upload-time = "2026-05-20T00:07:27.748Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/67/bda357f9c0f5ab051ebe9360d66026d8567b9706185ac3d075932536b110/policyengine_us-1.700.1.tar.gz", hash = "sha256:e808b5f52db49ed5040d164acc40b1d67e11e054ac6c86adc198b04b5985b513", size = 9864390, upload-time = "2026-05-20T21:14:19.185Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/e9/2837a0d98e99efaf4d82aade276eee6eeff419df614863f08e3512961d2d/policyengine_us-1.700.0-py3-none-any.whl", hash = "sha256:7633d8aefcaf02d7628f841bc56750606f1d7fe409ff3ae7b0ef7e364a88e945", size = 10614505, upload-time = "2026-05-20T00:07:23.699Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e4/d5fe8a946c2e06512b52d01086ba6b97858e4f0fc2f8d5bef740eddfa910/policyengine_us-1.700.1-py3-none-any.whl", hash = "sha256:28d341438f541844e41e62c619144b0703b8f65089046b7b56d0ed2f6d771b19", size = 10615973, upload-time = "2026-05-20T21:14:15.679Z" },
 ]
 
 [[package]]
 name = "policyengine-us-data"
-version = "1.115.4"
+version = "1.115.5"
 source = { editable = "." }
 dependencies = [
     { name = "google-auth" },
@@ -2204,7 +2204,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", specifier = "==1.700.0" },
+    { name = "policyengine-us", specifier = "==1.700.1" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },


### PR DESCRIPTION
## Summary
- align pyproject and lockfile package version with finalized HF data release 1.115.5
- unblock main publication guard before CRFB long-run rebuilds

## Checks
- uv run python .github/scripts/check_data_release_version.py --mode fail
- uv run python -c "from policyengine_us_data.__version__ import __version__; print(__version__)"