### PR TITLE
Harden publication push commit-message guards

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -57,8 +57,8 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     if: |
-      github.event.head_commit.message != 'Update publication candidate' &&
-      github.event.head_commit.message != 'Finalize package version'
+      !startsWith(github.event.head_commit.message, 'Update publication candidate') &&
+      !startsWith(github.event.head_commit.message, 'Finalize package version')
     permissions:
       contents: write
     steps:
@@ -93,8 +93,8 @@ jobs:
       - policyengine-us-freshness
       - data-release-version
     if: |
-      github.event.head_commit.message != 'Update publication candidate' &&
-      github.event.head_commit.message != 'Finalize package version'
+      !startsWith(github.event.head_commit.message, 'Update publication candidate') &&
+      !startsWith(github.event.head_commit.message, 'Finalize package version')
     outputs:
       version_sha: ${{ steps.version-commit.outputs.sha }}
     steps:
@@ -139,7 +139,7 @@ jobs:
       - run-context
       - policyengine-us-freshness
       - data-release-version
-    if: github.event.head_commit.message == 'Update publication candidate'
+    if: startsWith(github.event.head_commit.message, 'Update publication candidate')
     permissions:
       actions: write
       contents: read

--- a/changelog.d/1092.changed
+++ b/changelog.d/1092.changed
@@ -1,0 +1,1 @@
+Hardened publication workflow commit-message guards against squash commit bodies.

--- a/changelog.d/1092.changed
+++ b/changelog.d/1092.changed
@@ -1,1 +1,1 @@
-Hardened publication workflow commit-message guards against squash commit bodies.
+Hardened publication workflow commit-message guards against squash commit bodies and fixed clone-all long-run support sanitization for partnership SE income.

--- a/policyengine_us_data/datasets/cps/long_term/prototype_synthetic_2100_support.py
+++ b/policyengine_us_data/datasets/cps/long_term/prototype_synthetic_2100_support.py
@@ -2423,7 +2423,7 @@ def _compose_role_donor_rows_to_target(
             cloned,
             cloned.index,
             base_year=base_year,
-            raw_columns=WORKER_DONOR_NON_TARGET_INCOME_COMPONENTS,
+            raw_columns=NON_TARGET_CLONE_INCOME_COMPONENTS,
         )
         cloned.attrs["sanitized_clone_non_target_income_columns"] = tuple(
             sanitized_columns
@@ -2834,7 +2834,7 @@ def build_role_composite_augmented_input_dataframe(
             sanitized_worker_non_target_income_columns
         ),
         "clone_non_target_income_requested_components": list(
-            WORKER_DONOR_NON_TARGET_INCOME_COMPONENTS
+            NON_TARGET_CLONE_INCOME_COMPONENTS
         ),
         "clone_non_target_income_sanitized_columns": sorted(
             sanitized_clone_non_target_income_columns

--- a/tests/unit/test_long_term_calibration_contract.py
+++ b/tests/unit/test_long_term_calibration_contract.py
@@ -3069,6 +3069,13 @@ def test_compose_role_donor_rows_can_sanitize_worker_non_target_income():
         0.0,
         8_000.0,
     ]
+    enriched["partnership_se_income__2024"] = [
+        0.0,
+        0.0,
+        -9_000.0,
+        0.0,
+        -11_000.0,
+    ]
 
     older_rows = enriched[enriched["person_tax_unit_id__2024"] == 201].copy()
     worker_rows = enriched[enriched["person_tax_unit_id__2024"] == 301].copy()
@@ -3152,6 +3159,13 @@ def test_compose_role_donor_rows_can_sanitize_all_clone_non_target_income():
         0.0,
         8_000.0,
     ]
+    enriched["partnership_se_income__2024"] = [
+        0.0,
+        0.0,
+        -9_000.0,
+        0.0,
+        -11_000.0,
+    ]
 
     older_rows = enriched[enriched["person_tax_unit_id__2024"] == 201].copy()
     worker_rows = enriched[enriched["person_tax_unit_id__2024"] == 301].copy()
@@ -3199,10 +3213,15 @@ def test_compose_role_donor_rows_can_sanitize_all_clone_non_target_income():
         )
         assert clone["taxable_private_pension_income__2024"] == pytest.approx(0.0)
         assert clone["partnership_s_corp_income__2024"] == pytest.approx(0.0)
+        assert clone["partnership_se_income__2024"] == pytest.approx(0.0)
     assert older_clone["social_security_retirement__2024"] == pytest.approx(20_000.0)
     assert worker_clone["employment_income_before_lsr__2024"] == pytest.approx(50_000.0)
     assert (
         "long_term_capital_gains_before_response__2024"
+        in clone_df.attrs["sanitized_clone_non_target_income_columns"]
+    )
+    assert (
+        "partnership_se_income__2024"
         in clone_df.attrs["sanitized_clone_non_target_income_columns"]
     )
     assert "sanitized_worker_non_target_income_columns" not in clone_df.attrs


### PR DESCRIPTION
## Summary
- Treat release/candidate commit-message guards as prefix checks so squash commit bodies do not bypass them
- Keep the publication launch trigger aligned with the same prefix behavior

## Test plan
- Not run; workflow-only condition change