### PR TITLE
Stabilize early long-run calibration

### DIFF
--- a/changelog.d/1093.fixed.md
+++ b/changelog.d/1093.fixed.md
@@ -1,0 +1,1 @@
+Stabilize long-run calibration for early CRFB projection years.

--- a/policyengine_us_data/datasets/cps/long_term/calibration.py
+++ b/policyengine_us_data/datasets/cps/long_term/calibration.py
@@ -920,7 +920,39 @@ def calibrate_weights(
                 extra_constraints=extra_constraints,
                 n_ages=n_ages,
             )
-            approximate_error_pct = float(feasibility["best_case_max_pct_error"])
+            reported_error_pct = float(feasibility["best_case_max_pct_error"])
+            realized_audit = build_calibration_audit(
+                X=X,
+                y_target=y_target,
+                weights=w_new,
+                baseline_weights=baseline_weights,
+                calibration_event=audit,
+                ss_values=ss_values,
+                ss_target=ss_target,
+                payroll_values=payroll_values,
+                payroll_target=payroll_target,
+                h6_income_values=h6_income_values,
+                h6_revenue_target=h6_revenue_target,
+                oasdi_tob_values=oasdi_tob_values,
+                oasdi_tob_target=oasdi_tob_target,
+                hi_tob_values=hi_tob_values,
+                hi_tob_target=hi_tob_target,
+                extra_constraints=extra_constraints,
+            )
+            realized_constraint_error_pct = float(
+                realized_audit.get("max_constraint_pct_error", float("inf"))
+            )
+            realized_age_error_pct = float(
+                realized_audit.get("age_max_pct_error", float("inf"))
+            )
+            approximate_error_pct = max(
+                reported_error_pct,
+                realized_constraint_error_pct,
+                realized_age_error_pct,
+            )
+            audit["lp_reported_constraint_error_pct"] = reported_error_pct
+            audit["lp_realized_constraint_error_pct"] = realized_constraint_error_pct
+            audit["lp_realized_age_error_pct"] = realized_age_error_pct
             exact_lp_available = approximate_error_pct <= max(tol * 100, 1e-6)
             if exact_lp_available and (
                 not allow_approximate_entropy or approximate_max_error_pct is None
@@ -968,6 +1000,12 @@ def calibrate_weights(
                     w_new,
                     approximate_max_error_pct,
                 )
+                if (
+                    dense_lp_info.get("best_case_max_pct_error", float("inf"))
+                    > float(approximate_max_error_pct) + 1e-6
+                ):
+                    dense_lp_weights = None
+                    dense_lp_info = None
             except Exception:
                 dense_lp_weights = None
                 dense_lp_info = None

--- a/policyengine_us_data/datasets/cps/long_term/calibration_profiles.py
+++ b/policyengine_us_data/datasets/cps/long_term/calibration_profiles.py
@@ -54,6 +54,18 @@ class CalibrationProfile:
 
 DEFAULT_LONG_RUN_APPROXIMATE_WINDOWS = (
     ApproximateCalibrationWindow(
+        start_year=2026,
+        end_year=2074,
+        max_constraint_error_pct=1.0,
+        max_age_error_pct=1.0,
+        max_negative_weight_pct=0.0,
+        age_bucket_size=5,
+        min_positive_household_count=1000,
+        min_effective_sample_size=75.0,
+        max_top_10_weight_share_pct=25.0,
+        max_top_100_weight_share_pct=95.0,
+    ),
+    ApproximateCalibrationWindow(
         start_year=2075,
         end_year=2078,
         max_constraint_error_pct=0.5,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us==1.700.1",
+    "policyengine-us==1.700.2",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/tests/unit/test_long_term_calibration_contract.py
+++ b/tests/unit/test_long_term_calibration_contract.py
@@ -1063,6 +1063,34 @@ def test_approximate_window_none_selects_open_ended_tail():
     assert window.end_year is None
 
 
+def test_long_run_approximate_window_boundaries():
+    profile = get_profile("ss-payroll-tob")
+
+    assert approximate_window_for_year(profile, 2025) is None
+
+    window_2026 = approximate_window_for_year(profile, 2026)
+    assert window_2026 is not None
+    assert window_2026.end_year == 2074
+    assert window_2026.max_constraint_error_pct == pytest.approx(1.0)
+    assert window_2026.age_bucket_size == 5
+
+    window_2074 = approximate_window_for_year(profile, 2074)
+    assert window_2074 is window_2026
+
+    window_2075 = approximate_window_for_year(profile, 2075)
+    assert window_2075 is not None
+    assert window_2075.start_year == 2075
+    assert window_2075.max_constraint_error_pct == pytest.approx(0.5)
+    assert window_2075.age_bucket_size == 5
+
+    window_2100 = approximate_window_for_year(profile, 2100)
+    assert window_2100 is not None
+    assert window_2100.start_year == 2096
+    assert window_2100.end_year is None
+    assert window_2100.max_constraint_error_pct == pytest.approx(35.0)
+    assert window_2100.age_bucket_size == 5
+
+
 def test_strict_greg_failure_raises():
     X = np.array([[1.0, 0.0], [0.0, 1.0]])
     y_target = np.array([1.0, 1.0])
@@ -1234,11 +1262,34 @@ def test_approximate_window_is_year_bounded():
     quality = classify_calibration_quality(
         {
             "fell_back_to_ipf": False,
-            "age_max_pct_error": 3.0,
+            "age_max_pct_error": 0.0,
             "negative_weight_pct": 0.0,
+            "positive_weight_count": 1200,
+            "effective_sample_size": 100.0,
+            "top_10_weight_share_pct": 20.0,
+            "top_100_weight_share_pct": 90.0,
             "constraints": {
                 "ss_total": {"pct_error": 0.0},
-                "payroll_total": {"pct_error": 3.0},
+                "payroll_total": {"pct_error": 0.5},
+            },
+        },
+        profile,
+        year=2035,
+    )
+    assert quality == "approximate"
+
+    quality = classify_calibration_quality(
+        {
+            "fell_back_to_ipf": False,
+            "age_max_pct_error": 0.0,
+            "negative_weight_pct": 0.0,
+            "positive_weight_count": 1200,
+            "effective_sample_size": 100.0,
+            "top_10_weight_share_pct": 20.0,
+            "top_100_weight_share_pct": 90.0,
+            "constraints": {
+                "ss_total": {"pct_error": 0.0},
+                "payroll_total": {"pct_error": 1.5},
             },
         },
         profile,
@@ -1522,7 +1573,7 @@ def test_entropy_calibration_uses_lp_exact_fallback_even_before_approximate_wind
     assert audit["approximation_method"] == "lp_minimax_exact"
 
 
-def test_entropy_calibration_rejects_large_constraint_error_without_exception(
+def test_entropy_calibration_rejects_misreported_lp_exact_fallback(
     monkeypatch,
 ):
     monkeypatch.setattr(
@@ -1540,21 +1591,17 @@ def test_entropy_calibration_rejects_large_constraint_error_without_exception(
         ),
     )
 
-    weights, _, audit = calibrate_weights(
-        X=np.array([[1.0], [0.0]]),
-        y_target=np.array([1.0]),
-        baseline_weights=np.array([1.0, 1.0]),
-        method="entropy",
-        payroll_values=np.array([1.0, 0.0]),
-        payroll_target=10.0,
-        n_ages=1,
-        allow_approximate_entropy=False,
-    )
-
-    np.testing.assert_allclose(weights, np.array([10.0, 2.0]))
-    assert audit["lp_fallback_used"] is True
-    assert audit["approximation_method"] == "lp_minimax_exact"
-    assert "above allowable" in audit["entropy_error"]
+    with pytest.raises(RuntimeError):
+        calibrate_weights(
+            X=np.array([[1.0], [0.0]]),
+            y_target=np.array([1.0]),
+            baseline_weights=np.array([1.0, 1.0]),
+            method="entropy",
+            payroll_values=np.array([1.0, 0.0]),
+            payroll_target=10.0,
+            n_ages=1,
+            allow_approximate_entropy=False,
+        )
 
 
 def test_nonnegative_feasibility_diagnostic_distinguishes_feasible_and_infeasible():

--- a/uv.lock
+++ b/uv.lock
@@ -2122,7 +2122,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.700.1"
+version = "1.700.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2132,9 +2132,9 @@ dependencies = [
     { name = "tables" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/67/bda357f9c0f5ab051ebe9360d66026d8567b9706185ac3d075932536b110/policyengine_us-1.700.1.tar.gz", hash = "sha256:e808b5f52db49ed5040d164acc40b1d67e11e054ac6c86adc198b04b5985b513", size = 9864390, upload-time = "2026-05-20T21:14:19.185Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/d5/184a594b7c61d4603e25e80c617f998b2e1374080c440089a2b861b4e6d5/policyengine_us-1.700.2.tar.gz", hash = "sha256:05d7e0eac4d7566029e3f9910ddae79bc182c7af0ff6cd21688e6d5b04a0970a", size = 9869566, upload-time = "2026-05-20T23:02:41.858Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/e4/d5fe8a946c2e06512b52d01086ba6b97858e4f0fc2f8d5bef740eddfa910/policyengine_us-1.700.1-py3-none-any.whl", hash = "sha256:28d341438f541844e41e62c619144b0703b8f65089046b7b56d0ed2f6d771b19", size = 10615973, upload-time = "2026-05-20T21:14:15.679Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/b8/87ca409631fc478fdac4cc219ef4e45ea3416106c6d2ef96c2c115bbc33f/policyengine_us-1.700.2-py3-none-any.whl", hash = "sha256:a6e32e0048dee22a1558a136d2a24df812140695205194a4256c787a5d6140bd", size = 10625770, upload-time = "2026-05-20T23:02:38.359Z" },
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", specifier = "==1.700.1" },
+    { name = "policyengine-us", specifier = "==1.700.2" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },


### PR DESCRIPTION
## Summary
- add a 2026-2074 long-run approximate window using 5-year age buckets while keeping 1% fiscal/age validation thresholds
- verify LP fallback certificates against realized age and fiscal errors before accepting an exact fallback
- extend calibration contract tests for early-year approximate windows and misreported LP exact fallbacks

## Validation
- uv run python -m py_compile policyengine_us_data/datasets/cps/long_term/calibration.py policyengine_us_data/datasets/cps/long_term/calibration_profiles.py tests/unit/test_long_term_calibration_contract.py
- uv run pytest tests/unit/test_long_term_calibration_contract.py
- Local sentinels passed: 2026, 2035, 2070, 2075, 2100
- CRFB 2100 business-income audit passed on /tmp/crfb_debug_2100_support_patch/2100.h5