### PR TITLE
Improve SSI asset imputation and calibration targets

### DIFF
--- a/changelog.d/1096.changed
+++ b/changelog.d/1096.changed
@@ -1,0 +1,1 @@
+Improved SSI-sensitive liquid asset imputation predictors and added SSA SSI recipient calibration targets.

--- a/policyengine_us_data/calibration/source_impute.py
+++ b/policyengine_us_data/calibration/source_impute.py
@@ -36,6 +36,8 @@ from policyengine_us_data.datasets.cps.tipped_occupation import (
     derive_is_tipped_occupation,
 )
 from policyengine_us_data.datasets.sipp.sipp import (
+    ASSET_JOB_EARNINGS_COLUMNS,
+    ASSET_PREDICTORS,
     VEHICLE_MODEL_PREDICTORS,
     build_vehicle_training_frame,
 )
@@ -121,16 +123,7 @@ SIPP_TIPS_PREDICTORS = [
     "is_tipped_occupation",
 ]
 
-SIPP_ASSETS_PREDICTORS = [
-    "employment_income",
-    "interest_income",
-    "dividend_income",
-    "rental_income",
-    "age",
-    "is_female",
-    "is_married",
-    "count_under_18",
-]
+SIPP_ASSETS_PREDICTORS = ASSET_PREDICTORS
 
 SCF_PREDICTORS = [
     "age",
@@ -314,6 +307,164 @@ def _person_state_fips(
     counts = np.full(n_hh, base, dtype=int)
     counts[:remainder] += 1
     return np.repeat(state_fips, counts)
+
+
+def _person_is_married(
+    data: Dict[str, Dict[int, np.ndarray]],
+    time_period: int,
+    n_persons: int,
+) -> np.ndarray:
+    """Return a person-level married flag from CPS-compatible inputs."""
+    if "is_married" in data and time_period in data["is_married"]:
+        values = np.asarray(data["is_married"][time_period])
+        if len(values) == n_persons:
+            return values.astype(np.float32)
+
+    marital_unit_id = data.get("person_marital_unit_id", {}).get(time_period)
+    if marital_unit_id is not None and len(marital_unit_id) == n_persons:
+        marital_unit_id = np.asarray(marital_unit_id)
+        counts = pd.Series(marital_unit_id).map(
+            pd.Series(marital_unit_id).value_counts()
+        )
+        return (counts.to_numpy() > 1).astype(np.float32)
+
+    return np.zeros(n_persons, dtype=np.float32)
+
+
+def _add_person_household_counts(
+    df: pd.DataFrame,
+    data: Dict[str, Dict[int, np.ndarray]],
+    time_period: int,
+) -> pd.DataFrame:
+    """Add household composition predictors to a person-level CPS frame."""
+    if "age" not in df.columns and "age" in data:
+        df["age"] = data["age"][time_period].astype(np.float32)
+
+    hh_ids_person = data.get("person_household_id", {}).get(time_period)
+    if hh_ids_person is None or "age" not in df.columns:
+        df["count_under_18"] = 0.0
+        df["count_under_6"] = 0.0
+        df["household_size"] = 1.0
+        return df
+
+    age_df = pd.DataFrame(
+        {
+            "hh": hh_ids_person,
+            "age": np.asarray(df["age"]),
+        }
+    )
+    grouped = age_df.groupby("hh")["age"]
+    df["count_under_18"] = (
+        grouped.transform(lambda values: (values < 18).sum())
+        .to_numpy()
+        .astype(np.float32)
+    )
+    df["count_under_6"] = (
+        grouped.transform(lambda values: (values < 6).sum())
+        .to_numpy()
+        .astype(np.float32)
+    )
+    df["household_size"] = grouped.transform("size").to_numpy().astype(np.float32)
+    return df
+
+
+def _add_sipp_asset_predictors(asset_df: pd.DataFrame) -> pd.DataFrame:
+    """Add SIPP-side liquid-asset model predictors without SSI receipt."""
+    asset_df = asset_df.copy()
+    asset_df["bank_account_assets"] = asset_df["TVAL_BANK"].fillna(0)
+    asset_df["stock_assets"] = asset_df["TVAL_STMF"].fillna(0)
+    asset_df["bond_assets"] = asset_df["TVAL_BOND"].fillna(0)
+    asset_df["age"] = asset_df.TAGE
+    asset_df["is_female"] = asset_df.ESEX == 2
+    asset_df["is_married"] = asset_df.EMS == 1
+
+    job_cols = [col for col in ASSET_JOB_EARNINGS_COLUMNS if col in asset_df]
+    if job_cols:
+        asset_df["employment_income"] = asset_df[job_cols].fillna(0).sum(axis=1) * 12
+    elif "TPTOTINC" in asset_df:
+        asset_df["employment_income"] = asset_df.TPTOTINC.fillna(0) * 12
+    else:
+        asset_df["employment_income"] = 0.0
+
+    asset_df["interest_income"] = (
+        asset_df["TINC_BANK"].fillna(0) + asset_df["TINC_BOND"].fillna(0)
+    ) * 12
+    asset_df["dividend_income"] = asset_df["TINC_STMF"].fillna(0) * 12
+    asset_df["rental_income"] = asset_df["TINC_RENT"].fillna(0) * 12
+    asset_df["social_security"] = asset_df["TSSSAMT"].fillna(0) * 12
+    asset_df["retirement_income"] = asset_df["TRETINCAMT"].fillna(0) * 12
+    asset_df["non_ssi_income"] = (
+        asset_df["employment_income"]
+        + asset_df["social_security"]
+        + asset_df["retirement_income"]
+    )
+    asset_df["household_weight"] = asset_df.WPFINWGT
+
+    asset_df["is_under_18"] = asset_df.TAGE < 18
+    asset_df["is_under_6"] = asset_df.TAGE < 6
+    grouped = asset_df.groupby("SSUID")
+    asset_df["count_under_18"] = grouped["is_under_18"].transform("sum")
+    asset_df["count_under_6"] = grouped["is_under_6"].transform("sum")
+    asset_df["household_size"] = grouped["PNUM"].transform("count")
+    return asset_df
+
+
+def _add_cps_asset_predictors(
+    cps_asset_df: pd.DataFrame,
+    data: Dict[str, Dict[int, np.ndarray]],
+    time_period: int,
+) -> pd.DataFrame:
+    """Add CPS-side predictors aligned to the SIPP liquid-asset model."""
+    cps_asset_df = cps_asset_df.copy()
+    n_persons = len(cps_asset_df)
+
+    if "is_male" in cps_asset_df.columns:
+        cps_asset_df["is_female"] = (~cps_asset_df["is_male"].astype(bool)).astype(
+            np.float32
+        )
+    elif "is_female" in data:
+        cps_asset_df["is_female"] = data["is_female"][time_period].astype(np.float32)
+    else:
+        cps_asset_df["is_female"] = 0.0
+
+    cps_asset_df["is_married"] = _person_is_married(
+        data,
+        time_period,
+        n_persons,
+    )
+    cps_asset_df = _add_person_household_counts(cps_asset_df, data, time_period)
+
+    for var in [
+        "employment_income",
+        "interest_income",
+        "dividend_income",
+        "rental_income",
+        "social_security",
+        "pension_income",
+        "retirement_distributions",
+    ]:
+        if var in cps_asset_df.columns:
+            continue
+        if var in data:
+            cps_asset_df[var] = data[var][time_period].astype(np.float32)
+        else:
+            cps_asset_df[var] = 0.0
+
+    cps_asset_df["retirement_income"] = cps_asset_df["pension_income"].fillna(
+        0
+    ) + cps_asset_df["retirement_distributions"].fillna(0)
+    cps_asset_df["non_ssi_income"] = (
+        cps_asset_df["employment_income"].fillna(0)
+        + cps_asset_df["social_security"].fillna(0)
+        + cps_asset_df["retirement_income"].fillna(0)
+    )
+
+    for predictor in SIPP_ASSETS_PREDICTORS:
+        if predictor not in cps_asset_df.columns:
+            cps_asset_df[predictor] = 0.0
+        cps_asset_df[predictor] = cps_asset_df[predictor].fillna(0).astype(np.float32)
+
+    return cps_asset_df
 
 
 @pipeline_node(
@@ -571,7 +722,8 @@ def _impute_sipp(
             "TAGE",
             "ESEX",
             "EMS",
-            "TPTOTINC",
+            "TSSSAMT",
+            "TRETINCAMT",
             "TVAL_BANK",
             "TVAL_STMF",
             "TVAL_BOND",
@@ -579,48 +731,21 @@ def _impute_sipp(
             "TINC_STMF",
             "TINC_BOND",
             "TINC_RENT",
-        ]
+        ] + ASSET_JOB_EARNINGS_COLUMNS
         asset_df = pd.read_csv(
             STORAGE_FOLDER / "pu2023.csv",
             delimiter="|",
             usecols=asset_cols,
         )
         asset_df = asset_df[asset_df.MONTHCODE == 12]
-
-        asset_df["bank_account_assets"] = asset_df["TVAL_BANK"].fillna(0)
-        asset_df["stock_assets"] = asset_df["TVAL_STMF"].fillna(0)
-        asset_df["bond_assets"] = asset_df["TVAL_BOND"].fillna(0)
-        asset_df["age"] = asset_df.TAGE
-        asset_df["is_female"] = asset_df.ESEX == 2
-        asset_df["is_married"] = asset_df.EMS == 1
-        asset_df["employment_income"] = asset_df.TPTOTINC * 12
-        asset_df["interest_income"] = (
-            asset_df["TINC_BANK"].fillna(0) + asset_df["TINC_BOND"].fillna(0)
-        ) * 12
-        asset_df["dividend_income"] = asset_df["TINC_STMF"].fillna(0) * 12
-        asset_df["rental_income"] = asset_df["TINC_RENT"].fillna(0) * 12
-        asset_df["household_weight"] = asset_df.WPFINWGT
-        asset_df["is_under_18"] = asset_df.TAGE < 18
-        asset_df["count_under_18"] = (
-            asset_df.groupby("SSUID")["is_under_18"]
-            .sum()
-            .loc[asset_df.SSUID.values]
-            .values
-        )
+        asset_df = _add_sipp_asset_predictors(asset_df)
 
         asset_train_cols = [
-            "employment_income",
-            "interest_income",
-            "dividend_income",
-            "rental_income",
             "bank_account_assets",
             "stock_assets",
             "bond_assets",
-            "age",
-            "is_female",
-            "is_married",
-            "count_under_18",
             "household_weight",
+            *SIPP_ASSETS_PREDICTORS,
         ]
         asset_train = asset_df[asset_train_cols].dropna()
         asset_train = asset_train.loc[
@@ -641,39 +766,18 @@ def _impute_sipp(
                 "interest_income",
                 "dividend_income",
                 "rental_income",
+                "social_security",
+                "pension_income",
+                "retirement_distributions",
                 "age",
                 "is_male",
             ],
         )
-        if "is_male" in cps_asset_df.columns:
-            cps_asset_df["is_female"] = (~cps_asset_df["is_male"].astype(bool)).astype(
-                np.float32
-            )
-        else:
-            cps_asset_df["is_female"] = 0.0
-        if "is_married" in data:
-            cps_asset_df["is_married"] = data["is_married"][time_period].astype(
-                np.float32
-            )
-        else:
-            cps_asset_df["is_married"] = 0.0
-        cps_asset_df["count_under_18"] = (
-            cps_tip_df["count_under_18"]
-            if "count_under_18" in cps_tip_df.columns
-            else 0.0
+        cps_asset_df = _add_cps_asset_predictors(
+            cps_asset_df,
+            data,
+            time_period,
         )
-        for cap_var in [
-            "interest_income",
-            "dividend_income",
-            "rental_income",
-        ]:
-            if cap_var not in cps_asset_df.columns:
-                if cap_var in data:
-                    cps_asset_df[cap_var] = data[cap_var][time_period].astype(
-                        np.float32
-                    )
-                else:
-                    cps_asset_df[cap_var] = 0.0
 
         asset_vars = [
             "bank_account_assets",
@@ -738,12 +842,11 @@ def _impute_sipp(
             ).astype(np.float32)
         else:
             cps_vehicle_df["is_female"] = 0.0
-        if "is_married" in data:
-            cps_vehicle_df["is_married"] = data["is_married"][time_period].astype(
-                np.float32
-            )
-        else:
-            cps_vehicle_df["is_married"] = 0.0
+        cps_vehicle_df["is_married"] = _person_is_married(
+            data,
+            time_period,
+            len(cps_vehicle_df),
+        )
         for cap_var in [
             "interest_income",
             "dividend_income",

--- a/policyengine_us_data/calibration/target_config.yaml
+++ b/policyengine_us_data/calibration/target_config.yaml
@@ -207,6 +207,12 @@ include:
     geo_level: national
   - variable: ssi
     geo_level: national
+  - variable: person_count
+    geo_level: national
+    domain_variable: ssi
+  - variable: person_count
+    geo_level: national
+    domain_variable: age,ssi
   - variable: tanf
     geo_level: national
   - variable: spm_unit_count

--- a/policyengine_us_data/calibration/unified_matrix_builder.py
+++ b/policyengine_us_data/calibration/unified_matrix_builder.py
@@ -2110,8 +2110,26 @@ class UnifiedMatrixBuilder:
 
         if "domain_variables" in target_filter:
             dvs = target_filter["domain_variables"]
-            ph = ",".join(f"'{dv}'" for dv in dvs)
-            and_conditions.append(f"tv.domain_variable IN ({ph})")
+            exact_ph = ",".join(f"'{dv}'" for dv in dvs)
+            single_constraint_dvs = [dv for dv in dvs if "," not in str(dv)]
+            if single_constraint_dvs:
+                component_ph = ",".join(f"'{dv}'" for dv in single_constraint_dvs)
+                and_conditions.append(
+                    "("
+                    f"tv.domain_variable IN ({exact_ph}) "
+                    "OR EXISTS ("
+                    "SELECT 1 FROM stratum_constraints sc_domain "
+                    "WHERE sc_domain.stratum_id = tv.stratum_id "
+                    "AND sc_domain.constraint_variable NOT IN ("
+                    "'state_fips', 'congressional_district_geoid', "
+                    "'tax_unit_is_filer', 'ucgid_str'"
+                    ") "
+                    f"AND sc_domain.constraint_variable IN ({component_ph})"
+                    ")"
+                    ")"
+                )
+            else:
+                and_conditions.append(f"tv.domain_variable IN ({exact_ph})")
 
         if "variables" in target_filter:
             vs = ",".join(f"'{v}'" for v in target_filter["variables"])

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -2574,6 +2574,24 @@ def add_tips(self, cps: h5py.File):
                     np.zeros(len(person_household_id), dtype=np.float32),
                 )
             ),
+            "social_security": np.asarray(
+                existing_data.get(
+                    "social_security",
+                    np.zeros(len(person_household_id), dtype=np.float32),
+                )
+            ),
+            "pension_income": np.asarray(
+                existing_data.get(
+                    "pension_income",
+                    np.zeros(len(person_household_id), dtype=np.float32),
+                )
+            ),
+            "retirement_distributions": np.asarray(
+                existing_data.get(
+                    "retirement_distributions",
+                    np.zeros(len(person_household_id), dtype=np.float32),
+                )
+            ),
             "age": np.asarray(existing_data["age"]),
             "is_female": np.asarray(existing_data["is_female"]),
         }
@@ -2618,6 +2636,20 @@ def add_tips(self, cps: h5py.File):
         .sum()
         .loc[cps.household_id.values]
         .values
+    )
+    cps["household_size"] = (
+        cps.groupby("household_id")["person_id"]
+        .transform("count")
+        .astype(np.float32)
+        .values
+    )
+    cps["retirement_income"] = cps["pension_income"].fillna(0) + cps[
+        "retirement_distributions"
+    ].fillna(0)
+    cps["non_ssi_income"] = (
+        cps["employment_income"].fillna(0)
+        + cps["social_security"].fillna(0)
+        + cps["retirement_income"].fillna(0)
     )
     cps = pd.DataFrame(cps)
 
@@ -2680,7 +2712,15 @@ def add_tips(self, cps: h5py.File):
     # is_married is person-level here but policyengine-us defines it at Family
     # level, so we must not save it
     cps = cps.drop(
-        columns=["is_married", "is_under_18", "is_under_6", "is_household_head"],
+        columns=[
+            "is_married",
+            "is_under_18",
+            "is_under_6",
+            "is_household_head",
+            "household_size",
+            "retirement_income",
+            "non_ssi_income",
+        ],
         errors="ignore",
     )
     self.save_dataset(cps)

--- a/policyengine_us_data/datasets/sipp/__init__.py
+++ b/policyengine_us_data/datasets/sipp/__init__.py
@@ -1,4 +1,6 @@
 from .sipp import (
+    ASSET_JOB_EARNINGS_COLUMNS,
+    ASSET_PREDICTORS,
     train_tip_model,
     get_tip_model,
     train_asset_model,
@@ -7,3 +9,15 @@ from .sipp import (
     train_vehicle_model,
     get_vehicle_model,
 )
+
+__all__ = [
+    "ASSET_JOB_EARNINGS_COLUMNS",
+    "ASSET_PREDICTORS",
+    "train_tip_model",
+    "get_tip_model",
+    "train_asset_model",
+    "get_asset_model",
+    "build_vehicle_training_frame",
+    "train_vehicle_model",
+    "get_vehicle_model",
+]

--- a/policyengine_us_data/datasets/sipp/sipp.py
+++ b/policyengine_us_data/datasets/sipp/sipp.py
@@ -185,6 +185,8 @@ def get_tip_model() -> QRF:
 # Asset imputation from SIPP 2023
 # Imputes asset categories separately for policy flexibility
 
+ASSET_JOB_EARNINGS_COLUMNS = [f"TJB{i}_MSUM" for i in range(1, 8)]
+
 ASSET_COLUMNS = [
     "SSUID",
     "PNUM",
@@ -195,7 +197,8 @@ ASSET_COLUMNS = [
     "TAGE",
     "ESEX",
     "EMS",
-    "TPTOTINC",
+    "TSSSAMT",
+    "TRETINCAMT",
     # Asset values (person-level sums from SIPP)
     "TVAL_BANK",  # Checking, savings, money market
     "TVAL_STMF",  # Stocks and mutual funds
@@ -205,8 +208,22 @@ ASSET_COLUMNS = [
     "TINC_STMF",  # Dividends from stocks/mutual funds
     "TINC_BOND",  # Interest from bonds
     "TINC_RENT",  # Rental income
-    # SSI receipt (for validation)
-    "RSSI_YRYN",  # Received SSI in at least one month
+] + ASSET_JOB_EARNINGS_COLUMNS
+
+ASSET_PREDICTORS = [
+    "employment_income",
+    "interest_income",
+    "dividend_income",
+    "rental_income",
+    "social_security",
+    "retirement_income",
+    "non_ssi_income",
+    "age",
+    "is_female",
+    "is_married",
+    "count_under_18",
+    "count_under_6",
+    "household_size",
 ]
 
 VEHICLE_COLUMNS = [
@@ -226,6 +243,42 @@ VEHICLE_COLUMNS = [
     "THVAL_VEH",
     "THVAL_HOME",
 ]
+
+
+def _add_asset_predictors(df: pd.DataFrame) -> pd.DataFrame:
+    """Add SIPP predictors shared by legacy and source-impute asset models."""
+    df = df.copy()
+    df["age"] = df.TAGE
+    df["is_female"] = df.ESEX == 2
+    df["is_married"] = df.EMS == 1
+    df["household_weight"] = df.WPFINWGT
+    df["household_id"] = df.SSUID
+
+    job_cols = [col for col in ASSET_JOB_EARNINGS_COLUMNS if col in df]
+    if job_cols:
+        df["employment_income"] = df[job_cols].fillna(0).sum(axis=1) * 12
+    elif "TPTOTINC" in df:
+        df["employment_income"] = df.TPTOTINC.fillna(0) * 12
+    else:
+        df["employment_income"] = 0.0
+
+    df["interest_income"] = (df["TINC_BANK"].fillna(0) + df["TINC_BOND"].fillna(0)) * 12
+    df["dividend_income"] = df["TINC_STMF"].fillna(0) * 12
+    df["rental_income"] = df["TINC_RENT"].fillna(0) * 12
+    df["social_security"] = df["TSSSAMT"].fillna(0) * 12
+    df["retirement_income"] = df["TRETINCAMT"].fillna(0) * 12
+    df["non_ssi_income"] = (
+        df["employment_income"] + df["social_security"] + df["retirement_income"]
+    )
+
+    df["is_under_18"] = df.TAGE < 18
+    df["is_under_6"] = df.TAGE < 6
+    grouped = df.groupby("SSUID")
+    df["count_under_18"] = grouped["is_under_18"].transform("sum")
+    df["count_under_6"] = grouped["is_under_6"].transform("sum")
+    df["household_size"] = grouped["PNUM"].transform("count")
+
+    return df
 
 
 def train_asset_model():
@@ -259,41 +312,16 @@ def train_asset_model():
     df["stock_assets"] = df["TVAL_STMF"].fillna(0)
     df["bond_assets"] = df["TVAL_BOND"].fillna(0)
 
-    # Prepare predictors
-    df["age"] = df.TAGE
-    df["is_female"] = df.ESEX == 2
-    df["is_married"] = df.EMS == 1
-    df["employment_income"] = df.TPTOTINC * 12
-    df["household_weight"] = df.WPFINWGT
-    df["household_id"] = df.SSUID
-
-    # Capital income predictors (annualized from monthly SIPP)
-    # Maps to CPS: interest_income, dividend_income, rental_income
-    df["interest_income"] = (df["TINC_BANK"].fillna(0) + df["TINC_BOND"].fillna(0)) * 12
-    df["dividend_income"] = df["TINC_STMF"].fillna(0) * 12
-    df["rental_income"] = df["TINC_RENT"].fillna(0) * 12
-
-    # Calculate household-level counts
-    df["is_under_18"] = df.TAGE < 18
-    df["count_under_18"] = (
-        df.groupby("SSUID")["is_under_18"].sum().loc[df.SSUID.values].values
-    )
+    df = _add_asset_predictors(df)
 
     sipp = df[
         [
             "household_id",
-            "employment_income",
-            "interest_income",
-            "dividend_income",
-            "rental_income",
             "bank_account_assets",
             "stock_assets",
             "bond_assets",
-            "age",
-            "is_female",
-            "is_married",
-            "count_under_18",
             "household_weight",
+            *ASSET_PREDICTORS,
         ]
     ]
 
@@ -315,16 +343,7 @@ def train_asset_model():
 
     model = model.fit(
         X_train=sipp,
-        predictors=[
-            "employment_income",
-            "interest_income",
-            "dividend_income",
-            "rental_income",
-            "age",
-            "is_female",
-            "is_married",
-            "count_under_18",
-        ],
+        predictors=ASSET_PREDICTORS,
         imputed_variables=[
             "bank_account_assets",
             "stock_assets",
@@ -337,7 +356,7 @@ def train_asset_model():
 
 def get_asset_model() -> QRF:
     """Get or train the liquid asset imputation model."""
-    model_path = STORAGE_FOLDER / "liquid_assets.pkl"
+    model_path = STORAGE_FOLDER / "liquid_assets_v2.pkl"
 
     if not model_path.exists():
         model = train_asset_model()

--- a/policyengine_us_data/db/etl_national_targets.py
+++ b/policyengine_us_data/db/etl_national_targets.py
@@ -26,6 +26,12 @@ from policyengine_us_data.utils.db import (
     etl_argparser,
     get_geographic_strata,
 )
+from policyengine_us_data.utils.ssi_targets import (
+    SSI_RECIPIENT_TARGET_NOTES,
+    SSI_RECIPIENT_TARGET_SOURCE,
+    SSI_RECIPIENT_TARGET_YEAR,
+    SSI_RECIPIENT_TARGETS_2024,
+)
 from policyengine_us_data.utils.target_variables import (
     target_variable_components,
 )
@@ -148,6 +154,47 @@ WIC_NATIONAL_ANNUAL_SUMMARY_SOURCE = (
     "https://www.fns.usda.gov/sites/default/files/resource-files/wisummary-4.xlsx"
 )
 MEDICARE_PART_B_AGE_TARGET_YEAR = 2024
+
+
+def _target_notes(target_data: dict) -> str:
+    notes_parts = []
+    if pd.notna(target_data.get("notes")):
+        notes_parts.append(target_data["notes"])
+    notes_parts.append(f"Source: {target_data.get('source', 'Unknown')}")
+    return " | ".join(notes_parts)
+
+
+def _ssi_recipient_count_targets() -> list[dict]:
+    targets = []
+    for spec in SSI_RECIPIENT_TARGETS_2024.values():
+        constraints = [
+            {
+                "constraint_variable": "ssi",
+                "operation": ">",
+                "value": "0",
+            }
+        ]
+        constraints.extend(
+            {
+                "constraint_variable": "age",
+                "operation": operation,
+                "value": value,
+            }
+            for operation, value in spec["age_constraints"]
+        )
+        targets.append(
+            {
+                "constraint_variable": "ssi",
+                "target_variable": "person_count",
+                "person_count": spec["person_count"],
+                "source": SSI_RECIPIENT_TARGET_SOURCE,
+                "notes": SSI_RECIPIENT_TARGET_NOTES,
+                "year": SSI_RECIPIENT_TARGET_YEAR,
+                "stratum_notes": spec["stratum_notes"],
+                "constraints": constraints,
+            }
+        )
+    return targets
 
 
 def _best_available_yeared_csv(stem: str, requested_year: int):
@@ -654,6 +701,7 @@ def extract_national_targets(year: int = DEFAULT_YEAR):
             "year": 2024,
         },
     ]
+    conditional_count_targets.extend(_ssi_recipient_count_targets())
 
     # Add SSN card type NONE targets for multiple years
     # Based on loss.py lines 445-460
@@ -1057,32 +1105,44 @@ def load_national_targets(
             target_year = cond_target["year"]
             target_variable = cond_target.get("target_variable", "person_count")
             target_value = cond_target.get(target_variable)
+            combined_notes = _target_notes(cond_target)
 
             # Determine constraint details
-            if constraint_var == "medicaid_enrolled":
-                stratum_notes = "National Medicaid Enrollment"
-                constraint_operation = ">"
-                constraint_value = "0"
-            elif constraint_var == "aca_ptc":
-                stratum_notes = "National ACA Premium Tax Credit Recipients"
-                constraint_operation = ">"
-                constraint_value = "0"
-            elif constraint_var == "spm_unit_energy_subsidy":
-                stratum_notes = "National LIHEAP Recipient Households"
-                constraint_operation = ">"
-                constraint_value = "0"
-            elif constraint_var == "wic":
-                stratum_notes = "National WIC Recipients"
-                constraint_operation = ">"
-                constraint_value = "0"
-            elif constraint_var == "ssn_card_type":
-                stratum_notes = "National Undocumented Population"
-                constraint_operation = "=="
-                constraint_value = cond_target.get("constraint_value", "NONE")
+            if "constraints" in cond_target:
+                stratum_notes = cond_target["stratum_notes"]
+                constraints = cond_target["constraints"]
             else:
-                stratum_notes = f"National {constraint_var} Recipients"
-                constraint_operation = ">"
-                constraint_value = "0"
+                if constraint_var == "medicaid_enrolled":
+                    stratum_notes = "National Medicaid Enrollment"
+                    constraint_operation = ">"
+                    constraint_value = "0"
+                elif constraint_var == "aca_ptc":
+                    stratum_notes = "National ACA Premium Tax Credit Recipients"
+                    constraint_operation = ">"
+                    constraint_value = "0"
+                elif constraint_var == "spm_unit_energy_subsidy":
+                    stratum_notes = "National LIHEAP Recipient Households"
+                    constraint_operation = ">"
+                    constraint_value = "0"
+                elif constraint_var == "wic":
+                    stratum_notes = "National WIC Recipients"
+                    constraint_operation = ">"
+                    constraint_value = "0"
+                elif constraint_var == "ssn_card_type":
+                    stratum_notes = "National Undocumented Population"
+                    constraint_operation = "=="
+                    constraint_value = cond_target.get("constraint_value", "NONE")
+                else:
+                    stratum_notes = f"National {constraint_var} Recipients"
+                    constraint_operation = ">"
+                    constraint_value = "0"
+                constraints = [
+                    {
+                        "constraint_variable": constraint_var,
+                        "operation": constraint_operation,
+                        "value": constraint_value,
+                    }
+                ]
 
             # Check if this stratum already exists
             existing_stratum = session.exec(
@@ -1105,6 +1165,8 @@ def load_national_targets(
                 if existing_target:
                     existing_target.value = target_value
                     existing_target.source = "PolicyEngine"
+                    existing_target.notes = combined_notes
+                    existing_target.active = True
                     print(f"Updated enrollment target for {constraint_var}")
                 else:
                     # Add new target to existing stratum
@@ -1115,7 +1177,7 @@ def load_national_targets(
                         value=target_value,
                         active=True,
                         source="PolicyEngine",
-                        notes=f"{cond_target['notes']} | Source: {cond_target['source']}",
+                        notes=combined_notes,
                     )
                     session.add(new_target)
                     print(f"Added enrollment target for {constraint_var}")
@@ -1129,10 +1191,11 @@ def load_national_targets(
                 # Add constraint
                 new_stratum.constraints_rel = [
                     StratumConstraint(
-                        constraint_variable=constraint_var,
-                        operation=constraint_operation,
-                        value=constraint_value,
+                        constraint_variable=constraint["constraint_variable"],
+                        operation=constraint["operation"],
+                        value=constraint["value"],
                     )
+                    for constraint in constraints
                 ]
 
                 # Add target
@@ -1143,7 +1206,7 @@ def load_national_targets(
                         value=target_value,
                         active=True,
                         source="PolicyEngine",
-                        notes=f"{cond_target['notes']} | Source: {cond_target['source']}",
+                        notes=combined_notes,
                     )
                 ]
 

--- a/policyengine_us_data/utils/loss.py
+++ b/policyengine_us_data/utils/loss.py
@@ -26,6 +26,7 @@ from policyengine_us_data.db.etl_irs_soi import (
 )
 from policyengine_core.reforms import Reform
 from policyengine_us_data.utils.soi import pe_to_soi, get_soi, get_tracked_soi_row
+from policyengine_us_data.utils.ssi_targets import SSI_RECIPIENT_TARGETS_2024
 from policyengine_us_data.utils.target_variables import (
     target_variable_components,
 )
@@ -201,6 +202,34 @@ def _add_medicare_enrollment_target(loss_matrix, targets_array, sim, time_period
     ).values
     loss_matrix[label] = sim.map_result(enrolled.astype(float), "person", "household")
     targets_array.append(get_medicare_enrollment_target(time_period))
+    return targets_array, loss_matrix
+
+
+def _add_ssi_recipient_targets(loss_matrix, targets_array, sim, time_period):
+    """Add SSA SSI recipient count controls by age group."""
+    ssi = sim.calculate("ssi", map_to="person", period=time_period).values
+    age = sim.calculate("age", map_to="person", period=time_period).values
+    receives_ssi = ssi > 0
+
+    for key, target in SSI_RECIPIENT_TARGETS_2024.items():
+        in_group = receives_ssi.copy()
+        for operation, value in target["age_constraints"]:
+            threshold = float(value)
+            if operation == "<":
+                in_group &= age < threshold
+            elif operation == ">=":
+                in_group &= age >= threshold
+            else:
+                raise ValueError(f"Unsupported SSI age constraint {operation!r}")
+
+        label = f"nation/ssa/ssi_recipients/{key}"
+        loss_matrix[label] = sim.map_result(
+            in_group.astype(float),
+            "person",
+            "household",
+        )
+        targets_array.append(target["person_count"])
+
     return targets_array, loss_matrix
 
 
@@ -1311,6 +1340,13 @@ def build_loss_matrix(dataset: type, time_period):
                 time_period
             ).calibration.gov.cbo._children[param_name]
         )
+
+    targets_array, loss_matrix = _add_ssi_recipient_targets(
+        loss_matrix,
+        targets_array,
+        sim,
+        time_period,
+    )
 
     # CBO's detailed AGI-by-source targets are tax-return concepts,
     # so keep them restricted to filing tax units.

--- a/policyengine_us_data/utils/ssi_targets.py
+++ b/policyengine_us_data/utils/ssi_targets.py
@@ -1,0 +1,37 @@
+"""Shared SSI calibration targets."""
+
+SSI_RECIPIENT_TARGET_YEAR = 2024
+SSI_RECIPIENT_TARGET_SOURCE = (
+    "https://www.ssa.gov/policy/docs/statcomps/ssi_monthly/2024-12/table01.html"
+)
+SSI_RECIPIENT_TARGET_NOTES = (
+    "SSI recipients with a federal payment, December 2024, SSA SSI Monthly "
+    "Statistics Table 1"
+)
+
+SSI_RECIPIENT_TARGETS_2024 = {
+    "all": {
+        "label": "all",
+        "stratum_notes": "National SSI Federal Payment Recipients",
+        "person_count": 7_289_843,
+        "age_constraints": (),
+    },
+    "under_18": {
+        "label": "under_18",
+        "stratum_notes": "National SSI Federal Payment Recipients - Under 18",
+        "person_count": 1_001_922,
+        "age_constraints": (("<", "18"),),
+    },
+    "18_64": {
+        "label": "18_64",
+        "stratum_notes": "National SSI Federal Payment Recipients - Ages 18-64",
+        "person_count": 3_905_779,
+        "age_constraints": ((">=", "18"), ("<", "65")),
+    },
+    "65_plus": {
+        "label": "65_plus",
+        "stratum_notes": "National SSI Federal Payment Recipients - Ages 65+",
+        "person_count": 2_382_142,
+        "age_constraints": ((">=", "65"),),
+    },
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us==1.700.2",
+    "policyengine-us==1.701.1",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/tests/unit/calibration/test_loss_targets.py
+++ b/tests/unit/calibration/test_loss_targets.py
@@ -26,6 +26,7 @@ from policyengine_us_data.utils.loss import (
     _add_irs_soi_aggregate_targets,
     _add_medicare_enrollment_target,
     _add_real_estate_tax_targets,
+    _add_ssi_recipient_targets,
     _add_transfer_balance_targets,
     _get_medicaid_national_targets,
     _get_aca_national_targets,
@@ -38,6 +39,7 @@ from policyengine_us_data.utils.loss import (
     get_target_loss_weights,
 )
 from policyengine_us_data.db import etl_national_targets
+from policyengine_us_data.utils.ssi_targets import SSI_RECIPIENT_TARGETS_2024
 
 
 def test_legacy_loss_targets_include_aggregate_qbi_deduction():
@@ -208,6 +210,24 @@ class _FakeMedicareEnrollmentSimulation:
         return np.asarray(values, dtype=np.float32)
 
 
+class _FakeSSIRecipientSimulation:
+    def calculate(self, variable, map_to=None, period=None):
+        values = {
+            "ssi": [100.0, 50.0, 0.0, 75.0],
+            "age": [10.0, 40.0, 80.0, 70.0],
+        }
+        if variable not in values:
+            raise AssertionError(f"Unexpected variable {variable!r}")
+        assert map_to == "person"
+        assert period == 2024
+        return _FakeArrayResult(values[variable])
+
+    def map_result(self, values, source_entity, target_entity, how=None):
+        assert source_entity == "person"
+        assert target_entity == "household"
+        return np.asarray(values, dtype=np.float32)
+
+
 class _FakeCapitalGainsSimulation:
     def __init__(self):
         self.calculate_calls = []
@@ -302,6 +322,35 @@ def test_state_agi_targets_are_limited_to_filers(tmp_path, monkeypatch):
     np.testing.assert_array_equal(
         loss_matrix["state/CA/adjusted_gross_income/amount/1_10000"],
         np.array([0.0, 0.0, 5_000.0, 0.0]),
+    )
+
+
+def test_add_ssi_recipient_targets_adds_total_and_age_counts():
+    targets, loss_matrix = _add_ssi_recipient_targets(
+        pd.DataFrame(),
+        [],
+        _FakeSSIRecipientSimulation(),
+        2024,
+    )
+
+    assert targets == [
+        spec["person_count"] for spec in SSI_RECIPIENT_TARGETS_2024.values()
+    ]
+    np.testing.assert_array_equal(
+        loss_matrix["nation/ssa/ssi_recipients/all"],
+        np.array([1.0, 1.0, 0.0, 1.0], dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        loss_matrix["nation/ssa/ssi_recipients/under_18"],
+        np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        loss_matrix["nation/ssa/ssi_recipients/18_64"],
+        np.array([0.0, 1.0, 0.0, 0.0], dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        loss_matrix["nation/ssa/ssi_recipients/65_plus"],
+        np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32),
     )
 
 

--- a/tests/unit/calibration/test_source_impute.py
+++ b/tests/unit/calibration/test_source_impute.py
@@ -15,13 +15,16 @@ from policyengine_us_data.calibration.source_impute import (
     SIPP_ASSETS_PREDICTORS,
     SIPP_IMPUTED_VARIABLES,
     SIPP_TIPS_PREDICTORS,
+    _add_cps_asset_predictors,
     _impute_acs,
     _impute_org,
     _impute_scf,
     _impute_sipp,
+    _person_is_married,
     _person_state_fips,
     impute_source_variables,
 )
+from policyengine_us_data.datasets.sipp.sipp import ASSET_PREDICTORS
 from policyengine_us_data.datasets.cps.tipped_occupation import (
     derive_any_treasury_tipped_occupation_code,
     derive_is_tipped_occupation,
@@ -120,6 +123,30 @@ class TestPredictorLists:
 
     def test_sipp_assets_has_income(self):
         assert "employment_income" in SIPP_ASSETS_PREDICTORS
+
+    def test_sipp_assets_use_shared_asset_predictors(self):
+        assert SIPP_ASSETS_PREDICTORS == ASSET_PREDICTORS
+
+    def test_sipp_assets_exclude_circular_and_noncomparable_predictors(self):
+        assert "ssi" not in SIPP_ASSETS_PREDICTORS
+        assert "ssi_reported" not in SIPP_ASSETS_PREDICTORS
+        assert "RSSI_YRYN" not in SIPP_ASSETS_PREDICTORS
+        assert not any("disab" in pred.lower() for pred in SIPP_ASSETS_PREDICTORS)
+
+    def test_sipp_assets_include_comparable_income_and_household_predictors(self):
+        expected = {
+            "employment_income",
+            "interest_income",
+            "dividend_income",
+            "rental_income",
+            "social_security",
+            "retirement_income",
+            "non_ssi_income",
+            "count_under_18",
+            "count_under_6",
+            "household_size",
+        }
+        assert expected <= set(SIPP_ASSETS_PREDICTORS)
 
     def test_scf_has_income(self):
         assert "employment_income" in SCF_PREDICTORS
@@ -232,6 +259,62 @@ class TestPersonStateFips:
 
         result = _person_state_fips(data, state_fips, 2024)
         assert len(result) == 5
+
+
+class TestAssetPredictorHelpers:
+    def test_person_is_married_uses_existing_flag(self):
+        data = {"is_married": {2024: np.array([1, 0, 1], dtype=bool)}}
+
+        result = _person_is_married(data, 2024, 3)
+
+        np.testing.assert_array_equal(result, np.array([1.0, 0.0, 1.0]))
+
+    def test_person_is_married_falls_back_to_marital_unit_id(self):
+        data = {
+            "person_marital_unit_id": {
+                2024: np.array([10, 10, 20, 30, 30]),
+            }
+        }
+
+        result = _person_is_married(data, 2024, 5)
+
+        np.testing.assert_array_equal(
+            result,
+            np.array([1.0, 1.0, 0.0, 1.0, 1.0]),
+        )
+
+    def test_add_cps_asset_predictors_builds_non_ssi_income(self):
+        data = {
+            "person_household_id": {2024: np.array([1, 1, 2])},
+            "age": {2024: np.array([40, 6, 70], dtype=np.float32)},
+            "person_marital_unit_id": {2024: np.array([1, 1, 2])},
+            "social_security": {2024: np.array([100.0, 0.0, 500.0])},
+            "retirement_distributions": {2024: np.array([10.0, 0.0, 20.0])},
+            "pension_income": {2024: np.array([5.0, 0.0, 30.0])},
+        }
+        cps = pd.DataFrame(
+            {
+                "employment_income": [1000.0, 0.0, 200.0],
+                "interest_income": [1.0, 0.0, 2.0],
+                "dividend_income": [3.0, 0.0, 4.0],
+                "rental_income": [0.0, 0.0, 5.0],
+                "age": [40.0, 6.0, 70.0],
+                "is_male": [True, False, False],
+            }
+        )
+
+        result = _add_cps_asset_predictors(cps, data, 2024)
+
+        assert set(SIPP_ASSETS_PREDICTORS) <= set(result.columns)
+        np.testing.assert_array_equal(result["count_under_18"], [1.0, 1.0, 0.0])
+        np.testing.assert_array_equal(result["count_under_6"], [0.0, 0.0, 0.0])
+        np.testing.assert_array_equal(result["household_size"], [2.0, 2.0, 1.0])
+        np.testing.assert_array_equal(result["is_married"], [1.0, 1.0, 0.0])
+        np.testing.assert_array_equal(result["retirement_income"], [15.0, 0.0, 50.0])
+        np.testing.assert_array_equal(
+            result["non_ssi_income"],
+            [1115.0, 0.0, 750.0],
+        )
 
 
 class TestSubfunctions:

--- a/tests/unit/calibration/test_target_config.py
+++ b/tests/unit/calibration/test_target_config.py
@@ -535,6 +535,28 @@ class TestLoadTargetConfig:
             "domain_variable": "wic",
         } in include_rules
 
+    def test_training_config_includes_ssi_recipient_count_targets(self):
+        config = load_target_config(
+            str(
+                Path(__file__).resolve().parents[3]
+                / "policyengine_us_data"
+                / "calibration"
+                / "target_config.yaml"
+            )
+        )
+
+        include_rules = config["include"]
+        assert {
+            "variable": "person_count",
+            "geo_level": "national",
+            "domain_variable": "ssi",
+        } in include_rules
+        assert {
+            "variable": "person_count",
+            "geo_level": "national",
+            "domain_variable": "age,ssi",
+        } in include_rules
+
     def test_training_config_includes_ported_loss_py_target_families(self):
         config = load_target_config(
             str(

--- a/tests/unit/calibration/test_unified_matrix_builder.py
+++ b/tests/unit/calibration/test_unified_matrix_builder.py
@@ -128,7 +128,7 @@ GROUP BY t.target_id, t.stratum_id, t.variable,
 
 def _insert_aca_ptc_data(engine):
     with engine.connect() as conn:
-        strata = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+        strata = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
         for sid in strata:
             conn.execute(
                 text(
@@ -161,6 +161,10 @@ def _insert_aca_ptc_data(engine):
             (16, 9, "aca_ptc", ">", "0"),
             (17, 10, "congressional_district_geoid", "=", "601"),
             (18, 11, "congressional_district_geoid", "=", "602"),
+            (19, 12, "ssi", ">", "0"),
+            (20, 12, "age", "<", "18"),
+            (21, 13, "adjusted_gross_income", ">", "0"),
+            (22, 13, "refundable_ctc", ">", "0"),
         ]
         for cid, sid, var, op, val in constraints:
             conn.execute(
@@ -200,6 +204,8 @@ def _insert_aca_ptc_data(engine):
             (20, 10, "adjusted_gross_income", 0, 1000.0, 2021, 1),
             (21, 10, "adjusted_gross_income", 0, 1500.0, 2022, 1),
             (22, 11, "adjusted_gross_income", 0, 800.0, 2022, 1),
+            (23, 12, "person_count", 0, 1001922.0, 2024, 1),
+            (24, 13, "tax_unit_count", 0, 123.0, 2024, 1),
         ]
         for tid, sid, var, reform_id, val, period, active in targets:
             conn.execute(
@@ -266,6 +272,33 @@ class TestQueryTargets(unittest.TestCase):
         self.assertIn("geo_level", df.columns)
         self.assertIn("geographic_id", df.columns)
         self.assertIn("domain_variable", df.columns)
+
+    def test_domain_variables_filter_matches_multi_constraint_strata(self):
+        b = self._make_builder()
+        df = b._query_targets({"domain_variables": ["ssi"]})
+
+        self.assertEqual(len(df), 1)
+        self.assertEqual(df.iloc[0]["variable"], "person_count")
+        self.assertEqual(df.iloc[0]["domain_variable"], "age,ssi")
+
+    def test_domain_variables_filter_preserves_exact_comma_joined_domains(self):
+        b = self._make_builder()
+        df = b._query_targets(
+            {"domain_variables": ["adjusted_gross_income,refundable_ctc"]}
+        )
+
+        self.assertEqual(len(df), 1)
+        self.assertEqual(df.iloc[0]["variable"], "tax_unit_count")
+        self.assertEqual(
+            df.iloc[0]["domain_variable"],
+            "adjusted_gross_income,refundable_ctc",
+        )
+
+    def test_domain_variables_filter_excludes_non_domain_constraints(self):
+        b = self._make_builder()
+        df = b._query_targets({"domain_variables": ["tax_unit_is_filer"]})
+
+        self.assertEqual(len(df), 0)
 
     def test_all_geo_levels_returned(self):
         b = self._make_builder()

--- a/tests/unit/test_etl_national_targets.py
+++ b/tests/unit/test_etl_national_targets.py
@@ -13,11 +13,13 @@ from policyengine_us_data.db.create_database_tables import (
 )
 from policyengine_us_data.db.etl_national_targets import (
     MEDICARE_PART_B_AGE_TARGET_YEAR,
+    _ssi_recipient_count_targets,
     extract_national_targets,
     load_medicare_part_b_age_targets,
     load_national_targets,
     load_state_acs_rent_targets,
 )
+from policyengine_us_data.utils.ssi_targets import SSI_RECIPIENT_TARGETS_2024
 
 
 def test_national_targets_do_not_extract_treasury_eitc():
@@ -399,6 +401,44 @@ def test_extract_national_targets_includes_wic_targets():
     assert wic_count_targets[0]["person_count"] == 6_704_000
 
 
+def test_ssi_recipient_count_targets_are_count_only_and_age_stratified():
+    targets = _ssi_recipient_count_targets()
+
+    assert len(targets) == 4
+    assert {target["target_variable"] for target in targets} == {"person_count"}
+    assert {target["person_count"] for target in targets} == {
+        spec["person_count"] for spec in SSI_RECIPIENT_TARGETS_2024.values()
+    }
+    assert all(
+        constraint["constraint_variable"] != "social_security"
+        for target in targets
+        for constraint in target["constraints"]
+    )
+    under_18 = next(
+        target for target in targets if target["stratum_notes"].endswith("Under 18")
+    )
+    assert {"constraint_variable": "ssi", "operation": ">", "value": "0"} in under_18[
+        "constraints"
+    ]
+    assert {"constraint_variable": "age", "operation": "<", "value": "18"} in under_18[
+        "constraints"
+    ]
+
+
+def test_extract_national_targets_includes_ssi_count_targets():
+    targets = extract_national_targets(year=2024)
+    ssi_targets = [
+        target
+        for target in targets["conditional_count_targets"]
+        if target["constraint_variable"] == "ssi"
+    ]
+
+    assert len(ssi_targets) == 4
+    assert {target["person_count"] for target in ssi_targets} == {
+        spec["person_count"] for spec in SSI_RECIPIENT_TARGETS_2024.values()
+    }
+
+
 def test_load_national_targets_uses_medicaid_enrolled_for_enrollment_counts(
     tmp_path, monkeypatch
 ):
@@ -458,6 +498,68 @@ def test_load_national_targets_uses_medicaid_enrolled_for_enrollment_counts(
         ).first()
         assert medicaid_target is not None
         assert medicaid_target.value == 72_429_055
+
+
+def test_load_national_targets_supports_multi_constraint_ssi_counts(
+    tmp_path, monkeypatch
+):
+    calibration_dir = tmp_path / "calibration"
+    calibration_dir.mkdir()
+    db_uri = f"sqlite:///{calibration_dir / 'policy_data.db'}"
+    engine = create_database(db_uri)
+
+    with Session(engine) as session:
+        _make_stratum(session, notes="United States")
+
+    monkeypatch.setattr(
+        "policyengine_us_data.db.etl_national_targets.STORAGE_FOLDER",
+        tmp_path,
+    )
+
+    conditional_targets = [
+        target
+        for target in _ssi_recipient_count_targets()
+        if target["stratum_notes"].endswith("Ages 18-64")
+    ]
+
+    load_national_targets(
+        direct_targets_df=pd.DataFrame(),
+        tax_filer_df=pd.DataFrame(),
+        tax_expenditure_df=pd.DataFrame(),
+        conditional_targets=conditional_targets,
+    )
+
+    with Session(engine) as session:
+        ssi_stratum = session.exec(
+            select(Stratum).where(
+                Stratum.notes == "National SSI Federal Payment Recipients - Ages 18-64"
+            )
+        ).first()
+        assert ssi_stratum is not None
+
+        constraints = {
+            (
+                constraint.constraint_variable,
+                constraint.operation,
+                constraint.value,
+            )
+            for constraint in ssi_stratum.constraints_rel
+        }
+        assert constraints == {
+            ("ssi", ">", "0"),
+            ("age", ">=", "18"),
+            ("age", "<", "65"),
+        }
+
+        ssi_target = session.exec(
+            select(Target).where(
+                Target.stratum_id == ssi_stratum.stratum_id,
+                Target.variable == "person_count",
+                Target.period == 2024,
+            )
+        ).first()
+        assert ssi_target is not None
+        assert ssi_target.value == 3_905_779
 
 
 def test_load_national_targets_supports_medicare_enrollment_counts(

--- a/uv.lock
+++ b/uv.lock
@@ -2122,7 +2122,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.700.2"
+version = "1.701.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2132,9 +2132,9 @@ dependencies = [
     { name = "tables" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/d5/184a594b7c61d4603e25e80c617f998b2e1374080c440089a2b861b4e6d5/policyengine_us-1.700.2.tar.gz", hash = "sha256:05d7e0eac4d7566029e3f9910ddae79bc182c7af0ff6cd21688e6d5b04a0970a", size = 9869566, upload-time = "2026-05-20T23:02:41.858Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/b1/a4702d55f1dae96bde410a69ac026b6e4133336183dcaf47655c1c769dc4/policyengine_us-1.701.1.tar.gz", hash = "sha256:2c457bfadd0fb0a2e70430dd1ea0be330c112653b7bf4a87adb90fb583a709d2", size = 9870104, upload-time = "2026-05-21T13:24:51.155Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/b8/87ca409631fc478fdac4cc219ef4e45ea3416106c6d2ef96c2c115bbc33f/policyengine_us-1.700.2-py3-none-any.whl", hash = "sha256:a6e32e0048dee22a1558a136d2a24df812140695205194a4256c787a5d6140bd", size = 10625770, upload-time = "2026-05-20T23:02:38.359Z" },
+    { url = "https://files.pythonhosted.org/packages/de/6f/45d66cbced930595741e4fc0b90a88781d7d77bf68e029a7e226914178b0/policyengine_us-1.701.1-py3-none-any.whl", hash = "sha256:0516eedbadb3a51f0dd3beefca39e4075ff1b929d2fbd36bb7185837a462fb31", size = 10626923, upload-time = "2026-05-21T13:24:47.979Z" },
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", specifier = "==1.700.2" },
+    { name = "policyengine-us", specifier = "==1.701.1" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },


### PR DESCRIPTION
Fixes #1096

## Summary
- remove SSI participation from liquid asset imputation predictors and avoid disability predictors
- add comparable income and household predictors for SIPP/CPS liquid asset imputation
- add SSA December 2024 SSI recipient count targets to legacy loss, DB ETL, and target config
- preserve exact comma-joined domain filtering while allowing single-domain filters like `ssi` to find multi-constraint strata such as `age,ssi`

## Verification
- `uv run pytest -q tests/unit/calibration/test_source_impute.py tests/unit/test_etl_national_targets.py tests/unit/calibration/test_loss_targets.py tests/unit/calibration/test_unified_matrix_builder.py tests/unit/calibration/test_target_config.py tests/unit/test_etl_irs_soi_overlay.py::test_load_national_geography_ctc_agi_targets_creates_agi_domain_strata tests/unit/datasets/test_sipp_monthcode_filter.py tests/unit/datasets/test_sipp_tip_columns.py`
- `uv run make lint`
- `$cycle` read-only review loop completed with no actionable findings on the final pass

## Not run
- full end-to-end calibration pipeline
- SIPP donor asset model retraining/download validation
