### PR TITLE
Expose Stage 1 substep status in pipeline status payloads

### DIFF
--- a/changelog.d/1114.added
+++ b/changelog.d/1114.added
@@ -1,0 +1,1 @@
+Expose run-scoped Stage 1 substep status in pipeline status payloads.

--- a/modal_app/data_build.py
+++ b/modal_app/data_build.py
@@ -30,6 +30,7 @@ from policyengine_us_data.build_datasets import (  # noqa: E402
     DatasetBuildOutputContractBuilder,
     PipelineArtifactStager,
     Stage1Coordinator,
+    Stage1StatusRecorder,
     stage_1_artifact_specs,
     stage_1_script_outputs,
     stage_1_substep_id_for_script,
@@ -716,6 +717,11 @@ def build_datasets(
     )
     log_file.flush()
     coordinator = Stage1Coordinator()
+    if run_id:
+        coordinator.status_recorder = Stage1StatusRecorder(
+            Path(PIPELINE_MOUNT) / "runs" / run_id,
+            commit_callback=pipeline_volume.commit,
+        )
     recorded_skips: set[tuple[str, str]] = set()
 
     def record_skipped_script(script: str, reason: str) -> None:

--- a/modal_app/step_manifests/status.py
+++ b/modal_app/step_manifests/status.py
@@ -11,6 +11,10 @@ from policyengine_us_data.utils.step_manifest import (
     run_manifest_path,
     step_manifest_dir,
 )
+from policyengine_us_data.build_datasets import (
+    empty_stage_1_status_snapshot,
+    read_stage_1_status_snapshot,
+)
 from policyengine_us_data.utils.error_redaction import (
     DEFAULT_ERROR_MESSAGE_MAX_CHARS,
     bound_error_text,
@@ -24,7 +28,11 @@ from modal_app.step_manifests.errors import (
     read_latest_pipeline_error,
     stage_ids_for_manifest,
 )
-from modal_app.step_manifests.specs import RUN_MANIFEST_STEP_IDS, step_title
+from modal_app.step_manifests.specs import (
+    BUILD_DATASETS,
+    RUN_MANIFEST_STEP_IDS,
+    step_title,
+)
 
 PIPELINE_STATUS_SCHEMA_VERSION = "1"
 DEFAULT_RUNS_LIMIT = 25
@@ -112,6 +120,7 @@ def _message(
     status: str,
     stage_manifests: list[dict[str, Any]],
     error: dict[str, Any] | None,
+    stage_1_status: dict[str, Any] | None = None,
 ) -> str:
     if error:
         location = (
@@ -125,6 +134,19 @@ def _message(
         return "Pipeline run not found."
     if stage_manifests:
         latest = stage_manifests[-1]
+        current_stage_1 = (stage_1_status or {}).get("current") or {}
+        if (
+            latest["step_id"] == BUILD_DATASETS.id
+            and latest["status"] == "running"
+            and current_stage_1
+        ):
+            substep_id = current_stage_1.get("substep_id")
+            title = current_stage_1.get("title") or substep_id
+            substep_status = current_stage_1.get("status", "unknown")
+            return (
+                f"Pipeline {status}; current Stage 1 substep "
+                f"{substep_id} ({title}) is {substep_status}."
+            )
         return (
             f"Pipeline {status}; latest manifest "
             f"{latest['substage_id'] or latest['stage_id']} is {latest['status']}."
@@ -215,6 +237,11 @@ def _latest_manifest_payload(
     }
 
 
+def _stage_1_status_payload(run_dir: Path) -> dict[str, Any]:
+    snapshot = read_stage_1_status_snapshot(run_dir)
+    return _sanitize_error_value(snapshot.to_dict())
+
+
 def _run_index_item(
     run_id: str,
     *,
@@ -241,6 +268,7 @@ def _run_index_item(
         "hf_staging_prefix": run_manifest.get("hf_staging_prefix"),
         "github_run_url": (run_manifest.get("run_context") or {}).get("github_run_url"),
         "latest_manifest": _latest_manifest_payload(stage_manifests),
+        "stage_1_current": (payload.get("stage_1_status") or {}).get("current"),
         "progress": {
             "expected_manifests": len(expected),
             "present_manifests": len(stage_manifests),
@@ -271,6 +299,7 @@ def _unreadable_run_index_item(run_id: str, exc: BaseException) -> dict[str, Any
         "hf_staging_prefix": None,
         "github_run_url": None,
         "latest_manifest": None,
+        "stage_1_current": None,
         "progress": {
             "expected_manifests": 0,
             "present_manifests": 0,
@@ -357,6 +386,7 @@ def build_pipeline_status_payload(
             "stage_manifests": [],
             "missing_expected_manifest_ids": [],
             "error": None,
+            "stage_1_status": empty_stage_1_status_snapshot().to_dict(),
         }
 
     run_dir = _run_dir(run_id, runs_dir)
@@ -371,6 +401,7 @@ def build_pipeline_status_payload(
             "stage_manifests": [],
             "missing_expected_manifest_ids": list(RUN_MANIFEST_STEP_IDS),
             "error": None,
+            "stage_1_status": empty_stage_1_status_snapshot().to_dict(),
         }
 
     run_manifest = read_run_manifest(manifest_path)
@@ -391,6 +422,7 @@ def build_pipeline_status_payload(
         run_manifest.error
     )
     status = run_manifest.status
+    stage_1_status = _stage_1_status_payload(run_dir)
     return {
         "schema_version": PIPELINE_STATUS_SCHEMA_VERSION,
         "run_id": run_id,
@@ -399,11 +431,13 @@ def build_pipeline_status_payload(
             status=status,
             stage_manifests=stage_manifests,
             error=error,
+            stage_1_status=stage_1_status,
         ),
         "run_manifest": _run_manifest_payload(run_manifest),
         "stage_manifests": stage_manifests,
         "missing_expected_manifest_ids": missing_expected,
         "error": error,
+        "stage_1_status": stage_1_status,
         "updated_at": run_manifest.updated_at,
         "modal_app_name": run_manifest.modal_app_name,
         "modal_environment": run_manifest.modal_environment,

--- a/policyengine_us_data/build_datasets/__init__.py
+++ b/policyengine_us_data/build_datasets/__init__.py
@@ -43,7 +43,9 @@ from .staging import PipelineArtifactStager
 from .status import Stage1ErrorRecord, Stage1StatusEvent
 from .status_store import (
     Stage1StatusRecorder,
+    Stage1StatusReadError,
     Stage1StatusSnapshot,
+    Stage1StoredStatusEvent,
     empty_stage_1_status_snapshot,
     read_stage_1_status_snapshot,
 )
@@ -69,9 +71,11 @@ __all__ = [
     "Stage1Coordinator",
     "Stage1ErrorRecord",
     "Stage1StatusRecorder",
+    "Stage1StatusReadError",
     "Stage1StatusEvent",
     "Stage1StatusSink",
     "Stage1StatusSnapshot",
+    "Stage1StoredStatusEvent",
     "Stage1SubstepRunner",
     "SubprocessLogCapture",
     "TargetDatabaseSchemaSummaryWriter",

--- a/policyengine_us_data/build_datasets/__init__.py
+++ b/policyengine_us_data/build_datasets/__init__.py
@@ -20,6 +20,7 @@ from .contracts import DatasetBuildOutputContractBuilder
 from .coordinator import (
     CommandBackedSubstepRunner,
     Stage1Coordinator,
+    Stage1StatusSink,
     Stage1SubstepRunner,
     stage_1_substep_id_for_script,
     stage_1_substep_title,
@@ -40,6 +41,12 @@ from .specs import (
 from .results import DatasetCommandResult, DatasetSubstepResult
 from .staging import PipelineArtifactStager
 from .status import Stage1ErrorRecord, Stage1StatusEvent
+from .status_store import (
+    Stage1StatusRecorder,
+    Stage1StatusSnapshot,
+    empty_stage_1_status_snapshot,
+    read_stage_1_status_snapshot,
+)
 
 __all__ = [
     "ARTIFACT_SCHEMA_VERSION",
@@ -61,10 +68,15 @@ __all__ = [
     "SourceDatasetSchemaSummaryWriter",
     "Stage1Coordinator",
     "Stage1ErrorRecord",
+    "Stage1StatusRecorder",
     "Stage1StatusEvent",
+    "Stage1StatusSink",
+    "Stage1StatusSnapshot",
     "Stage1SubstepRunner",
     "SubprocessLogCapture",
     "TargetDatabaseSchemaSummaryWriter",
+    "empty_stage_1_status_snapshot",
+    "read_stage_1_status_snapshot",
     "stage_1_artifact_specs",
     "stage_1_contract_artifact_specs",
     "stage_1_diagnostic_artifact_specs",

--- a/policyengine_us_data/build_datasets/coordinator.py
+++ b/policyengine_us_data/build_datasets/coordinator.py
@@ -26,6 +26,16 @@ class Stage1SubstepRunner(Protocol):
         """Run the substep action."""
 
 
+class Stage1StatusSink(Protocol):
+    """Persistence sink for Stage 1 status transitions and results."""
+
+    def record_event(self, event: Stage1StatusEvent) -> None:
+        """Persist one status event."""
+
+    def record_result(self, result: DatasetSubstepResult) -> None:
+        """Persist one substep result."""
+
+
 @dataclass(frozen=True, kw_only=True)
 class CommandBackedSubstepRunner:
     """Run a Stage 1 substep backed by existing side-effecting commands."""
@@ -60,6 +70,7 @@ class _SubstepAggregate:
 class Stage1Coordinator:
     """Collect Stage 1 substep status events, errors, and results."""
 
+    status_recorder: Stage1StatusSink | None = None
     results: list[DatasetSubstepResult] = field(default_factory=list)
     status_events: list[Stage1StatusEvent] = field(default_factory=list)
     error_records: list[Stage1ErrorRecord] = field(default_factory=list)
@@ -244,22 +255,24 @@ class Stage1Coordinator:
         *,
         metadata: Mapping[str, Any] | None,
     ) -> None:
+        event: Stage1StatusEvent | None = None
         with self._lock:
             state = self._aggregate_state(runner)
             if state.started_dt is None:
                 state.started_dt = started_dt
-                self.status_events.append(
-                    Stage1StatusEvent(
-                        substep_id=runner.substep_id,
-                        status="started",
-                        created_at=utc_timestamp(started_dt),
-                        message=f"Started {runner.title}",
-                        metadata=dict(metadata or {}),
-                    )
+                event = Stage1StatusEvent(
+                    substep_id=runner.substep_id,
+                    status="started",
+                    created_at=utc_timestamp(started_dt),
+                    message=f"Started {runner.title}",
+                    metadata=dict(metadata or {}),
                 )
+                self.status_events.append(event)
             elif started_dt < state.started_dt:
                 state.started_dt = started_dt
             state.metadata.update(dict(metadata or {}))
+        if event is not None and self.status_recorder is not None:
+            self.status_recorder.record_event(event)
 
     def _record_aggregate_skip(
         self,
@@ -418,23 +431,27 @@ class Stage1Coordinator:
         )
 
     def _record(self, result: DatasetSubstepResult) -> None:
+        event = Stage1StatusEvent(
+            substep_id=result.substep_id,
+            status=result.status,
+            created_at=result.completed_at,
+            message=f"{result.title}: {result.status}",
+            metadata=dict(result.metadata),
+        )
         with self._lock:
             self.results.append(result)
-            self.status_events.append(
-                Stage1StatusEvent(
-                    substep_id=result.substep_id,
-                    status=result.status,
-                    created_at=result.completed_at,
-                    message=f"{result.title}: {result.status}",
-                    metadata=dict(result.metadata),
-                )
-            )
+            self.status_events.append(event)
             if result.error is not None:
                 self.error_records.append(result.error)
+        if self.status_recorder is not None:
+            self.status_recorder.record_result(result)
+            self.status_recorder.record_event(event)
 
     def _record_event(self, event: Stage1StatusEvent) -> None:
         with self._lock:
             self.status_events.append(event)
+        if self.status_recorder is not None:
+            self.status_recorder.record_event(event)
 
 
 def stage_1_substep_id_for_script(script_path: str) -> str:
@@ -519,6 +536,7 @@ def _error_record_from_exception(
 __all__ = [
     "CommandBackedSubstepRunner",
     "Stage1Coordinator",
+    "Stage1StatusSink",
     "Stage1SubstepRunner",
     "stage_1_substep_id_for_script",
     "stage_1_substep_title",

--- a/policyengine_us_data/build_datasets/results.py
+++ b/policyengine_us_data/build_datasets/results.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from .status import Stage1ErrorRecord, Stage1SubstepStatus
 
@@ -26,6 +26,24 @@ class DatasetCommandResult:
     combined_output_tail: tuple[str, ...] = ()
     error: Stage1ErrorRecord | None = None
     metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "DatasetCommandResult":
+        """Build a command result from a JSON-compatible payload."""
+
+        error = _error_record_from_payload(data.get("error"))
+        return cls(
+            command_name=str(data["command_name"]),
+            argv=_string_tuple(data.get("argv", ())),
+            status=_command_execution_status(data["status"]),
+            returncode=_optional_int(data.get("returncode")),
+            started_at=str(data["started_at"]),
+            completed_at=str(data["completed_at"]),
+            duration_s=float(data["duration_s"]),
+            combined_output_tail=_string_tuple(data.get("combined_output_tail", ())),
+            error=error,
+            metadata=_metadata_mapping(data.get("metadata", {})),
+        )
 
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-compatible command result payload."""
@@ -60,6 +78,32 @@ class DatasetSubstepResult:
     error: Stage1ErrorRecord | None = None
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "DatasetSubstepResult":
+        """Build a substep result from a JSON-compatible payload."""
+
+        command_results = data.get("command_results", ())
+        if not isinstance(command_results, Sequence) or isinstance(
+            command_results, str
+        ):
+            raise TypeError("command_results must be a sequence")
+        return cls(
+            substep_id=str(data["substep_id"]),
+            title=str(data["title"]),
+            status=_stage_1_substep_status(data["status"]),
+            started_at=_optional_str(data.get("started_at")),
+            completed_at=str(data["completed_at"]),
+            duration_s=_optional_float(data.get("duration_s")),
+            command_names=_string_tuple(data.get("command_names", ())),
+            command_results=tuple(
+                DatasetCommandResult.from_dict(_mapping_payload(result))
+                for result in command_results
+            ),
+            artifact_paths=_string_tuple(data.get("artifact_paths", ())),
+            error=_error_record_from_payload(data.get("error")),
+            metadata=_metadata_mapping(data.get("metadata", {})),
+        )
+
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-compatible substep result payload."""
 
@@ -76,6 +120,54 @@ class DatasetSubstepResult:
             "error": self.error.to_dict() if self.error else None,
             "metadata": dict(self.metadata),
         }
+
+
+def _command_execution_status(value: Any) -> CommandExecutionStatus:
+    if value in ("completed", "failed"):
+        return cast(CommandExecutionStatus, value)
+    raise ValueError(f"Invalid command execution status: {value!r}")
+
+
+def _stage_1_substep_status(value: Any) -> Stage1SubstepStatus:
+    if value in ("started", "completed", "skipped", "failed"):
+        return cast(Stage1SubstepStatus, value)
+    raise ValueError(f"Invalid Stage 1 substep status: {value!r}")
+
+
+def _string_tuple(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, str):
+        raise TypeError("Expected a sequence")
+    return tuple(str(item) for item in value)
+
+
+def _mapping_payload(value: Any) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise TypeError("Expected a mapping")
+    return value
+
+
+def _metadata_mapping(value: Any) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise TypeError("metadata must be a mapping")
+    return dict(value)
+
+
+def _error_record_from_payload(value: Any) -> Stage1ErrorRecord | None:
+    if value is None:
+        return None
+    return Stage1ErrorRecord.from_dict(_mapping_payload(value))
+
+
+def _optional_str(value: Any) -> str | None:
+    return None if value is None else str(value)
+
+
+def _optional_int(value: Any) -> int | None:
+    return None if value is None else int(value)
+
+
+def _optional_float(value: Any) -> float | None:
+    return None if value is None else float(value)
 
 
 __all__ = [

--- a/policyengine_us_data/build_datasets/status.py
+++ b/policyengine_us_data/build_datasets/status.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 if TYPE_CHECKING:
     from modal_app.step_manifests.errors import PipelineErrorRecord
@@ -37,6 +37,19 @@ class Stage1StatusEvent:
     command_name: str | None = None
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "Stage1StatusEvent":
+        """Build a status event from a JSON-compatible payload."""
+
+        return cls(
+            substep_id=str(data["substep_id"]),
+            status=_stage_1_substep_status(data["status"]),
+            created_at=str(data["created_at"]),
+            message=_optional_str(data.get("message")),
+            command_name=_optional_str(data.get("command_name")),
+            metadata=_metadata_mapping(data.get("metadata", {})),
+        )
+
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-compatible status event payload."""
 
@@ -66,6 +79,20 @@ class Stage1ErrorRecord:
     returncode: int | None = None
     created_at: str = field(default_factory=utc_timestamp)
     metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "Stage1ErrorRecord":
+        """Build an error record from a JSON-compatible payload."""
+
+        return cls(
+            substep_id=_optional_str(data.get("substep_id")),
+            command_name=_optional_str(data.get("command_name")),
+            error_type=str(data["error_type"]),
+            message=str(data["message"]),
+            returncode=_optional_int(data.get("returncode")),
+            created_at=str(data.get("created_at") or utc_timestamp()),
+            metadata=_metadata_mapping(data.get("metadata", {})),
+        )
 
     @classmethod
     def from_exception(
@@ -157,6 +184,26 @@ def _pipeline_traceback_text(error: Stage1ErrorRecord) -> str:
     if not parts:
         parts.append(error.message)
     return "\n\n".join(parts)
+
+
+def _stage_1_substep_status(value: Any) -> Stage1SubstepStatus:
+    if value in ("started", "completed", "skipped", "failed"):
+        return cast(Stage1SubstepStatus, value)
+    raise ValueError(f"Invalid Stage 1 substep status: {value!r}")
+
+
+def _optional_str(value: Any) -> str | None:
+    return None if value is None else str(value)
+
+
+def _optional_int(value: Any) -> int | None:
+    return None if value is None else int(value)
+
+
+def _metadata_mapping(value: Any) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise TypeError("metadata must be a mapping")
+    return dict(value)
 
 
 __all__ = [

--- a/policyengine_us_data/build_datasets/status_store.py
+++ b/policyengine_us_data/build_datasets/status_store.py
@@ -1,0 +1,264 @@
+"""Durable Stage 1 status storage for pipeline status readers."""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .results import DatasetSubstepResult
+from .specs import STAGE_1_BUILD_STEP_SPECS
+from .status import Stage1StatusEvent
+
+
+STAGE_1_STATUS_DIRNAME = "stage_1"
+STAGE_1_STATUS_EVENTS_FILENAME = "status_events.jsonl"
+STAGE_1_SUBSTEP_RESULTS_FILENAME = "substep_results.jsonl"
+STAGE_1_CURRENT_SUBSTEP_FILENAME = "current_substep.json"
+DEFAULT_MAX_STAGE_1_STATUS_RECORDS = 500
+
+
+@dataclass(frozen=True, kw_only=True)
+class Stage1StatusSnapshot:
+    """A JSON-compatible snapshot of durable Stage 1 substep status."""
+
+    current: dict[str, Any] | None
+    events: tuple[dict[str, Any], ...]
+    results: tuple[dict[str, Any], ...]
+    read_errors: tuple[dict[str, str], ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the snapshot as the pipeline status endpoint payload."""
+
+        return {
+            "current": self.current,
+            "events": list(self.events),
+            "results": list(self.results),
+            "read_errors": list(self.read_errors),
+        }
+
+
+class Stage1StatusRecorder:
+    """Persist Stage 1 substep transitions into a run-scoped directory."""
+
+    def __init__(
+        self,
+        run_dir: str | Path,
+        *,
+        commit_callback: Callable[[], None] | None = None,
+        strict: bool = False,
+    ) -> None:
+        self.run_dir = Path(run_dir)
+        self.status_dir = self.run_dir / STAGE_1_STATUS_DIRNAME
+        self.commit_callback = commit_callback
+        self.strict = strict
+        self._lock = threading.Lock()
+
+    def record_event(self, event: Stage1StatusEvent) -> None:
+        """Persist one Stage 1 status event and mark it current."""
+
+        payload = _event_payload(event)
+
+        def write() -> None:
+            _append_jsonl(_status_events_path(self.run_dir), payload)
+            _write_json(_current_substep_path(self.run_dir), payload)
+
+        self._write_best_effort(write)
+
+    def record_result(self, result: DatasetSubstepResult) -> None:
+        """Persist one finalized Stage 1 substep result."""
+
+        self._write_best_effort(
+            lambda: _append_jsonl(_substep_results_path(self.run_dir), result.to_dict())
+        )
+
+    def _write_best_effort(self, write: Callable[[], None]) -> None:
+        with self._lock:
+            try:
+                self.status_dir.mkdir(parents=True, exist_ok=True)
+                write()
+                if self.commit_callback is not None:
+                    self.commit_callback()
+            except Exception as exc:
+                if self.strict:
+                    raise
+                print(f"Stage 1 status persistence failed: {type(exc).__name__}: {exc}")
+
+
+def empty_stage_1_status_snapshot() -> Stage1StatusSnapshot:
+    """Return an empty Stage 1 status snapshot."""
+
+    return Stage1StatusSnapshot(current=None, events=(), results=())
+
+
+def read_stage_1_status_snapshot(
+    run_dir: str | Path,
+    *,
+    max_records: int = DEFAULT_MAX_STAGE_1_STATUS_RECORDS,
+) -> Stage1StatusSnapshot:
+    """Read persisted Stage 1 status without failing the caller."""
+
+    run_dir = Path(run_dir)
+    read_errors: list[dict[str, str]] = []
+
+    current = _read_json_best_effort(
+        _current_substep_path(run_dir),
+        read_errors=read_errors,
+    )
+    events = _read_jsonl_best_effort(
+        _status_events_path(run_dir),
+        max_records=max_records,
+        read_errors=read_errors,
+    )
+    results = _read_jsonl_best_effort(
+        _substep_results_path(run_dir),
+        max_records=max_records,
+        read_errors=read_errors,
+    )
+
+    if current is None and events:
+        current = events[-1]
+
+    return Stage1StatusSnapshot(
+        current=current,
+        events=tuple(events),
+        results=tuple(results),
+        read_errors=tuple(read_errors),
+    )
+
+
+def _status_events_path(run_dir: Path) -> Path:
+    return run_dir / STAGE_1_STATUS_DIRNAME / STAGE_1_STATUS_EVENTS_FILENAME
+
+
+def _substep_results_path(run_dir: Path) -> Path:
+    return run_dir / STAGE_1_STATUS_DIRNAME / STAGE_1_SUBSTEP_RESULTS_FILENAME
+
+
+def _current_substep_path(run_dir: Path) -> Path:
+    return run_dir / STAGE_1_STATUS_DIRNAME / STAGE_1_CURRENT_SUBSTEP_FILENAME
+
+
+def _event_payload(event: Stage1StatusEvent) -> dict[str, Any]:
+    payload = event.to_dict()
+    payload["title"] = _stage_1_substep_title(event.substep_id)
+    return payload
+
+
+def _stage_1_substep_title(substep_id: str) -> str:
+    for spec in STAGE_1_BUILD_STEP_SPECS:
+        if spec.id == substep_id:
+            return spec.title
+    return substep_id
+
+
+def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as file:
+        file.write(json.dumps(payload, sort_keys=True, default=str) + "\n")
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, default=str) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _read_json_best_effort(
+    path: Path,
+    *,
+    read_errors: list[dict[str, str]],
+) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        _append_read_error(read_errors, path=path, exc=exc)
+        return None
+    if not isinstance(data, dict):
+        read_errors.append(
+            {
+                "path": str(path),
+                "error_type": "TypeError",
+                "message": "Expected JSON object.",
+            }
+        )
+        return None
+    return data
+
+
+def _read_jsonl_best_effort(
+    path: Path,
+    *,
+    max_records: int,
+    read_errors: list[dict[str, str]],
+) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except Exception as exc:
+        _append_read_error(read_errors, path=path, exc=exc)
+        return records
+    for line_number, line in enumerate(lines[-max_records:], start=1):
+        if not line.strip():
+            continue
+        try:
+            data = json.loads(line)
+        except Exception as exc:
+            read_errors.append(
+                {
+                    "path": str(path),
+                    "line": str(line_number),
+                    "error_type": type(exc).__name__,
+                    "message": str(exc),
+                }
+            )
+            continue
+        if isinstance(data, dict):
+            records.append(data)
+        else:
+            read_errors.append(
+                {
+                    "path": str(path),
+                    "line": str(line_number),
+                    "error_type": "TypeError",
+                    "message": "Expected JSON object.",
+                }
+            )
+    return records
+
+
+def _append_read_error(
+    read_errors: list[dict[str, str]],
+    *,
+    path: Path,
+    exc: BaseException,
+) -> None:
+    read_errors.append(
+        {
+            "path": str(path),
+            "error_type": type(exc).__name__,
+            "message": str(exc),
+        }
+    )
+
+
+__all__ = [
+    "DEFAULT_MAX_STAGE_1_STATUS_RECORDS",
+    "STAGE_1_CURRENT_SUBSTEP_FILENAME",
+    "STAGE_1_STATUS_DIRNAME",
+    "STAGE_1_STATUS_EVENTS_FILENAME",
+    "STAGE_1_SUBSTEP_RESULTS_FILENAME",
+    "Stage1StatusRecorder",
+    "Stage1StatusSnapshot",
+    "empty_stage_1_status_snapshot",
+    "read_stage_1_status_snapshot",
+]

--- a/policyengine_us_data/build_datasets/status_store.py
+++ b/policyengine_us_data/build_datasets/status_store.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 import json
 import threading
-from collections.abc import Callable
-from dataclasses import dataclass
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeVar
 
 from .results import DatasetSubstepResult
 from .specs import STAGE_1_BUILD_STEP_SPECS
-from .status import Stage1StatusEvent
+from .status import Stage1StatusEvent, Stage1SubstepStatus
 
 
 STAGE_1_STATUS_DIRNAME = "stage_1"
@@ -19,25 +19,103 @@ STAGE_1_STATUS_EVENTS_FILENAME = "status_events.jsonl"
 STAGE_1_SUBSTEP_RESULTS_FILENAME = "substep_results.jsonl"
 STAGE_1_CURRENT_SUBSTEP_FILENAME = "current_substep.json"
 DEFAULT_MAX_STAGE_1_STATUS_RECORDS = 500
+_T = TypeVar("_T")
+
+
+@dataclass(frozen=True, kw_only=True)
+class Stage1StoredStatusEvent:
+    """Durable status event record with display metadata for readers."""
+
+    substep_id: str
+    title: str
+    status: Stage1SubstepStatus
+    created_at: str
+    message: str | None = None
+    command_name: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_event(cls, event: Stage1StatusEvent) -> "Stage1StoredStatusEvent":
+        """Add the canonical title to an in-memory Stage 1 status event."""
+
+        return cls(
+            substep_id=event.substep_id,
+            title=_stage_1_substep_title(event.substep_id),
+            status=event.status,
+            created_at=event.created_at,
+            message=event.message,
+            command_name=event.command_name,
+            metadata=dict(event.metadata),
+        )
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "Stage1StoredStatusEvent":
+        """Build a stored status event from a JSON-compatible payload."""
+
+        event = Stage1StatusEvent.from_dict(data)
+        return cls(
+            substep_id=event.substep_id,
+            title=str(data.get("title") or _stage_1_substep_title(event.substep_id)),
+            status=event.status,
+            created_at=event.created_at,
+            message=event.message,
+            command_name=event.command_name,
+            metadata=dict(event.metadata),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the event as the pipeline status endpoint payload."""
+
+        return {
+            "substep_id": self.substep_id,
+            "status": self.status,
+            "created_at": self.created_at,
+            "message": self.message,
+            "command_name": self.command_name,
+            "metadata": dict(self.metadata or {}),
+            "title": self.title,
+        }
+
+
+@dataclass(frozen=True, kw_only=True)
+class Stage1StatusReadError:
+    """A non-fatal read error from durable Stage 1 status files."""
+
+    path: str
+    error_type: str
+    message: str
+    line: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible read error payload."""
+
+        payload: dict[str, Any] = {
+            "path": self.path,
+            "error_type": self.error_type,
+            "message": self.message,
+        }
+        if self.line is not None:
+            payload["line"] = self.line
+        return payload
 
 
 @dataclass(frozen=True, kw_only=True)
 class Stage1StatusSnapshot:
     """A JSON-compatible snapshot of durable Stage 1 substep status."""
 
-    current: dict[str, Any] | None
-    events: tuple[dict[str, Any], ...]
-    results: tuple[dict[str, Any], ...]
-    read_errors: tuple[dict[str, str], ...] = ()
+    current: Stage1StoredStatusEvent | None
+    events: tuple[Stage1StoredStatusEvent, ...]
+    results: tuple[DatasetSubstepResult, ...]
+    read_errors: tuple[Stage1StatusReadError, ...] = ()
 
     def to_dict(self) -> dict[str, Any]:
         """Return the snapshot as the pipeline status endpoint payload."""
 
         return {
-            "current": self.current,
-            "events": list(self.events),
-            "results": list(self.results),
-            "read_errors": list(self.read_errors),
+            "current": self.current.to_dict() if self.current else None,
+            "events": [event.to_dict() for event in self.events],
+            "results": [result.to_dict() for result in self.results],
+            "read_errors": [error.to_dict() for error in self.read_errors],
         }
 
 
@@ -60,7 +138,7 @@ class Stage1StatusRecorder:
     def record_event(self, event: Stage1StatusEvent) -> None:
         """Persist one Stage 1 status event and mark it current."""
 
-        payload = _event_payload(event)
+        payload = Stage1StoredStatusEvent.from_event(event).to_dict()
 
         def write() -> None:
             _append_jsonl(_status_events_path(self.run_dir), payload)
@@ -102,19 +180,22 @@ def read_stage_1_status_snapshot(
     """Read persisted Stage 1 status without failing the caller."""
 
     run_dir = Path(run_dir)
-    read_errors: list[dict[str, str]] = []
+    read_errors: list[Stage1StatusReadError] = []
 
     current = _read_json_best_effort(
         _current_substep_path(run_dir),
+        parser=Stage1StoredStatusEvent.from_dict,
         read_errors=read_errors,
     )
     events = _read_jsonl_best_effort(
         _status_events_path(run_dir),
+        parser=Stage1StoredStatusEvent.from_dict,
         max_records=max_records,
         read_errors=read_errors,
     )
     results = _read_jsonl_best_effort(
         _substep_results_path(run_dir),
+        parser=DatasetSubstepResult.from_dict,
         max_records=max_records,
         read_errors=read_errors,
     )
@@ -142,12 +223,6 @@ def _current_substep_path(run_dir: Path) -> Path:
     return run_dir / STAGE_1_STATUS_DIRNAME / STAGE_1_CURRENT_SUBSTEP_FILENAME
 
 
-def _event_payload(event: Stage1StatusEvent) -> dict[str, Any]:
-    payload = event.to_dict()
-    payload["title"] = _stage_1_substep_title(event.substep_id)
-    return payload
-
-
 def _stage_1_substep_title(substep_id: str) -> str:
     for spec in STAGE_1_BUILD_STEP_SPECS:
         if spec.id == substep_id:
@@ -172,8 +247,9 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
 def _read_json_best_effort(
     path: Path,
     *,
-    read_errors: list[dict[str, str]],
-) -> dict[str, Any] | None:
+    parser: Callable[[Mapping[str, Any]], _T],
+    read_errors: list[Stage1StatusReadError],
+) -> _T | None:
     if not path.exists():
         return None
     try:
@@ -183,25 +259,30 @@ def _read_json_best_effort(
         return None
     if not isinstance(data, dict):
         read_errors.append(
-            {
-                "path": str(path),
-                "error_type": "TypeError",
-                "message": "Expected JSON object.",
-            }
+            Stage1StatusReadError(
+                path=str(path),
+                error_type="TypeError",
+                message="Expected JSON object.",
+            )
         )
         return None
-    return data
+    try:
+        return parser(data)
+    except Exception as exc:
+        _append_read_error(read_errors, path=path, exc=exc)
+        return None
 
 
 def _read_jsonl_best_effort(
     path: Path,
     *,
+    parser: Callable[[Mapping[str, Any]], _T],
     max_records: int,
-    read_errors: list[dict[str, str]],
-) -> list[dict[str, Any]]:
+    read_errors: list[Stage1StatusReadError],
+) -> list[_T]:
     if not path.exists():
         return []
-    records: list[dict[str, Any]] = []
+    records: list[_T] = []
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
     except Exception as exc:
@@ -214,40 +295,50 @@ def _read_jsonl_best_effort(
             data = json.loads(line)
         except Exception as exc:
             read_errors.append(
-                {
-                    "path": str(path),
-                    "line": str(line_number),
-                    "error_type": type(exc).__name__,
-                    "message": str(exc),
-                }
+                Stage1StatusReadError(
+                    path=str(path),
+                    line=line_number,
+                    error_type=type(exc).__name__,
+                    message=str(exc),
+                )
             )
             continue
         if isinstance(data, dict):
-            records.append(data)
+            try:
+                records.append(parser(data))
+            except Exception as exc:
+                read_errors.append(
+                    Stage1StatusReadError(
+                        path=str(path),
+                        line=line_number,
+                        error_type=type(exc).__name__,
+                        message=str(exc),
+                    )
+                )
         else:
             read_errors.append(
-                {
-                    "path": str(path),
-                    "line": str(line_number),
-                    "error_type": "TypeError",
-                    "message": "Expected JSON object.",
-                }
+                Stage1StatusReadError(
+                    path=str(path),
+                    line=line_number,
+                    error_type="TypeError",
+                    message="Expected JSON object.",
+                )
             )
     return records
 
 
 def _append_read_error(
-    read_errors: list[dict[str, str]],
+    read_errors: list[Stage1StatusReadError],
     *,
     path: Path,
     exc: BaseException,
 ) -> None:
     read_errors.append(
-        {
-            "path": str(path),
-            "error_type": type(exc).__name__,
-            "message": str(exc),
-        }
+        Stage1StatusReadError(
+            path=str(path),
+            error_type=type(exc).__name__,
+            message=str(exc),
+        )
     )
 
 
@@ -258,7 +349,9 @@ __all__ = [
     "STAGE_1_STATUS_EVENTS_FILENAME",
     "STAGE_1_SUBSTEP_RESULTS_FILENAME",
     "Stage1StatusRecorder",
+    "Stage1StatusReadError",
     "Stage1StatusSnapshot",
+    "Stage1StoredStatusEvent",
     "empty_stage_1_status_snapshot",
     "read_stage_1_status_snapshot",
 ]

--- a/tests/unit/test_build_dataset_status_store.py
+++ b/tests/unit/test_build_dataset_status_store.py
@@ -37,7 +37,8 @@ def test_stage_1_status_recorder_persists_events_results_and_current(tmp_path):
     snapshot = read_stage_1_status_snapshot(tmp_path / "runs" / "run-1")
 
     assert commits == ["commit", "commit"]
-    assert snapshot.current == {
+    assert snapshot.current is not None
+    assert snapshot.current.to_dict() == {
         "substep_id": "1c_extended_cps_puf_clone",
         "status": "started",
         "created_at": "2026-05-22T12:00:00Z",
@@ -47,8 +48,8 @@ def test_stage_1_status_recorder_persists_events_results_and_current(tmp_path):
         "title": "Extended CPS PUF clone",
     }
     assert snapshot.events == (snapshot.current,)
-    assert snapshot.results[0]["substep_id"] == "1c_extended_cps_puf_clone"
-    assert snapshot.results[0]["status"] == "completed"
+    assert snapshot.results[0].substep_id == "1c_extended_cps_puf_clone"
+    assert snapshot.results[0].status == "completed"
 
 
 def test_stage_1_status_recorder_is_best_effort_by_default(tmp_path):
@@ -70,7 +71,8 @@ def test_stage_1_status_recorder_is_best_effort_by_default(tmp_path):
 
     snapshot = read_stage_1_status_snapshot(tmp_path / "runs" / "run-1")
 
-    assert snapshot.current["substep_id"] == "1a_raw_data_download"
+    assert snapshot.current is not None
+    assert snapshot.current.substep_id == "1a_raw_data_download"
 
 
 def test_read_stage_1_status_snapshot_survives_malformed_records(tmp_path):
@@ -92,9 +94,10 @@ def test_read_stage_1_status_snapshot_survives_malformed_records(tmp_path):
 
     snapshot = read_stage_1_status_snapshot(run_dir)
 
-    assert snapshot.current["substep_id"] == "1a_raw_data_download"
+    assert snapshot.current is not None
+    assert snapshot.current.substep_id == "1a_raw_data_download"
     assert len(snapshot.events) == 1
-    assert [error["error_type"] for error in snapshot.read_errors] == [
+    assert [error.error_type for error in snapshot.read_errors] == [
         "TypeError",
         "JSONDecodeError",
     ]
@@ -113,12 +116,13 @@ def test_stage_1_coordinator_writes_to_status_recorder(tmp_path):
 
     snapshot = read_stage_1_status_snapshot(tmp_path / "runs" / "run-1")
 
-    assert [event["status"] for event in snapshot.events] == [
+    assert [event.status for event in snapshot.events] == [
         "started",
         "completed",
     ]
-    assert snapshot.current["status"] == "completed"
-    assert snapshot.results[0]["substep_id"] == "1b_base_dataset_construction"
+    assert snapshot.current is not None
+    assert snapshot.current.status == "completed"
+    assert snapshot.results[0].substep_id == "1b_base_dataset_construction"
 
 
 def test_stage_1_coordinator_writes_aggregated_status_on_finalize(tmp_path):
@@ -137,9 +141,9 @@ def test_stage_1_coordinator_writes_aggregated_status_on_finalize(tmp_path):
     coordinator.finalize_results()
     after_finalize = read_stage_1_status_snapshot(tmp_path / "runs" / "run-1")
 
-    assert [event["status"] for event in before_finalize.events] == ["started"]
-    assert [event["status"] for event in after_finalize.events] == [
+    assert [event.status for event in before_finalize.events] == ["started"]
+    assert [event.status for event in after_finalize.events] == [
         "started",
         "completed",
     ]
-    assert after_finalize.results[0]["substep_id"] == "1e_stratified_cps"
+    assert after_finalize.results[0].substep_id == "1e_stratified_cps"

--- a/tests/unit/test_build_dataset_status_store.py
+++ b/tests/unit/test_build_dataset_status_store.py
@@ -1,0 +1,145 @@
+import json
+
+from policyengine_us_data.build_datasets import (
+    DatasetSubstepResult,
+    Stage1Coordinator,
+    Stage1StatusEvent,
+    Stage1StatusRecorder,
+    read_stage_1_status_snapshot,
+)
+
+
+def test_stage_1_status_recorder_persists_events_results_and_current(tmp_path):
+    commits = []
+    recorder = Stage1StatusRecorder(
+        tmp_path / "runs" / "run-1",
+        commit_callback=lambda: commits.append("commit"),
+    )
+    event = Stage1StatusEvent(
+        substep_id="1c_extended_cps_puf_clone",
+        status="started",
+        created_at="2026-05-22T12:00:00Z",
+        message="Started Extended CPS PUF clone",
+    )
+    result = DatasetSubstepResult(
+        substep_id="1c_extended_cps_puf_clone",
+        title="Extended CPS PUF clone",
+        status="completed",
+        started_at="2026-05-22T12:00:00Z",
+        completed_at="2026-05-22T12:05:00Z",
+        duration_s=300.0,
+        command_names=("extended-cps",),
+    )
+
+    recorder.record_event(event)
+    recorder.record_result(result)
+
+    snapshot = read_stage_1_status_snapshot(tmp_path / "runs" / "run-1")
+
+    assert commits == ["commit", "commit"]
+    assert snapshot.current == {
+        "substep_id": "1c_extended_cps_puf_clone",
+        "status": "started",
+        "created_at": "2026-05-22T12:00:00Z",
+        "message": "Started Extended CPS PUF clone",
+        "command_name": None,
+        "metadata": {},
+        "title": "Extended CPS PUF clone",
+    }
+    assert snapshot.events == (snapshot.current,)
+    assert snapshot.results[0]["substep_id"] == "1c_extended_cps_puf_clone"
+    assert snapshot.results[0]["status"] == "completed"
+
+
+def test_stage_1_status_recorder_is_best_effort_by_default(tmp_path):
+    def fail_commit():
+        raise RuntimeError("volume unavailable")
+
+    recorder = Stage1StatusRecorder(
+        tmp_path / "runs" / "run-1",
+        commit_callback=fail_commit,
+    )
+
+    recorder.record_event(
+        Stage1StatusEvent(
+            substep_id="1a_raw_data_download",
+            status="started",
+            created_at="2026-05-22T12:00:00Z",
+        )
+    )
+
+    snapshot = read_stage_1_status_snapshot(tmp_path / "runs" / "run-1")
+
+    assert snapshot.current["substep_id"] == "1a_raw_data_download"
+
+
+def test_read_stage_1_status_snapshot_survives_malformed_records(tmp_path):
+    run_dir = tmp_path / "runs" / "run-1"
+    status_dir = run_dir / "stage_1"
+    status_dir.mkdir(parents=True)
+    (status_dir / "current_substep.json").write_text("[]\n")
+    (status_dir / "status_events.jsonl").write_text(
+        json.dumps(
+            {
+                "substep_id": "1a_raw_data_download",
+                "status": "started",
+                "created_at": "2026-05-22T12:00:00Z",
+                "title": "Raw data download",
+            }
+        )
+        + "\n{not-json\n"
+    )
+
+    snapshot = read_stage_1_status_snapshot(run_dir)
+
+    assert snapshot.current["substep_id"] == "1a_raw_data_download"
+    assert len(snapshot.events) == 1
+    assert [error["error_type"] for error in snapshot.read_errors] == [
+        "TypeError",
+        "JSONDecodeError",
+    ]
+
+
+def test_stage_1_coordinator_writes_to_status_recorder(tmp_path):
+    recorder = Stage1StatusRecorder(tmp_path / "runs" / "run-1")
+    coordinator = Stage1Coordinator(status_recorder=recorder)
+
+    coordinator.run_substep(
+        "1b_base_dataset_construction",
+        "Base dataset construction",
+        lambda: "done",
+        command_names=("build-cps",),
+    )
+
+    snapshot = read_stage_1_status_snapshot(tmp_path / "runs" / "run-1")
+
+    assert [event["status"] for event in snapshot.events] == [
+        "started",
+        "completed",
+    ]
+    assert snapshot.current["status"] == "completed"
+    assert snapshot.results[0]["substep_id"] == "1b_base_dataset_construction"
+
+
+def test_stage_1_coordinator_writes_aggregated_status_on_finalize(tmp_path):
+    recorder = Stage1StatusRecorder(tmp_path / "runs" / "run-1")
+    coordinator = Stage1Coordinator(status_recorder=recorder)
+
+    coordinator.run_substep(
+        "1e_stratified_cps",
+        "Stratified CPS",
+        lambda: "done",
+        command_names=("stratified-cps",),
+        aggregate=True,
+    )
+    before_finalize = read_stage_1_status_snapshot(tmp_path / "runs" / "run-1")
+
+    coordinator.finalize_results()
+    after_finalize = read_stage_1_status_snapshot(tmp_path / "runs" / "run-1")
+
+    assert [event["status"] for event in before_finalize.events] == ["started"]
+    assert [event["status"] for event in after_finalize.events] == [
+        "started",
+        "completed",
+    ]
+    assert after_finalize.results[0]["substep_id"] == "1e_stratified_cps"

--- a/tests/unit/test_modal_data_build.py
+++ b/tests/unit/test_modal_data_build.py
@@ -75,6 +75,7 @@ def test_build_datasets_records_stage_base_handoff_substep(tmp_path, monkeypatch
     data_build = _load_data_build_module()
     calls = []
     command_envs = []
+    created_coordinators = []
 
     class FakeVolume:
         def reload(self):
@@ -84,6 +85,11 @@ def test_build_datasets_records_stage_base_handoff_substep(tmp_path, monkeypatch
             pass
 
     class FakeCoordinator:
+        def __init__(self):
+            self.status_recorder = None
+            created_coordinators.append(self)
+            calls.append(("coordinator_created", {}))
+
         def run_substep(self, substep_id, title, action, **kwargs):
             calls.append((substep_id, kwargs))
             return action()
@@ -153,10 +159,12 @@ def test_build_datasets_records_stage_base_handoff_substep(tmp_path, monkeypatch
     )
 
     assert [call[0] for call in calls] == [
+        "coordinator_created",
         "1a_raw_data_download",
         "finalize",
         "1g_stage_base_datasets",
     ]
+    assert created_coordinators[0].status_recorder is not None
     stage_base_kwargs = calls[-1][1]
     assert stage_base_kwargs["command_names"] == ("stage_base_datasets",)
     assert any(

--- a/tests/unit/test_pipeline_status.py
+++ b/tests/unit/test_pipeline_status.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from policyengine_us_data.build_datasets import Stage1StatusEvent, Stage1StatusRecorder
 from modal_app.step_manifests.errors import (
     PipelineErrorRecord,
     build_pipeline_error_record,
@@ -266,6 +267,108 @@ def test_status_payload_orders_manifests_and_includes_bounded_traceback(
     assert payload["error"]["traceback_truncated"] is False
     assert "secret-value" not in payload["run_manifest"]["error"]
     assert payload["pipeline_volume_name"] == "pipeline-artifacts-run-1"
+
+
+def test_status_payload_reports_stage_1_current_substep(tmp_path):
+    runs_dir = tmp_path / "runs"
+    run_dir = runs_dir / "run-1"
+    write_run_manifest(
+        run_manifest_path(run_dir),
+        RunManifest(
+            run_id="run-1",
+            branch="main",
+            sha="abc123",
+            version="1.0.0",
+            status="running",
+            started_at="2026-05-12T12:00:00+00:00",
+            known_step_ids=[BUILD_DATASETS.id],
+        ),
+    )
+    write_step_manifest(
+        step_manifest_path(run_dir, BUILD_DATASETS.id),
+        _manifest(BUILD_DATASETS.id),
+    )
+    Stage1StatusRecorder(run_dir).record_event(
+        Stage1StatusEvent(
+            substep_id="1c_extended_cps_puf_clone",
+            status="started",
+            created_at="2026-05-12T12:01:00+00:00",
+            message="Started Extended CPS PUF clone",
+        )
+    )
+
+    payload = build_pipeline_status_payload("run-1", runs_dir=runs_dir)
+
+    assert payload["stage_1_status"]["current"]["substep_id"] == (
+        "1c_extended_cps_puf_clone"
+    )
+    assert payload["stage_1_status"]["current"]["title"] == "Extended CPS PUF clone"
+    assert payload["message"] == (
+        "Pipeline running; current Stage 1 substep "
+        "1c_extended_cps_puf_clone (Extended CPS PUF clone) is started."
+    )
+
+
+def test_runs_payload_includes_stage_1_current_substep(tmp_path):
+    runs_dir = tmp_path / "runs"
+    run_dir = runs_dir / "run-1"
+    write_run_manifest(
+        run_manifest_path(run_dir),
+        RunManifest(
+            run_id="run-1",
+            branch="main",
+            sha="abc123",
+            version="1.0.0",
+            status="running",
+            started_at="2026-05-12T12:00:00+00:00",
+            known_step_ids=[BUILD_DATASETS.id],
+        ),
+    )
+    write_step_manifest(
+        step_manifest_path(run_dir, BUILD_DATASETS.id),
+        _manifest(BUILD_DATASETS.id),
+    )
+    Stage1StatusRecorder(run_dir).record_event(
+        Stage1StatusEvent(
+            substep_id="1a_raw_data_download",
+            status="started",
+            created_at="2026-05-12T12:01:00+00:00",
+        )
+    )
+
+    payload = build_pipeline_runs_payload(runs_dir=runs_dir)
+
+    assert payload["runs"][0]["stage_1_current"]["substep_id"] == (
+        "1a_raw_data_download"
+    )
+
+
+def test_status_payload_survives_unreadable_stage_1_status(tmp_path):
+    runs_dir = tmp_path / "runs"
+    run_dir = runs_dir / "run-1"
+    write_run_manifest(
+        run_manifest_path(run_dir),
+        RunManifest(
+            run_id="run-1",
+            branch="main",
+            sha="abc123",
+            version="1.0.0",
+            status="running",
+            started_at="2026-05-12T12:00:00+00:00",
+            known_step_ids=[BUILD_DATASETS.id],
+        ),
+    )
+    status_dir = run_dir / "stage_1"
+    status_dir.mkdir(parents=True)
+    (status_dir / "current_substep.json").write_text("{not-json")
+
+    payload = build_pipeline_status_payload("run-1", runs_dir=runs_dir)
+
+    assert payload["status"] == "running"
+    assert payload["stage_1_status"]["current"] is None
+    assert payload["stage_1_status"]["read_errors"][0]["error_type"] == (
+        "JSONDecodeError"
+    )
 
 
 def test_status_payload_uses_run_manifest_error_as_last_resort(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes #1114

## Summary

- Persist Stage 1 substep status events, finalized substep results, and the current Stage 1 substep under each run directory.
- Wire `build_datasets` to attach the recorder when a run ID is present, committing status updates to the pipeline volume as they are written.
- Expose `stage_1_status` in detailed pipeline status payloads and `stage_1_current` in pipeline run indexes.

## Testing

- `make lint`
- `uv run --no-sync ruff check modal_app/data_build.py modal_app/step_manifests/status.py policyengine_us_data/build_datasets/__init__.py policyengine_us_data/build_datasets/coordinator.py policyengine_us_data/build_datasets/status_store.py tests/unit/test_build_dataset_status_store.py tests/unit/test_pipeline_status.py tests/unit/test_modal_data_build.py`
- `uv run --no-sync pytest tests/unit/test_build_dataset_status_store.py tests/unit/test_pipeline_status.py tests/unit/test_modal_data_build.py -q`
- `uv run --no-sync --with pyyaml python scripts/run_quality_guards.py`

Note: full `uv run --no-sync ruff check .` is currently blocked by pre-existing unrelated lint failures outside this change set.