### PR TITLE
Default eCPS reweighting to zero L0 penalty

### DIFF
--- a/changelog.d/zero-ecps-l0.changed.md
+++ b/changelog.d/zero-ecps-l0.changed.md
@@ -1,0 +1,1 @@
+Default enhanced CPS reweighting to no L0 sparsity penalty while preserving the configurable penalty for large calibration runs.

--- a/policyengine_us_data/datasets/cps/enhanced_cps.py
+++ b/policyengine_us_data/datasets/cps/enhanced_cps.py
@@ -490,7 +490,7 @@ def reweight(
     targets_array,
     log_path="calibration_log.csv",
     epochs=500,
-    l0_lambda=2.6445e-07,
+    l0_lambda=0.0,
     init_mean=0.999,  # initial proportion with non-zero weights
     temperature=0.25,
     seed=1456,
@@ -534,7 +534,7 @@ def reweight(
         return rel_error_normalized.mean()
 
     logging.info(
-        f"Sparse optimization using seed {seed}, temp {temperature} "
+        f"Hard-concrete optimization using seed {seed}, temp {temperature} "
         + f"init_mean {init_mean}, l0_lambda {l0_lambda}"
     )
     set_seeds(seed)
@@ -600,7 +600,7 @@ def reweight(
         final_weights_sparse,
         loss_matrix,
         targets_array,
-        "L0 Sparse Solution",
+        "L0 Sparse Solution" if l0_lambda else "Unpenalized HardConcrete Solution",
         target_names=target_names,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us==1.705.1",
+    "policyengine-us==1.705.15",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/tests/unit/test_enhanced_cps.py
+++ b/tests/unit/test_enhanced_cps.py
@@ -1,3 +1,5 @@
+import inspect
+
 import numpy as np
 
 from policyengine_us_data.datasets.cps import enhanced_cps
@@ -7,6 +9,12 @@ from policyengine_us_data.datasets.cps.enhanced_cps import (
     _set_period_array,
     create_aca_2025_takeup_override,
 )
+
+
+def test_reweight_default_does_not_penalize_l0():
+    signature = inspect.signature(enhanced_cps.reweight)
+
+    assert signature.parameters["l0_lambda"].default == 0.0
 
 
 def test_get_base_aca_takeup_uses_stored_values():

--- a/uv.lock
+++ b/uv.lock
@@ -2122,7 +2122,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.705.1"
+version = "1.705.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2132,9 +2132,9 @@ dependencies = [
     { name = "tables" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/a1/1f5fac9080680f490fc8c0222e1206585fa573928c6e5a76dc11b772e3cc/policyengine_us-1.705.1.tar.gz", hash = "sha256:4467ff3c74b468593a38a65854c037a5650552abb5cb0fb3aab248d47a5b1f99", size = 9910341, upload-time = "2026-05-22T18:34:58.827Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/cc/921f994e5c688be0f45dbe8d7bce209ee45225d328a9724cf363df225ce8/policyengine_us-1.705.15.tar.gz", hash = "sha256:559d79690cb1d79615479ed2c71a53510e8cfea56d2398a37120f6797548c26b", size = 9927111, upload-time = "2026-05-24T02:32:30.769Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/1d/71653e73a243ffb6e74463403b2a198cdea9ce9fa2dab8038d99ad70991b/policyengine_us-1.705.1-py3-none-any.whl", hash = "sha256:9db5121748d62961cb4867f18dab03da1be9abc986676e12e147e19afc6fd6aa", size = 10735178, upload-time = "2026-05-22T18:34:55.376Z" },
+    { url = "https://files.pythonhosted.org/packages/24/02/b8ae7ec50124bc4f442c8e3f662bf02d0f670d288c63e367dff75ed8c374/policyengine_us-1.705.15-py3-none-any.whl", hash = "sha256:aeafbbbef2a8de88cb73da8c234943784789023e7d32e05a9560e1a7dd713c70", size = 10758474, upload-time = "2026-05-24T02:32:26.588Z" },
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", specifier = "==1.705.1" },
+    { name = "policyengine-us", specifier = "==1.705.15" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },


### PR DESCRIPTION
## Summary
- default standard enhanced CPS reweighting to no L0 sparsity penalty
- keep the L0 penalty parameter available for large local calibration runs that need sparsification
- update logging/diagnostics to avoid labeling the unpenalized default as sparse L0

## Tests
- uv run ruff check policyengine_us_data/datasets/cps/enhanced_cps.py tests/unit/test_enhanced_cps.py
- uv run pytest tests/unit/test_enhanced_cps.py -q