### PR TITLE
Export FLSA overtime premium proxy

### DIFF
--- a/.github/scripts/check_policyengine_us_dependency.py
+++ b/.github/scripts/check_policyengine_us_dependency.py
@@ -17,7 +17,9 @@ from urllib.request import urlopen
 REPO_ROOT = Path(__file__).resolve().parents[2]
 PYPI_JSON_TIMEOUT_SECONDS = 20
 POLICYENGINE_US = "policyengine-us"
+POLICYENGINE_US_GITHUB_REPO = "github.com/PolicyEngine/policyengine-us"
 STALE_LOCK_PREFIX = "uv.lock has policyengine-us "
+GIT_REF_PREFIX = "uv.lock resolves policyengine-us from a Git ref"
 
 
 def _annotation(level: str, message: str) -> str:
@@ -83,9 +85,39 @@ def _latest_pypi_version() -> str:
     return version
 
 
+def _is_policyengine_us_git_source(source: dict[str, object]) -> bool:
+    git_source = source.get("git")
+    return isinstance(git_source, str) and POLICYENGINE_US_GITHUB_REPO in git_source
+
+
+def _is_policyengine_us_git_dependency(dependency: str) -> bool:
+    return (
+        dependency.startswith(f"{POLICYENGINE_US} @ git+")
+        and POLICYENGINE_US_GITHUB_REPO in dependency
+        and re.search(r"@[0-9a-f]{40}$", dependency) is not None
+    )
+
+
+def _allows_temporary_git_ref(
+    locked_version: str,
+    source: dict[str, object],
+    project_dependency: str,
+    latest_version: str | None,
+) -> bool:
+    return (
+        latest_version is not None
+        and _compare_versions(locked_version, latest_version) > 0
+        and _is_policyengine_us_git_source(source)
+        and _is_policyengine_us_git_dependency(project_dependency)
+    )
+
+
 def check_dependency(root: Path, latest_version: str | None = None) -> list[str]:
     locked_version, source = _locked_policyengine_us(root)
     project_dependency = _project_policyengine_us_dependency(root)
+    git_ref_allowed = _allows_temporary_git_ref(
+        locked_version, source, project_dependency, latest_version
+    )
 
     violations: list[str] = []
     if (
@@ -99,19 +131,23 @@ def check_dependency(root: Path, latest_version: str | None = None) -> list[str]
         )
 
     expected_dependency = f"{POLICYENGINE_US}=={locked_version}"
-    if project_dependency != expected_dependency:
+    if project_dependency != expected_dependency and not git_ref_allowed:
         violations.append(
             f"pyproject.toml must pin {expected_dependency} to match uv.lock; "
             f"found {project_dependency!r}."
         )
 
-    if "git" in source:
+    if "git" in source and not git_ref_allowed:
         violations.append(
-            "uv.lock resolves policyengine-us from a Git ref. Prefer an exact "
+            f"{GIT_REF_PREFIX}. Prefer an exact "
             f"PyPI release pin once policyengine-us {locked_version} is published."
         )
 
-    if "@" in project_dependency and "git+" in project_dependency:
+    if (
+        "@" in project_dependency
+        and "git+" in project_dependency
+        and not git_ref_allowed
+    ):
         violations.append(
             "pyproject.toml pins policyengine-us to a Git ref. Prefer an exact "
             "PyPI release pin for production data builds."
@@ -159,8 +195,22 @@ def main() -> int:
         return 0
 
     if not violations:
-        locked_version, _source = _locked_policyengine_us(REPO_ROOT)
+        locked_version, source = _locked_policyengine_us(REPO_ROOT)
         print(f"policyengine-us dependency is current at {locked_version}.")
+        if _allows_temporary_git_ref(
+            locked_version,
+            source,
+            _project_policyengine_us_dependency(REPO_ROOT),
+            latest_version,
+        ):
+            print(
+                _annotation(
+                    "warning",
+                    f"policyengine-us {locked_version} is temporarily pinned to "
+                    "GitHub because it is newer than the latest PyPI release. "
+                    "Replace it with an exact PyPI release pin once published.",
+                )
+            )
         return 0
 
     has_blocking_violation = False

--- a/changelog.d/fsla-overtime-premium.added
+++ b/changelog.d/fsla-overtime-premium.added
@@ -1,0 +1,1 @@
+Export a data-backed FLSA overtime premium proxy from CPS and enhanced CPS.

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -1,4 +1,5 @@
 from contextlib import closing, contextmanager
+from functools import lru_cache
 from importlib.resources import files
 from policyengine_core.data import Dataset
 from policyengine_us_data.storage import STORAGE_FOLDER, DOCS_FOLDER
@@ -86,11 +87,6 @@ ACS_RENT_TARGET_ALLOCATION_COLUMNS = {
 FLSA_STANDARD_HOURS_PER_WEEK = np.float32(40)
 FLSA_OVERTIME_RATE_MULTIPLIER = np.float32(1.5)
 FLSA_WORKWEEKS_PER_YEAR = np.float32(52)
-FLSA_HCE_SALARY_THRESHOLD_2024 = np.float32(107_432)
-FLSA_SALARY_BASIS_THRESHOLD_ANNUAL_2024 = np.float32(684 * FLSA_WORKWEEKS_PER_YEAR)
-FLSA_COMPUTER_SALARY_THRESHOLD_ANNUAL_2024 = np.float32(
-    27.63 * FLSA_STANDARD_HOURS_PER_WEEK * FLSA_WORKWEEKS_PER_YEAR
-)
 FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES = np.array(
     [
         1,  # Chief executives, and managers
@@ -124,6 +120,32 @@ FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES = np.array(
     ],
     dtype=np.int16,
 )
+
+
+@lru_cache(maxsize=1)
+def _policyengine_us_parameters():
+    from policyengine_us import CountryTaxBenefitSystem
+
+    return CountryTaxBenefitSystem().parameters
+
+
+@lru_cache(maxsize=16)
+def _flsa_overtime_thresholds_for_year(
+    time_period: int,
+) -> tuple[np.float32, np.float32, np.float32]:
+    overtime = _policyengine_us_parameters()(
+        f"{int(time_period)}-01-01"
+    ).gov.irs.income.exemption.overtime
+    return (
+        np.float32(overtime.hce_salary_threshold),
+        np.float32(overtime.salary_basis_threshold * FLSA_WORKWEEKS_PER_YEAR),
+        np.float32(
+            overtime.computer_salary_threshold
+            * FLSA_STANDARD_HOURS_PER_WEEK
+            * FLSA_WORKWEEKS_PER_YEAR
+        ),
+    )
+
 
 CURRENT_HEALTH_COVERAGE_REPORTED_VAR_MAP = {
     "reported_has_direct_purchase_health_coverage_at_interview": "NOW_DIR",
@@ -346,7 +368,7 @@ class CPS(Dataset):
         logging.info("Adding tips")
         add_tips(self, cps)
         logging.info("Adding ORG labor-market inputs")
-        add_org_labor_market_inputs(cps)
+        add_org_labor_market_inputs(cps, self.time_period)
         logging.info("Adding auto loan balance, interest and wealth")
         add_auto_loan_interest_and_net_worth(self, cps)
         logging.info("Added all variables")
@@ -1234,6 +1256,7 @@ def derive_weeks_worked(weeks_worked: Series | np.ndarray) -> Series | np.ndarra
 
 def derive_flsa_overtime_premium(
     *,
+    time_period: int,
     employment_income: Series | np.ndarray,
     hours_worked_last_week: Series | np.ndarray,
     weeks_worked: Series | np.ndarray,
@@ -1287,25 +1310,25 @@ def derive_flsa_overtime_premium(
         where=straight_time_equivalent_hours > 0,
     )
 
+    (
+        hce_salary_threshold,
+        salary_basis_threshold,
+        computer_salary_threshold,
+    ) = _flsa_overtime_thresholds_for_year(time_period)
+
     salary_threshold = np.full_like(
         employment_income,
-        FLSA_HCE_SALARY_THRESHOLD_2024,
+        hce_salary_threshold,
         dtype=np.float32,
     )
     salary_threshold = np.where(
         is_computer_scientist,
-        min(
-            FLSA_COMPUTER_SALARY_THRESHOLD_ANNUAL_2024,
-            FLSA_HCE_SALARY_THRESHOLD_2024,
-        ),
+        min(computer_salary_threshold, hce_salary_threshold),
         salary_threshold,
     )
     salary_threshold = np.where(
         is_executive_administrative_professional | is_farmer_fisher,
-        min(
-            FLSA_SALARY_BASIS_THRESHOLD_ANNUAL_2024,
-            FLSA_HCE_SALARY_THRESHOLD_2024,
-        ),
+        min(salary_basis_threshold, hce_salary_threshold),
         salary_threshold,
     )
     always_exempt = has_never_worked | is_military
@@ -2964,7 +2987,7 @@ def add_tips(self, cps: h5py.File):
         validation_commands=["uv run pytest tests/unit/datasets/test_org.py"],
     )
 )
-def add_org_labor_market_inputs(cps: h5py.File) -> None:
+def add_org_labor_market_inputs(cps: h5py.File, time_period: int) -> None:
     """Impute ORG-derived labor-market inputs and derive overtime premium."""
     n_persons = len(np.asarray(cps["age"]))
     household_ids = np.asarray(cps["household_id"], dtype=np.int64)
@@ -3023,6 +3046,7 @@ def add_org_labor_market_inputs(cps: h5py.File) -> None:
             cps[variable] = values.astype(np.float32)
 
     cps["fsla_overtime_premium"] = derive_flsa_overtime_premium(
+        time_period=time_period,
         employment_income=cps["employment_income"],
         hours_worked_last_week=cps["hours_worked_last_week"],
         weeks_worked=cps["weeks_worked"],

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -83,6 +83,15 @@ ACS_RENT_TARGET_ALLOCATION_COLUMNS = {
     "real_estate_taxes": ["real_estate_taxes_is_allocated"],
 }
 
+FLSA_STANDARD_HOURS_PER_WEEK = np.float32(40)
+FLSA_OVERTIME_RATE_MULTIPLIER = np.float32(1.5)
+FLSA_WORKWEEKS_PER_YEAR = np.float32(52)
+FLSA_HCE_SALARY_THRESHOLD_2024 = np.float32(107_432)
+FLSA_SALARY_BASIS_THRESHOLD_ANNUAL_2024 = np.float32(684 * FLSA_WORKWEEKS_PER_YEAR)
+FLSA_COMPUTER_SALARY_THRESHOLD_ANNUAL_2024 = np.float32(
+    27.63 * FLSA_STANDARD_HOURS_PER_WEEK * FLSA_WORKWEEKS_PER_YEAR
+)
+
 CURRENT_HEALTH_COVERAGE_REPORTED_VAR_MAP = {
     "reported_has_direct_purchase_health_coverage_at_interview": "NOW_DIR",
     "reported_has_marketplace_health_coverage_at_interview": "NOW_MRK",
@@ -1188,6 +1197,94 @@ def add_personal_variables(cps: h5py.File, person: DataFrame) -> None:
 
 def derive_weeks_worked(weeks_worked: Series | np.ndarray) -> Series | np.ndarray:
     return np.clip(weeks_worked, 0, 52)
+
+
+def derive_flsa_overtime_premium(
+    *,
+    employment_income: Series | np.ndarray,
+    hours_worked_last_week: Series | np.ndarray,
+    weeks_worked: Series | np.ndarray,
+    is_paid_hourly: Series | np.ndarray,
+    has_never_worked: Series | np.ndarray,
+    is_military: Series | np.ndarray,
+    is_executive_administrative_professional: Series | np.ndarray,
+    is_farmer_fisher: Series | np.ndarray,
+    is_computer_scientist: Series | np.ndarray,
+) -> np.ndarray:
+    """Proxy annual FLSA overtime premium from CPS annual wages and hours.
+
+    CPS ASEC does not contain a week-by-week earnings history. This constructs
+    the premium share implied by the reported/reference week, then applies that
+    share to annual employment income for workers not screened as FLSA-exempt.
+    """
+    employment_income = np.maximum(
+        np.nan_to_num(np.asarray(employment_income, dtype=np.float32), nan=0),
+        0,
+    )
+    hours_worked_last_week = np.maximum(
+        np.nan_to_num(np.asarray(hours_worked_last_week, dtype=np.float32), nan=0),
+        0,
+    )
+    weeks_worked = np.maximum(
+        np.nan_to_num(np.asarray(weeks_worked, dtype=np.float32), nan=0),
+        0,
+    )
+    is_paid_hourly = np.asarray(is_paid_hourly, dtype=bool)
+    has_never_worked = np.asarray(has_never_worked, dtype=bool)
+    is_military = np.asarray(is_military, dtype=bool)
+    is_executive_administrative_professional = np.asarray(
+        is_executive_administrative_professional,
+        dtype=bool,
+    )
+    is_farmer_fisher = np.asarray(is_farmer_fisher, dtype=bool)
+    is_computer_scientist = np.asarray(is_computer_scientist, dtype=bool)
+
+    overtime_hours = np.maximum(
+        hours_worked_last_week - FLSA_STANDARD_HOURS_PER_WEEK,
+        0,
+    )
+    straight_time_equivalent_hours = (
+        np.minimum(hours_worked_last_week, FLSA_STANDARD_HOURS_PER_WEEK)
+        + overtime_hours * FLSA_OVERTIME_RATE_MULTIPLIER
+    )
+    premium_share = np.divide(
+        (FLSA_OVERTIME_RATE_MULTIPLIER - 1) * overtime_hours,
+        straight_time_equivalent_hours,
+        out=np.zeros_like(employment_income, dtype=np.float32),
+        where=straight_time_equivalent_hours > 0,
+    )
+
+    salary_threshold = np.full_like(
+        employment_income,
+        FLSA_HCE_SALARY_THRESHOLD_2024,
+        dtype=np.float32,
+    )
+    salary_threshold = np.where(
+        is_computer_scientist,
+        min(
+            FLSA_COMPUTER_SALARY_THRESHOLD_ANNUAL_2024,
+            FLSA_HCE_SALARY_THRESHOLD_2024,
+        ),
+        salary_threshold,
+    )
+    salary_threshold = np.where(
+        is_executive_administrative_professional | is_farmer_fisher,
+        min(
+            FLSA_SALARY_BASIS_THRESHOLD_ANNUAL_2024,
+            FLSA_HCE_SALARY_THRESHOLD_2024,
+        ),
+        salary_threshold,
+    )
+    salary_threshold = np.where(
+        has_never_worked | is_military,
+        0,
+        salary_threshold,
+    )
+
+    is_exempt = (employment_income >= salary_threshold) & ~is_paid_hourly
+    eligible = ~is_exempt & (weeks_worked > 0)
+    premium = np.where(eligible, employment_income * premium_share, 0)
+    return np.minimum(premium, employment_income).astype(np.float32)
 
 
 @pipeline_node(
@@ -2824,7 +2921,10 @@ def add_tips(self, cps: h5py.File):
         id="add_org_inputs",
         label="ORG Labor-Market Inputs",
         node_type="library",
-        description="Impute hourly wage, hourly-pay status, and union coverage from CPS ORG donors.",
+        description=(
+            "Impute hourly wage, hourly-pay status, and union coverage from CPS "
+            "ORG donors, then derive FLSA overtime premium."
+        ),
         source_file="policyengine_us_data/datasets/cps/cps.py",
         status="current",
         stability="moving",
@@ -2833,7 +2933,7 @@ def add_tips(self, cps: h5py.File):
     )
 )
 def add_org_labor_market_inputs(cps: h5py.File) -> None:
-    """Impute ORG-derived wage and union inputs onto CPS persons."""
+    """Impute ORG-derived labor-market inputs and derive overtime premium."""
     n_persons = len(np.asarray(cps["age"]))
     household_ids = np.asarray(cps["household_id"], dtype=np.int64)
     person_household_ids = np.asarray(
@@ -2889,6 +2989,20 @@ def add_org_labor_market_inputs(cps: h5py.File) -> None:
             cps[variable] = values.astype(bool)
         else:
             cps[variable] = values.astype(np.float32)
+
+    cps["fsla_overtime_premium"] = derive_flsa_overtime_premium(
+        employment_income=cps["employment_income"],
+        hours_worked_last_week=cps["hours_worked_last_week"],
+        weeks_worked=cps["weeks_worked"],
+        is_paid_hourly=cps["is_paid_hourly"],
+        has_never_worked=cps["has_never_worked"],
+        is_military=cps["is_military"],
+        is_executive_administrative_professional=cps[
+            "is_executive_administrative_professional"
+        ],
+        is_farmer_fisher=cps["is_farmer_fisher"],
+        is_computer_scientist=cps["is_computer_scientist"],
+    )
 
 
 def add_overtime_occupation(cps: h5py.File, person: DataFrame) -> None:

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -91,6 +91,39 @@ FLSA_SALARY_BASIS_THRESHOLD_ANNUAL_2024 = np.float32(684 * FLSA_WORKWEEKS_PER_YE
 FLSA_COMPUTER_SALARY_THRESHOLD_ANNUAL_2024 = np.float32(
     27.63 * FLSA_STANDARD_HOURS_PER_WEEK * FLSA_WORKWEEKS_PER_YEAR
 )
+FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES = np.array(
+    [
+        1,  # Chief executives, and managers
+        2,  # Compensation, human resources, and infrastructure managers
+        3,  # All other managers
+        5,  # Business operations specialists
+        6,  # Accountants and auditors
+        7,  # Financial specialists
+        9,  # Mathematical science occupations
+        10,  # Architects, except naval
+        11,  # Surveyors, cartographers, & photogrammetrists
+        12,  # Engineering technologists and technicians
+        13,  # Earth scientists
+        14,  # Economists
+        15,  # Psychologists, and other social scientists
+        16,  # Health and safety specialists
+        18,  # Lawyers, judges, magistrates, and other judicial workers
+        19,  # Paralegals and all other legal support workers
+        25,  # Registered nurses, therapists, and specific pathologists
+        26,  # Veterinarians
+        27,  # Health technicians and other healthcare practitioners
+        28,  # Healthcare support occupations
+        29,  # First-line supervisors of protective service workers
+        34,  # First-line supervisors of housekeeping and janitorial workers
+        36,  # Supervisors of personal care and service workers
+        38,  # First-line supervisors of retail/non-retail sales workers
+        39,  # Sales and related occupations
+        40,  # Office & administrative support occupations
+        42,  # First-line supervisors of construction trades workers
+        50,  # Supervisors of transportation and flight related workers
+    ],
+    dtype=np.int16,
+)
 
 CURRENT_HEALTH_COVERAGE_REPORTED_VAR_MAP = {
     "reported_has_direct_purchase_health_coverage_at_interview": "NOW_DIR",
@@ -3016,36 +3049,7 @@ def add_overtime_occupation(cps: h5py.File, person: DataFrame) -> None:
     cps["is_computer_scientist"] = person.POCCU2 == 8
     cps["is_farmer_fisher"] = person.POCCU2 == 41
     cps["is_executive_administrative_professional"] = person.POCCU2.isin(
-        [
-            1,  # Chief executives, and managers
-            2,  # Compensation, human resources, and infrastructure managers
-            3,  # All other managers
-            5,  # Business operations specialists
-            6,  # Accountants and auditors
-            7,  # Financial specialists
-            9,  # Mathematical science occupations
-            10,  # Architects, except naval
-            11,  # Surveyors, cartographers, & photogrammetrists
-            12,  # Engineering technologists and technicians
-            13,  # Earth scientists
-            14,  # Economists
-            15,  # Psychologists, and other social scientists
-            16,  # Health and safety specialists
-            18,  # Lawyers, judges, magistrates, and other judicial workers
-            19,  # Paralegals and all other legal support workers
-            25,  # Registered nurses, therapists, and specific pathologists
-            26,  # Veterinarians
-            27,  # Health technicians and other healthcare practitioners
-            28,  # Healthcare support occupations
-            29,  # First-line supervisors of protective service workers
-            34,  # First-line supervisors of housekeeping and janitorial workers
-            36,  # Supervisors of personal care and service workers
-            38,  # First-line supervisors of retail/non-retail sales workers
-            39,  # Sales and related occupations
-            40,  # Office & administrative support occupations
-            42,  # First-line supervisors of construction trades workers
-            50,  # Supervisors of transportation and flight related workers
-        ]
+        FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES
     )
 
 

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -1308,13 +1308,12 @@ def derive_flsa_overtime_premium(
         ),
         salary_threshold,
     )
-    salary_threshold = np.where(
-        has_never_worked | is_military,
-        0,
-        salary_threshold,
-    )
+    always_exempt = has_never_worked | is_military
+    salary_threshold = np.where(always_exempt, 0, salary_threshold)
 
-    is_exempt = (employment_income >= salary_threshold) & ~is_paid_hourly
+    is_exempt = always_exempt | (
+        (employment_income >= salary_threshold) & ~is_paid_hourly
+    )
     eligible = ~is_exempt & (weeks_worked > 0)
     premium = np.where(eligible, employment_income * premium_share, 0)
     return np.minimum(premium, employment_income).astype(np.float32)

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -19,6 +19,7 @@ import numpy as np
 import pandas as pd
 import yaml
 from typing import Type
+from policyengine_us.model_api import WEEKS_IN_YEAR
 from policyengine_us_data.utils.uprating import (
     create_policyengine_uprating_factors_table,
 )
@@ -84,42 +85,58 @@ ACS_RENT_TARGET_ALLOCATION_COLUMNS = {
     "real_estate_taxes": ["real_estate_taxes_is_allocated"],
 }
 
-FLSA_STANDARD_HOURS_PER_WEEK = np.float32(40)
-FLSA_OVERTIME_RATE_MULTIPLIER = np.float32(1.5)
-FLSA_WORKWEEKS_PER_YEAR = np.float32(52)
-FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES = np.array(
-    [
-        1,  # Chief executives, and managers
-        2,  # Compensation, human resources, and infrastructure managers
-        3,  # All other managers
-        5,  # Business operations specialists
-        6,  # Accountants and auditors
-        7,  # Financial specialists
-        9,  # Mathematical science occupations
-        10,  # Architects, except naval
-        11,  # Surveyors, cartographers, & photogrammetrists
-        12,  # Engineering technologists and technicians
-        13,  # Earth scientists
-        14,  # Economists
-        15,  # Psychologists, and other social scientists
-        16,  # Health and safety specialists
-        18,  # Lawyers, judges, magistrates, and other judicial workers
-        19,  # Paralegals and all other legal support workers
-        25,  # Registered nurses, therapists, and specific pathologists
-        26,  # Veterinarians
-        27,  # Health technicians and other healthcare practitioners
-        28,  # Healthcare support occupations
-        29,  # First-line supervisors of protective service workers
-        34,  # First-line supervisors of housekeeping and janitorial workers
-        36,  # Supervisors of personal care and service workers
-        38,  # First-line supervisors of retail/non-retail sales workers
-        39,  # Sales and related occupations
-        40,  # Office & administrative support occupations
-        42,  # First-line supervisors of construction trades workers
-        50,  # Supervisors of transportation and flight related workers
-    ],
-    dtype=np.int16,
+try:
+    from policyengine_us.data.cps import (
+        CPS_FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES,
+        CPS_FLSA_OVERTIME_OCCUPATION_CODES,
+    )
+except ImportError:
+    # Remove this compatibility fallback after policyengine-us #8429 is
+    # released and this package pins that release.
+    CPS_FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES = np.array(
+        [
+            1,  # Chief executives, and managers
+            2,  # Compensation, human resources, and infrastructure managers
+            3,  # All other managers
+            5,  # Business operations specialists
+            6,  # Accountants and auditors
+            7,  # Financial specialists
+            9,  # Mathematical science occupations
+            10,  # Architects, except naval
+            11,  # Surveyors, cartographers, & photogrammetrists
+            12,  # Engineering technologists and technicians
+            13,  # Earth scientists
+            14,  # Economists
+            15,  # Psychologists, and other social scientists
+            16,  # Health and safety specialists
+            18,  # Lawyers, judges, magistrates, and other judicial workers
+            19,  # Paralegals and all other legal support workers
+            25,  # Registered nurses, therapists, and specific pathologists
+            26,  # Veterinarians
+            27,  # Health technicians and other healthcare practitioners
+            28,  # Healthcare support occupations
+            29,  # First-line supervisors of protective service workers
+            34,  # First-line supervisors of housekeeping and janitorial workers
+            36,  # Supervisors of personal care and service workers
+            38,  # First-line supervisors of retail/non-retail sales workers
+            39,  # Sales and related occupations
+            40,  # Office & administrative support occupations
+            42,  # First-line supervisors of construction trades workers
+            50,  # Supervisors of transportation and flight related workers
+        ],
+        dtype=np.int16,
+    )
+    CPS_FLSA_OVERTIME_OCCUPATION_CODES = {
+        "has_never_worked": 53,
+        "is_military": 52,
+        "is_computer_scientist": 8,
+        "is_farmer_fisher": 41,
+    }
+
+FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES = (
+    CPS_FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES
 )
+FLSA_OVERTIME_OCCUPATION_CODES = CPS_FLSA_OVERTIME_OCCUPATION_CODES
 
 
 @lru_cache(maxsize=1)
@@ -130,21 +147,30 @@ def _policyengine_us_parameters():
 
 
 @lru_cache(maxsize=16)
-def _flsa_overtime_thresholds_for_year(
+def _flsa_overtime_policy_for_year(
     time_period: int,
-) -> tuple[np.float32, np.float32, np.float32]:
+) -> tuple[np.float32, np.float32, np.float32, np.float32, np.float32]:
     overtime = _policyengine_us_parameters()(
         f"{int(time_period)}-01-01"
     ).gov.irs.income.exemption.overtime
+    hours_threshold = np.float32(overtime.hours_threshold)
+    rate_multiplier = np.float32(overtime.rate_multiplier)
+    workweeks_per_year = np.float32(WEEKS_IN_YEAR)
     return (
         np.float32(overtime.hce_salary_threshold),
-        np.float32(overtime.salary_basis_threshold * FLSA_WORKWEEKS_PER_YEAR),
+        np.float32(overtime.salary_basis_threshold * workweeks_per_year),
         np.float32(
-            overtime.computer_salary_threshold
-            * FLSA_STANDARD_HOURS_PER_WEEK
-            * FLSA_WORKWEEKS_PER_YEAR
+            overtime.computer_salary_threshold * hours_threshold * workweeks_per_year
         ),
+        hours_threshold,
+        rate_multiplier,
     )
+
+
+def _flsa_overtime_thresholds_for_year(
+    time_period: int,
+) -> tuple[np.float32, np.float32, np.float32]:
+    return _flsa_overtime_policy_for_year(time_period)[:3]
 
 
 CURRENT_HEALTH_COVERAGE_REPORTED_VAR_MAP = {
@@ -1295,26 +1321,28 @@ def derive_flsa_overtime_premium(
     is_farmer_fisher = np.asarray(is_farmer_fisher, dtype=bool)
     is_computer_scientist = np.asarray(is_computer_scientist, dtype=bool)
 
-    overtime_hours = np.maximum(
-        hours_worked_last_week - FLSA_STANDARD_HOURS_PER_WEEK,
-        0,
-    )
-    straight_time_equivalent_hours = (
-        np.minimum(hours_worked_last_week, FLSA_STANDARD_HOURS_PER_WEEK)
-        + overtime_hours * FLSA_OVERTIME_RATE_MULTIPLIER
-    )
-    premium_share = np.divide(
-        (FLSA_OVERTIME_RATE_MULTIPLIER - 1) * overtime_hours,
-        straight_time_equivalent_hours,
-        out=np.zeros_like(employment_income, dtype=np.float32),
-        where=straight_time_equivalent_hours > 0,
-    )
-
     (
         hce_salary_threshold,
         salary_basis_threshold,
         computer_salary_threshold,
-    ) = _flsa_overtime_thresholds_for_year(time_period)
+        hours_threshold,
+        rate_multiplier,
+    ) = _flsa_overtime_policy_for_year(time_period)
+
+    overtime_hours = np.maximum(
+        hours_worked_last_week - hours_threshold,
+        0,
+    )
+    straight_time_equivalent_hours = (
+        np.minimum(hours_worked_last_week, hours_threshold)
+        + overtime_hours * rate_multiplier
+    )
+    premium_share = np.divide(
+        (rate_multiplier - 1) * overtime_hours,
+        straight_time_equivalent_hours,
+        out=np.zeros_like(employment_income, dtype=np.float32),
+        where=straight_time_equivalent_hours > 0,
+    )
 
     salary_threshold = np.full_like(
         employment_income,
@@ -3067,10 +3095,8 @@ def add_overtime_occupation(cps: h5py.File, person: DataFrame) -> None:
     https://www.law.cornell.edu/uscode/text/29/213
     https://www.congress.gov/crs-product/IF12480
     """
-    cps["has_never_worked"] = person.POCCU2 == 53
-    cps["is_military"] = person.POCCU2 == 52
-    cps["is_computer_scientist"] = person.POCCU2 == 8
-    cps["is_farmer_fisher"] = person.POCCU2 == 41
+    for variable, occupation_code in FLSA_OVERTIME_OCCUPATION_CODES.items():
+        cps[variable] = person.POCCU2 == occupation_code
     cps["is_executive_administrative_professional"] = person.POCCU2.isin(
         FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES
     )

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -20,6 +20,10 @@ import pandas as pd
 import yaml
 from typing import Type
 from policyengine_us.model_api import WEEKS_IN_YEAR
+from policyengine_us.data.cps import (
+    CPS_FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES,
+    CPS_FLSA_OVERTIME_OCCUPATION_CODES,
+)
 from policyengine_us_data.utils.uprating import (
     create_policyengine_uprating_factors_table,
 )
@@ -84,54 +88,6 @@ ACS_RENT_TARGET_ALLOCATION_COLUMNS = {
     "rent": ["rent_is_allocated"],
     "real_estate_taxes": ["real_estate_taxes_is_allocated"],
 }
-
-try:
-    from policyengine_us.data.cps import (
-        CPS_FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES,
-        CPS_FLSA_OVERTIME_OCCUPATION_CODES,
-    )
-except ImportError:
-    # Remove this compatibility fallback after policyengine-us #8429 is
-    # released and this package pins that release.
-    CPS_FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES = np.array(
-        [
-            1,  # Chief executives, and managers
-            2,  # Compensation, human resources, and infrastructure managers
-            3,  # All other managers
-            5,  # Business operations specialists
-            6,  # Accountants and auditors
-            7,  # Financial specialists
-            9,  # Mathematical science occupations
-            10,  # Architects, except naval
-            11,  # Surveyors, cartographers, & photogrammetrists
-            12,  # Engineering technologists and technicians
-            13,  # Earth scientists
-            14,  # Economists
-            15,  # Psychologists, and other social scientists
-            16,  # Health and safety specialists
-            18,  # Lawyers, judges, magistrates, and other judicial workers
-            19,  # Paralegals and all other legal support workers
-            25,  # Registered nurses, therapists, and specific pathologists
-            26,  # Veterinarians
-            27,  # Health technicians and other healthcare practitioners
-            28,  # Healthcare support occupations
-            29,  # First-line supervisors of protective service workers
-            34,  # First-line supervisors of housekeeping and janitorial workers
-            36,  # Supervisors of personal care and service workers
-            38,  # First-line supervisors of retail/non-retail sales workers
-            39,  # Sales and related occupations
-            40,  # Office & administrative support occupations
-            42,  # First-line supervisors of construction trades workers
-            50,  # Supervisors of transportation and flight related workers
-        ],
-        dtype=np.int16,
-    )
-    CPS_FLSA_OVERTIME_OCCUPATION_CODES = {
-        "has_never_worked": 53,
-        "is_military": 52,
-        "is_computer_scientist": 8,
-        "is_farmer_fisher": 41,
-    }
 
 FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES = (
     CPS_FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES

--- a/policyengine_us_data/datasets/cps/extended_cps.py
+++ b/policyengine_us_data/datasets/cps/extended_cps.py
@@ -19,6 +19,7 @@ from policyengine_us_data.datasets.cps.cps import (
     CPS_2024,
     CPS_2024_Full,
     ESI_POLICYHOLDER_VARIABLE,
+    FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES,
     _open_dataset_read_only,
     load_take_up_rate,
 )
@@ -125,39 +126,6 @@ _OVERTIME_OCCUPATION_CODES = {
     "is_computer_scientist": 8,
     "is_farmer_fisher": 41,
 }
-_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_CODES = np.array(
-    [
-        1,
-        2,
-        3,
-        5,
-        7,
-        9,
-        10,
-        11,
-        12,
-        13,
-        14,
-        15,
-        16,
-        18,
-        19,
-        20,
-        21,
-        22,
-        24,
-        25,
-        27,
-        28,
-        29,
-        30,
-        32,
-        33,
-        34,
-    ],
-    dtype=np.int16,
-)
-
 # CPS-only variables that should be QRF-imputed for the PUF clone half
 # instead of naively duplicated from the CPS donor. Most demographics,
 # IDs, weights, and random seeds are fine to duplicate; the categorical
@@ -478,7 +446,7 @@ def _derive_overtime_occupation_inputs(
     }
     derived["is_executive_administrative_professional"] = np.isin(
         occupation_codes,
-        _EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_CODES,
+        FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES,
     )
     return pd.DataFrame(derived)
 

--- a/policyengine_us_data/datasets/cps/extended_cps.py
+++ b/policyengine_us_data/datasets/cps/extended_cps.py
@@ -497,10 +497,10 @@ def _derive_clone_flsa_overtime_premium(data: dict, time_period: int) -> dict:
         variable: np.asarray(data[variable][time_period][n_half:])
         for variable in FLSA_OVERTIME_PREMIUM_INPUTS
     }
-    values[n_half:] = derive_flsa_overtime_premium(**clone_inputs).astype(
-        values.dtype,
-        copy=False,
-    )
+    values[n_half:] = derive_flsa_overtime_premium(
+        time_period=time_period,
+        **clone_inputs,
+    ).astype(values.dtype, copy=False)
     data[FLSA_OVERTIME_PREMIUM_VARIABLE] = {time_period: values}
     return data
 

--- a/policyengine_us_data/datasets/cps/extended_cps.py
+++ b/policyengine_us_data/datasets/cps/extended_cps.py
@@ -20,6 +20,7 @@ from policyengine_us_data.datasets.cps.cps import (
     CPS_2024_Full,
     ESI_POLICYHOLDER_VARIABLE,
     FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES,
+    FLSA_OVERTIME_OCCUPATION_CODES,
     _open_dataset_read_only,
     derive_flsa_overtime_premium,
     load_take_up_rate,
@@ -121,12 +122,7 @@ CPS_CLONE_FEATURE_PREDICTORS = [
     "social_security",
 ]
 
-_OVERTIME_OCCUPATION_CODES = {
-    "has_never_worked": 53,
-    "is_military": 52,
-    "is_computer_scientist": 8,
-    "is_farmer_fisher": 41,
-}
+_OVERTIME_OCCUPATION_CODES = dict(FLSA_OVERTIME_OCCUPATION_CODES)
 FLSA_OVERTIME_PREMIUM_VARIABLE = "fsla_overtime_premium"
 FLSA_OVERTIME_PREMIUM_INPUTS = (
     "employment_income",

--- a/policyengine_us_data/datasets/cps/extended_cps.py
+++ b/policyengine_us_data/datasets/cps/extended_cps.py
@@ -21,6 +21,7 @@ from policyengine_us_data.datasets.cps.cps import (
     ESI_POLICYHOLDER_VARIABLE,
     FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES,
     _open_dataset_read_only,
+    derive_flsa_overtime_premium,
     load_take_up_rate,
 )
 from policyengine_us_data.datasets.cps.takeup import prioritize_reported_recipients
@@ -126,10 +127,24 @@ _OVERTIME_OCCUPATION_CODES = {
     "is_computer_scientist": 8,
     "is_farmer_fisher": 41,
 }
+FLSA_OVERTIME_PREMIUM_VARIABLE = "fsla_overtime_premium"
+FLSA_OVERTIME_PREMIUM_INPUTS = (
+    "employment_income",
+    "hours_worked_last_week",
+    "weeks_worked",
+    "is_paid_hourly",
+    "has_never_worked",
+    "is_military",
+    "is_executive_administrative_professional",
+    "is_farmer_fisher",
+    "is_computer_scientist",
+)
+CLONE_DERIVED_VARIABLES = frozenset({FLSA_OVERTIME_PREMIUM_VARIABLE})
 # CPS-only variables that should be QRF-imputed for the PUF clone half
 # instead of naively duplicated from the CPS donor. Most demographics,
 # IDs, weights, and random seeds are fine to duplicate; the categorical
-# clone features above are rematched separately.
+# clone features above are rematched separately, and clone-derived variables
+# are recomputed from final clone inputs after QRF splicing.
 CPS_ONLY_IMPUTED_VARIABLES = [
     # Retirement distributions
     "taxable_401k_distributions",
@@ -177,7 +192,6 @@ CPS_ONLY_IMPUTED_VARIABLES = [
     "weekly_hours_worked",
     "hours_worked_last_week",
     "weeks_worked",
-    "fsla_overtime_premium",
     # ORG labor-market variables
     "hourly_wage",
     "is_paid_hourly",
@@ -320,7 +334,11 @@ def _cps_clone_feature_variables_for_data(
         if variable in seen:
             continue
         seen.add(variable)
-        if variable in PUF_IMPUTED_VARIABLES or variable in _CPS_ONLY_SET:
+        if (
+            variable in PUF_IMPUTED_VARIABLES
+            or variable in _CPS_ONLY_SET
+            or variable in CLONE_DERIVED_VARIABLES
+        ):
             continue
         is_explicit_clone_feature = variable in explicit_clone_features
         if not is_explicit_clone_feature and _is_structural_clone_variable(variable):
@@ -449,6 +467,42 @@ def _derive_overtime_occupation_inputs(
         FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES,
     )
     return pd.DataFrame(derived)
+
+
+def _derive_clone_flsa_overtime_premium(data: dict, time_period: int) -> dict:
+    """Recompute clone-half FLSA overtime premiums from final clone inputs."""
+    if FLSA_OVERTIME_PREMIUM_VARIABLE not in data:
+        return data
+
+    missing = [
+        variable
+        for variable in FLSA_OVERTIME_PREMIUM_INPUTS
+        if variable not in data or time_period not in data[variable]
+    ]
+    if missing:
+        raise ValueError(
+            "Cannot derive clone FLSA overtime premium; missing inputs: "
+            + ", ".join(missing)
+        )
+
+    values = np.array(data[FLSA_OVERTIME_PREMIUM_VARIABLE][time_period], copy=True)
+    n_persons = len(data["person_id"][time_period])
+    if len(values) != n_persons:
+        raise ValueError(
+            "fsla_overtime_premium must be person-level to derive clone values"
+        )
+
+    n_half = n_persons // 2
+    clone_inputs = {
+        variable: np.asarray(data[variable][time_period][n_half:])
+        for variable in FLSA_OVERTIME_PREMIUM_INPUTS
+    }
+    values[n_half:] = derive_flsa_overtime_premium(**clone_inputs).astype(
+        values.dtype,
+        copy=False,
+    )
+    data[FLSA_OVERTIME_PREMIUM_VARIABLE] = {time_period: values}
+    return data
 
 
 def _impute_clone_cps_features(
@@ -1130,6 +1184,7 @@ class ExtendedCPS(Dataset):
             time_period=self.time_period,
             dataset_path=str(self.cps.file_path),
         )
+        new_data = _derive_clone_flsa_overtime_premium(new_data, self.time_period)
         new_data = self._finalize_stage2_computed_variables(new_data)
 
         new_data = self._impute_aotc_eligibility_inputs(new_data, self.time_period)

--- a/policyengine_us_data/datasets/cps/extended_cps.py
+++ b/policyengine_us_data/datasets/cps/extended_cps.py
@@ -209,6 +209,7 @@ CPS_ONLY_IMPUTED_VARIABLES = [
     "weekly_hours_worked",
     "hours_worked_last_week",
     "weeks_worked",
+    "fsla_overtime_premium",
     # ORG labor-market variables
     "hourly_wage",
     "is_paid_hourly",

--- a/policyengine_us_data/utils/dataset_validation.py
+++ b/policyengine_us_data/utils/dataset_validation.py
@@ -39,6 +39,7 @@ STRUCTURAL_COMPUTED_EXPORT_VARIABLES = frozenset(
 # inputs that should override the fallback.
 DATA_OVERRIDABLE_COMPUTED_EXPORT_VARIABLES = frozenset(
     {
+        "fsla_overtime_premium",
         "meets_ssi_disability_criteria",
     }
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us==1.705.15",
+    "policyengine-us==1.705.16",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,10 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us==1.705.16",
+    # Temporary GitHub pin: policyengine-us 1.706.14 is blocked from PyPI by
+    # the project-size limit, but us-data needs the merged FLSA overtime
+    # constants before the next PyPI release is available.
+    "policyengine-us @ git+https://github.com/PolicyEngine/policyengine-us.git@0dcc69aa7a38be901141d38c8dbb7a9c870f2561",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/tests/unit/datasets/test_cps_income_variables.py
+++ b/tests/unit/datasets/test_cps_income_variables.py
@@ -1,7 +1,10 @@
 import numpy as np
 import pandas as pd
 
-from policyengine_us_data.datasets.cps.cps import add_personal_income_variables
+from policyengine_us_data.datasets.cps.cps import (
+    add_personal_income_variables,
+    derive_flsa_overtime_premium,
+)
 
 
 def _minimal_person_income_frame() -> pd.DataFrame:
@@ -93,3 +96,22 @@ def test_add_personal_income_variables_maps_spm_income_leaves():
     np.testing.assert_array_equal(cps["educational_assistance"], [10.0, 11.0, 12.0])
     np.testing.assert_array_equal(cps["financial_assistance"], [20.0, 21.0, 22.0])
     np.testing.assert_array_equal(cps["survivor_benefits"], [30.0, 31.0, 32.0])
+
+
+def test_derive_flsa_overtime_premium_uses_wage_share_and_exemption_screen():
+    premium = derive_flsa_overtime_premium(
+        employment_income=np.array([57_200.0, 100_000.0, 30_000.0, 60_000.0]),
+        hours_worked_last_week=np.array([50.0, 50.0, 50.0, 40.0]),
+        weeks_worked=np.array([52.0, 52.0, 52.0, 52.0]),
+        is_paid_hourly=np.array([True, False, False, True]),
+        has_never_worked=np.array([False, False, False, False]),
+        is_military=np.array([False, False, False, False]),
+        is_executive_administrative_professional=np.array([False, True, True, False]),
+        is_farmer_fisher=np.array([False, False, False, False]),
+        is_computer_scientist=np.array([False, False, False, False]),
+    )
+
+    np.testing.assert_allclose(
+        premium,
+        np.array([5_200.0, 0.0, 30_000 * 5 / 55, 0.0], dtype=np.float32),
+    )

--- a/tests/unit/datasets/test_cps_income_variables.py
+++ b/tests/unit/datasets/test_cps_income_variables.py
@@ -100,18 +100,25 @@ def test_add_personal_income_variables_maps_spm_income_leaves():
 
 def test_derive_flsa_overtime_premium_uses_wage_share_and_exemption_screen():
     premium = derive_flsa_overtime_premium(
-        employment_income=np.array([57_200.0, 100_000.0, 30_000.0, 60_000.0]),
-        hours_worked_last_week=np.array([50.0, 50.0, 50.0, 40.0]),
-        weeks_worked=np.array([52.0, 52.0, 52.0, 52.0]),
-        is_paid_hourly=np.array([True, False, False, True]),
-        has_never_worked=np.array([False, False, False, False]),
-        is_military=np.array([False, False, False, False]),
-        is_executive_administrative_professional=np.array([False, True, True, False]),
-        is_farmer_fisher=np.array([False, False, False, False]),
-        is_computer_scientist=np.array([False, False, False, False]),
+        employment_income=np.array(
+            [57_200.0, 100_000.0, 30_000.0, 60_000.0, 50_000.0, 50_000.0]
+        ),
+        hours_worked_last_week=np.array([50.0, 50.0, 50.0, 40.0, 50.0, 50.0]),
+        weeks_worked=np.array([52.0, 52.0, 52.0, 52.0, 52.0, 52.0]),
+        is_paid_hourly=np.array([True, False, False, True, True, True]),
+        has_never_worked=np.array([False, False, False, False, True, False]),
+        is_military=np.array([False, False, False, False, False, True]),
+        is_executive_administrative_professional=np.array(
+            [False, True, True, False, False, False]
+        ),
+        is_farmer_fisher=np.array([False, False, False, False, False, False]),
+        is_computer_scientist=np.array([False, False, False, False, False, False]),
     )
 
     np.testing.assert_allclose(
         premium,
-        np.array([5_200.0, 0.0, 30_000 * 5 / 55, 0.0], dtype=np.float32),
+        np.array(
+            [5_200.0, 0.0, 30_000 * 5 / 55, 0.0, 0.0, 0.0],
+            dtype=np.float32,
+        ),
     )

--- a/tests/unit/datasets/test_cps_income_variables.py
+++ b/tests/unit/datasets/test_cps_income_variables.py
@@ -4,6 +4,7 @@ import pandas as pd
 from policyengine_us_data.datasets.cps.cps import (
     add_personal_income_variables,
     derive_flsa_overtime_premium,
+    _flsa_overtime_thresholds_for_year,
 )
 
 
@@ -100,6 +101,7 @@ def test_add_personal_income_variables_maps_spm_income_leaves():
 
 def test_derive_flsa_overtime_premium_uses_wage_share_and_exemption_screen():
     premium = derive_flsa_overtime_premium(
+        time_period=2024,
         employment_income=np.array(
             [57_200.0, 100_000.0, 30_000.0, 60_000.0, 50_000.0, 50_000.0]
         ),
@@ -121,4 +123,43 @@ def test_derive_flsa_overtime_premium_uses_wage_share_and_exemption_screen():
             [5_200.0, 0.0, 30_000 * 5 / 55, 0.0, 0.0, 0.0],
             dtype=np.float32,
         ),
+    )
+
+
+def test_derive_flsa_overtime_premium_uses_historical_salary_thresholds():
+    inputs = dict(
+        employment_income=np.array([30_000.0, 40_000.0]),
+        hours_worked_last_week=np.array([50.0, 50.0]),
+        weeks_worked=np.array([52.0, 52.0]),
+        is_paid_hourly=np.array([False, False]),
+        has_never_worked=np.array([False, False]),
+        is_military=np.array([False, False]),
+        is_executive_administrative_professional=np.array([True, True]),
+        is_farmer_fisher=np.array([False, False]),
+        is_computer_scientist=np.array([False, False]),
+    )
+    premium_2019 = derive_flsa_overtime_premium(
+        time_period=2019,
+        **inputs,
+    )
+    premium_2024 = derive_flsa_overtime_premium(
+        time_period=2024,
+        **inputs,
+    )
+
+    np.testing.assert_allclose(premium_2019, np.array([0.0, 0.0], dtype=np.float32))
+    np.testing.assert_allclose(
+        premium_2024,
+        np.array([30_000 * 5 / 55, 0.0], dtype=np.float32),
+    )
+
+
+def test_flsa_overtime_thresholds_match_policyengine_us_parameters():
+    assert _flsa_overtime_thresholds_for_year(2019)[:2] == (
+        np.float32(100_000),
+        np.float32(455 * 52),
+    )
+    assert _flsa_overtime_thresholds_for_year(2024)[:2] == (
+        np.float32(107_432),
+        np.float32(684 * 52),
     )

--- a/tests/unit/datasets/test_cps_income_variables.py
+++ b/tests/unit/datasets/test_cps_income_variables.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-import pytest
 
 from policyengine_us_data.datasets.cps import cps as cps_module
 from policyengine_us_data.datasets.cps.cps import (
@@ -219,7 +218,7 @@ def test_flsa_overtime_hours_and_rate_match_policyengine_us_parameters():
 
 
 def test_flsa_overtime_occupation_codes_match_policyengine_us_when_available():
-    policyengine_us_cps = pytest.importorskip("policyengine_us.data.cps")
+    from policyengine_us.data import cps as policyengine_us_cps
 
     np.testing.assert_array_equal(
         FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES,

--- a/tests/unit/datasets/test_cps_income_variables.py
+++ b/tests/unit/datasets/test_cps_income_variables.py
@@ -1,9 +1,14 @@
 import numpy as np
 import pandas as pd
+import pytest
 
+from policyengine_us_data.datasets.cps import cps as cps_module
 from policyengine_us_data.datasets.cps.cps import (
+    FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES,
+    FLSA_OVERTIME_OCCUPATION_CODES,
     add_personal_income_variables,
     derive_flsa_overtime_premium,
+    _flsa_overtime_policy_for_year,
     _flsa_overtime_thresholds_for_year,
 )
 
@@ -154,6 +159,38 @@ def test_derive_flsa_overtime_premium_uses_historical_salary_thresholds():
     )
 
 
+def test_derive_flsa_overtime_premium_uses_policy_hours_and_rate(monkeypatch):
+    monkeypatch.setattr(
+        cps_module,
+        "_flsa_overtime_policy_for_year",
+        lambda _year: (
+            np.float32(100_000),
+            np.float32(100_000),
+            np.float32(100_000),
+            np.float32(35),
+            np.float32(2),
+        ),
+    )
+
+    premium = derive_flsa_overtime_premium(
+        time_period=2024,
+        employment_income=np.array([60_000.0]),
+        hours_worked_last_week=np.array([45.0]),
+        weeks_worked=np.array([52.0]),
+        is_paid_hourly=np.array([True]),
+        has_never_worked=np.array([False]),
+        is_military=np.array([False]),
+        is_executive_administrative_professional=np.array([False]),
+        is_farmer_fisher=np.array([False]),
+        is_computer_scientist=np.array([False]),
+    )
+
+    np.testing.assert_allclose(
+        premium,
+        np.array([60_000 * 10 / 55], dtype=np.float32),
+    )
+
+
 def test_flsa_overtime_thresholds_match_policyengine_us_parameters():
     assert _flsa_overtime_thresholds_for_year(2019)[:2] == (
         np.float32(100_000),
@@ -162,4 +199,33 @@ def test_flsa_overtime_thresholds_match_policyengine_us_parameters():
     assert _flsa_overtime_thresholds_for_year(2024)[:2] == (
         np.float32(107_432),
         np.float32(684 * 52),
+    )
+
+
+def test_flsa_overtime_hours_and_rate_match_policyengine_us_parameters():
+    from policyengine_us import CountryTaxBenefitSystem
+
+    policy = _flsa_overtime_policy_for_year(2024)
+    overtime = (
+        CountryTaxBenefitSystem()
+        .parameters("2024-01-01")
+        .gov.irs.income.exemption.overtime
+    )
+
+    assert policy[3:] == (
+        np.float32(overtime.hours_threshold),
+        np.float32(overtime.rate_multiplier),
+    )
+
+
+def test_flsa_overtime_occupation_codes_match_policyengine_us_when_available():
+    policyengine_us_cps = pytest.importorskip("policyengine_us.data.cps")
+
+    np.testing.assert_array_equal(
+        FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES,
+        policyengine_us_cps.CPS_FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES,
+    )
+    assert (
+        FLSA_OVERTIME_OCCUPATION_CODES
+        == policyengine_us_cps.CPS_FLSA_OVERTIME_OCCUPATION_CODES
     )

--- a/tests/unit/datasets/test_org.py
+++ b/tests/unit/datasets/test_org.py
@@ -552,6 +552,13 @@ def test_add_org_labor_market_inputs_handles_nonsequential_household_index(
         "cps_race": np.array([1.0, 2.0]),
         "employment_income": np.array([50_000.0, 60_000.0]),
         "weekly_hours_worked": np.array([40.0, 40.0]),
+        "hours_worked_last_week": np.array([50.0, 40.0]),
+        "weeks_worked": np.array([52.0, 52.0]),
+        "has_never_worked": np.array([False, False]),
+        "is_military": np.array([False, False]),
+        "is_computer_scientist": np.array([False, False]),
+        "is_farmer_fisher": np.array([False, False]),
+        "is_executive_administrative_professional": np.array([False, False]),
     }
     captured_state_fips = {}
 
@@ -591,4 +598,8 @@ def test_add_org_labor_market_inputs_handles_nonsequential_household_index(
     np.testing.assert_array_equal(
         cps["is_union_member_or_covered"],
         np.array([False, True]),
+    )
+    np.testing.assert_allclose(
+        cps["fsla_overtime_premium"],
+        np.array([50_000 * 5 / 55, 0], dtype=np.float32),
     )

--- a/tests/unit/datasets/test_org.py
+++ b/tests/unit/datasets/test_org.py
@@ -587,7 +587,7 @@ def test_add_org_labor_market_inputs_handles_nonsequential_household_index(
         fake_predict_org_features,
     )
 
-    cps_module.add_org_labor_market_inputs(cps)
+    cps_module.add_org_labor_market_inputs(cps, 2024)
 
     np.testing.assert_array_equal(
         captured_state_fips["value"],

--- a/tests/unit/test_extended_cps.py
+++ b/tests/unit/test_extended_cps.py
@@ -206,6 +206,9 @@ class TestVariableListConsistency:
     def test_weeks_worked_is_cps_only_imputed_for_clone_records(self):
         assert "weeks_worked" in set(CPS_ONLY_IMPUTED_VARIABLES)
 
+    def test_flsa_overtime_premium_is_cps_only_imputed_for_clone_records(self):
+        assert "fsla_overtime_premium" in set(CPS_ONLY_IMPUTED_VARIABLES)
+
     def test_ssi_disability_criteria_is_cps_only_imputed_for_clone_records(self):
         assert "meets_ssi_disability_criteria" in set(CPS_ONLY_IMPUTED_VARIABLES)
 
@@ -289,6 +292,15 @@ class TestVariableListConsistency:
     ):
         data = {
             "meets_ssi_disability_criteria": {2024: np.array([True, False])},
+        }
+
+        ExtendedCPS._assert_no_computed_variables_exported(data, 2024)
+
+    def test_final_export_contract_allows_data_overridden_flsa_overtime_premium(
+        self,
+    ):
+        data = {
+            "fsla_overtime_premium": {2024: np.array([1_000.0, 0.0])},
         }
 
         ExtendedCPS._assert_no_computed_variables_exported(data, 2024)

--- a/tests/unit/test_extended_cps.py
+++ b/tests/unit/test_extended_cps.py
@@ -34,6 +34,7 @@ from policyengine_us_data.datasets.cps.extended_cps import (
     _build_clone_test_frame,
     _build_ssi_disability_clone_receiver,
     _cps_clone_feature_variables_for_data,
+    _derive_clone_flsa_overtime_premium,
     _derive_overtime_occupation_inputs,
     _impute_clone_cps_features,
     _splice_cps_only_predictions,
@@ -209,8 +210,8 @@ class TestVariableListConsistency:
     def test_weeks_worked_is_cps_only_imputed_for_clone_records(self):
         assert "weeks_worked" in set(CPS_ONLY_IMPUTED_VARIABLES)
 
-    def test_flsa_overtime_premium_is_cps_only_imputed_for_clone_records(self):
-        assert "fsla_overtime_premium" in set(CPS_ONLY_IMPUTED_VARIABLES)
+    def test_flsa_overtime_premium_is_derived_for_clone_records(self):
+        assert "fsla_overtime_premium" not in set(CPS_ONLY_IMPUTED_VARIABLES)
 
     def test_ssi_disability_criteria_is_cps_only_imputed_for_clone_records(self):
         assert "meets_ssi_disability_criteria" in set(CPS_ONLY_IMPUTED_VARIABLES)
@@ -227,6 +228,7 @@ class TestVariableListConsistency:
             "is_tax_unit_head": {2024: np.array([True, False, True, False])},
             "is_disabled": {2024: np.array([True, False, True, False])},
             "difficulty_hearing": {2024: np.array([False, True, False, True])},
+            "fsla_overtime_premium": {2024: np.array([1_000.0, 0.0, 2_000.0, 0.0])},
             "meets_ssi_disability_criteria": {
                 2024: np.array([True, False, True, False])
             },
@@ -243,6 +245,7 @@ class TestVariableListConsistency:
         assert "employment_income" not in result
         assert "is_household_head" not in result
         assert "is_tax_unit_head" not in result
+        assert "fsla_overtime_premium" not in result
         assert "meets_ssi_disability_criteria" not in result
 
     def test_spm_threshold_is_formula_output_not_qrf_imputed(self):
@@ -1374,6 +1377,35 @@ class TestCloneFeatureImputation:
             *([True] * eap_count),
             False,
         ]
+
+    def test_derive_clone_flsa_overtime_premium_uses_final_clone_inputs(self):
+        tp = 2024
+        data = {
+            "person_id": {tp: np.array([1, 2, 101, 102])},
+            "fsla_overtime_premium": {
+                tp: np.array([111.0, 222.0, 9_999.0, 9_999.0], dtype=np.float32)
+            },
+            "employment_income": {
+                tp: np.array([20_000.0, 25_000.0, 57_200.0, 60_000.0])
+            },
+            "hours_worked_last_week": {tp: np.array([45.0, 45.0, 50.0, 40.0])},
+            "weeks_worked": {tp: np.array([52.0, 52.0, 52.0, 52.0])},
+            "is_paid_hourly": {tp: np.array([True, True, True, True])},
+            "has_never_worked": {tp: np.array([False, False, False, False])},
+            "is_military": {tp: np.array([False, False, False, False])},
+            "is_executive_administrative_professional": {
+                tp: np.array([False, False, False, False])
+            },
+            "is_farmer_fisher": {tp: np.array([False, False, False, False])},
+            "is_computer_scientist": {tp: np.array([False, False, False, False])},
+        }
+
+        result = _derive_clone_flsa_overtime_premium(data, tp)
+
+        np.testing.assert_allclose(
+            result["fsla_overtime_premium"][tp],
+            np.array([111.0, 222.0, 5_200.0, 0.0], dtype=np.float32),
+        )
 
     def test_clone_feature_imputation_rematches_outputs_and_derives_flags(
         self, monkeypatch

--- a/tests/unit/test_extended_cps.py
+++ b/tests/unit/test_extended_cps.py
@@ -18,7 +18,10 @@ from policyengine_us_data.calibration.puf_impute import (
     OVERRIDDEN_IMPUTED_VARIABLES,
 )
 from policyengine_us_data.datasets.cps import extended_cps as extended_cps_module
-from policyengine_us_data.datasets.cps.cps import ESI_POLICYHOLDER_VARIABLE
+from policyengine_us_data.datasets.cps.cps import (
+    ESI_POLICYHOLDER_VARIABLE,
+    FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES,
+)
 from policyengine_us_data.datasets.cps.extended_cps import (
     CPS_CLONE_FEATURE_VARIABLES,
     CPS_ONLY_IMPUTED_VARIABLES,
@@ -1317,14 +1320,26 @@ class TestCloneFeatureImputation:
         assert result["tax_unit_is_joint"].tolist() == [0, 1]
 
     def test_derive_overtime_occupation_inputs(self):
-        derived = _derive_overtime_occupation_inputs(np.array([53, 52, 8, 41, 1, 99]))
+        occupation_codes = np.array(
+            [
+                53,
+                52,
+                8,
+                41,
+                *FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES,
+                99,
+            ]
+        )
+        eap_count = len(FLSA_EXECUTIVE_ADMINISTRATIVE_PROFESSIONAL_OCCUPATION_CODES)
+
+        derived = _derive_overtime_occupation_inputs(occupation_codes)
 
         assert derived["has_never_worked"].tolist() == [
             True,
             False,
             False,
             False,
-            False,
+            *([False] * eap_count),
             False,
         ]
         assert derived["is_military"].tolist() == [
@@ -1332,7 +1347,7 @@ class TestCloneFeatureImputation:
             True,
             False,
             False,
-            False,
+            *([False] * eap_count),
             False,
         ]
         assert derived["is_computer_scientist"].tolist() == [
@@ -1340,7 +1355,7 @@ class TestCloneFeatureImputation:
             False,
             True,
             False,
-            False,
+            *([False] * eap_count),
             False,
         ]
         assert derived["is_farmer_fisher"].tolist() == [
@@ -1348,7 +1363,7 @@ class TestCloneFeatureImputation:
             False,
             False,
             True,
-            False,
+            *([False] * eap_count),
             False,
         ]
         assert derived["is_executive_administrative_professional"].tolist() == [
@@ -1356,7 +1371,7 @@ class TestCloneFeatureImputation:
             False,
             False,
             False,
-            True,
+            *([True] * eap_count),
             False,
         ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2122,7 +2122,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.705.15"
+version = "1.705.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2132,9 +2132,9 @@ dependencies = [
     { name = "tables" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/54/cc/921f994e5c688be0f45dbe8d7bce209ee45225d328a9724cf363df225ce8/policyengine_us-1.705.15.tar.gz", hash = "sha256:559d79690cb1d79615479ed2c71a53510e8cfea56d2398a37120f6797548c26b", size = 9927111, upload-time = "2026-05-24T02:32:30.769Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/9f/faa4ceee8157d4ceb3c589ca25e77af678787662949637409938c97ef5e1/policyengine_us-1.705.16.tar.gz", hash = "sha256:3eb8c31be571492566d6684ce12626eac6ae409d50819e42acdeb4dd5c7712ea", size = 9927762, upload-time = "2026-05-24T02:55:40.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/02/b8ae7ec50124bc4f442c8e3f662bf02d0f670d288c63e367dff75ed8c374/policyengine_us-1.705.15-py3-none-any.whl", hash = "sha256:aeafbbbef2a8de88cb73da8c234943784789023e7d32e05a9560e1a7dd713c70", size = 10758474, upload-time = "2026-05-24T02:32:26.588Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/74/44b3eecac9d624c512c85932146a7dabe47dc32c76645ef449edb930c2dd/policyengine_us-1.705.16-py3-none-any.whl", hash = "sha256:eb1f5a04b3b0f1b3fc46706a47ac9ccc2b726bddd15ee9d55055803f415f8aeb", size = 10759039, upload-time = "2026-05-24T02:55:36.665Z" },
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", specifier = "==1.705.15" },
+    { name = "policyengine-us", specifier = "==1.705.16" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -2122,8 +2122,8 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.705.16"
-source = { registry = "https://pypi.org/simple" }
+version = "1.706.14"
+source = { git = "https://github.com/PolicyEngine/policyengine-us.git?rev=0dcc69aa7a38be901141d38c8dbb7a9c870f2561#0dcc69aa7a38be901141d38c8dbb7a9c870f2561" }
 dependencies = [
     { name = "microdf-python" },
     { name = "pandas" },
@@ -2131,10 +2131,6 @@ dependencies = [
     { name = "spm-calculator" },
     { name = "tables" },
     { name = "tqdm" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/9f/faa4ceee8157d4ceb3c589ca25e77af678787662949637409938c97ef5e1/policyengine_us-1.705.16.tar.gz", hash = "sha256:3eb8c31be571492566d6684ce12626eac6ae409d50819e42acdeb4dd5c7712ea", size = 9927762, upload-time = "2026-05-24T02:55:40.346Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/74/44b3eecac9d624c512c85932146a7dabe47dc32c76645ef449edb930c2dd/policyengine_us-1.705.16-py3-none-any.whl", hash = "sha256:eb1f5a04b3b0f1b3fc46706a47ac9ccc2b726bddd15ee9d55055803f415f8aeb", size = 10759039, upload-time = "2026-05-24T02:55:36.665Z" },
 ]
 
 [[package]]
@@ -2204,7 +2200,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", specifier = "==1.705.16" },
+    { name = "policyengine-us", git = "https://github.com/PolicyEngine/policyengine-us.git?rev=0dcc69aa7a38be901141d38c8dbb7a9c870f2561" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },


### PR DESCRIPTION
## Summary
- Derive and export `fsla_overtime_premium` from CPS after ORG labor-market inputs are added.
- Use reported annual wages, reported/reference-week overtime-hour evidence, weeks-worked presence, and CPS occupation exemption flags to create a documented proxy instead of relying on a `policyengine-us` formula.
- Re-impute the premium for enhanced-CPS clone records and allow it as an intentional data override while the paired country-package PR is released.
- Bump the locked `policyengine-us` dependency to `1.705.16` to satisfy the freshness check.

Paired country-package PR: https://github.com/PolicyEngine/policyengine-us/pull/8429

## Tests
- `uv run ruff check policyengine_us_data/datasets/cps/cps.py policyengine_us_data/datasets/cps/extended_cps.py policyengine_us_data/utils/dataset_validation.py tests/unit/datasets/test_cps_income_variables.py tests/unit/datasets/test_org.py tests/unit/test_extended_cps.py`
- `uv run pytest tests/unit/datasets/test_cps_income_variables.py tests/unit/datasets/test_org.py::test_add_org_labor_market_inputs_handles_nonsequential_household_index tests/unit/test_extended_cps.py::TestVariableListConsistency::test_flsa_overtime_premium_is_cps_only_imputed_for_clone_records tests/unit/test_extended_cps.py::TestVariableListConsistency::test_final_export_contract_allows_data_overridden_flsa_overtime_premium -q`
