### PR TITLE
Migrate GREG calibration to svy

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -132,6 +132,23 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  calibration-extra-tests:
+    name: Calibration extra tests
+    runs-on: ubuntu-latest
+    needs: [check-fork, lint]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+      - uses: astral-sh/setup-uv@v8.1.0
+      - run: uv sync --dev --extra calibration
+      - name: Run svy GREG adapter regression
+        run: >
+          uv run --extra calibration pytest
+          tests/unit/test_long_term_calibration_contract.py::test_greg_calibrator_hits_linear_controls_with_svy
+          -v
+
   bundle-release-manifest-contract:
     name: Validate bundle release manifest contract
     runs-on: ubuntu-latest

--- a/changelog.d/1129.changed.md
+++ b/changelog.d/1129.changed.md
@@ -1,0 +1,1 @@
+Migrate long-term GREG calibration from archived samplics to svy.

--- a/policyengine_us_data/datasets/cps/long_term/assess_publishable_horizon.py
+++ b/policyengine_us_data/datasets/cps/long_term/assess_publishable_horizon.py
@@ -12,6 +12,7 @@ import numpy as np
 from policyengine_us import Microsimulation
 
 from calibration import build_calibration_audit, calibrate_weights
+from calibration import GregCalibrator
 from calibration_profiles import (
     approximate_window_for_year,
     classify_calibration_quality,
@@ -34,12 +35,6 @@ from ssa_data import (
     load_taxable_payroll_projections,
     set_long_term_target_source,
 )
-
-try:
-    from samplics.weighting import SampleWeight
-except ImportError:  # pragma: no cover - only needed for greg profiles
-    SampleWeight = None
-
 
 DEFAULT_BASE_DATASET_PATH = (
     "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5"
@@ -90,12 +85,7 @@ def parse_years(raw: str) -> list[int]:
 def maybe_build_calibrator(method: str):
     if method != "greg":
         return None
-    if SampleWeight is None:
-        raise ImportError(
-            "samplics is required for GREG calibration. "
-            "Install with: pip install policyengine-us-data[calibration]"
-        )
-    return SampleWeight()
+    return GregCalibrator()
 
 
 def benchmark_tob_values(

--- a/policyengine_us_data/datasets/cps/long_term/calibration.py
+++ b/policyengine_us_data/datasets/cps/long_term/calibration.py
@@ -3,6 +3,66 @@ import pandas as pd
 from scipy import optimize, sparse
 
 
+class GregCalibrator:
+    """Small adapter around svy's GREG calibration workflow."""
+
+    _base_weight_column = "_policyengine_base_weight"
+    _calibrated_weight_column = "_policyengine_greg_weight"
+
+    def __init__(self):
+        try:
+            import polars as pl
+            import svy
+        except ImportError as e:  # pragma: no cover - exercised without extra
+            raise ImportError(
+                "svy is required for GREG calibration. "
+                "Install with: pip install policyengine-us-data[calibration]"
+            ) from e
+
+        self._pl = pl
+        self._svy = svy
+
+    def calibrate(self, *, samp_weight, aux_vars, control):
+        control = {str(name): float(target) for name, target in control.items()}
+        aux_df = self._auxiliary_dataframe(aux_vars, list(control))
+        aux_df[self._base_weight_column] = np.asarray(samp_weight, dtype=float)
+
+        sample = self._svy.Sample(
+            self._pl.from_pandas(aux_df),
+            design=self._svy.Design(wgt=self._base_weight_column),
+        )
+        sample.weighting.calibrate(
+            controls=control,
+            wgt_name=self._calibrated_weight_column,
+        )
+        return (
+            sample.data.get_column(self._calibrated_weight_column)
+            .to_numpy()
+            .astype(float)
+        )
+
+    def _auxiliary_dataframe(self, aux_vars, control_names):
+        if isinstance(aux_vars, pd.DataFrame):
+            aux_df = aux_vars.copy()
+            aux_df.columns = [str(column) for column in aux_df.columns]
+            return aux_df
+
+        if sparse.issparse(aux_vars):
+            aux_array = aux_vars.toarray()
+        else:
+            aux_array = np.asarray(aux_vars)
+
+        if aux_array.ndim == 1:
+            aux_array = aux_array.reshape(-1, 1)
+
+        if aux_array.shape[1] != len(control_names):
+            raise ValueError(
+                "aux_vars column count must match the number of GREG controls"
+            )
+
+        return pd.DataFrame(aux_array.astype(float), columns=control_names)
+
+
 def _pct_error(achieved, target):
     if target == 0:
         return 0.0 if achieved == 0 else float("inf")
@@ -106,10 +166,10 @@ def calibrate_greg(
     n_ages=86,
 ):
     """
-    Calibrate weights using GREG method via samplics.
+    Calibrate weights using GREG method via svy.
 
     Args:
-        calibrator: SampleWeight instance from samplics
+        calibrator: GregCalibrator instance
         X: Design matrix (n_households x n_ages)
         y_target: Target age distribution
         baseline_weights: Initial household weights

--- a/policyengine_us_data/datasets/cps/long_term/run_household_projection.py
+++ b/policyengine_us_data/datasets/cps/long_term/run_household_projection.py
@@ -56,6 +56,7 @@ from ssa_data import (
     set_long_term_target_source,
 )
 from calibration import (
+    GregCalibrator,
     build_calibration_audit,
     build_clone_donor_component_weight_concentration_audit,
     build_clone_donor_family_weight_concentration_audit,
@@ -787,14 +788,7 @@ if USE_TOB or BENCHMARK_TOB:
     from ssa_data import load_hi_tob_projections, load_oasdi_tob_projections
 
 if USE_GREG:
-    try:
-        from samplics.weighting import SampleWeight
-    except ImportError:
-        raise ImportError(
-            "samplics is required for GREG calibration. "
-            "Install with: pip install policyengine-us-data[calibration]"
-        )
-    calibrator = SampleWeight()
+    calibrator = GregCalibrator()
 else:
     calibrator = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
 
 [project.optional-dependencies]
 calibration = [
-    "samplics",
+    "svy>=0.18.2",
 ]
 l0 = [
     "l0-python",

--- a/tests/unit/test_long_term_calibration_contract.py
+++ b/tests/unit/test_long_term_calibration_contract.py
@@ -21,6 +21,7 @@ from policyengine_us_data.datasets.cps.long_term import (
 )
 from policyengine_us_data.datasets.cps.long_term import run_long_term_production
 from policyengine_us_data.datasets.cps.long_term.calibration import (
+    GregCalibrator,
     assess_nonnegative_feasibility,
     build_calibration_audit,
     calibrate_entropy,
@@ -1105,6 +1106,29 @@ def test_strict_greg_failure_raises():
             calibrator=ExplodingCalibrator(),
             allow_fallback_to_ipf=False,
         )
+
+
+def test_greg_calibrator_hits_linear_controls_with_svy():
+    pytest.importorskip("svy")
+
+    X = np.array([[1.0, 0.0], [0.0, 1.0]])
+    y_target = np.array([2.0, 3.0])
+    baseline_weights = np.array([1.0, 1.0])
+
+    weights, iterations, audit = calibrate_weights(
+        X=X,
+        y_target=y_target,
+        baseline_weights=baseline_weights,
+        method="greg",
+        calibrator=GregCalibrator(),
+        n_ages=2,
+        allow_fallback_to_ipf=False,
+    )
+
+    assert iterations == 1
+    assert audit["method_used"] == "greg"
+    assert audit["fell_back_to_ipf"] is False
+    np.testing.assert_allclose(X.T @ weights, y_target)
 
 
 def test_build_calibration_audit_reports_constraint_error():

--- a/uv.lock
+++ b/uv.lock
@@ -1494,6 +1494,46 @@ wheels = [
 ]
 
 [[package]]
+name = "msgspec"
+version = "0.21.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/60/f79b9b013a16fa3a58350c9295ddc6789f2e335f36ea61ed10a21b215364/msgspec-0.21.1.tar.gz", hash = "sha256:2313508e394b0d208f8f56892ca9b2799e2561329de9763b19619595a6c0f72c", size = 319193, upload-time = "2026-04-12T21:44:50.394Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/cf/317224852c00248c620a9bcf4b26e2e4ab8afd752f18d2a6ef73ebd423b6/msgspec-0.21.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d4248cf0b6129b7d230eacd493c17cc2d4f3989f3bb7f633a928a85b7dcfa251", size = 196188, upload-time = "2026-04-12T21:44:07.181Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/81/074612945c0666078f7366f40000013de9f6ba687491d450df699bceebc9/msgspec-0.21.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5102c7e9b3acff82178449b85006d96310e690291bb1ea0142f1b24bcb8aabcb", size = 188473, upload-time = "2026-04-12T21:44:08.736Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/37/655101799590bcc5fddb2bd3fe0e6194e816c2d1da7c361725f5eb89a910/msgspec-0.21.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:846758412e9518252b2ac9bffd6f0e54d9ff614f5f9488df7749f81ff5c80920", size = 218871, upload-time = "2026-04-12T21:44:09.917Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d1/d4cd9fe89c7d400d7a18f86ccc94daa3f0927f53558846fcb60791dce5d6/msgspec-0.21.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21995e74b5c598c2e004110ad66ec7f1b8c20bf2bcf3b2de8fd9a3094422d3ff", size = 225025, upload-time = "2026-04-12T21:44:11.191Z" },
+    { url = "https://files.pythonhosted.org/packages/24/bf/e20549e602b9edccadeeff98760345a416f9cce846a657e8b18e3396b212/msgspec-0.21.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6129f0cca52992e898fd5344187f7c8127b63d810b2fd73e36fca73b4c6475ee", size = 222672, upload-time = "2026-04-12T21:44:12.481Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/68/04d7a8f0f786545cf9b8c280c57aa6befb5977af6e884b8b54191cbe44b3/msgspec-0.21.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ef3ec2296248d1f8b9231acb051b6d471dfde8f21819e86c9adaaa9f42918521", size = 227303, upload-time = "2026-04-12T21:44:13.709Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4d/619866af2840875be408047bf9e70ceafbae6ab50660de7134ed1b25eb86/msgspec-0.21.1-cp312-cp312-win_amd64.whl", hash = "sha256:d4ab834a054c6f0cbeef6df9e7e1b33d5f1bc7b86dea1d2fd7cad003873e783d", size = 190017, upload-time = "2026-04-12T21:44:14.977Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/2e/a8f9eca8fd00e097d7a9e99ba8a4685db994494448e3d4f0b7f6e9a3c0f7/msgspec-0.21.1-cp312-cp312-win_arm64.whl", hash = "sha256:628aaa35c74950a8c59da330d7e98917e1c7188f983745782027748ee4ca573e", size = 175345, upload-time = "2026-04-12T21:44:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/74/f11ede02839b19ff459f88e3145df5d711626ca84da4e23520cebf819367/msgspec-0.21.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:764173717a01743f007e9f74520ed281f24672c604514f7d76c1c3a10e8edb66", size = 196176, upload-time = "2026-04-12T21:44:17.613Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/40/4476c1bd341418a046c4955aff632ec769315d1e3cb94e6acf86d461f9ed/msgspec-0.21.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:344c7cd0eaed1fb81d7959f99100ef71ec9b536881a376f11b9a6c4803365697", size = 188524, upload-time = "2026-04-12T21:44:18.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/d9/9e9d7d7e5061b47540d03d640fab9b3965ba7ae49c1b2154861c8f007518/msgspec-0.21.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48943e278b3854c2f89f955ddc6f9f430d3f0784b16e47d10604ee0463cd21f5", size = 218880, upload-time = "2026-04-12T21:44:20.028Z" },
+    { url = "https://files.pythonhosted.org/packages/74/66/2bb344f34abb4b57e60c7c9c761994e0417b9718ec1460bf00c296f2a7ea/msgspec-0.21.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9aa659ebb0101b1cbc31461212b87e341d961f0ab0772aaf068a99e001ec4aa", size = 225050, upload-time = "2026-04-12T21:44:21.577Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/84/7c1e412f76092277bf760cef12b7979d03314d259ab5b5cafde5d0c1722d/msgspec-0.21.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7b27d1a8ead2b6f5b0c4f2d07b8be1ccfcc041c8a0e704781edebe3ae13c484", size = 222713, upload-time = "2026-04-12T21:44:22.83Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/27/0bba04b2b4ef05f3d068429410bc71d2cea925f1596a8f41152cccd5edb8/msgspec-0.21.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:38fe93e86b61328fe544cb7fd871fad5a27c8734bfda90f65e5dbe288ae50f61", size = 227259, upload-time = "2026-04-12T21:44:24.11Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/2d/09574b0eea02fed2c2c1383dbaae2c7f79dc16dcd6487a886000afb5d7c4/msgspec-0.21.1-cp313-cp313-win_amd64.whl", hash = "sha256:8bc666331c35fcce05a7cd2d6221adbe0f6058f8e750711413d22793c080ac6a", size = 189857, upload-time = "2026-04-12T21:44:25.359Z" },
+    { url = "https://files.pythonhosted.org/packages/46/34/105b1576ad182879914f0c821f17ee1d13abb165cb060448f96fe2aff078/msgspec-0.21.1-cp313-cp313-win_arm64.whl", hash = "sha256:42bb1241e0750c1a4346f2aa84db26c5ffd99a4eb3a954927d9f149ff2f42898", size = 175403, upload-time = "2026-04-12T21:44:26.608Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ad/86954e987d1d6a5c579e2c2e7832b65e0fff194179fdac4f581536086024/msgspec-0.21.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fab48eb45fdbfbdb2c0edfec00ffc53b6b6085beefc6b50b61e01659f9f8757f", size = 196261, upload-time = "2026-04-12T21:44:27.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a1/c5e46c3e42b866199365e35d11dddfd1fbd8bba4fdb3c52f965b1607ce94/msgspec-0.21.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3cb779ea0c35bc807ff941d415875c1f69ca0be91a2e907ab99a171811d86a9a", size = 188729, upload-time = "2026-04-12T21:44:28.99Z" },
+    { url = "https://files.pythonhosted.org/packages/85/7d/1e29a319d678d6cb962ae5bdf32a6858ebdf38f73bc654c0e9c742a0c2c8/msgspec-0.21.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:68604db36b3b4dd9bf160e436e12798a4738848144cea1aca1cb984011eb160f", size = 219866, upload-time = "2026-04-12T21:44:31.104Z" },
+    { url = "https://files.pythonhosted.org/packages/25/1f/cca084ca2572810fff12ea9dbdcbe39eac048f40daf4a9077b49fcbe8cee/msgspec-0.21.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d6b9dc50948eaf65df54d2fd0ff66e6d8c32f116037209ee861810eb9b676cb", size = 224993, upload-time = "2026-04-12T21:44:32.649Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/d2120fc9d419a89a3a7c13e5b7078798c4b392a96a02a6e2b3ce43a8766c/msgspec-0.21.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:52c5e21930942302394429c5a582ce7e6b62c7f983b3760834c2ce107e0dd6df", size = 223535, upload-time = "2026-04-12T21:44:33.839Z" },
+    { url = "https://files.pythonhosted.org/packages/75/17/42418b66a3ad972a89bab73dd78b79cc6282bb488a25e73c853cee7443b9/msgspec-0.21.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:abbb39d65681fa24ed394e01af3d59d869068324f900c61d06062b7fb9980f2f", size = 227222, upload-time = "2026-04-12T21:44:35.093Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/33/265c894268cca88ff67b144ca2b4c522fc8b9a6f1966a3640c70516e78e1/msgspec-0.21.1-cp314-cp314-win_amd64.whl", hash = "sha256:5666b1b560b97b6ec2eb3fca8a502298ebac56e13bbca1f88523538ce83d01ea", size = 193810, upload-time = "2026-04-12T21:44:36.612Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8f/a6d35f25bf1fc63c492fdd88fdce01ba0875ead48c2b91f90f33653b4131/msgspec-0.21.1-cp314-cp314-win_arm64.whl", hash = "sha256:d8b8578e4c83b14ceea4cef0d0b747e31d9330fe4b03b2b2ad4063866a178f93", size = 179125, upload-time = "2026-04-12T21:44:38.198Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/39/74839641e64b99d87da55af0fc472854d42b46e2183b9e2a67fe1bb2a512/msgspec-0.21.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:15f523d51c00ebad412213bfe9f06f0a50ec2b93e0c19e824a2d267cabb48ea2", size = 200171, upload-time = "2026-04-12T21:44:39.414Z" },
+    { url = "https://files.pythonhosted.org/packages/70/9b/ce0cca6d2d87fcd4b6ff97600790494e64f26a2c55d61507cd2755c16193/msgspec-0.21.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e47390360583ba3d5c6cb44cf0a9f61b0a06a899d3c2c00627cedebb2e2884b", size = 192879, upload-time = "2026-04-12T21:44:40.882Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/08/673a7bb05e5702dc787ddd3011195b509f9867927970da59052211929987/msgspec-0.21.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f60800e6299b798142dc40b0644da77ceac5ea0568be58228417eae14135c847", size = 226281, upload-time = "2026-04-12T21:44:42.181Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/45/86508cf57283e9070b3c447e3ab25b792a7a0855a3ea4e0c6d111ac34c97/msgspec-0.21.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5f8e9dfcd98419cf7568808470c4317a3fb30bef0e3715b568730a2b272a20d7", size = 229863, upload-time = "2026-04-12T21:44:43.442Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/62/e7c9367cd08d590559faacd711edbae36840342843e669440363f33c7d36/msgspec-0.21.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:92d89dfad13bd1ea640dc3e37e724ed380da1030b272bdf5ecafb983c3ad7c75", size = 230445, upload-time = "2026-04-12T21:44:44.806Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b4/c0f54632103846b658a10930025f4de41c8724b5e4805a5f3b395586cb7e/msgspec-0.21.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0d03867786e5d7ba25d666df4b11320c27170f4aeafcb8e3a8b0a50a4fb742ca", size = 231822, upload-time = "2026-04-12T21:44:46.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/1d/0d85cc79d0ccf5508e9c846cc66552a6a16bf92abd1dbd8362617f7b35cd/msgspec-0.21.1-cp314-cp314t-win_amd64.whl", hash = "sha256:740fbf1c9d59992ca3537d6fbe9ebbf9eaf726a65fbf31448e0ecbc710697a63", size = 206650, upload-time = "2026-04-12T21:44:47.601Z" },
+    { url = "https://files.pythonhosted.org/packages/90/91/56c5d560f20e6c20e9e4f55bd0e458f7f162aa689ee350346c04c48eac0b/msgspec-0.21.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0d2cc73df6058d811a126ac3a8ad63a4dfa210c82f9cf5a004802eaf4712de90", size = 183149, upload-time = "2026-04-12T21:44:48.833Z" },
+]
+
+[[package]]
 name = "mystmd"
 version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2064,14 +2104,14 @@ wheels = [
 
 [[package]]
 name = "polars"
-version = "1.36.1"
+version = "1.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "polars-runtime-32" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/dc/56f2a90c79a2cb13f9e956eab6385effe54216ae7a2068b3a6406bae4345/polars-1.36.1.tar.gz", hash = "sha256:12c7616a2305559144711ab73eaa18814f7aa898c522e7645014b68f1432d54c", size = 711993, upload-time = "2025-12-10T01:14:53.033Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/13/fe30b3e2f9ab54a27d82af04fb2edc51c7342cbaa88815e175769a9f5901/polars-1.41.0.tar.gz", hash = "sha256:7cb5465eb66eb868fde779bf5c41c9f2f244481d72c52133e8ed10ba64372e4f", size = 737530, upload-time = "2026-05-22T20:20:56.209Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/c6/36a1b874036b49893ecae0ac44a2f63d1a76e6212631a5b2f50a86e0e8af/polars-1.36.1-py3-none-any.whl", hash = "sha256:853c1bbb237add6a5f6d133c15094a9b727d66dd6a4eb91dbb07cdb056b2b8ef", size = 802429, upload-time = "2025-12-10T01:13:53.838Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c8/5807714256c5f3de08593113df17f14f99417a451cb2d91530ad94785003/polars-1.41.0-py3-none-any.whl", hash = "sha256:35dcd24de88a198dc50929924f064ba12a0a0a4a3e77e116689491b4b3ab58ac", size = 832953, upload-time = "2026-05-22T20:19:30.958Z" },
 ]
 
 [package.optional-dependencies]
@@ -2081,16 +2121,18 @@ pyarrow = [
 
 [[package]]
 name = "polars-runtime-32"
-version = "1.36.1"
+version = "1.41.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/31/df/597c0ef5eb8d761a16d72327846599b57c5d40d7f9e74306fc154aba8c37/polars_runtime_32-1.36.1.tar.gz", hash = "sha256:201c2cfd80ceb5d5cd7b63085b5fd08d6ae6554f922bcb941035e39638528a09", size = 2788751, upload-time = "2025-12-10T01:14:54.172Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/8f/30dc715ea1135b4b80397edf33fe7b1bb124850e96e38d9918e2b3d6d0b0/polars_runtime_32-1.41.0.tar.gz", hash = "sha256:37ffbe5414f14bf43bcc8e08a0386c97c692e3fd4e87af74529d7f14b1b2d1cb", size = 2985826, upload-time = "2026-05-22T20:20:57.622Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/ea/871129a2d296966c0925b078a9a93c6c5e7facb1c5eebfcd3d5811aeddc1/polars_runtime_32-1.36.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:327b621ca82594f277751f7e23d4b939ebd1be18d54b4cdf7a2f8406cecc18b2", size = 43494311, upload-time = "2025-12-10T01:13:56.096Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/76/0038210ad1e526ce5bb2933b13760d6b986b3045eccc1338e661bd656f77/polars_runtime_32-1.36.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ab0d1f23084afee2b97de8c37aa3e02ec3569749ae39571bd89e7a8b11ae9e83", size = 39300602, upload-time = "2025-12-10T01:13:59.366Z" },
-    { url = "https://files.pythonhosted.org/packages/54/1e/2707bee75a780a953a77a2c59829ee90ef55708f02fc4add761c579bf76e/polars_runtime_32-1.36.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:899b9ad2e47ceb31eb157f27a09dbc2047efbf4969a923a6b1ba7f0412c3e64c", size = 44511780, upload-time = "2025-12-10T01:14:02.285Z" },
-    { url = "https://files.pythonhosted.org/packages/11/b2/3fede95feee441be64b4bcb32444679a8fbb7a453a10251583053f6efe52/polars_runtime_32-1.36.1-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:d9d077bb9df711bc635a86540df48242bb91975b353e53ef261c6fae6cb0948f", size = 40688448, upload-time = "2025-12-10T01:14:05.131Z" },
-    { url = "https://files.pythonhosted.org/packages/05/0f/e629713a72999939b7b4bfdbf030a32794db588b04fdf3dc977dd8ea6c53/polars_runtime_32-1.36.1-cp39-abi3-win_amd64.whl", hash = "sha256:cc17101f28c9a169ff8b5b8d4977a3683cd403621841623825525f440b564cf0", size = 44464898, upload-time = "2025-12-10T01:14:08.296Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/d8/a12e6aa14f63784cead437083319ec7cece0d5bb9a5bfe7678cc6578b52a/polars_runtime_32-1.36.1-cp39-abi3-win_arm64.whl", hash = "sha256:809e73857be71250141225ddd5d2b30c97e6340aeaa0d445f930e01bef6888dc", size = 39798896, upload-time = "2025-12-10T01:14:11.568Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e7/9d1630d666eca6a67e2096c0ed2c0e18f1355fe440043fd0830de1b71ab6/polars_runtime_32-1.41.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:766b60c74550382731b604ed62a385a8403b341bf18282d3fd2f746fa3c4cafd", size = 52163350, upload-time = "2026-05-22T20:19:34.431Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b3/01538d51cd2790729ae13c23db44bc787bdfe20867faeb1087afc390c53b/polars_runtime_32-1.41.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:bee0d294daca79cedd5749e1bf3373c2d4107eb849fe544a60df6c08abc972ce", size = 46474331, upload-time = "2026-05-22T20:19:37.936Z" },
+    { url = "https://files.pythonhosted.org/packages/79/29/efa82e1b3e6711f254df3793f3d3fd99f26ef1bcaffa6533266fa6522de4/polars_runtime_32-1.41.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08b3f915468bf00d327b4a1236935a4ec3174dcb163785fcd98185ad1319a503", size = 50358997, upload-time = "2026-05-22T20:19:42.209Z" },
+    { url = "https://files.pythonhosted.org/packages/53/18/5a04b06b773047cbf43912ab802eef3c1d50ef7e66d51a41b16726f9bc62/polars_runtime_32-1.41.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e72269f768c57229190dba0cb5abb8a1b228e96cc6331273a77a7957576885bd", size = 56332032, upload-time = "2026-05-22T20:19:45.928Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d5/d728ce7a39ea925555db7d2c9f7b5df3ca17568e483db6501783f653e0b9/polars_runtime_32-1.41.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1532c7560a5c0fd06943080ee42aade721f186becdfbb1baafa622e3199c3b62", size = 50529017, upload-time = "2026-05-22T20:19:49.489Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/92/6b2092dfed4278f636499217767204fce19ed72695690e2c4eba99e2892e/polars_runtime_32-1.41.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:43368d8a754ee274f1e1099a7c09aae59cd69d22b8a6f83c0f782a00cd3a6662", size = 54244707, upload-time = "2026-05-22T20:19:52.852Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/46b43be0f5becbef65843f438de3950ac6f8d0fa0008d7de0025eed00097/polars_runtime_32-1.41.0-cp310-abi3-win_amd64.whl", hash = "sha256:a9bd6095ecadc6799d166b9e8f7183a7ca8ba0a5aef8a426ec41df8ed8b09df7", size = 51918379, upload-time = "2026-05-22T20:19:55.832Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/da/30f15f0c3959b70e7a6583eccd37140a30b5c643ca374792d150b3a357df/polars_runtime_32-1.41.0-cp310-abi3-win_arm64.whl", hash = "sha256:ed922400f0eb393345fd7b6874b150eb943af2b816297a3dde03735cb5f3de08", size = 45921961, upload-time = "2026-05-22T20:19:59.525Z" },
 ]
 
 [[package]]
@@ -2164,7 +2206,7 @@ dependencies = [
 
 [package.optional-dependencies]
 calibration = [
-    { name = "samplics" },
+    { name = "svy" },
 ]
 l0 = [
     { name = "l0-python" },
@@ -2202,13 +2244,13 @@ requires-dist = [
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
     { name = "policyengine-us", git = "https://github.com/PolicyEngine/policyengine-us.git?rev=0dcc69aa7a38be901141d38c8dbb7a9c870f2561" },
     { name = "requests", specifier = ">=2.25.0" },
-    { name = "samplics", marker = "extra == 'calibration'" },
     { name = "scipy", specifier = ">=1.15.3" },
     { name = "setuptools", specifier = ">=60" },
     { name = "spm-calculator", specifier = ">=0.3.1" },
     { name = "sqlalchemy", specifier = ">=2.0.41" },
     { name = "sqlmodel", specifier = ">=0.0.24" },
     { name = "statsmodels", specifier = ">=0.14.5" },
+    { name = "svy", marker = "extra == 'calibration'", specifier = ">=0.18.2" },
     { name = "tables", specifier = ">=3.11.1" },
     { name = "tenacity", specifier = ">=8.0.0" },
     { name = "torch", specifier = ">=2.7.1" },
@@ -2893,20 +2935,6 @@ wheels = [
 ]
 
 [[package]]
-name = "samplics"
-version = "0.4.55"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-    { name = "polars", extra = ["pyarrow"] },
-    { name = "statsmodels" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/b5/e5eaafb91852ca68202f5d9e8a3fc4a0b0aa28d2260f4431ece47581e8ee/samplics-0.4.55.tar.gz", hash = "sha256:19f829b892d48ffa144a9683e2df5908ddb52b1322d1850aeb87d1034938cac7", size = 3345671, upload-time = "2025-08-22T00:03:25.981Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/57/bd011568272351a534970a1e590ec7c06c7bf7080dee1fb79a3d9472a594/samplics-0.4.55-py3-none-any.whl", hash = "sha256:053e8d916cce6f0ba7de7b6b9633a808177752dbe059d0af13c25e067c75ec25", size = 246176, upload-time = "2025-08-22T00:03:24.175Z" },
-]
-
-[[package]]
 name = "scikit-learn"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3287,6 +3315,54 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/34/0e/2408735aca9e764643196212f9069912100151414dd617d39ffc72d77eee/statsmodels-0.14.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3414e40c073d725007a6603a18247ab7af3467e1af4a5e5a24e4c27bc26673b4", size = 10337587, upload-time = "2025-12-05T23:13:37.597Z" },
     { url = "https://files.pythonhosted.org/packages/0f/36/4d44f7035ab3c0b2b6a4c4ebb98dedf36246ccbc1b3e2f51ebcd7ac83abb/statsmodels-0.14.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a518d3f9889ef920116f9fa56d0338069e110f823926356946dae83bc9e33e19", size = 10363350, upload-time = "2025-12-05T23:13:53.08Z" },
     { url = "https://files.pythonhosted.org/packages/26/33/f1652d0c59fa51de18492ee2345b65372550501ad061daa38f950be390b6/statsmodels-0.14.6-cp314-cp314-win_amd64.whl", hash = "sha256:151b73e29f01fe619dbce7f66d61a356e9d1fe5e906529b78807df9189c37721", size = 9588010, upload-time = "2025-12-05T23:14:07.28Z" },
+]
+
+[[package]]
+name = "svy"
+version = "0.18.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "msgspec" },
+    { name = "numpy" },
+    { name = "polars", extra = ["pyarrow"] },
+    { name = "scipy" },
+    { name = "svy-io" },
+    { name = "svy-rs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/e4/2c28449ba767c52c8c4ea8119d4b9f1817c1f4b4ee2708b3b8655ad37ace/svy-0.18.2.tar.gz", hash = "sha256:a3c2df1691c9d86d17c5acb268c7b3623a925fe260e55d3419f9597b37aa75bd", size = 337236, upload-time = "2026-05-20T08:47:42.365Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/4e/50b9e211e948da27bb0c66d899934b23a4cfde43854851a16290e9a801cc/svy-0.18.2-py3-none-any.whl", hash = "sha256:00a248d97079a250b227005fd90f50f4e9981914fde43b61ff31a1076d54a54a", size = 411680, upload-time = "2026-05-20T08:47:40.603Z" },
+]
+
+[[package]]
+name = "svy-io"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars", extra = ["pyarrow"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/85/dca7723948b82339caea55a07cf50f0f2ae00d8ff2ce34a5e860721f92e2/svy_io-0.1.0.tar.gz", hash = "sha256:2c1986eeb32e2de2e820b2f899c5cbec12e437b54d9f454ed4c3abed7d36a1af", size = 69851, upload-time = "2026-04-16T17:20:05.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/66/ad0762db3a0629b70d5d755f9ad741c8c2eb0046ec27e8f08b65a15c1336/svy_io-0.1.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:568c48458c0d36ca6d982dbf0cbbb005a7ed7dd87962e21a9581935d0f32682e", size = 1163057, upload-time = "2026-04-16T17:20:00.397Z" },
+    { url = "https://files.pythonhosted.org/packages/50/3c/a2576f3810a2f01b43e09e857c7670ef48e65df4b2e114798b2e16b5f76b/svy_io-0.1.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9555b57ffc7a39c400da91030bdea49b90c67b6152bbd66f287681b19099fa15", size = 1257429, upload-time = "2026-04-16T17:20:01.697Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/8b/66a6959423012288dd6647a22942ff58133dafbf9f0824645b4149c652f0/svy_io-0.1.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:40c7d2eb515d006366bf9c572b169440743f55e03a2fd3e3756008d98b90ffcc", size = 1306156, upload-time = "2026-04-16T17:20:02.972Z" },
+    { url = "https://files.pythonhosted.org/packages/90/b9/b490eab8d3018874abb8c915487cb2d45ccf0c6d82a132385b23db58561c/svy_io-0.1.0-cp311-abi3-win_amd64.whl", hash = "sha256:124550398b7a3c3ede8d9a2b70bbd31de1aa7fe222c0ae4b5ae72f94272d8185", size = 1184543, upload-time = "2026-04-16T17:20:04.281Z" },
+]
+
+[[package]]
+name = "svy-rs"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars", extra = ["pyarrow"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/76/18e54b86b02a7c3d839134e609e0fe0321568feb7252684263a3a6c86591/svy_rs-0.9.0.tar.gz", hash = "sha256:be5217da94c0f775bfec26536c647d0c816d55c626d25cb79291c3f9127b1042", size = 120528, upload-time = "2026-05-19T17:26:31.207Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/2d/a6c66e1c5cf2cec9d7965682b89abbef64b3a6d121a513585984204f18da/svy_rs-0.9.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:b4d6a8727a2f441f8cf415aca28f280926abd397d278eb5bf1a9936664264da0", size = 5432186, upload-time = "2026-05-19T17:26:24.959Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/7e/043780f17f4a49f0f5e35f95533af0c07d7ccffb56659f29ef594b2b65ea/svy_rs-0.9.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e2ea70c3574d16f4ac2bf5a202da4983316607301a21205cf06839a84e4b9c66", size = 5809760, upload-time = "2026-05-19T17:26:26.431Z" },
+    { url = "https://files.pythonhosted.org/packages/33/93/a0bd37d17f83cb46036a05850fe8d17e3dd53b3629f1d4d1e225122301e3/svy_rs-0.9.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f055af31347bf9b596747e08ed94bbcf649b188c012e9c41beb53445a4c32c1e", size = 6855402, upload-time = "2026-05-19T17:26:27.97Z" },
+    { url = "https://files.pythonhosted.org/packages/15/50/b5156ed950d6483acb563670be99d0c3cd15c092107c096052a3610c0108/svy_rs-0.9.0-cp311-abi3-win_amd64.whl", hash = "sha256:db8d6dd4130be07fc863b39079f5f436d3f6dc049b0bcc92af25aa8ceaffdb18", size = 6018001, upload-time = "2026-05-19T17:26:29.535Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- replace the archived samplics calibration extra with svy
- add a small GregCalibrator adapter so existing long-term GREG calibration call sites keep their current interface
- update long-term GREG construction in the projection and publishable-horizon tools
- add focused coverage that svy-backed GREG hits linear controls

Closes #1129.

## Tests
- UV_FROZEN=0 uv lock --locked
- UV_FROZEN=0 uv run ruff format --check .
- UV_FROZEN=0 uv run ruff check policyengine_us_data/datasets/cps/long_term/calibration.py policyengine_us_data/datasets/cps/long_term/run_household_projection.py policyengine_us_data/datasets/cps/long_term/assess_publishable_horizon.py tests/unit/test_long_term_calibration_contract.py
- UV_FROZEN=0 uv run --extra calibration pytest tests/unit/test_long_term_calibration_contract.py -q
- UV_FROZEN=0 uv run --extra calibration python - <<'PY'
from policyengine_us_data.datasets.cps.long_term.calibration import GregCalibrator
GregCalibrator()
PY