### PR TITLE
Ensure imputed premiums and auto loan interest are nonnegative

### DIFF
--- a/changelog.d/1137.fixed
+++ b/changelog.d/1137.fixed
@@ -1,0 +1,1 @@
+Prevent negative derived health insurance premium residuals and auto-loan interest artifacts in generated US data.

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -841,10 +841,10 @@ def derive_other_health_insurance_premiums(self):
     """Create other premium inputs net of baseline computed premiums.
 
     The model adds computed premiums back explicitly, so it needs a separate
-    other-premium input for the parts of CPS-reported non-Medicare premiums
-    not explained by baseline computed Marketplace, CHIP, or Medicaid
-    premiums. The original CPS-reported premium inputs remain unchanged as raw
-    source fields. The data package requires a policyengine-us release with
+    other-premium input for the non-negative part of CPS-reported non-Medicare
+    premiums not explained by baseline computed Marketplace, CHIP, or Medicaid
+    premiums. The CPS-reported premium inputs remain separate source fields.
+    The data package requires a policyengine-us release with
     these modeled premium variables, so missing variables fail fast instead of
     silently producing an incomplete decomposition.
     """
@@ -895,10 +895,11 @@ def compute_other_health_insurance_premiums(
     reported_premium: np.ndarray,
     baseline_computed_premium: np.ndarray,
 ) -> np.ndarray:
-    """Return other premiums after subtracting baseline computed premiums."""
-    return np.asarray(reported_premium, dtype=float) - np.asarray(
+    """Return non-negative other premiums net of baseline computed premiums."""
+    residual = np.asarray(reported_premium, dtype=float) - np.asarray(
         baseline_computed_premium, dtype=float
     )
+    return np.clip(residual, 0, None)
 
 
 def _premium_values_to_person(

--- a/policyengine_us_data/datasets/scf/scf.py
+++ b/policyengine_us_data/datasets/scf/scf.py
@@ -15,6 +15,11 @@ from filelock import FileLock
 
 from policyengine_us_data.utils.downsample import downsample_dataset_arrays
 
+SCF_AUTO_LOAN_IDENTIFIER_COLUMNS = ["yy1", "y1"]
+SCF_AUTO_LOAN_BALANCE_COLUMNS = ["x2209", "x2309", "x2409", "x7158"]
+SCF_AUTO_LOAN_RATE_COLUMNS = ["x2219", "x2319", "x2419", "x7170"]
+SCF_AUTO_LOAN_COLUMNS = SCF_AUTO_LOAN_BALANCE_COLUMNS + SCF_AUTO_LOAN_RATE_COLUMNS
+
 
 class SCF(Dataset):
     """Dataset containing processed Survey of Consumer Finances data."""
@@ -82,7 +87,7 @@ class SCF(Dataset):
         """
         # Check if file exists
         if not os.path.exists(self.file_path):
-            print(f"SCF dataset file not found. Generating it.")
+            print("SCF dataset file not found. Generating it.")
             self._generate_unlocked()
 
         # Open the HDF5 file and handle potential errors
@@ -218,6 +223,13 @@ def rename_columns_to_match_cps(scf: dict, raw_data: pd.DataFrame) -> None:
             scf[pe_var] = raw_data[scf_var].fillna(0).values
 
 
+def _clean_auto_loan_columns(auto_df: pd.DataFrame) -> pd.DataFrame:
+    """Replace SCF auto-loan missing-code artifacts with valid zero values."""
+    auto_df = auto_df.copy()
+    auto_df[SCF_AUTO_LOAN_COLUMNS] = auto_df[SCF_AUTO_LOAN_COLUMNS].clip(lower=0)
+    return auto_df
+
+
 def add_auto_loan_interest(scf: dict, year: int) -> None:
     """Adds auto loan balance and interest to the summarized SCF dataset from the full SCF."""
     import requests
@@ -228,19 +240,6 @@ def add_auto_loan_interest(scf: dict, year: int) -> None:
     logger = logging.getLogger(__name__)
 
     url = f"https://www.federalreserve.gov/econres/files/scf{year}s.zip"
-
-    # Define columns of interest
-    IDENTIFYER_COLUMNS = ["yy1", "y1"]
-    AUTO_LOAN_COLUMNS = [
-        "x2209",  # loan amount on car 1
-        "x2309",  # loan amount on car 2
-        "x2409",  # loan amount on car 3
-        "x7158",  # loan amount on car 4
-        "x2219",  # loan interest rate on car 1
-        "x2319",  # loan interest rate on car 2
-        "x2419",  # loan interest rate on car 3
-        "x7170",  # loan interest rate on car 4
-    ]
 
     try:
         # Download zip file
@@ -273,7 +272,9 @@ def add_auto_loan_interest(scf: dict, year: int) -> None:
                 with z.open(dta_files[0]) as f:
                     df = pd.read_stata(
                         io.BytesIO(f.read()),
-                        columns=(IDENTIFYER_COLUMNS + AUTO_LOAN_COLUMNS),
+                        columns=(
+                            SCF_AUTO_LOAN_IDENTIFIER_COLUMNS + SCF_AUTO_LOAN_COLUMNS
+                        ),
                     )
                     logger.info(f"Read DataFrame with shape {df.shape}")
             except Exception as e:
@@ -287,17 +288,17 @@ def add_auto_loan_interest(scf: dict, year: int) -> None:
             raise RuntimeError(f"Downloaded zip file is corrupt for year {year}") from e
 
         # Process the interest data and add to final SCF dictionary
-        auto_df = df[IDENTIFYER_COLUMNS + AUTO_LOAN_COLUMNS].copy()
-        auto_df[AUTO_LOAN_COLUMNS].replace(-1, 0, inplace=True)
+        auto_df = _clean_auto_loan_columns(
+            df[SCF_AUTO_LOAN_IDENTIFIER_COLUMNS + SCF_AUTO_LOAN_COLUMNS]
+        )
 
         # Interest rate columns are in percent * 10,000 format, we need to divide by 10,000 to leave them in percentage format
-        RATE_COLUMNS = ["x2219", "x2319", "x2419", "x7170"]
-        auto_df[RATE_COLUMNS] /= 10_000
+        auto_df[SCF_AUTO_LOAN_RATE_COLUMNS] /= 10_000
 
         # Calculate total auto loan balance (sum of all auto loan balance variables)
-        auto_df["auto_loan_balance"] = auto_df[
-            ["x2209", "x2309", "x2409", "x7158"]
-        ].sum(axis=1)
+        auto_df["auto_loan_balance"] = auto_df[SCF_AUTO_LOAN_BALANCE_COLUMNS].sum(
+            axis=1
+        )
 
         # Calculate total auto loan interest (sum of the amounts of each balance variable multiplied by its respective interest rate variable)
         auto_df["auto_loan_interest"] = (

--- a/tests/unit/datasets/test_other_health_insurance_premiums.py
+++ b/tests/unit/datasets/test_other_health_insurance_premiums.py
@@ -18,7 +18,7 @@ def test_other_health_insurance_premiums_subtracts_computed_premiums() -> None:
         baseline_computed_premium=computed,
     )
 
-    np.testing.assert_allclose(result, [375.0, -50.0, 50.0])
+    np.testing.assert_allclose(result, [375.0, 0.0, 50.0])
 
 
 def test_other_health_insurance_premiums_preserves_reported_input() -> None:

--- a/tests/unit/datasets/test_scf.py
+++ b/tests/unit/datasets/test_scf.py
@@ -1,0 +1,29 @@
+import pandas as pd
+
+from policyengine_us_data.datasets.scf.scf import (
+    SCF_AUTO_LOAN_COLUMNS,
+    _clean_auto_loan_columns,
+)
+
+
+def test_clean_auto_loan_columns_clips_negative_missing_codes():
+    auto_df = pd.DataFrame(
+        {
+            "yy1": [1],
+            "y1": [2],
+            "x2209": [-1.0],
+            "x2309": [10_000.0],
+            "x2409": [0.0],
+            "x7158": [5_000.0],
+            "x2219": [-1.0],
+            "x2319": [500.0],
+            "x2419": [0.0],
+            "x7170": [750.0],
+        }
+    )
+
+    cleaned = _clean_auto_loan_columns(auto_df)
+
+    assert cleaned.loc[0, "yy1"] == 1
+    assert cleaned.loc[0, "y1"] == 2
+    assert (cleaned[SCF_AUTO_LOAN_COLUMNS].to_numpy() >= 0).all()


### PR DESCRIPTION
## Summary

- Clip derived `other_health_insurance_premiums` at zero when modeled CHIP, Marketplace, or Medicaid premiums exceed reported non-Medicare premiums.
- Fix SCF auto-loan missing-code cleanup so negative sentinel values cannot survive into `auto_loan_interest`.
- Add focused unit tests for nonnegative premium residuals and SCF auto-loan cleanup.
- Add a Towncrier changelog fragment.

## Notes

The 2024 CPS ASEC data dictionary defines `PHIP_VAL` itself as `0 - 999999`, so this PR does not clip the raw CPS premium field. The negative premium issue comes from the derived residual: modeled premiums can exceed reported non-Medicare premiums, so `other_health_insurance_premiums` is now floored at zero instead of storing a negative premium.

Codebook reference: https://www2.census.gov/programs-surveys/cps/datasets/2024/march/asec2024_ddl_pub_full.pdf

## Checks

- `uv run towncrier check --compare-with upstream/main`
- `uv run ruff format --check policyengine_us_data/datasets/cps/cps.py policyengine_us_data/datasets/scf/scf.py tests/unit/datasets/test_other_health_insurance_premiums.py tests/unit/datasets/test_scf.py`
- `uv run ruff check policyengine_us_data/datasets/cps/cps.py policyengine_us_data/datasets/scf/scf.py tests/unit/datasets/test_other_health_insurance_premiums.py tests/unit/datasets/test_scf.py`
- `uv run pytest tests/unit/datasets/test_other_health_insurance_premiums.py tests/unit/datasets/test_scf.py -q`
