### PR TITLE
Allocate Medicaid cost if enrolled from SLCSP

### DIFF
--- a/changelog.d/1138.changed.md
+++ b/changelog.d/1138.changed.md
@@ -1,0 +1,1 @@
+Allocate conditional Medicaid cost from an SLCSP age/location index in us-data.

--- a/policyengine_us_data/build_outputs/us_augmentations.py
+++ b/policyengine_us_data/build_outputs/us_augmentations.py
@@ -13,6 +13,9 @@ from policyengine_us.variables.gov.hud.is_eligible_for_housing_assistance import
 from policyengine_us_data.calibration.block_assignment import (
     derive_geography_from_blocks,
 )
+from policyengine_us_data.datasets.cps.medicaid_cost import (
+    add_medicaid_cost_if_enrolled_to_time_period_data,
+)
 from policyengine_us_data.pipeline_metadata import pipeline_node
 from policyengine_us_data.utils.takeup import (
     SIMPLE_TAKEUP_VARS,
@@ -31,11 +34,14 @@ __all__ = [
     "TAKEUP_VARIABLE_ENTITIES",
     "US_ENTITY_POSTPROCESSOR_KEY",
     "US_GEOGRAPHY_POSTPROCESSOR_KEY",
+    "US_MEDICAID_COST_POSTPROCESSOR_KEY",
     "US_TAKEUP_POSTPROCESSOR_KEY",
     "USEntityPostProcessor",
     "USEntityPostProcessorResult",
     "USGeographyPostProcessor",
     "USGeographyPostProcessorResult",
+    "USMedicaidCostPostProcessor",
+    "USMedicaidCostPostProcessorResult",
     "USTakeupPostProcessor",
     "USTakeupPostProcessorResult",
     "default_us_postprocessors",
@@ -45,6 +51,7 @@ PeriodData = dict[Any, np.ndarray]
 PayloadData = dict[str, PeriodData]
 GeographyDeriver = Callable[[np.ndarray], Mapping[str, np.ndarray]]
 TakeupApplier = Callable[..., Mapping[str, np.ndarray]]
+MedicaidCostAdder = Callable[[PayloadData, int], PayloadData]
 TAKEUP_VARIABLE_ENTITIES = {
     str(spec["variable"]): str(spec["entity"]) for spec in SIMPLE_TAKEUP_VARS
 }
@@ -52,6 +59,7 @@ REQUIRED_TAKEUP_SUBENTITIES = ("tax_unit", "spm_unit")
 US_ENTITY_POSTPROCESSOR_KEY = "us_entity"
 US_GEOGRAPHY_POSTPROCESSOR_KEY = "us_geography"
 US_TAKEUP_POSTPROCESSOR_KEY = "us_takeup"
+US_MEDICAID_COST_POSTPROCESSOR_KEY = "us_medicaid_cost"
 
 
 @pipeline_node(
@@ -126,6 +134,32 @@ class USTakeupPostProcessorResult:
 
     payload: H5Payload
     takeup_variables: tuple[str, ...] = ()
+
+    @property
+    def data(self) -> PayloadData:
+        """Augmented payload data retained for transitional callers."""
+
+        return self.payload.data
+
+
+@pipeline_node(
+    id="local_h5_us_medicaid_cost_postprocessor_result",
+    label="USMedicaidCostPostProcessorResult",
+    node_type="library",
+    description="US Medicaid conditional-cost local H5 payload data.",
+    source_file="policyengine_us_data/build_outputs/us_augmentations.py",
+    status="current",
+    stability="moving",
+    pathways=["local_h5"],
+    validation_commands=[
+        "uv run pytest tests/unit/build_outputs/test_us_augmentations.py"
+    ],
+)
+@dataclass(frozen=True)
+class USMedicaidCostPostProcessorResult:
+    """Payload after conditional Medicaid cost fields are applied."""
+
+    payload: H5Payload
 
     @property
     def data(self) -> PayloadData:
@@ -571,8 +605,67 @@ class USTakeupPostProcessor:
         }
 
 
+@pipeline_node(
+    id="local_h5_us_medicaid_cost_postprocessor",
+    label="USMedicaidCostPostProcessor",
+    node_type="library",
+    description="Apply SLCSP-indexed Medicaid cost-if-enrolled to local H5 payloads.",
+    source_file="policyengine_us_data/build_outputs/us_augmentations.py",
+    status="current",
+    stability="moving",
+    pathways=["local_h5"],
+    validation_commands=[
+        "uv run pytest tests/unit/build_outputs/test_us_augmentations.py"
+    ],
+)
+@dataclass(frozen=True)
+class USMedicaidCostPostProcessor:
+    """Apply Medicaid conditional cost after entity, geography, and take-up."""
+
+    spec = PayloadPostProcessorSpec(
+        key=US_MEDICAID_COST_POSTPROCESSOR_KEY,
+        requires=(
+            US_ENTITY_POSTPROCESSOR_KEY,
+            US_GEOGRAPHY_POSTPROCESSOR_KEY,
+            US_TAKEUP_POSTPROCESSOR_KEY,
+        ),
+    )
+    medicaid_cost_adder: MedicaidCostAdder = (
+        add_medicaid_cost_if_enrolled_to_time_period_data
+    )
+
+    def apply(
+        self,
+        *,
+        payload: H5Payload,
+        context: PayloadBuildContext,
+    ) -> USMedicaidCostPostProcessorResult:
+        """Return a payload with conditional Medicaid costs applied."""
+
+        output = self.medicaid_cost_adder(
+            _copy_payload(payload.data),
+            context.time_period,
+        )
+        variable_entities = {
+            **payload.variable_entities,
+            "medicaid_cost_if_enrolled": "person",
+        }
+        return USMedicaidCostPostProcessorResult(
+            payload=H5Payload(
+                data=output,
+                time_period=payload.time_period,
+                entity_lengths=payload.entity_lengths,
+                variable_entities=variable_entities,
+            ),
+        )
+
+
 def default_us_postprocessors() -> tuple[
-    USEntityPostProcessor | USGeographyPostProcessor | USTakeupPostProcessor, ...
+    USEntityPostProcessor
+    | USGeographyPostProcessor
+    | USTakeupPostProcessor
+    | USMedicaidCostPostProcessor,
+    ...,
 ]:
     """Return production US postprocessors in their required order."""
 
@@ -580,6 +673,7 @@ def default_us_postprocessors() -> tuple[
         USEntityPostProcessor(),
         USGeographyPostProcessor(),
         USTakeupPostProcessor(),
+        USMedicaidCostPostProcessor(),
     )
 
 

--- a/policyengine_us_data/build_outputs/us_augmentations.py
+++ b/policyengine_us_data/build_outputs/us_augmentations.py
@@ -13,9 +13,6 @@ from policyengine_us.variables.gov.hud.is_eligible_for_housing_assistance import
 from policyengine_us_data.calibration.block_assignment import (
     derive_geography_from_blocks,
 )
-from policyengine_us_data.datasets.cps.medicaid_cost import (
-    add_medicaid_cost_if_enrolled_to_time_period_data,
-)
 from policyengine_us_data.pipeline_metadata import pipeline_node
 from policyengine_us_data.utils.takeup import (
     SIMPLE_TAKEUP_VARS,
@@ -51,7 +48,6 @@ PeriodData = dict[Any, np.ndarray]
 PayloadData = dict[str, PeriodData]
 GeographyDeriver = Callable[[np.ndarray], Mapping[str, np.ndarray]]
 TakeupApplier = Callable[..., Mapping[str, np.ndarray]]
-MedicaidCostAdder = Callable[[PayloadData, int], PayloadData]
 TAKEUP_VARIABLE_ENTITIES = {
     str(spec["variable"]): str(spec["entity"]) for spec in SIMPLE_TAKEUP_VARS
 }
@@ -609,7 +605,7 @@ class USTakeupPostProcessor:
     id="local_h5_us_medicaid_cost_postprocessor",
     label="USMedicaidCostPostProcessor",
     node_type="library",
-    description="Apply SLCSP-indexed Medicaid cost-if-enrolled to local H5 payloads.",
+    description="Preserve Medicaid cost-if-enrolled inputs in local H5 payloads.",
     source_file="policyengine_us_data/build_outputs/us_augmentations.py",
     status="current",
     stability="moving",
@@ -620,7 +616,7 @@ class USTakeupPostProcessor:
 )
 @dataclass(frozen=True)
 class USMedicaidCostPostProcessor:
-    """Apply Medicaid conditional cost after entity, geography, and take-up."""
+    """Preserve source Medicaid conditional costs after local H5 transforms."""
 
     spec = PayloadPostProcessorSpec(
         key=US_MEDICAID_COST_POSTPROCESSOR_KEY,
@@ -630,9 +626,6 @@ class USMedicaidCostPostProcessor:
             US_TAKEUP_POSTPROCESSOR_KEY,
         ),
     )
-    medicaid_cost_adder: MedicaidCostAdder = (
-        add_medicaid_cost_if_enrolled_to_time_period_data
-    )
 
     def apply(
         self,
@@ -640,16 +633,23 @@ class USMedicaidCostPostProcessor:
         payload: H5Payload,
         context: PayloadBuildContext,
     ) -> USMedicaidCostPostProcessorResult:
-        """Return a payload with conditional Medicaid costs applied."""
+        """Return a payload with source conditional Medicaid costs preserved."""
 
-        output = self.medicaid_cost_adder(
-            _copy_payload(payload.data),
-            context.time_period,
-        )
-        variable_entities = {
-            **payload.variable_entities,
-            "medicaid_cost_if_enrolled": "person",
-        }
+        output = _copy_payload(payload.data)
+        cost_periods = output.get("medicaid_cost_if_enrolled", {})
+        if context.time_period not in cost_periods:
+            source_values = _source_person_period_values(
+                context=context,
+                variable="medicaid_cost_if_enrolled",
+            )
+            if source_values is not None:
+                output["medicaid_cost_if_enrolled"] = {
+                    context.time_period: source_values.astype(np.float32)
+                }
+
+        variable_entities = dict(payload.variable_entities)
+        if "medicaid_cost_if_enrolled" in output:
+            variable_entities["medicaid_cost_if_enrolled"] = "person"
         return USMedicaidCostPostProcessorResult(
             payload=H5Payload(
                 data=output,
@@ -679,6 +679,26 @@ def default_us_postprocessors() -> tuple[
 
 def _copy_payload(data: Mapping[str, Mapping[Any, np.ndarray]]) -> PayloadData:
     return {variable: dict(periods) for variable, periods in data.items()}
+
+
+def _source_person_period_values(
+    *,
+    context: PayloadBuildContext,
+    variable: str,
+) -> np.ndarray | None:
+    """Return a source person input mapped to the local payload, if available."""
+
+    if variable not in context.source.input_variables:
+        return None
+    provider = context.source.variable_provider
+    get_array = getattr(provider, "get_array", None)
+    if not callable(get_array):
+        return None
+    try:
+        values = np.asarray(get_array(variable, context.time_period))
+    except (KeyError, ValueError):
+        return None
+    return values[context.reindexed.person_source_indices]
 
 
 def _required_period_array(

--- a/policyengine_us_data/datasets/cps/cps.py
+++ b/policyengine_us_data/datasets/cps/cps.py
@@ -49,6 +49,9 @@ from policyengine_us_data.datasets.cps.tipped_occupation import (
     derive_treasury_tipped_occupation_code,
     derive_is_tipped_occupation,
 )
+from policyengine_us_data.datasets.cps.medicaid_cost import (
+    add_medicaid_cost_if_enrolled_to_dataset,
+)
 from policyengine_us_data.utils.takeup import (
     _sum_person_values_to_tax_units,
     _voluntary_filing_age_bin,
@@ -360,6 +363,8 @@ class CPS(Dataset):
         add_takeup(self)
         logging.info("Imputing Marketplace plan benchmark ratio")
         add_marketplace_plan_benchmark_ratio(self)
+        logging.info("Adding Medicaid cost if enrolled")
+        add_medicaid_cost_if_enrolled_to_dataset(self)
         logging.info("Deriving other health insurance premiums")
         derive_other_health_insurance_premiums(self)
         logging.info("Downsampling")

--- a/policyengine_us_data/datasets/cps/extended_cps.py
+++ b/policyengine_us_data/datasets/cps/extended_cps.py
@@ -25,6 +25,9 @@ from policyengine_us_data.datasets.cps.cps import (
     derive_flsa_overtime_premium,
     load_take_up_rate,
 )
+from policyengine_us_data.datasets.cps.medicaid_cost import (
+    add_medicaid_cost_if_enrolled_to_time_period_data,
+)
 from policyengine_us_data.datasets.cps.takeup import prioritize_reported_recipients
 from policyengine_us_data.datasets.org import (
     ORG_IMPUTED_VARIABLES,
@@ -1187,6 +1190,10 @@ class ExtendedCPS(Dataset):
         new_data = self._impute_llc_eligibility_inputs(new_data, self.time_period)
         new_data = self._rename_imputed_to_inputs(new_data)
         new_data = self._reassign_housing_assistance_takeup_with_geography(
+            new_data,
+            self.time_period,
+        )
+        new_data = add_medicaid_cost_if_enrolled_to_time_period_data(
             new_data,
             self.time_period,
         )

--- a/policyengine_us_data/datasets/cps/medicaid_cost.py
+++ b/policyengine_us_data/datasets/cps/medicaid_cost.py
@@ -1,0 +1,496 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any, Mapping
+
+import numpy as np
+
+
+@lru_cache(maxsize=1)
+def _policyengine_us_parameters():
+    from policyengine_us import CountryTaxBenefitSystem
+
+    return CountryTaxBenefitSystem().parameters
+
+
+def add_medicaid_cost_if_enrolled_to_dataset(dataset) -> None:
+    """Add person-level conditional Medicaid cost to an array-format dataset."""
+
+    data = dataset.load_dataset()
+
+    from policyengine_us import Microsimulation
+
+    simulation = Microsimulation(dataset=dataset)
+    values = calculate_medicaid_cost_if_enrolled(
+        simulation=simulation,
+        time_period=dataset.time_period,
+    )
+    data["medicaid_cost_if_enrolled"] = values.astype(np.float32)
+    dataset.save_dataset(data)
+
+
+def add_medicaid_cost_if_enrolled_to_time_period_data(
+    data: dict,
+    time_period: int,
+    microsimulation_cls=None,
+    dataset_cls=None,
+) -> dict:
+    """Add conditional Medicaid cost to time-period-array data."""
+
+    if microsimulation_cls is None:
+        from policyengine_us import Microsimulation
+
+        microsimulation_cls = Microsimulation
+
+    if dataset_cls is None:
+        from policyengine_core.data import Dataset
+        from policyengine_us_data.storage import STORAGE_FOLDER
+
+        class InMemoryTimePeriodDataset(Dataset):
+            name = "medicaid_cost_if_enrolled_build"
+            label = "Medicaid cost build"
+            data_format = Dataset.TIME_PERIOD_ARRAYS
+            file_path = STORAGE_FOLDER / "medicaid_cost_if_enrolled_build.h5"
+
+            def __init__(self, source_data: dict, source_time_period: int):
+                self._data = source_data
+                self.time_period = source_time_period
+                super().__init__()
+
+            def load(self):
+                return self._data
+
+            def load_dataset(self):
+                return self._data
+
+        dataset_cls = InMemoryTimePeriodDataset
+
+    simulation = microsimulation_cls(dataset=dataset_cls(data, time_period))
+    values = calculate_medicaid_cost_if_enrolled(
+        simulation=simulation,
+        time_period=time_period,
+    )
+    data["medicaid_cost_if_enrolled"] = {time_period: values.astype(np.float32)}
+    return data
+
+
+def calculate_medicaid_cost_if_enrolled(
+    simulation: Any, time_period: int
+) -> np.ndarray:
+    """Return SLCSP-indexed Medicaid cost if each person enrolled.
+
+    The allocator uses only an SLCSP-derived age/location premium index for
+    within-state variation. It normalizes by state against current Medicaid
+    enrollees so baseline weighted Medicaid costs match state spending totals,
+    while non-enrollees still receive a conditional cost for reform analysis.
+    """
+
+    person_slcsp = calculate_person_slcsp_cost_index(simulation, time_period)
+    medicaid_enrolled = _calculate(
+        simulation,
+        "medicaid_enrolled",
+        time_period,
+        map_to="person",
+    ).astype(bool)
+    person_weight = _calculate(
+        simulation,
+        "person_weight",
+        time_period,
+        map_to="person",
+    ).astype(float)
+    state_codes = _as_str_array(
+        _calculate(
+            simulation,
+            "state_code_str",
+            time_period,
+            map_to="person",
+        )
+    )
+    spending = medicaid_spending_by_state(time_period)
+    return allocate_medicaid_cost_if_enrolled_by_slcsp(
+        person_slcsp=person_slcsp,
+        medicaid_enrolled=medicaid_enrolled,
+        person_weight=person_weight,
+        state_codes=state_codes,
+        state_spending=spending,
+    )
+
+
+def calculate_person_slcsp_cost_index(
+    simulation: Any,
+    time_period: int,
+) -> np.ndarray:
+    """Return an SLCSP premium index for each person."""
+
+    age = _calculate(simulation, "age", time_period, map_to="person").astype(float)
+    is_tax_unit_dependent = _calculate(
+        simulation,
+        "is_tax_unit_dependent",
+        time_period,
+        map_to="person",
+    ).astype(bool)
+    person_tax_unit_id = _calculate(
+        simulation,
+        "person_tax_unit_id",
+        time_period,
+        map_to="person",
+    )
+    tax_unit_id = _calculate(
+        simulation,
+        "tax_unit_id",
+        time_period,
+        map_to="tax_unit",
+    )
+    state_codes = _as_str_array(
+        _calculate(simulation, "state_code_str", time_period, map_to="person")
+    )
+    rating_area = _calculate(
+        simulation,
+        "slcsp_rating_area_default",
+        time_period,
+        map_to="person",
+    ).astype(int)
+    base_cost = slcsp_age_0_by_state_rating_area(
+        state_codes,
+        rating_area,
+        time_period,
+    )
+    age_rated_index = base_cost * age_curve_multiplier(age, state_codes, time_period)
+    return np.clip(
+        family_tier_slcsp_person_share(
+            state_codes=state_codes,
+            base_cost=base_cost,
+            age=age,
+            is_tax_unit_dependent=is_tax_unit_dependent,
+            person_tax_unit_id=person_tax_unit_id,
+            tax_unit_id=tax_unit_id,
+            fallback=age_rated_index,
+            time_period=time_period,
+        ),
+        0,
+        None,
+    )
+
+
+def slcsp_age_0_by_state_rating_area(
+    state_codes: np.ndarray,
+    rating_areas: np.ndarray,
+    time_period: int,
+) -> np.ndarray:
+    """Return the age-0 SLCSP premium by state and county-level rating area."""
+
+    parameters = _policyengine_us_parameters()(f"{int(time_period)}-01-01")
+    costs = parameters.gov.aca.state_rating_area_cost
+    state_codes = _as_str_array(state_codes)
+    rating_areas = np.asarray(rating_areas, dtype=int)
+    output = np.zeros(len(state_codes), dtype=float)
+    for state_value in np.unique(state_codes):
+        state = str(state_value)
+        state_mask = state_codes == state
+        if state not in STATE_CODES:
+            continue
+        state_costs = costs[state]
+        for rating_area in np.unique(rating_areas[state_mask]):
+            safe_rating_area = str(int(rating_area))
+            try:
+                cost = float(state_costs[safe_rating_area])
+            except KeyError:
+                cost = float(state_costs["1"])
+            output[state_mask & (rating_areas == rating_area)] = cost
+    return output
+
+
+def age_curve_multiplier(
+    age: np.ndarray,
+    state_codes: np.ndarray,
+    time_period: int,
+) -> np.ndarray:
+    """Return ACA SLCSP age-curve multipliers by person."""
+
+    parameters = _policyengine_us_parameters()(f"{int(time_period)}-01-01")
+    curves = parameters.gov.aca.age_curves
+    age = np.asarray(age, dtype=float)
+    state_codes = _as_str_array(state_codes)
+    result = np.asarray(curves.default.calc(age), dtype=float)
+    state_specific_curves = {
+        "AL": curves.al,
+        "DC": curves.dc,
+        "MA": curves.ma,
+        "MN": curves.mn,
+        "MS": curves.ms,
+        "NY": curves.ny,
+        "OR": curves["or"],
+        "UT": curves.ut,
+        "VT": curves.vt,
+    }
+    for state, curve in state_specific_curves.items():
+        result = np.where(
+            state_codes == state, _calculate_age_curve(curve, age), result
+        )
+    return result
+
+
+def _calculate_age_curve(curve, age: np.ndarray) -> np.ndarray:
+    if hasattr(curve, "calc"):
+        return np.asarray(curve.calc(age), dtype=float)
+    return np.full(len(age), float(curve), dtype=float)
+
+
+def family_tier_slcsp_person_share(
+    *,
+    state_codes: np.ndarray,
+    base_cost: np.ndarray,
+    age: np.ndarray,
+    is_tax_unit_dependent: np.ndarray,
+    person_tax_unit_id: np.ndarray,
+    tax_unit_id: np.ndarray,
+    fallback: np.ndarray,
+    time_period: int,
+) -> np.ndarray:
+    """Return tax-unit SLCSP shares for NY/VT family-tier states."""
+
+    state_codes = _as_str_array(state_codes)
+    output = np.asarray(fallback, dtype=float).copy()
+    family_tier_mask = np.isin(state_codes, FAMILY_TIER_STATES)
+    if not family_tier_mask.any():
+        return output
+
+    base_cost = np.asarray(base_cost, dtype=float)
+    age = np.asarray(age, dtype=float)
+    is_tax_unit_dependent = np.asarray(is_tax_unit_dependent, dtype=bool)
+    person_tax_unit_id = np.asarray(person_tax_unit_id)
+    tax_unit_id = np.asarray(tax_unit_id)
+
+    parameters = _policyengine_us_parameters()(f"{int(time_period)}-01-01").gov.aca
+    max_child_age = float(parameters.slcsp.max_child_age)
+    dependent_child_age_threshold = float(
+        parameters.family_tier_dependent_child_age_threshold
+    )
+
+    for unit_id in tax_unit_id:
+        members = person_tax_unit_id == unit_id
+        members = members & family_tier_mask
+        if not members.any():
+            continue
+        member_states = state_codes[members]
+        state = str(member_states[0])
+        if state not in FAMILY_TIER_STATES:
+            continue
+
+        dependent_child = (age[members] <= max_child_age) | (
+            is_tax_unit_dependent[members]
+            & (age[members] < dependent_child_age_threshold)
+        )
+        adult_count = int(np.count_nonzero(~dependent_child))
+        child_count = int(np.count_nonzero(dependent_child))
+        member_count = adult_count + child_count
+        if member_count == 0:
+            continue
+
+        multiplier = _family_tier_multiplier(
+            state=state,
+            adult_count=adult_count,
+            child_count=child_count,
+            parameters=parameters,
+        )
+        if multiplier is None:
+            continue
+
+        positive_base_cost = base_cost[members][base_cost[members] > 0]
+        if not positive_base_cost.size:
+            continue
+        output[members] = float(np.mean(positive_base_cost)) * multiplier / member_count
+
+    return output
+
+
+def _family_tier_multiplier(
+    *,
+    state: str,
+    adult_count: int,
+    child_count: int,
+    parameters,
+) -> float | None:
+    ratings = (
+        parameters.family_tier_ratings.ny
+        if state == "NY"
+        else parameters.family_tier_ratings.vt
+    )
+    extra_adults = max(adult_count - 2, 0)
+    one_adult = float(ratings.ONE_ADULT)
+
+    if adult_count == 0:
+        if state == "NY" and child_count > 0:
+            return float(ratings.CHILD_ONLY)
+        # Vermont has no child-only family-tier multiplier; retain fallback.
+        return None
+    if child_count == 0:
+        base = one_adult if adult_count == 1 else float(ratings.TWO_ADULTS)
+    elif adult_count == 1:
+        base = float(ratings.ONE_ADULT_AND_ONE_OR_MORE_CHILDREN)
+    else:
+        base = float(ratings.TWO_ADULTS_AND_ONE_OR_MORE_CHILDREN)
+    return base + extra_adults * one_adult
+
+
+def medicaid_spending_by_state(time_period: int) -> dict[str, float]:
+    """Return total Medicaid spending targets by state."""
+
+    spending = _policyengine_us_parameters()(
+        f"{int(time_period)}-01-01"
+    ).calibration.gov.hhs.medicaid.totals.spending
+    return {state: float(spending[state]) for state in STATE_CODES}
+
+
+def allocate_medicaid_cost_if_enrolled_by_slcsp(
+    *,
+    person_slcsp: np.ndarray,
+    medicaid_enrolled: np.ndarray,
+    person_weight: np.ndarray,
+    state_codes: np.ndarray,
+    state_spending: Mapping[str, float],
+) -> np.ndarray:
+    """Allocate state Medicaid spending using only SLCSP as the cost index."""
+
+    person_slcsp = np.nan_to_num(np.asarray(person_slcsp, dtype=float), nan=0)
+    person_slcsp = np.clip(person_slcsp, 0, None)
+    medicaid_enrolled = np.asarray(medicaid_enrolled, dtype=bool)
+    person_weight = np.nan_to_num(np.asarray(person_weight, dtype=float), nan=0)
+    state_codes = _as_str_array(state_codes)
+
+    if not (
+        len(person_slcsp)
+        == len(medicaid_enrolled)
+        == len(person_weight)
+        == len(state_codes)
+    ):
+        raise ValueError("Medicaid cost allocator inputs must have the same length.")
+
+    output = np.zeros(len(person_slcsp), dtype=float)
+    positive_slcsp = person_slcsp > 0
+    national_fallback = (
+        float(np.mean(person_slcsp[positive_slcsp])) if positive_slcsp.any() else 1.0
+    )
+
+    for state, target in state_spending.items():
+        state_mask = state_codes == state
+        if not state_mask.any() or target <= 0:
+            continue
+
+        state_index = _fill_missing_slcsp(
+            person_slcsp[state_mask],
+            fallback=national_fallback,
+        )
+        enrolled_within_state = medicaid_enrolled[state_mask]
+        if not enrolled_within_state.any():
+            continue
+
+        denominator = float(
+            np.sum(
+                person_weight[state_mask][enrolled_within_state]
+                * state_index[enrolled_within_state]
+            )
+        )
+        if denominator <= 0:
+            continue
+
+        output[state_mask] = float(target) * state_index / denominator
+
+    return output
+
+
+def _fill_missing_slcsp(values: np.ndarray, *, fallback: float) -> np.ndarray:
+    values = np.asarray(values, dtype=float)
+    positive = values > 0
+    if positive.any():
+        fallback = float(np.mean(values[positive]))
+    return np.where(positive, values, fallback)
+
+
+def _calculate(
+    simulation: Any,
+    variable: str,
+    time_period: int,
+    *,
+    map_to: str | None = None,
+) -> np.ndarray:
+    kwargs: dict[str, Any] = {"period": time_period}
+    if map_to is not None:
+        kwargs["map_to"] = map_to
+    result = simulation.calculate(variable, **kwargs)
+    if hasattr(result, "values"):
+        result = result.values
+    return np.asarray(result)
+
+
+def _as_str_array(values: np.ndarray) -> np.ndarray:
+    values = np.asarray(values)
+    if values.dtype.kind == "S":
+        return np.char.decode(values.astype("S"), "utf-8")
+    if values.dtype.kind == "O":
+        return np.asarray(
+            [
+                value.decode("utf-8")
+                if isinstance(value, (bytes, bytearray))
+                else str(value)
+                for value in values
+            ]
+        )
+    return values.astype(str)
+
+
+FAMILY_TIER_STATES = ("NY", "VT")
+
+STATE_CODES = (
+    "AL",
+    "AK",
+    "AZ",
+    "AR",
+    "CA",
+    "CO",
+    "CT",
+    "DE",
+    "DC",
+    "FL",
+    "GA",
+    "HI",
+    "ID",
+    "IL",
+    "IN",
+    "IA",
+    "KS",
+    "KY",
+    "LA",
+    "ME",
+    "MD",
+    "MA",
+    "MI",
+    "MN",
+    "MS",
+    "MO",
+    "MT",
+    "NE",
+    "NV",
+    "NH",
+    "NJ",
+    "NM",
+    "NY",
+    "NC",
+    "ND",
+    "OH",
+    "OK",
+    "OR",
+    "PA",
+    "RI",
+    "SC",
+    "SD",
+    "TN",
+    "TX",
+    "UT",
+    "VT",
+    "VA",
+    "WA",
+    "WV",
+    "WI",
+    "WY",
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     # the project-size limit, but us-data needs the merged FLSA overtime
     # constants and data-backed Medicaid cost input before the next PyPI
     # release is available.
-    "policyengine-us @ git+https://github.com/PolicyEngine/policyengine-us.git@6a5061a4c51102f870e90637463f65e5fb1b0a11",
+    "policyengine-us @ git+https://github.com/PolicyEngine/policyengine-us.git@9419df6f0cea065faa3eac04500226485f2d395a",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,9 @@ classifiers = [
 dependencies = [
     # Temporary GitHub pin: policyengine-us 1.706.14 is blocked from PyPI by
     # the project-size limit, but us-data needs the merged FLSA overtime
-    # constants before the next PyPI release is available.
-    "policyengine-us @ git+https://github.com/PolicyEngine/policyengine-us.git@0dcc69aa7a38be901141d38c8dbb7a9c870f2561",
+    # constants and data-backed Medicaid cost input before the next PyPI
+    # release is available.
+    "policyengine-us @ git+https://github.com/PolicyEngine/policyengine-us.git@6a5061a4c51102f870e90637463f65e5fb1b0a11",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     # the project-size limit, but us-data needs the merged FLSA overtime
     # constants and data-backed Medicaid cost input before the next PyPI
     # release is available.
-    "policyengine-us @ git+https://github.com/PolicyEngine/policyengine-us.git@9419df6f0cea065faa3eac04500226485f2d395a",
+    "policyengine-us @ git+https://github.com/PolicyEngine/policyengine-us.git@1da04a64dcdce26834b063d68daa835765a5d8ed",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/tests/unit/build_outputs/test_us_augmentations.py
+++ b/tests/unit/build_outputs/test_us_augmentations.py
@@ -15,9 +15,11 @@ from policyengine_us_data.build_outputs.source_dataset import (
 from policyengine_us_data.build_outputs.us_augmentations import (
     US_ENTITY_POSTPROCESSOR_KEY,
     US_GEOGRAPHY_POSTPROCESSOR_KEY,
+    US_MEDICAID_COST_POSTPROCESSOR_KEY,
     US_TAKEUP_POSTPROCESSOR_KEY,
     USEntityPostProcessor,
     USGeographyPostProcessor,
+    USMedicaidCostPostProcessor,
     USTakeupPostProcessor,
     _build_reported_takeup_anchors,
     default_us_postprocessors,
@@ -140,11 +142,13 @@ def test_default_us_postprocessors_are_in_runtime_order():
         USEntityPostProcessor,
         USGeographyPostProcessor,
         USTakeupPostProcessor,
+        USMedicaidCostPostProcessor,
     )
     assert tuple(processor.spec.key for processor in postprocessors) == (
         US_ENTITY_POSTPROCESSOR_KEY,
         US_GEOGRAPHY_POSTPROCESSOR_KEY,
         US_TAKEUP_POSTPROCESSOR_KEY,
+        US_MEDICAID_COST_POSTPROCESSOR_KEY,
     )
     seen = set()
     for processor in postprocessors:
@@ -422,3 +426,42 @@ def test_us_takeup_postprocessor_rejects_unknown_takeup_results():
             payload=_geography_payload(),
             context=_context(),
         )
+
+
+def test_us_medicaid_cost_postprocessor_applies_conditional_costs():
+    seen = {}
+
+    def fake_medicaid_cost_adder(data, time_period):
+        seen["time_period"] = time_period
+        np.testing.assert_array_equal(
+            data["takes_up_snap_if_eligible"][2024],
+            np.array([True, False]),
+        )
+        data["medicaid_cost_if_enrolled"] = {
+            time_period: np.array([100.0, 200.0, 300.0], dtype=np.float32)
+        }
+        return data
+
+    payload = (
+        USTakeupPostProcessor(
+            takeup_applier=lambda **kwargs: {
+                "takes_up_snap_if_eligible": np.array([True, False])
+            },
+        )
+        .apply(
+            payload=_geography_payload(),
+            context=_context(),
+        )
+        .payload
+    )
+
+    result = USMedicaidCostPostProcessor(
+        medicaid_cost_adder=fake_medicaid_cost_adder,
+    ).apply(payload=payload, context=_context())
+
+    assert seen["time_period"] == 2024
+    assert result.payload.variable_entities["medicaid_cost_if_enrolled"] == "person"
+    np.testing.assert_array_equal(
+        result.data["medicaid_cost_if_enrolled"][2024],
+        np.array([100.0, 200.0, 300.0], dtype=np.float32),
+    )

--- a/tests/unit/build_outputs/test_us_augmentations.py
+++ b/tests/unit/build_outputs/test_us_augmentations.py
@@ -428,20 +428,7 @@ def test_us_takeup_postprocessor_rejects_unknown_takeup_results():
         )
 
 
-def test_us_medicaid_cost_postprocessor_applies_conditional_costs():
-    seen = {}
-
-    def fake_medicaid_cost_adder(data, time_period):
-        seen["time_period"] = time_period
-        np.testing.assert_array_equal(
-            data["takes_up_snap_if_eligible"][2024],
-            np.array([True, False]),
-        )
-        data["medicaid_cost_if_enrolled"] = {
-            time_period: np.array([100.0, 200.0, 300.0], dtype=np.float32)
-        }
-        return data
-
+def test_us_medicaid_cost_postprocessor_preserves_cloned_conditional_costs():
     payload = (
         USTakeupPostProcessor(
             takeup_applier=lambda **kwargs: {
@@ -454,14 +441,50 @@ def test_us_medicaid_cost_postprocessor_applies_conditional_costs():
         )
         .payload
     )
+    payload = H5Payload(
+        data={
+            **payload.data,
+            "medicaid_cost_if_enrolled": {
+                2024: np.array([100.0, 200.0, 300.0], dtype=np.float32)
+            },
+        },
+        time_period=payload.time_period,
+        entity_lengths=payload.entity_lengths,
+    )
 
-    result = USMedicaidCostPostProcessor(
-        medicaid_cost_adder=fake_medicaid_cost_adder,
-    ).apply(payload=payload, context=_context())
+    result = USMedicaidCostPostProcessor().apply(payload=payload, context=_context())
 
-    assert seen["time_period"] == 2024
     assert result.payload.variable_entities["medicaid_cost_if_enrolled"] == "person"
     np.testing.assert_array_equal(
         result.data["medicaid_cost_if_enrolled"][2024],
         np.array([100.0, 200.0, 300.0], dtype=np.float32),
+    )
+
+
+def test_us_medicaid_cost_postprocessor_clones_source_cost_without_reallocating():
+    class SourceVariableProvider:
+        def get_array(self, variable, period):
+            assert variable == "medicaid_cost_if_enrolled"
+            assert period == 2024
+            return np.array([10.0, 20.0, 30.0], dtype=np.float32)
+
+    context = _context()
+    context = replace(
+        context,
+        source=replace(
+            context.source,
+            input_variables=frozenset({"medicaid_cost_if_enrolled"}),
+            variable_provider=SourceVariableProvider(),
+        ),
+    )
+
+    result = USMedicaidCostPostProcessor().apply(
+        payload=_geography_payload(context),
+        context=context,
+    )
+
+    assert result.payload.variable_entities["medicaid_cost_if_enrolled"] == "person"
+    np.testing.assert_array_equal(
+        result.data["medicaid_cost_if_enrolled"][2024],
+        np.array([30.0, 10.0, 20.0], dtype=np.float32),
     )

--- a/tests/unit/calibration/test_publish_local_area.py
+++ b/tests/unit/calibration/test_publish_local_area.py
@@ -217,6 +217,7 @@ def test_build_h5_facade_delegates_to_builder_and_writer(tmp_path, monkeypatch):
         "USEntityPostProcessor",
         "USGeographyPostProcessor",
         "USTakeupPostProcessor",
+        "USMedicaidCostPostProcessor",
     ]
     assert seen["build"]["source"] is source
     assert seen["build"]["takeup_filter"] == ("takes_up_snap",)

--- a/tests/unit/datasets/cps/test_medicaid_cost.py
+++ b/tests/unit/datasets/cps/test_medicaid_cost.py
@@ -1,0 +1,121 @@
+import numpy as np
+import pytest
+
+from policyengine_us_data.datasets.cps.medicaid_cost import (
+    allocate_medicaid_cost_if_enrolled_by_slcsp,
+    family_tier_slcsp_person_share,
+)
+
+
+def test_allocate_medicaid_cost_if_enrolled_matches_state_targets():
+    person_slcsp = np.array([100.0, 200.0, 300.0, 400.0])
+    medicaid_enrolled = np.array([True, True, False, True])
+    person_weight = np.array([1.0, 2.0, 1.0, 4.0])
+    state_codes = np.array(["CA", "CA", "CA", "NY"])
+    state_spending = {"CA": 5_000.0, "NY": 8_000.0}
+
+    costs = allocate_medicaid_cost_if_enrolled_by_slcsp(
+        person_slcsp=person_slcsp,
+        medicaid_enrolled=medicaid_enrolled,
+        person_weight=person_weight,
+        state_codes=state_codes,
+        state_spending=state_spending,
+    )
+
+    ca_baseline_cost = np.sum(costs[:2] * person_weight[:2])
+    ny_baseline_cost = costs[3] * person_weight[3]
+    assert ca_baseline_cost == pytest.approx(5_000.0)
+    assert ny_baseline_cost == pytest.approx(8_000.0)
+    assert costs[2] / costs[0] == pytest.approx(3)
+
+
+def test_allocate_medicaid_cost_if_enrolled_fills_missing_slcsp_with_state_mean():
+    person_slcsp = np.array([0.0, 200.0, 400.0])
+    medicaid_enrolled = np.array([True, True, False])
+    person_weight = np.array([1.0, 1.0, 1.0])
+    state_codes = np.array([b"CA", b"CA", b"CA"])
+
+    costs = allocate_medicaid_cost_if_enrolled_by_slcsp(
+        person_slcsp=person_slcsp,
+        medicaid_enrolled=medicaid_enrolled,
+        person_weight=person_weight,
+        state_codes=state_codes,
+        state_spending={"CA": 900.0},
+    )
+
+    assert np.sum(costs[:2] * person_weight[:2]) == pytest.approx(900.0)
+    assert costs[0] == pytest.approx(costs[1] * 1.5)
+    assert costs[2] == pytest.approx(costs[1] * 2)
+
+
+def test_allocate_medicaid_cost_if_enrolled_requires_aligned_inputs():
+    with pytest.raises(ValueError, match="same length"):
+        allocate_medicaid_cost_if_enrolled_by_slcsp(
+            person_slcsp=np.array([100.0]),
+            medicaid_enrolled=np.array([True, False]),
+            person_weight=np.array([1.0]),
+            state_codes=np.array(["CA"]),
+            state_spending={"CA": 100.0},
+        )
+
+
+def test_family_tier_slcsp_person_share_allocates_ny_tax_unit_premium():
+    share = family_tier_slcsp_person_share(
+        state_codes=np.array(["NY", "NY", "NY", "NY"]),
+        base_cost=np.array([500.0, 500.0, 500.0, 500.0]),
+        age=np.array([40, 38, 10, 8]),
+        is_tax_unit_dependent=np.array([False, False, True, True]),
+        person_tax_unit_id=np.array([1, 1, 1, 1]),
+        tax_unit_id=np.array([1]),
+        fallback=np.array([999.0, 999.0, 999.0, 999.0]),
+        time_period=2026,
+    )
+
+    np.testing.assert_allclose(share, np.full(4, 500.0 * 2.85 / 4))
+
+
+def test_family_tier_slcsp_person_share_uses_ny_child_only_tier():
+    share = family_tier_slcsp_person_share(
+        state_codes=np.array(["NY", "NY"]),
+        base_cost=np.array([500.0, 500.0]),
+        age=np.array([12, 10]),
+        is_tax_unit_dependent=np.array([True, True]),
+        person_tax_unit_id=np.array([1, 1]),
+        tax_unit_id=np.array([1]),
+        fallback=np.array([999.0, 999.0]),
+        time_period=2026,
+    )
+
+    np.testing.assert_allclose(share, np.full(2, 500.0 * 0.412 / 2))
+
+
+def test_family_tier_slcsp_person_share_preserves_vt_child_only_fallback():
+    fallback = np.array([500.0, 500.0])
+
+    share = family_tier_slcsp_person_share(
+        state_codes=np.array(["VT", "VT"]),
+        base_cost=np.array([500.0, 500.0]),
+        age=np.array([12, 10]),
+        is_tax_unit_dependent=np.array([True, True]),
+        person_tax_unit_id=np.array([1, 1]),
+        tax_unit_id=np.array([1]),
+        fallback=fallback,
+        time_period=2026,
+    )
+
+    np.testing.assert_allclose(share, fallback)
+
+
+def test_family_tier_slcsp_person_share_allocates_vt_family_tier_premium():
+    share = family_tier_slcsp_person_share(
+        state_codes=np.array(["VT", "VT", "VT"]),
+        base_cost=np.array([500.0, 500.0, 500.0]),
+        age=np.array([40, 10, 8]),
+        is_tax_unit_dependent=np.array([False, True, True]),
+        person_tax_unit_id=np.array([1, 1, 1]),
+        tax_unit_id=np.array([1]),
+        fallback=np.array([999.0, 999.0, 999.0]),
+        time_period=2026,
+    )
+
+    np.testing.assert_allclose(share, np.full(3, 500.0 * 1.93 / 3))

--- a/uv.lock
+++ b/uv.lock
@@ -2165,7 +2165,7 @@ wheels = [
 [[package]]
 name = "policyengine-us"
 version = "1.706.14"
-source = { git = "https://github.com/PolicyEngine/policyengine-us.git?rev=0dcc69aa7a38be901141d38c8dbb7a9c870f2561#0dcc69aa7a38be901141d38c8dbb7a9c870f2561" }
+source = { git = "https://github.com/PolicyEngine/policyengine-us.git?rev=6a5061a4c51102f870e90637463f65e5fb1b0a11#6a5061a4c51102f870e90637463f65e5fb1b0a11" }
 dependencies = [
     { name = "microdf-python" },
     { name = "pandas" },
@@ -2242,7 +2242,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", git = "https://github.com/PolicyEngine/policyengine-us.git?rev=0dcc69aa7a38be901141d38c8dbb7a9c870f2561" },
+    { name = "policyengine-us", git = "https://github.com/PolicyEngine/policyengine-us.git?rev=6a5061a4c51102f870e90637463f65e5fb1b0a11" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "scipy", specifier = ">=1.15.3" },
     { name = "setuptools", specifier = ">=60" },

--- a/uv.lock
+++ b/uv.lock
@@ -2165,7 +2165,7 @@ wheels = [
 [[package]]
 name = "policyengine-us"
 version = "1.706.14"
-source = { git = "https://github.com/PolicyEngine/policyengine-us.git?rev=6a5061a4c51102f870e90637463f65e5fb1b0a11#6a5061a4c51102f870e90637463f65e5fb1b0a11" }
+source = { git = "https://github.com/PolicyEngine/policyengine-us.git?rev=9419df6f0cea065faa3eac04500226485f2d395a#9419df6f0cea065faa3eac04500226485f2d395a" }
 dependencies = [
     { name = "microdf-python" },
     { name = "pandas" },
@@ -2242,7 +2242,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", git = "https://github.com/PolicyEngine/policyengine-us.git?rev=6a5061a4c51102f870e90637463f65e5fb1b0a11" },
+    { name = "policyengine-us", git = "https://github.com/PolicyEngine/policyengine-us.git?rev=9419df6f0cea065faa3eac04500226485f2d395a" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "scipy", specifier = ">=1.15.3" },
     { name = "setuptools", specifier = ">=60" },

--- a/uv.lock
+++ b/uv.lock
@@ -2165,7 +2165,7 @@ wheels = [
 [[package]]
 name = "policyengine-us"
 version = "1.706.14"
-source = { git = "https://github.com/PolicyEngine/policyengine-us.git?rev=9419df6f0cea065faa3eac04500226485f2d395a#9419df6f0cea065faa3eac04500226485f2d395a" }
+source = { git = "https://github.com/PolicyEngine/policyengine-us.git?rev=1da04a64dcdce26834b063d68daa835765a5d8ed#1da04a64dcdce26834b063d68daa835765a5d8ed" }
 dependencies = [
     { name = "microdf-python" },
     { name = "pandas" },
@@ -2242,7 +2242,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", git = "https://github.com/PolicyEngine/policyengine-us.git?rev=9419df6f0cea065faa3eac04500226485f2d395a" },
+    { name = "policyengine-us", git = "https://github.com/PolicyEngine/policyengine-us.git?rev=1da04a64dcdce26834b063d68daa835765a5d8ed" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "scipy", specifier = ">=1.15.3" },
     { name = "setuptools", specifier = ">=60" },


### PR DESCRIPTION
## Summary
- add a us-data Medicaid conditional-cost allocator that uses only an SLCSP age/location premium index for within-state variation
- normalize each state against baseline Medicaid enrollees so weighted baseline Medicaid costs match state Medicaid spending totals
- write `medicaid_cost_if_enrolled` in CPS, recompute it in Extended CPS after clone/geography/take-up updates, and recompute it for local H5 payloads
- pin policyengine-us to PolicyEngine/policyengine-us#8499 commit `6a5061a4c51102f870e90637463f65e5fb1b0a11`, where `medicaid_cost_if_enrolled` is data-backed

Depends on PolicyEngine/policyengine-us#8499.

## Tests
- `uv run ruff format --check policyengine_us_data/datasets/cps/medicaid_cost.py policyengine_us_data/datasets/cps/cps.py policyengine_us_data/datasets/cps/extended_cps.py policyengine_us_data/build_outputs/us_augmentations.py tests/unit/datasets/cps/test_medicaid_cost.py tests/unit/build_outputs/test_us_augmentations.py`
- `uv run ruff check policyengine_us_data/datasets/cps/medicaid_cost.py policyengine_us_data/datasets/cps/cps.py policyengine_us_data/datasets/cps/extended_cps.py policyengine_us_data/build_outputs/us_augmentations.py tests/unit/datasets/cps/test_medicaid_cost.py tests/unit/build_outputs/test_us_augmentations.py`
- `uv run pytest tests/unit/datasets/cps/test_medicaid_cost.py tests/unit/build_outputs/test_us_augmentations.py`
- export-contract smoke: `computed_policyengine_us_variables_for_period({'medicaid_cost_if_enrolled'}, 2026, CountryTaxBenefitSystem()) == set()`
