### PR TITLE
Reuse publication scope run ID for pipeline dispatch

### DIFF
--- a/.github/scripts/fetch_publication_scope.py
+++ b/.github/scripts/fetch_publication_scope.py
@@ -13,6 +13,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 PUBLICATION_SCOPE_PATH = REPO_ROOT / ".github" / "publication_scope.json"
 VALID_FIELDS = frozenset(
     {
+        "run_id",
         "base_release_version",
         "release_bump",
         "candidate_scope",

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -146,7 +146,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - lint
-      - run-context
       - data-release-version
     if: startsWith(github.event.head_commit.message, 'Update publication candidate')
     permissions:
@@ -157,9 +156,9 @@ jobs:
       - name: Dispatch pipeline workflow
         env:
           GH_TOKEN: ${{ github.token }}
-          US_DATA_RUN_ID: ${{ needs.run-context.outputs.run_id }}
           SOURCE_SHA: ${{ github.sha }}
         run: |
+          export US_DATA_RUN_ID="$(python .github/scripts/fetch_publication_scope.py run_id)"
           export CANDIDATE_VERSION="$(python .github/scripts/fetch_publication_scope.py candidate_scope)"
           export BASE_RELEASE_VERSION="$(python .github/scripts/fetch_publication_scope.py base_release_version)"
           export RELEASE_BUMP="$(python .github/scripts/fetch_publication_scope.py release_bump)"

--- a/changelog.d/1153.fixed.md
+++ b/changelog.d/1153.fixed.md
@@ -1,0 +1,1 @@
+Fixed publication pipeline dispatch to reuse the committed publication candidate run ID.

--- a/tests/unit/test_publication_scripts.py
+++ b/tests/unit/test_publication_scripts.py
@@ -171,6 +171,7 @@ def test_fetch_publication_scope_prints_requested_field(
     path.write_text(
         json.dumps(
             {
+                "run_id": "run-123",
                 "base_release_version": "1.73.0",
                 "release_bump": "minor",
                 "candidate_scope": "1.73.0-minor",
@@ -184,6 +185,35 @@ def test_fetch_publication_scope_prints_requested_field(
     module.main()
 
     assert capsys.readouterr().out.strip() == "1.73.0-minor"
+
+
+def test_fetch_publication_scope_prints_committed_run_id(
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    module = _load_script(
+        ".github/scripts/fetch_publication_scope.py",
+        "fetch_publication_scope_run_id_script_test",
+    )
+    path = tmp_path / "publication_scope.json"
+    path.write_text(
+        json.dumps(
+            {
+                "run_id": "run-123",
+                "base_release_version": "1.73.0",
+                "release_bump": "minor",
+                "candidate_scope": "1.73.0-minor",
+                "would_release_as_at_build_time": "1.74.0",
+            }
+        )
+    )
+    monkeypatch.setattr(module, "PUBLICATION_SCOPE_PATH", path)
+    monkeypatch.setattr(sys, "argv", ["fetch_publication_scope.py", "run_id"])
+
+    module.main()
+
+    assert capsys.readouterr().out.strip() == "run-123"
 
 
 def test_fetch_publication_scope_exits_on_missing_field(
@@ -204,6 +234,19 @@ def test_fetch_publication_scope_exits_on_missing_field(
         module.main()
 
     assert "Publication scope file is missing required field" in capsys.readouterr().err
+
+
+def test_launch_pipeline_reuses_publication_scope_run_id():
+    workflow = (REPO_ROOT / ".github" / "workflows" / "push.yaml").read_text()
+    launch_pipeline = workflow.split("  launch-pipeline:", maxsplit=1)[1]
+
+    assert (
+        'export US_DATA_RUN_ID="$(python .github/scripts/fetch_publication_scope.py run_id)"'
+        in launch_pipeline
+    )
+    assert (
+        "US_DATA_RUN_ID: ${{ needs.run-context.outputs.run_id }}" not in launch_pipeline
+    )
 
 
 def test_fetch_release_version_prints_stable_version(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- make the publication candidate launch job reuse the committed `.github/publication_scope.json` run ID
- expose `run_id` through `fetch_publication_scope.py`
- add regression coverage for the run-ID fetch and workflow wiring

## Tests
- `uv run ruff format --check .`
- `uv run ruff check .github/scripts/fetch_publication_scope.py tests/unit/test_publication_scripts.py`
- `uv run pytest tests/unit/test_publication_scripts.py tests/unit/test_run_context.py -q`
- `git diff --check`

Note: `uv run ruff check .` still fails on pre-existing unrelated lint issues outside this patch; PR CI currently only runs `ruff format --check .` for lint.