### PR TITLE
Document that Census TAX_ID is replaced by our tax-unit construction

### DIFF
--- a/changelog.d/1154.changed.md
+++ b/changelog.d/1154.changed.md
@@ -1,0 +1,1 @@
+Documented in `CensusCPS._create_tax_unit_table` that the raw Census ASEC `TAX_ID` is replaced by our `construct_tax_units()` assignment, with the original retained as `CENSUS_TAX_ID` for validation.

--- a/policyengine_us_data/datasets/cps/census_cps.py
+++ b/policyengine_us_data/datasets/cps/census_cps.py
@@ -160,6 +160,14 @@ class CensusCPS(Dataset):
         person: pd.DataFrame,
         mode: str | None = None,
     ) -> pd.DataFrame:
+        # The raw Census ASEC TAX_ID (a documented filing-unit grouping) is NOT
+        # used as our tax unit. We build tax units ourselves with
+        # construct_tax_units() (default mode "policyengine", which applies PE
+        # filing/dependency rules) and overwrite TAX_ID with that assignment
+        # below. The original Census value is preserved as CENSUS_TAX_ID so it
+        # stays available as the ground-truth baseline our construction is
+        # validated against (see validation/cps_tax_unit_validation.py) and is a
+        # required raw-schema column (see _validate_raw_cps_schema in cps.py).
         person["CENSUS_TAX_ID"] = person["TAX_ID"]
         mode = mode or self.tax_unit_construction_mode
         constructed_person, tax_unit_df = construct_tax_units(
@@ -167,6 +175,7 @@ class CensusCPS(Dataset):
             year=self.time_period,
             mode=mode,
         )
+        # Replace Census TAX_ID with our constructed tax-unit assignment.
         person["TAX_ID"] = constructed_person["TAX_ID"].values
         return tax_unit_df[["TAX_ID"]]
 


### PR DESCRIPTION
## What
Add an explanatory comment in `CensusCPS._create_tax_unit_table` documenting that the raw Census ASEC `TAX_ID` is **intentionally replaced** by our own `construct_tax_units()` assignment, with the original retained as `CENSUS_TAX_ID`.

## Why
Read cold, `person["TAX_ID"] = constructed_person["TAX_ID"].values` looks like it might be silently clobbering the Census filing-unit grouping. It's deliberate: we build tax units ourselves (default mode `"policyengine"`), and keep the original as `CENSUS_TAX_ID` because it's the validation baseline (`validation/cps_tax_unit_validation.py`) and a required raw-schema column (`_validate_raw_cps_schema`). So `CENSUS_TAX_ID` should be neither dropped nor renamed — only documented.

Comment-only; no behavior change.

## Note
Refile of #1154 from a canonical branch instead of a fork, so the `check-fork`-gated CI (calibration/integration jobs) actually runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
