### PR TITLE
Expose compatible model versions in release manifest backfill

### DIFF
--- a/.github/workflows/backfill_release_manifest.yaml
+++ b/.github/workflows/backfill_release_manifest.yaml
@@ -16,6 +16,11 @@ on:
         description: "Exact policyengine-us version used with this data release"
         required: true
         type: string
+      compatible_model_package_versions:
+        description: "Optional newline-separated additional exact policyengine-us runtime versions to certify"
+        required: false
+        default: ""
+        type: string
       core_package_version:
         description: "Exact policyengine-core version used with this data release"
         required: true
@@ -107,6 +112,7 @@ jobs:
           VERSION: ${{ inputs.version }}
           ARTIFACTS: ${{ inputs.artifacts }}
           MODEL_PACKAGE_VERSION: ${{ inputs.model_package_version }}
+          COMPATIBLE_MODEL_PACKAGE_VERSIONS: ${{ inputs.compatible_model_package_versions }}
           CORE_PACKAGE_VERSION: ${{ inputs.core_package_version }}
           COMPATIBLE_CORE_PACKAGE_VERSIONS: ${{ inputs.compatible_core_package_versions }}
           MODEL_PACKAGE_GIT_SHA: ${{ inputs.model_package_git_sha }}
@@ -153,6 +159,17 @@ jobs:
             --output "release_manifest-${VERSION}.json"
             "${artifact_args[@]}"
           )
+
+          while IFS= read -r model_version; do
+            if [ -z "${model_version}" ]; then
+              continue
+            fi
+            if [[ ! "${model_version}" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+              echo "::error::Compatible model version must use x.y.z form, got '${model_version}'."
+              exit 1
+            fi
+            cmd+=(--compatible-model-package-version "${model_version}")
+          done <<< "${COMPATIBLE_MODEL_PACKAGE_VERSIONS}"
 
           while IFS= read -r core_version; do
             if [ -z "${core_version}" ]; then

--- a/changelog.d/backfill-compatible-model-versions.changed.md
+++ b/changelog.d/backfill-compatible-model-versions.changed.md
@@ -1,0 +1,1 @@
+Expose additional compatible policyengine-us versions in release manifest backfill and bump policyengine-us to 1.722.4.

--- a/policyengine_us_data/storage/backfill_release_manifest.py
+++ b/policyengine_us_data/storage/backfill_release_manifest.py
@@ -111,6 +111,7 @@ def build_backfilled_release_manifest(
     artifacts: Sequence[HfArtifactMetadata],
     model_package_version: str,
     core_package_version: str,
+    compatible_model_package_versions: Sequence[str] | None = None,
     compatible_core_package_versions: Sequence[str] | None = None,
     hf_repo_name: str = DEFAULT_HF_REPO_NAME,
     model_package_name: str = DEFAULT_MODEL_PACKAGE_NAME,
@@ -132,6 +133,9 @@ def build_backfilled_release_manifest(
             "name": DEFAULT_CORE_PACKAGE_NAME,
             "version": core_package_version,
         },
+        additional_compatible_specifiers=[
+            f"=={version}" for version in compatible_model_package_versions or ()
+        ],
         additional_core_compatible_specifiers=[
             f"=={version}" for version in compatible_core_package_versions or ()
         ],
@@ -221,6 +225,17 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--model-package-version", required=True)
     parser.add_argument("--core-package-version", required=True)
     parser.add_argument(
+        "--compatible-model-package-version",
+        action="append",
+        dest="compatible_model_package_versions",
+        default=[],
+        help=(
+            "Additional exact policyengine-us runtime version to certify as "
+            "compatible. Repeat for multiple versions. The build model remains "
+            "--model-package-version."
+        ),
+    )
+    parser.add_argument(
         "--compatible-core-package-version",
         action="append",
         dest="compatible_core_package_versions",
@@ -278,6 +293,7 @@ def main() -> int:
         artifacts=artifacts,
         model_package_version=args.model_package_version,
         core_package_version=args.core_package_version,
+        compatible_model_package_versions=args.compatible_model_package_versions,
         compatible_core_package_versions=args.compatible_core_package_versions,
         hf_repo_name=args.hf_repo_name,
         model_package_git_sha=args.model_package_git_sha,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "policyengine-us==1.715.3",
+    "policyengine-us==1.722.4",
     # policyengine-core 3.26.1 is the current 3.26.x runtime and includes the fix for
     # PolicyEngine/policyengine-core#482 (user-set ETERNITY inputs lost
     # after _invalidate_all_caches) and is required by policyengine-us 1.682.1+.

--- a/tests/unit/test_backfill_release_manifest.py
+++ b/tests/unit/test_backfill_release_manifest.py
@@ -146,6 +146,28 @@ def test_build_backfilled_release_manifest_records_additional_core_compatibility
     ]
 
 
+def test_build_backfilled_release_manifest_records_additional_model_compatibility():
+    manifest = build_backfilled_release_manifest(
+        version="1.73.0",
+        artifacts=[
+            HfArtifactMetadata(
+                path="enhanced_cps_2024.h5",
+                sha256="a" * 64,
+                size_bytes=1,
+            )
+        ],
+        model_package_version="1.653.3",
+        compatible_model_package_versions=["1.722.4"],
+        core_package_version="3.26.0",
+    )
+
+    assert manifest["build"]["built_with_model_package"]["version"] == "1.653.3"
+    assert manifest["compatible_model_packages"] == [
+        {"name": "policyengine-us", "specifier": "==1.653.3"},
+        {"name": "policyengine-us", "specifier": "==1.722.4"},
+    ]
+
+
 def test_upload_backfilled_release_manifest_uploads_manifest_and_trace(monkeypatch):
     api = MagicMock()
     api.create_commit.return_value = SimpleNamespace(oid="commit-sha")

--- a/uv.lock
+++ b/uv.lock
@@ -2164,7 +2164,7 @@ wheels = [
 
 [[package]]
 name = "policyengine-us"
-version = "1.715.3"
+version = "1.722.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "microdf-python" },
@@ -2174,9 +2174,9 @@ dependencies = [
     { name = "tables" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/bc/ea8cf84d7653d4d76d1f7b05feb74722ff903637c616357610de1fd3b431/policyengine_us-1.715.3.tar.gz", hash = "sha256:5b41b22be90ef155a9440bcae7dd26115c887cad92ae8a51d9080a9692053b66", size = 10014788, upload-time = "2026-05-29T21:33:02.993Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/21/da9e789e4abc7d2c8e42c6913042e2e371b9054c468f28f2212a0652f13a/policyengine_us-1.722.4.tar.gz", hash = "sha256:2a60f294a3cfa891a82c1eeee0c31e7868859ca233075a8f81ceb3f235662ae7", size = 10134261, upload-time = "2026-06-08T09:04:58.953Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/0f/e6b594d46fffeb6e40db3a51441cec6a6e76ade2b178eab3836528dbc15c/policyengine_us-1.715.3-py3-none-any.whl", hash = "sha256:a34f305871f702d94f7a4d220bfd5312f11d83a417e793566892541871dfded3", size = 11037631, upload-time = "2026-05-29T21:32:59.464Z" },
+    { url = "https://files.pythonhosted.org/packages/20/fc/f6fa4ffbc79129a267d92782aba6889145fabfcb39023423fed1f468af3f/policyengine_us-1.722.4-py3-none-any.whl", hash = "sha256:691d4aa9b1512d71d283b0b5805af5ba95ffed798fe471a97cf2195f4950b6e3", size = 11319909, upload-time = "2026-06-08T09:04:55.761Z" },
 ]
 
 [[package]]
@@ -2246,7 +2246,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pip-system-certs", specifier = ">=3.0" },
     { name = "policyengine-core", specifier = ">=3.26.1,<3.27" },
-    { name = "policyengine-us", specifier = "==1.715.3" },
+    { name = "policyengine-us", specifier = "==1.722.4" },
     { name = "requests", specifier = ">=2.25.0" },
     { name = "scipy", specifier = ">=1.15.3" },
     { name = "setuptools", specifier = ">=60" },


### PR DESCRIPTION
## Summary
- add a backfill CLI/workflow option for additional compatible policyengine-us runtime versions
- keep the build model version separate from additional compatibility certs
- bump policyengine-us to 1.722.4 so the freshness guard remains current
- cover the new behavior in the backfill unit tests

## Verification
- env -u UV_FROZEN uv run python -m pytest tests/unit/test_backfill_release_manifest.py -q
- env -u UV_FROZEN uv run python -m ruff check policyengine_us_data/storage/backfill_release_manifest.py tests/unit/test_backfill_release_manifest.py
- env -u UV_FROZEN uv run python -m ruff format --check policyengine_us_data/storage/backfill_release_manifest.py tests/unit/test_backfill_release_manifest.py
- env -u UV_FROZEN uv run python .github/scripts/check_policyengine_us_dependency.py