### PR TITLE
Fix spurious negative auto_loan_interest from SCF -1 sentinels

### DIFF
--- a/changelog_entry.yaml
+++ b/changelog_entry.yaml
@@ -1,0 +1,4 @@
+- bump: patch
+  changes:
+    fixed:
+      - Floor SCF auto loan balance and rate sentinels so auto_loan_interest is never negative.

--- a/policyengine_us_data/datasets/scf/scf.py
+++ b/policyengine_us_data/datasets/scf/scf.py
@@ -234,6 +234,38 @@ def rename_columns_to_match_cps(scf: dict, raw_data: pd.DataFrame) -> None:
             scf[pe_var] = raw_data[scf_var].fillna(0).values
 
 
+def _summarize_auto_loans(auto_df: pd.DataFrame) -> pd.DataFrame:
+    """Compute total auto loan balance and interest from raw SCF columns.
+
+    The SCF codes inapplicable car loans and rates with negative sentinels
+    (``-1``). The original ``auto_df[cols].replace(-1, 0, inplace=True)`` ran on
+    a column-slice copy and silently did nothing, so a real loan balance times a
+    ``-1`` rate sentinel (after the /10,000 scaling) produced a spurious negative
+    interest amount. Floor the raw balance and rate columns at zero first so only
+    genuine loans contribute.
+
+    Args:
+        auto_df: Raw SCF rows carrying the per-car balance and rate columns.
+
+    Returns:
+        A copy with ``auto_loan_balance`` and ``auto_loan_interest`` columns.
+    """
+    balance_cols = ["x2209", "x2309", "x2409", "x7158"]
+    rate_cols = ["x2219", "x2319", "x2419", "x7170"]
+    auto_df = auto_df.copy()
+    auto_df[balance_cols + rate_cols] = auto_df[balance_cols + rate_cols].clip(
+        lower=0
+    )
+    # Rate columns are stored scaled by 10,000; divide to a plain fraction.
+    auto_df[rate_cols] = auto_df[rate_cols] / 10_000
+    auto_df["auto_loan_balance"] = auto_df[balance_cols].sum(axis=1)
+    auto_df["auto_loan_interest"] = sum(
+        auto_df[bal] * auto_df[rate]
+        for bal, rate in zip(balance_cols, rate_cols)
+    )
+    return auto_df
+
+
 def add_auto_loan_interest(scf: dict, year: int) -> None:
     """Adds auto loan balance and interest to the summarized SCF dataset from the full SCF."""
     import requests
@@ -311,25 +343,11 @@ def add_auto_loan_interest(scf: dict, year: int) -> None:
                 f"Downloaded zip file is corrupt for year {year}"
             ) from e
 
-        # Process the interest data and add to final SCF dictionary
-        auto_df = df[IDENTIFYER_COLUMNS + AUTO_LOAN_COLUMNS].copy()
-        auto_df[AUTO_LOAN_COLUMNS].replace(-1, 0, inplace=True)
-
-        # Interest rate columns are in percent * 10,000 format, we need to divide by 10,000 to leave them in percentage format
-        RATE_COLUMNS = ["x2219", "x2319", "x2419", "x7170"]
-        auto_df[RATE_COLUMNS] /= 10_000
-
-        # Calculate total auto loan balance (sum of all auto loan balance variables)
-        auto_df["auto_loan_balance"] = auto_df[
-            ["x2209", "x2309", "x2409", "x7158"]
-        ].sum(axis=1)
-
-        # Calculate total auto loan interest (sum of the amounts of each balance variable multiplied by its respective interest rate variable)
-        auto_df["auto_loan_interest"] = (
-            auto_df["x2209"] * auto_df["x2219"]
-            + auto_df["x2309"] * auto_df["x2319"]
-            + auto_df["x2409"] * auto_df["x2419"]
-            + auto_df["x7158"] * auto_df["x7170"]
+        # Process the interest data and add to final SCF dictionary. Negative
+        # "not applicable" sentinels in the raw balance/rate columns are floored
+        # to zero inside the helper before they can leak into the product.
+        auto_df = _summarize_auto_loans(
+            df[IDENTIFYER_COLUMNS + AUTO_LOAN_COLUMNS]
         )
 
         # Check if we have household identifiers (y1, yy1) in both datasets

--- a/tests/test_scf_auto_loans.py
+++ b/tests/test_scf_auto_loans.py
@@ -1,0 +1,39 @@
+"""Auto loan balance/interest summarization from raw SCF columns."""
+
+import pandas as pd
+
+from policyengine_us_data.datasets.scf.scf import _summarize_auto_loans
+
+
+def test_summarize_auto_loans_floors_negative_sentinels():
+    """Negative SCF "not applicable" sentinels must not produce negative or
+    inflated auto loan amounts.
+
+    Row 0: a real $20,000 loan at 5% (rate stored as 500 -> 0.05) plus -1
+    sentinels for the absent cars 2-4. Row 1: a real balance whose rate is
+    unreported (-1) -- the exact case that previously yielded a spurious
+    negative interest (balance * -1 / 10,000).
+    """
+    df = pd.DataFrame(
+        {
+            "x2209": [20000.0, 30000.0],  # balance car 1
+            "x2309": [-1.0, -1.0],  # balance car 2 (n/a sentinel)
+            "x2409": [-1.0, -1.0],
+            "x7158": [-1.0, -1.0],
+            "x2219": [500.0, -1.0],  # rate car 1 (0.05; row 1 unreported)
+            "x2319": [-1.0, -1.0],
+            "x2419": [-1.0, -1.0],
+            "x7170": [-1.0, -1.0],
+        }
+    )
+
+    out = _summarize_auto_loans(df)
+
+    assert (out["auto_loan_interest"] >= 0).all()
+    assert (out["auto_loan_balance"] >= 0).all()
+    # Only the real loan contributes: 20,000 * 0.05 = 1,000.
+    assert out["auto_loan_interest"].iloc[0] == 1000.0
+    # Real balance but unreported rate -> zero interest, not a negative.
+    assert out["auto_loan_interest"].iloc[1] == 0.0
+    # Sentinel balances do not inflate the total.
+    assert out["auto_loan_balance"].iloc[0] == 20000.0


### PR DESCRIPTION
## Problem

`add_auto_loan_interest` cleans the SCF "not applicable" sentinels with:

```python
auto_df[AUTO_LOAN_COLUMNS].replace(-1, 0, inplace=True)
```

That runs on a **column-slice copy**, so it is a silent no-op — the `-1` sentinels survive into the per-car `balance * rate` product. A real loan balance times a `-1` rate sentinel (after the `/10,000` scaling) yields a small negative interest: e.g. a $90k loan with an **unreported** rate becomes **-$9** of interest.

This is invisible inside policyengine-us-data but propagates: `populace-build`'s SCF wealth stage imputes `SCF_2022().load_dataset()` onto households, so **844 of 75,112 `populace_us_2024` households** carry impossible negative `auto_loan_interest`. Surfaced by the PolicyBench populace refresh, whose prompts then showed models facts like `auto loan interest: -$4.50`.

## Fix

Extract the balance/interest computation into `_summarize_auto_loans` and floor the raw balance and rate columns at zero with `clip(lower=0)` **before** combining. This assigns back (unlike the old in-place call) and is robust to any negative sentinel code, not just `-1`.

Positive magnitudes are unchanged — the `/10,000` rate scaling is preserved and the real median interest/balance stays ~0.04 (a sane ~4% APR). Adds a focused unit test covering both the sentinel-balance and unreported-rate cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
