### PR TITLE
Remove policyengine-bundles contract CI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -165,27 +165,6 @@ jobs:
           tests/unit/test_long_term_calibration_contract.py::test_greg_calibrator_hits_linear_controls_with_svy
           -v
 
-  bundle-release-manifest-contract:
-    name: Validate bundle release manifest contract
-    runs-on: ubuntu-latest
-    needs: [check-fork, lint]
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.14"
-      - uses: astral-sh/setup-uv@v8.1.0
-      - run: uv sync --dev
-      - name: Install bundle contract validator
-        run: >
-          uv pip install
-          "policyengine-bundles @ git+https://github.com/PolicyEngine/policyengine-bundles@e15d653b40926cfb39ddef9b445d1b0022da1b85"
-      - name: Validate release manifest shape
-        run: >
-          uv run pytest
-          tests/unit/test_release_manifest.py::test_build_release_manifest_validates_against_bundle_contract
-          -v
-
   target-integration-tests:
     runs-on: ubuntu-latest
     needs: [check-fork, lint, unit-tests, smoke-test, decide-test-scope]

--- a/changelog.d/remove-bundle-contract-ci.removed.md
+++ b/changelog.d/remove-bundle-contract-ci.removed.md
@@ -1,0 +1,1 @@
+Removed the policyengine-bundles metadata contract check from pull-request CI.


### PR DESCRIPTION
Fixes #1172

## Summary

- Remove the PR job that installed `policyengine-bundles` only to validate the release manifest bundle contract.
- Keep data package validation and release work local to `policyengine-us-data`.
- Certified runtime bundle inclusion is now handled by the `.py`-owned `policyengine bundle install` manifest and release workflow.

## Validation

- Not run locally; workflow-only cleanup.